### PR TITLE
Add support for azcore.HTTPResponse interface

### DIFF
--- a/src/generator/client.ts
+++ b/src/generator/client.ts
@@ -42,8 +42,6 @@ function generateContent(session: Session<CodeModel>, exportClient: boolean): st
   text += `type ${clientOptions} struct {\n`;
   text += '\t// HTTPClient sets the transport for making HTTP requests.\n';
   text += '\tHTTPClient azcore.Transport\n';
-  text += '\t// LogOptions configures the built-in request logging policy behavior.\n';
-  text += '\tLogOptions azcore.RequestLogOptions\n';
   text += '\t// Retry configures the built-in retry policy behavior.\n';
   text += '\tRetry azcore.RetryOptions\n';
   text += '\t// Telemetry configures the built-in telemetry policy behavior.\n';
@@ -157,7 +155,7 @@ function generateContent(session: Session<CodeModel>, exportClient: boolean): st
   const reqIDPolicy = 'azcore.NewUniqueRequestIDPolicy()';
   const retryPolicy = 'azcore.NewRetryPolicy(&options.Retry)';
   const credPolicy = 'cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}})';
-  const logPolicy = 'azcore.NewRequestLogPolicy(options.LogOptions))';
+  const logPolicy = 'azcore.NewRequestLogPolicy(nil))';
   // ARM will optionally inject the RP registration policy into the pipeline
   if (isARM && session.model.security.authenticationRequired) {
     text += '\tpolicies := []azcore.Policy{\n';

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,10 +16,10 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.13\n\n';
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
-  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0';
+  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0';
   if (session.model.language.go!.openApiType === 'arm') {
     text += 'require (\n';
-    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0\n';
+    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2\n';
     text += `\t${azcore}\n`;
     text += ')\n'
   } else {

--- a/test/autorest/additionalpropsgroup/zz_generated_client.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-additionalpropsgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -86,7 +86,7 @@ func (client *PetsClient) CreateApInPropertiesHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateApInPropertiesWithApstring - Create a Pet which contains more properties than what is defined.
@@ -132,7 +132,7 @@ func (client *PetsClient) CreateApInPropertiesWithApstringHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateApObject - Create a Pet which contains more properties than what is defined.
@@ -178,7 +178,7 @@ func (client *PetsClient) CreateApObjectHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateApString - Create a Pet which contains more properties than what is defined.
@@ -224,7 +224,7 @@ func (client *PetsClient) CreateApStringHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateApTrue - Create a Pet which contains more properties than what is defined.
@@ -270,7 +270,7 @@ func (client *PetsClient) CreateApTrueHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateCatApTrue - Create a CatAPTrue which contains more properties than what is defined.
@@ -316,5 +316,5 @@ func (client *PetsClient) CreateCatApTrueHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -213,7 +213,7 @@ func (client *ArrayClient) GetArrayEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
@@ -259,7 +259,7 @@ func (client *ArrayClient) GetArrayItemEmptyHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
@@ -305,7 +305,7 @@ func (client *ArrayClient) GetArrayItemNullHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayNull - Get a null array
@@ -351,7 +351,7 @@ func (client *ArrayClient) GetArrayNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
@@ -397,7 +397,7 @@ func (client *ArrayClient) GetArrayValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
@@ -443,7 +443,7 @@ func (client *ArrayClient) GetBase64URLHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanInvalidNull - Get boolean array value [true, null, false]
@@ -489,7 +489,7 @@ func (client *ArrayClient) GetBooleanInvalidNullHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
@@ -535,7 +535,7 @@ func (client *ArrayClient) GetBooleanInvalidStringHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
@@ -581,7 +581,7 @@ func (client *ArrayClient) GetBooleanTfftHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
@@ -627,7 +627,7 @@ func (client *ArrayClient) GetByteInvalidNullHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
@@ -673,7 +673,7 @@ func (client *ArrayClient) GetByteValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexEmpty - Get empty array of complex type []
@@ -719,7 +719,7 @@ func (client *ArrayClient) GetComplexEmptyHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
@@ -765,7 +765,7 @@ func (client *ArrayClient) GetComplexItemEmptyHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
@@ -811,7 +811,7 @@ func (client *ArrayClient) GetComplexItemNullHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexNull - Get array of complex type null value
@@ -857,7 +857,7 @@ func (client *ArrayClient) GetComplexNullHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
@@ -903,7 +903,7 @@ func (client *ArrayClient) GetComplexValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
@@ -949,7 +949,7 @@ func (client *ArrayClient) GetDateInvalidCharsHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
@@ -995,7 +995,7 @@ func (client *ArrayClient) GetDateInvalidNullHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
@@ -1048,7 +1048,7 @@ func (client *ArrayClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
@@ -1101,7 +1101,7 @@ func (client *ArrayClient) GetDateTimeInvalidNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
@@ -1154,7 +1154,7 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
@@ -1207,7 +1207,7 @@ func (client *ArrayClient) GetDateTimeValidHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
@@ -1253,7 +1253,7 @@ func (client *ArrayClient) GetDateValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
@@ -1299,7 +1299,7 @@ func (client *ArrayClient) GetDictionaryEmptyHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1345,7 +1345,7 @@ func (client *ArrayClient) GetDictionaryItemEmptyHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1391,7 +1391,7 @@ func (client *ArrayClient) GetDictionaryItemNullHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryNull - Get an array of Dictionaries with value null
@@ -1437,7 +1437,7 @@ func (client *ArrayClient) GetDictionaryNullHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -1483,7 +1483,7 @@ func (client *ArrayClient) GetDictionaryValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
@@ -1529,7 +1529,7 @@ func (client *ArrayClient) GetDoubleInvalidNullHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
@@ -1575,7 +1575,7 @@ func (client *ArrayClient) GetDoubleInvalidStringHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
@@ -1621,7 +1621,7 @@ func (client *ArrayClient) GetDoubleValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
@@ -1667,7 +1667,7 @@ func (client *ArrayClient) GetDurationValidHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEmpty - Get empty array value []
@@ -1713,7 +1713,7 @@ func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
@@ -1759,7 +1759,7 @@ func (client *ArrayClient) GetEnumValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
@@ -1805,7 +1805,7 @@ func (client *ArrayClient) GetFloatInvalidNullHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
@@ -1851,7 +1851,7 @@ func (client *ArrayClient) GetFloatInvalidStringHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
@@ -1897,7 +1897,7 @@ func (client *ArrayClient) GetFloatValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntInvalidNull - Get integer array value [1, null, 0]
@@ -1943,7 +1943,7 @@ func (client *ArrayClient) GetIntInvalidNullHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
@@ -1989,7 +1989,7 @@ func (client *ArrayClient) GetIntInvalidStringHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
@@ -2035,7 +2035,7 @@ func (client *ArrayClient) GetIntegerValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalid - Get invalid array [1, 2, 3
@@ -2081,7 +2081,7 @@ func (client *ArrayClient) GetInvalidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongInvalidNull - Get long array value [1, null, 0]
@@ -2127,7 +2127,7 @@ func (client *ArrayClient) GetLongInvalidNullHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
@@ -2173,7 +2173,7 @@ func (client *ArrayClient) GetLongInvalidStringHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongValid - Get integer array value [1, -1, 3, 300]
@@ -2219,7 +2219,7 @@ func (client *ArrayClient) GetLongValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null array value
@@ -2265,7 +2265,7 @@ func (client *ArrayClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
@@ -2311,7 +2311,7 @@ func (client *ArrayClient) GetStringEnumValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
@@ -2357,7 +2357,7 @@ func (client *ArrayClient) GetStringValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
@@ -2403,7 +2403,7 @@ func (client *ArrayClient) GetStringWithInvalidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
@@ -2449,7 +2449,7 @@ func (client *ArrayClient) GetStringWithNullHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUUIDInvalidChars - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
@@ -2495,7 +2495,7 @@ func (client *ArrayClient) GetUUIDInvalidCharsHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
@@ -2541,7 +2541,7 @@ func (client *ArrayClient) GetUUIDValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
@@ -2577,7 +2577,7 @@ func (client *ArrayClient) PutArrayValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
@@ -2613,7 +2613,7 @@ func (client *ArrayClient) PutBooleanTfftHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
@@ -2649,7 +2649,7 @@ func (client *ArrayClient) PutByteValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
@@ -2685,7 +2685,7 @@ func (client *ArrayClient) PutComplexValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
@@ -2725,7 +2725,7 @@ func (client *ArrayClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
@@ -2761,7 +2761,7 @@ func (client *ArrayClient) PutDateTimeValidHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
@@ -2797,7 +2797,7 @@ func (client *ArrayClient) PutDateValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
@@ -2833,7 +2833,7 @@ func (client *ArrayClient) PutDictionaryValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
@@ -2869,7 +2869,7 @@ func (client *ArrayClient) PutDoubleValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
@@ -2905,7 +2905,7 @@ func (client *ArrayClient) PutDurationValidHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEmpty - Set array value empty []
@@ -2941,7 +2941,7 @@ func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -2977,7 +2977,7 @@ func (client *ArrayClient) PutEnumValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
@@ -3013,7 +3013,7 @@ func (client *ArrayClient) PutFloatValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
@@ -3049,7 +3049,7 @@ func (client *ArrayClient) PutIntegerValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
@@ -3085,7 +3085,7 @@ func (client *ArrayClient) PutLongValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -3121,7 +3121,7 @@ func (client *ArrayClient) PutStringEnumValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
@@ -3157,7 +3157,7 @@ func (client *ArrayClient) PutStringValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
@@ -3193,5 +3193,5 @@ func (client *ArrayClient) PutUUIDValidHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/arraygroup/zz_generated_client.go
+++ b/test/autorest/arraygroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-arraygroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -81,5 +81,5 @@ func (client *AutoRestReportServiceForAzureClient) GetReportHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurereportgroup/zz_generated_client.go
+++ b/test/autorest/azurereportgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-azurereportgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
@@ -75,7 +75,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidHandleErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
@@ -114,7 +114,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValidHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
@@ -153,7 +153,7 @@ func (client *APIVersionDefaultClient) GetPathGlobalValidHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
@@ -192,5 +192,5 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValidHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
@@ -77,7 +77,7 @@ func (client *APIVersionLocalClient) GetMethodLocalNullHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -116,7 +116,7 @@ func (client *APIVersionLocalClient) GetMethodLocalValidHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -155,7 +155,7 @@ func (client *APIVersionLocalClient) GetPathLocalValidHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
@@ -194,5 +194,5 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValidHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-azurespecialsgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -84,7 +84,7 @@ func (client *HeaderClient) CustomNamedRequestIDHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
@@ -134,7 +134,7 @@ func (client *HeaderClient) CustomNamedRequestIDHeadHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CustomNamedRequestIDParamGrouping - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group
@@ -184,5 +184,5 @@ func (client *HeaderClient) CustomNamedRequestIDParamGroupingHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_odata.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata.go
@@ -78,5 +78,5 @@ func (client *OdataClient) GetWithFilterHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
@@ -80,7 +80,7 @@ func (client *SkipURLEncodingClient) GetMethodPathValidHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetMethodQueryNull - Get method with unencoded query parameter with value null
@@ -121,7 +121,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryNullHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -160,7 +160,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryValidHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -199,7 +199,7 @@ func (client *SkipURLEncodingClient) GetPathQueryValidHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
@@ -236,7 +236,7 @@ func (client *SkipURLEncodingClient) GetPathValidHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
@@ -273,7 +273,7 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValidHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
@@ -312,5 +312,5 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValidHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
@@ -81,7 +81,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidH
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostMethodGlobalNull - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call
@@ -118,7 +118,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullHandleError(r
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -155,7 +155,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -192,7 +192,7 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValidHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
@@ -229,5 +229,5 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
@@ -75,7 +75,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNullHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -112,7 +112,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValidHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -149,7 +149,7 @@ func (client *SubscriptionInMethodClient) PostPathLocalValidHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
@@ -186,5 +186,5 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValidHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
@@ -71,9 +71,9 @@ func (client *XMSClientRequestIDClient) GetHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -110,5 +110,5 @@ func (client *XMSClientRequestIDClient) ParamGetHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -86,7 +86,7 @@ func (client *BoolClient) GetFalseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalid - Get invalid Boolean value
@@ -132,7 +132,7 @@ func (client *BoolClient) GetInvalidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null Boolean value
@@ -178,7 +178,7 @@ func (client *BoolClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTrue - Get true Boolean value
@@ -224,7 +224,7 @@ func (client *BoolClient) GetTrueHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutFalse - Set Boolean value false
@@ -260,7 +260,7 @@ func (client *BoolClient) PutFalseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutTrue - Set Boolean value true
@@ -296,5 +296,5 @@ func (client *BoolClient) PutTrueHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/booleangroup/zz_generated_client.go
+++ b/test/autorest/booleangroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-booleangroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -84,7 +84,7 @@ func (client *ByteClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalid - Get invalid byte value ':::SWAGGER::::'
@@ -130,7 +130,7 @@ func (client *ByteClient) GetInvalidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
@@ -176,7 +176,7 @@ func (client *ByteClient) GetNonASCIIHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null byte value
@@ -222,7 +222,7 @@ func (client *ByteClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
@@ -258,5 +258,5 @@ func (client *ByteClient) PutNonASCIIHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/bytegroup/zz_generated_client.go
+++ b/test/autorest/bytegroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-bytegroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -84,7 +84,7 @@ func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotProvided - Get complex types with array property while server doesn't provide a response payload
@@ -130,7 +130,7 @@ func (client *ArrayClient) GetNotProvidedHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetValid - Get complex types with array property
@@ -176,7 +176,7 @@ func (client *ArrayClient) GetValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEmpty - Put complex types with array property which is empty
@@ -212,7 +212,7 @@ func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types with array property
@@ -248,5 +248,5 @@ func (client *ArrayClient) PutValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -86,7 +86,7 @@ func (client *BasicClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalid - Get a basic complex type that is invalid for the local strong type
@@ -132,7 +132,7 @@ func (client *BasicClient) GetInvalidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotProvided - Get a basic complex type while the server doesn't provide a response payload
@@ -178,7 +178,7 @@ func (client *BasicClient) GetNotProvidedHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get a basic complex type whose properties are null
@@ -224,7 +224,7 @@ func (client *BasicClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetValid - Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
@@ -270,7 +270,7 @@ func (client *BasicClient) GetValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Please put {id: 2, name: 'abc', color: 'Magenta'}
@@ -309,5 +309,5 @@ func (client *BasicClient) PutValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_client.go
+++ b/test/autorest/complexgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-complexgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -86,7 +86,7 @@ func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotProvided - Get complex types with dictionary property while server doesn't provide a response payload
@@ -132,7 +132,7 @@ func (client *DictionaryClient) GetNotProvidedHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get complex types with dictionary property which is null
@@ -178,7 +178,7 @@ func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetValid - Get complex types with dictionary property
@@ -224,7 +224,7 @@ func (client *DictionaryClient) GetValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEmpty - Put complex types with dictionary property which is empty
@@ -260,7 +260,7 @@ func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types with dictionary property
@@ -296,5 +296,5 @@ func (client *DictionaryClient) PutValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -78,7 +78,7 @@ func (client *FlattencomplexClient) GetValidHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -78,7 +78,7 @@ func (client *InheritanceClient) GetValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types that extend others
@@ -114,5 +114,5 @@ func (client *InheritanceClient) PutValidHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -78,7 +78,7 @@ func (client *PolymorphicrecursiveClient) GetValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types that are polymorphic and have recursive references
@@ -114,5 +114,5 @@ func (client *PolymorphicrecursiveClient) PutValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -92,7 +92,7 @@ func (client *PolymorphismClient) GetComplicatedHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
@@ -138,7 +138,7 @@ func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
@@ -184,7 +184,7 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
@@ -230,7 +230,7 @@ func (client *PolymorphismClient) GetDotSyntaxHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetValid - Get complex types that are polymorphic
@@ -276,7 +276,7 @@ func (client *PolymorphismClient) GetValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
@@ -312,7 +312,7 @@ func (client *PolymorphismClient) PutComplicatedHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
@@ -358,7 +358,7 @@ func (client *PolymorphismClient) PutMissingDiscriminatorHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types that are polymorphic
@@ -394,7 +394,7 @@ func (client *PolymorphismClient) PutValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
@@ -430,5 +430,5 @@ func (client *PolymorphismClient) PutValidMissingRequiredHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -118,7 +118,7 @@ func (client *PrimitiveClient) GetBoolHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetByte - Get complex types with byte properties
@@ -164,7 +164,7 @@ func (client *PrimitiveClient) GetByteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDate - Get complex types with date properties
@@ -210,7 +210,7 @@ func (client *PrimitiveClient) GetDateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTime - Get complex types with datetime properties
@@ -256,7 +256,7 @@ func (client *PrimitiveClient) GetDateTimeHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeRFC1123 - Get complex types with datetimeRfc1123 properties
@@ -302,7 +302,7 @@ func (client *PrimitiveClient) GetDateTimeRFC1123HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDouble - Get complex types with double properties
@@ -348,7 +348,7 @@ func (client *PrimitiveClient) GetDoubleHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDuration - Get complex types with duration properties
@@ -394,7 +394,7 @@ func (client *PrimitiveClient) GetDurationHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloat - Get complex types with float properties
@@ -440,7 +440,7 @@ func (client *PrimitiveClient) GetFloatHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInt - Get complex types with integer properties
@@ -486,7 +486,7 @@ func (client *PrimitiveClient) GetIntHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLong - Get complex types with long properties
@@ -532,7 +532,7 @@ func (client *PrimitiveClient) GetLongHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetString - Get complex types with string properties
@@ -578,7 +578,7 @@ func (client *PrimitiveClient) GetStringHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBool - Put complex types with bool properties
@@ -614,7 +614,7 @@ func (client *PrimitiveClient) PutBoolHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutByte - Put complex types with byte properties
@@ -650,7 +650,7 @@ func (client *PrimitiveClient) PutByteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDate - Put complex types with date properties
@@ -686,7 +686,7 @@ func (client *PrimitiveClient) PutDateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTime - Put complex types with datetime properties
@@ -722,7 +722,7 @@ func (client *PrimitiveClient) PutDateTimeHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTimeRFC1123 - Put complex types with datetimeRfc1123 properties
@@ -758,7 +758,7 @@ func (client *PrimitiveClient) PutDateTimeRFC1123HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDouble - Put complex types with double properties
@@ -794,7 +794,7 @@ func (client *PrimitiveClient) PutDoubleHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDuration - Put complex types with duration properties
@@ -830,7 +830,7 @@ func (client *PrimitiveClient) PutDurationHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutFloat - Put complex types with float properties
@@ -866,7 +866,7 @@ func (client *PrimitiveClient) PutFloatHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutInt - Put complex types with integer properties
@@ -902,7 +902,7 @@ func (client *PrimitiveClient) PutIntHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLong - Put complex types with long properties
@@ -938,7 +938,7 @@ func (client *PrimitiveClient) PutLongHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutString - Put complex types with string properties
@@ -974,5 +974,5 @@ func (client *PrimitiveClient) PutStringHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -78,7 +78,7 @@ func (client *ReadonlypropertyClient) GetValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutValid - Put complex types that have readonly properties
@@ -114,5 +114,5 @@ func (client *ReadonlypropertyClient) PutValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/complexmodelgroup/zz_generated_client.go
+++ b/test/autorest/complexmodelgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-complexmodelgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -87,7 +87,7 @@ func (client *ComplexModelClient) CreateHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
@@ -138,7 +138,7 @@ func (client *ComplexModelClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Update - Resets products.
@@ -189,5 +189,5 @@ func (client *ComplexModelClient) UpdateHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/custombaseurlgroup/zz_generated_client.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-custombaseurlgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -58,7 +56,7 @@ func NewClient(host *string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(host, p)
 }
 

--- a/test/autorest/custombaseurlgroup/zz_generated_paths.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths.go
@@ -70,5 +70,5 @@ func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/datetimegroup/zz_generated_client.go
+++ b/test/autorest/datetimegroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-datetimegroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -120,7 +120,7 @@ func (client *DatetimeClient) GetInvalidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
@@ -167,7 +167,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
@@ -214,7 +214,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
@@ -261,7 +261,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalNoOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00
@@ -308,7 +308,7 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
@@ -355,7 +355,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
@@ -402,7 +402,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
@@ -449,7 +449,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null datetime value
@@ -496,7 +496,7 @@ func (client *DatetimeClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetOverflow - Get overflow datetime value
@@ -543,7 +543,7 @@ func (client *DatetimeClient) GetOverflowHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
@@ -590,7 +590,7 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
@@ -637,7 +637,7 @@ func (client *DatetimeClient) GetUTCMinDateTimeHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
@@ -684,7 +684,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCUppercaseMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
@@ -731,7 +731,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUnderflow - Get underflow datetime value
@@ -778,7 +778,7 @@ func (client *DatetimeClient) GetUnderflowHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
@@ -814,7 +814,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
@@ -850,7 +850,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
@@ -886,7 +886,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
@@ -922,7 +922,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
@@ -958,7 +958,7 @@ func (client *DatetimeClient) PutUTCMaxDateTimeHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUTCMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
@@ -994,7 +994,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime7DigitsHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
@@ -1030,5 +1030,5 @@ func (client *DatetimeClient) PutUTCMinDateTimeHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/datetimerfc1123group/zz_generated_client.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-datetimerfc1123group/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -94,7 +94,7 @@ func (client *Datetimerfc1123Client) GetInvalidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null datetime value
@@ -141,7 +141,7 @@ func (client *Datetimerfc1123Client) GetNullHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetOverflow - Get overflow datetime value
@@ -188,7 +188,7 @@ func (client *Datetimerfc1123Client) GetOverflowHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
@@ -235,7 +235,7 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
@@ -282,7 +282,7 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
@@ -329,7 +329,7 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUnderflow - Get underflow datetime value
@@ -376,7 +376,7 @@ func (client *Datetimerfc1123Client) GetUnderflowHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
@@ -413,7 +413,7 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTimeHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
@@ -450,5 +450,5 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTimeHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/dictionarygroup/zz_generated_client.go
+++ b/test/autorest/dictionarygroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-dictionarygroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -205,7 +205,7 @@ func (client *DictionaryClient) GetArrayEmptyHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
@@ -251,7 +251,7 @@ func (client *DictionaryClient) GetArrayItemEmptyHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
@@ -297,7 +297,7 @@ func (client *DictionaryClient) GetArrayItemNullHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayNull - Get a null array
@@ -343,7 +343,7 @@ func (client *DictionaryClient) GetArrayNullHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
@@ -389,7 +389,7 @@ func (client *DictionaryClient) GetArrayValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBase64URL - Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
@@ -435,7 +435,7 @@ func (client *DictionaryClient) GetBase64URLHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
@@ -481,7 +481,7 @@ func (client *DictionaryClient) GetBooleanInvalidNullHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
@@ -527,7 +527,7 @@ func (client *DictionaryClient) GetBooleanInvalidStringHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
@@ -573,7 +573,7 @@ func (client *DictionaryClient) GetBooleanTfftHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
@@ -619,7 +619,7 @@ func (client *DictionaryClient) GetByteInvalidNullHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
@@ -665,7 +665,7 @@ func (client *DictionaryClient) GetByteValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexEmpty - Get empty dictionary of complex type {}
@@ -711,7 +711,7 @@ func (client *DictionaryClient) GetComplexEmptyHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
@@ -757,7 +757,7 @@ func (client *DictionaryClient) GetComplexItemEmptyHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
@@ -803,7 +803,7 @@ func (client *DictionaryClient) GetComplexItemNullHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexNull - Get dictionary of complex type null value
@@ -849,7 +849,7 @@ func (client *DictionaryClient) GetComplexNullHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
@@ -895,7 +895,7 @@ func (client *DictionaryClient) GetComplexValidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateInvalidChars - Get date dictionary value {"0": "2011-03-22", "1": "date"}
@@ -941,7 +941,7 @@ func (client *DictionaryClient) GetDateInvalidCharsHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
@@ -987,7 +987,7 @@ func (client *DictionaryClient) GetDateInvalidNullHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
@@ -1040,7 +1040,7 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
@@ -1093,7 +1093,7 @@ func (client *DictionaryClient) GetDateTimeInvalidNullHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
@@ -1146,7 +1146,7 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
@@ -1199,7 +1199,7 @@ func (client *DictionaryClient) GetDateTimeValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDateValid - Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
@@ -1245,7 +1245,7 @@ func (client *DictionaryClient) GetDateValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
@@ -1291,7 +1291,7 @@ func (client *DictionaryClient) GetDictionaryEmptyHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1337,7 +1337,7 @@ func (client *DictionaryClient) GetDictionaryItemEmptyHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1383,7 +1383,7 @@ func (client *DictionaryClient) GetDictionaryItemNullHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryNull - Get an dictionaries of dictionaries with value null
@@ -1429,7 +1429,7 @@ func (client *DictionaryClient) GetDictionaryNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -1475,7 +1475,7 @@ func (client *DictionaryClient) GetDictionaryValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
@@ -1521,7 +1521,7 @@ func (client *DictionaryClient) GetDoubleInvalidNullHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
@@ -1567,7 +1567,7 @@ func (client *DictionaryClient) GetDoubleInvalidStringHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -1613,7 +1613,7 @@ func (client *DictionaryClient) GetDoubleValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
@@ -1659,7 +1659,7 @@ func (client *DictionaryClient) GetDurationValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEmpty - Get empty dictionary value {}
@@ -1705,7 +1705,7 @@ func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEmptyStringKey - Get Dictionary with key as empty string
@@ -1751,7 +1751,7 @@ func (client *DictionaryClient) GetEmptyStringKeyHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
@@ -1797,7 +1797,7 @@ func (client *DictionaryClient) GetFloatInvalidNullHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
@@ -1843,7 +1843,7 @@ func (client *DictionaryClient) GetFloatInvalidStringHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -1889,7 +1889,7 @@ func (client *DictionaryClient) GetFloatValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
@@ -1935,7 +1935,7 @@ func (client *DictionaryClient) GetIntInvalidNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
@@ -1981,7 +1981,7 @@ func (client *DictionaryClient) GetIntInvalidStringHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2027,7 +2027,7 @@ func (client *DictionaryClient) GetIntegerValidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalid - Get invalid Dictionary value
@@ -2073,7 +2073,7 @@ func (client *DictionaryClient) GetInvalidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
@@ -2119,7 +2119,7 @@ func (client *DictionaryClient) GetLongInvalidNullHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
@@ -2165,7 +2165,7 @@ func (client *DictionaryClient) GetLongInvalidStringHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2211,7 +2211,7 @@ func (client *DictionaryClient) GetLongValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null dictionary value
@@ -2257,7 +2257,7 @@ func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNullKey - Get Dictionary with null key
@@ -2303,7 +2303,7 @@ func (client *DictionaryClient) GetNullKeyHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNullValue - Get Dictionary with null value
@@ -2349,7 +2349,7 @@ func (client *DictionaryClient) GetNullValueHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
@@ -2395,7 +2395,7 @@ func (client *DictionaryClient) GetStringValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
@@ -2441,7 +2441,7 @@ func (client *DictionaryClient) GetStringWithInvalidHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
@@ -2487,7 +2487,7 @@ func (client *DictionaryClient) GetStringWithNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
@@ -2523,7 +2523,7 @@ func (client *DictionaryClient) PutArrayValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
@@ -2559,7 +2559,7 @@ func (client *DictionaryClient) PutBooleanTfftHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
@@ -2595,7 +2595,7 @@ func (client *DictionaryClient) PutByteValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
@@ -2631,7 +2631,7 @@ func (client *DictionaryClient) PutComplexValidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
@@ -2671,7 +2671,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
@@ -2711,7 +2711,7 @@ func (client *DictionaryClient) PutDateTimeValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDateValid - Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
@@ -2747,7 +2747,7 @@ func (client *DictionaryClient) PutDateValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -2783,7 +2783,7 @@ func (client *DictionaryClient) PutDictionaryValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -2819,7 +2819,7 @@ func (client *DictionaryClient) PutDoubleValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
@@ -2855,7 +2855,7 @@ func (client *DictionaryClient) PutDurationValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEmpty - Set dictionary value empty {}
@@ -2891,7 +2891,7 @@ func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
@@ -2927,7 +2927,7 @@ func (client *DictionaryClient) PutFloatValidHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2963,7 +2963,7 @@ func (client *DictionaryClient) PutIntegerValidHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
@@ -2999,7 +2999,7 @@ func (client *DictionaryClient) PutLongValidHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
@@ -3035,5 +3035,5 @@ func (client *DictionaryClient) PutStringValidHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/durationgroup/zz_generated_client.go
+++ b/test/autorest/durationgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-durationgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -82,7 +82,7 @@ func (client *DurationClient) GetInvalidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null duration value
@@ -128,7 +128,7 @@ func (client *DurationClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPositiveDuration - Get a positive duration value
@@ -174,7 +174,7 @@ func (client *DurationClient) GetPositiveDurationHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutPositiveDuration - Put a positive duration value
@@ -210,5 +210,5 @@ func (client *DurationClient) PutPositiveDurationHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -5,6 +5,7 @@ package errorsgroup
 
 import (
 	"context"
+	"errors"
 	"generatortests/helpers"
 	"net/http"
 	"testing"
@@ -34,8 +35,8 @@ func TestDoSomethingSuccess(t *testing.T) {
 func TestDoSomethingError1(t *testing.T) {
 	client := newPetClient()
 	result, err := client.DoSomething(context.Background(), "jump")
-	sadErr, ok := err.(*PetSadError)
-	if !ok {
+	var sadErr *PetSadError
+	if !errors.As(err, &sadErr) {
 		t.Fatalf("expected PetSadError: %v", err)
 	}
 	helpers.DeepEqualOrFatal(t, sadErr, &PetSadError{
@@ -53,8 +54,8 @@ func TestDoSomethingError1(t *testing.T) {
 func TestDoSomethingError2(t *testing.T) {
 	client := newPetClient()
 	result, err := client.DoSomething(context.Background(), "fetch")
-	hungrErr, ok := err.(*PetHungryOrThirstyError)
-	if !ok {
+	var hungrErr *PetHungryOrThirstyError
+	if !errors.As(err, &hungrErr) {
 		t.Fatal("expected PetHungryOrThirstyError")
 	}
 	helpers.DeepEqualOrFatal(t, hungrErr, &PetHungryOrThirstyError{
@@ -75,8 +76,8 @@ func TestDoSomethingError2(t *testing.T) {
 func TestDoSomethingError3(t *testing.T) {
 	client := newPetClient()
 	result, err := client.DoSomething(context.Background(), "unknown")
-	actErr, ok := err.(*PetActionError)
-	if !ok {
+	var actErr *PetActionError
+	if !errors.As(err, &actErr) {
 		t.Fatal("expected PetActionError")
 	}
 	helpers.DeepEqualOrFatal(t, actErr, &PetActionError{})
@@ -112,8 +113,8 @@ func TestGetPetByIDSuccess2(t *testing.T) {
 func TestGetPetByIDError1(t *testing.T) {
 	client := newPetClient()
 	result, err := client.GetPetByID(context.Background(), "coyoteUgly")
-	anfe, ok := err.(*AnimalNotFound)
-	if !ok {
+	var anfe *AnimalNotFound
+	if !errors.As(err, &anfe) {
 		t.Fatal("expected AnimalNotFoundError")
 	}
 	helpers.DeepEqualOrFatal(t, anfe, &AnimalNotFound{
@@ -134,8 +135,8 @@ func TestGetPetByIDError1(t *testing.T) {
 func TestGetPetByIDError2(t *testing.T) {
 	client := newPetClient()
 	result, err := client.GetPetByID(context.Background(), "weirdAlYankovic")
-	lnfe, ok := err.(*LinkNotFound)
-	if !ok {
+	var lnfe *LinkNotFound
+	if !errors.As(err, &lnfe) {
 		t.Fatal("expected LinkNotFoundError")
 	}
 	helpers.DeepEqualOrFatal(t, lnfe, &LinkNotFound{

--- a/test/autorest/errorsgroup/zz_generated_client.go
+++ b/test/autorest/errorsgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-errorsgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -86,13 +86,13 @@ func (client *PetClient) DoSomethingHandleError(resp *azcore.Response) error {
 		if err := resp.UnmarshalAsJSON(&err); err != nil {
 			return err
 		}
-		return err.wrapped
+		return azcore.NewResponseError(err.wrapped, resp.Response)
 	default:
 		var err petActionError
 		if err := resp.UnmarshalAsJSON(&err); err != nil {
 			return err
 		}
-		return err.wrapped
+		return azcore.NewResponseError(err.wrapped, resp.Response)
 	}
 }
 
@@ -142,27 +142,27 @@ func (client *PetClient) GetPetByIDHandleError(resp *azcore.Response) error {
 		if err := resp.UnmarshalAsJSON(&err); err != nil {
 			return err
 		}
-		return fmt.Errorf("%v", err)
+		return azcore.NewResponseError(fmt.Errorf("%v", err), resp.Response)
 	case http.StatusNotFound:
 		var err notFoundErrorBase
 		if err := resp.UnmarshalAsJSON(&err); err != nil {
 			return err
 		}
-		return err.wrapped
+		return azcore.NewResponseError(err.wrapped, resp.Response)
 	case http.StatusNotImplemented:
 		var err int32
 		if err := resp.UnmarshalAsJSON(&err); err != nil {
 			return err
 		}
-		return fmt.Errorf("%v", err)
+		return azcore.NewResponseError(fmt.Errorf("%v", err), resp.Response)
 	default:
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 		}
 		if len(body) == 0 {
-			return errors.New(resp.Status)
+			return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 		}
-		return errors.New(string(body))
+		return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 	}
 }

--- a/test/autorest/extenumsgroup/zz_generated_client.go
+++ b/test/autorest/extenumsgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-extenumsgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -87,9 +87,9 @@ func (client *PetClient) AddPetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetByPetID - get pet by id
@@ -137,7 +137,7 @@ func (client *PetClient) GetByPetIDHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/filegroup/zz_generated_client.go
+++ b/test/autorest/filegroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-filegroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/filegroup/zz_generated_files.go
+++ b/test/autorest/filegroup/zz_generated_files.go
@@ -71,7 +71,7 @@ func (client *FilesClient) GetEmptyFileHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFile - Get file
@@ -108,7 +108,7 @@ func (client *FilesClient) GetFileHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFileLarge - Get a large file
@@ -145,5 +145,5 @@ func (client *FilesClient) GetFileLargeHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/headergroup/zz_generated_client.go
+++ b/test/autorest/headergroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-headergroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -125,7 +125,7 @@ func (client *HeaderClient) CustomRequestIDHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
@@ -163,7 +163,7 @@ func (client *HeaderClient) ParamBoolHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
@@ -201,7 +201,7 @@ func (client *HeaderClient) ParamByteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
@@ -239,7 +239,7 @@ func (client *HeaderClient) ParamDateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
@@ -277,7 +277,7 @@ func (client *HeaderClient) ParamDatetimeHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
@@ -317,7 +317,7 @@ func (client *HeaderClient) ParamDatetimeRFC1123HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
@@ -355,7 +355,7 @@ func (client *HeaderClient) ParamDoubleHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
@@ -393,7 +393,7 @@ func (client *HeaderClient) ParamDurationHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
@@ -433,7 +433,7 @@ func (client *HeaderClient) ParamEnumHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
@@ -470,7 +470,7 @@ func (client *HeaderClient) ParamExistingKeyHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
@@ -508,7 +508,7 @@ func (client *HeaderClient) ParamFloatHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
@@ -546,7 +546,7 @@ func (client *HeaderClient) ParamIntegerHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
@@ -584,7 +584,7 @@ func (client *HeaderClient) ParamLongHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
@@ -621,7 +621,7 @@ func (client *HeaderClient) ParamProtectedKeyHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
@@ -661,7 +661,7 @@ func (client *HeaderClient) ParamStringHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseBool - Get a response with header value "value": true or false
@@ -715,7 +715,7 @@ func (client *HeaderClient) ResponseBoolHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
@@ -769,7 +769,7 @@ func (client *HeaderClient) ResponseByteHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
@@ -823,7 +823,7 @@ func (client *HeaderClient) ResponseDateHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
@@ -877,7 +877,7 @@ func (client *HeaderClient) ResponseDatetimeHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
@@ -931,7 +931,7 @@ func (client *HeaderClient) ResponseDatetimeRFC1123HandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseDouble - Get a response with header value "value": 7e120 or -3.0
@@ -985,7 +985,7 @@ func (client *HeaderClient) ResponseDoubleHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
@@ -1035,7 +1035,7 @@ func (client *HeaderClient) ResponseDurationHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseEnum - Get a response with header values "GREY" or null
@@ -1085,7 +1085,7 @@ func (client *HeaderClient) ResponseEnumHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
@@ -1134,7 +1134,7 @@ func (client *HeaderClient) ResponseExistingKeyHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseFloat - Get a response with header value "value": 0.07 or -3.0
@@ -1189,7 +1189,7 @@ func (client *HeaderClient) ResponseFloatHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseInteger - Get a response with header value "value": 1 or -2
@@ -1244,7 +1244,7 @@ func (client *HeaderClient) ResponseIntegerHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseLong - Get a response with header value "value": 105 or -2
@@ -1298,7 +1298,7 @@ func (client *HeaderClient) ResponseLongHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
@@ -1347,7 +1347,7 @@ func (client *HeaderClient) ResponseProtectedKeyHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
@@ -1397,5 +1397,5 @@ func (client *HeaderClient) ResponseStringHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"errors"
 	"generatortests/helpers"
 	"net/http"
 	"testing"
@@ -56,11 +57,11 @@ func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
 func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
 	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background())
-	r, ok := err.(Error)
-	if !ok {
+	var r *Error
+	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
 	}
-	helpers.DeepEqualOrFatal(t, r, Error{
+	helpers.DeepEqualOrFatal(t, r, &Error{
 		Message: to.StringPtr("client error"),
 		Status:  to.Int32Ptr(400),
 	})
@@ -85,11 +86,11 @@ func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
 func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
 	client := newMultipleResponsesClient()
 	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background())
-	r, ok := err.(Error)
-	if !ok {
+	var r *Error
+	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
 	}
-	helpers.DeepEqualOrFatal(t, r, Error{})
+	helpers.DeepEqualOrFatal(t, r, &Error{})
 	if result != nil {
 		t.Fatal("expected nil result")
 	}
@@ -99,11 +100,11 @@ func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
 func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
 	client := newMultipleResponsesClient()
 	result, err := client.Get200Model204NoModelDefaultError202None(context.Background())
-	r, ok := err.(Error)
-	if !ok {
+	var r *Error
+	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
 	}
-	helpers.DeepEqualOrFatal(t, r, Error{})
+	helpers.DeepEqualOrFatal(t, r, &Error{})
 	if result != nil {
 		t.Fatal("expected nil result")
 	}
@@ -126,11 +127,11 @@ func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
 	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background())
-	r, ok := err.(Error)
-	if !ok {
+	var r *Error
+	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
 	}
-	helpers.DeepEqualOrFatal(t, r, Error{
+	helpers.DeepEqualOrFatal(t, r, &Error{
 		Message: to.StringPtr("client error"),
 		Status:  to.Int32Ptr(400),
 	})
@@ -204,11 +205,11 @@ func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
 func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background())
-	r, ok := err.(Error)
-	if !ok {
+	var r *Error
+	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
 	}
-	helpers.DeepEqualOrFatal(t, r, Error{
+	helpers.DeepEqualOrFatal(t, r, &Error{
 		Message: to.StringPtr("client error"),
 		Status:  to.Int32Ptr(400),
 	})

--- a/test/autorest/httpinfrastructuregroup/zz_generated_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-httpinfrastructuregroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
@@ -116,7 +116,7 @@ func (client *HTTPClientFailureClient) Delete400HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete407 - Return 407 status code - should be represented in the client as an error
@@ -152,7 +152,7 @@ func (client *HTTPClientFailureClient) Delete407HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete417 - Return 417 status code - should be represented in the client as an error
@@ -188,7 +188,7 @@ func (client *HTTPClientFailureClient) Delete417HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get400 - Return 400 status code - should be represented in the client as an error
@@ -224,7 +224,7 @@ func (client *HTTPClientFailureClient) Get400HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get402 - Return 402 status code - should be represented in the client as an error
@@ -260,7 +260,7 @@ func (client *HTTPClientFailureClient) Get402HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get403 - Return 403 status code - should be represented in the client as an error
@@ -296,7 +296,7 @@ func (client *HTTPClientFailureClient) Get403HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get411 - Return 411 status code - should be represented in the client as an error
@@ -332,7 +332,7 @@ func (client *HTTPClientFailureClient) Get411HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get412 - Return 412 status code - should be represented in the client as an error
@@ -368,7 +368,7 @@ func (client *HTTPClientFailureClient) Get412HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get416 - Return 416 status code - should be represented in the client as an error
@@ -404,7 +404,7 @@ func (client *HTTPClientFailureClient) Get416HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head400 - Return 400 status code - should be represented in the client as an error
@@ -440,7 +440,7 @@ func (client *HTTPClientFailureClient) Head400HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head401 - Return 401 status code - should be represented in the client as an error
@@ -476,7 +476,7 @@ func (client *HTTPClientFailureClient) Head401HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head410 - Return 410 status code - should be represented in the client as an error
@@ -512,7 +512,7 @@ func (client *HTTPClientFailureClient) Head410HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head429 - Return 429 status code - should be represented in the client as an error
@@ -548,7 +548,7 @@ func (client *HTTPClientFailureClient) Head429HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options400 - Return 400 status code - should be represented in the client as an error
@@ -584,7 +584,7 @@ func (client *HTTPClientFailureClient) Options400HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options403 - Return 403 status code - should be represented in the client as an error
@@ -620,7 +620,7 @@ func (client *HTTPClientFailureClient) Options403HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options412 - Return 412 status code - should be represented in the client as an error
@@ -656,7 +656,7 @@ func (client *HTTPClientFailureClient) Options412HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch400 - Return 400 status code - should be represented in the client as an error
@@ -692,7 +692,7 @@ func (client *HTTPClientFailureClient) Patch400HandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch405 - Return 405 status code - should be represented in the client as an error
@@ -728,7 +728,7 @@ func (client *HTTPClientFailureClient) Patch405HandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch414 - Return 414 status code - should be represented in the client as an error
@@ -764,7 +764,7 @@ func (client *HTTPClientFailureClient) Patch414HandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post400 - Return 400 status code - should be represented in the client as an error
@@ -800,7 +800,7 @@ func (client *HTTPClientFailureClient) Post400HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post406 - Return 406 status code - should be represented in the client as an error
@@ -836,7 +836,7 @@ func (client *HTTPClientFailureClient) Post406HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post415 - Return 415 status code - should be represented in the client as an error
@@ -872,7 +872,7 @@ func (client *HTTPClientFailureClient) Post415HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put400 - Return 400 status code - should be represented in the client as an error
@@ -908,7 +908,7 @@ func (client *HTTPClientFailureClient) Put400HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put404 - Return 404 status code - should be represented in the client as an error
@@ -944,7 +944,7 @@ func (client *HTTPClientFailureClient) Put404HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put409 - Return 409 status code - should be represented in the client as an error
@@ -980,7 +980,7 @@ func (client *HTTPClientFailureClient) Put409HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put413 - Return 413 status code - should be represented in the client as an error
@@ -1016,5 +1016,5 @@ func (client *HTTPClientFailureClient) Put413HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -83,7 +83,7 @@ func (client *HTTPFailureClient) GetEmptyErrorHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNoModelEmpty - Get empty response from server
@@ -130,9 +130,9 @@ func (client *HTTPFailureClient) GetNoModelEmptyHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetNoModelError - Get empty error form server
@@ -179,7 +179,7 @@ func (client *HTTPFailureClient) GetNoModelErrorHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -98,7 +98,7 @@ func (client *HTTPRedirectsClient) Delete307HandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get300 - Return 300 status code and redirect to /http/success/200
@@ -159,7 +159,7 @@ func (client *HTTPRedirectsClient) Get300HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get301 - Return 301 status code and redirect to /http/success/200
@@ -195,7 +195,7 @@ func (client *HTTPRedirectsClient) Get301HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get302 - Return 302 status code and redirect to /http/success/200
@@ -231,7 +231,7 @@ func (client *HTTPRedirectsClient) Get302HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get307 - Redirect get with 307, resulting in a 200 success
@@ -267,7 +267,7 @@ func (client *HTTPRedirectsClient) Get307HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head300 - Return 300 status code and redirect to /http/success/200
@@ -316,7 +316,7 @@ func (client *HTTPRedirectsClient) Head300HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head301 - Return 301 status code and redirect to /http/success/200
@@ -352,7 +352,7 @@ func (client *HTTPRedirectsClient) Head301HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head302 - Return 302 status code and redirect to /http/success/200
@@ -388,7 +388,7 @@ func (client *HTTPRedirectsClient) Head302HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head307 - Redirect with 307, resulting in a 200 success
@@ -424,7 +424,7 @@ func (client *HTTPRedirectsClient) Head307HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options307 - options redirected with 307, resulting in a 200 after redirect
@@ -460,7 +460,7 @@ func (client *HTTPRedirectsClient) Options307HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch302 - Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation
@@ -509,7 +509,7 @@ func (client *HTTPRedirectsClient) Patch302HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch307 - Patch redirected with 307, resulting in a 200 after redirect
@@ -545,7 +545,7 @@ func (client *HTTPRedirectsClient) Patch307HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post303 - Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code
@@ -594,7 +594,7 @@ func (client *HTTPRedirectsClient) Post303HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post307 - Post redirected with 307, resulting in a 200 after redirect
@@ -630,7 +630,7 @@ func (client *HTTPRedirectsClient) Post307HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put301 - Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation
@@ -679,7 +679,7 @@ func (client *HTTPRedirectsClient) Put301HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put307 - Put redirected with 307, resulting in a 200 after redirect
@@ -715,5 +715,5 @@ func (client *HTTPRedirectsClient) Put307HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -82,7 +82,7 @@ func (client *HTTPRetryClient) Delete503HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get502 - Return 502 status code, then 200 after retry
@@ -118,7 +118,7 @@ func (client *HTTPRetryClient) Get502HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head408 - Return 408 status code, then 200 after retry
@@ -154,7 +154,7 @@ func (client *HTTPRetryClient) Head408HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options502 - Return 502 status code, then 200 after retry
@@ -200,7 +200,7 @@ func (client *HTTPRetryClient) Options502HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch500 - Return 500 status code, then 200 after retry
@@ -236,7 +236,7 @@ func (client *HTTPRetryClient) Patch500HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch504 - Return 504 status code, then 200 after retry
@@ -272,7 +272,7 @@ func (client *HTTPRetryClient) Patch504HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post503 - Return 503 status code, then 200 after retry
@@ -308,7 +308,7 @@ func (client *HTTPRetryClient) Post503HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put500 - Return 500 status code, then 200 after retry
@@ -344,7 +344,7 @@ func (client *HTTPRetryClient) Put500HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put504 - Return 504 status code, then 200 after retry
@@ -380,5 +380,5 @@ func (client *HTTPRetryClient) Put504HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
@@ -72,7 +72,7 @@ func (client *HTTPServerFailureClient) Delete505HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get501 - Return 501 status code - should be represented in the client as an error
@@ -108,7 +108,7 @@ func (client *HTTPServerFailureClient) Get501HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head501 - Return 501 status code - should be represented in the client as an error
@@ -144,7 +144,7 @@ func (client *HTTPServerFailureClient) Head501HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post505 - Return 505 status code - should be represented in the client as an error
@@ -180,5 +180,5 @@ func (client *HTTPServerFailureClient) Post505HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -102,7 +102,7 @@ func (client *HTTPSuccessClient) Delete200HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete202 - Delete true Boolean value in request returns 202 (accepted)
@@ -138,7 +138,7 @@ func (client *HTTPSuccessClient) Delete202HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete204 - Delete true Boolean value in request returns 204 (no content)
@@ -174,7 +174,7 @@ func (client *HTTPSuccessClient) Delete204HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200 - Get 200 success
@@ -220,7 +220,7 @@ func (client *HTTPSuccessClient) Get200HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head200 - Return 200 status code if successful
@@ -256,7 +256,7 @@ func (client *HTTPSuccessClient) Head200HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head204 - Return 204 status code if successful
@@ -292,7 +292,7 @@ func (client *HTTPSuccessClient) Head204HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Head404 - Return 404 status code
@@ -328,7 +328,7 @@ func (client *HTTPSuccessClient) Head404HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Options200 - Options 200 success
@@ -374,7 +374,7 @@ func (client *HTTPSuccessClient) Options200HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch200 - Patch true Boolean value in request returning 200
@@ -410,7 +410,7 @@ func (client *HTTPSuccessClient) Patch200HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch202 - Patch true Boolean value in request returns 202
@@ -446,7 +446,7 @@ func (client *HTTPSuccessClient) Patch202HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Patch204 - Patch true Boolean value in request returns 204 (no content)
@@ -482,7 +482,7 @@ func (client *HTTPSuccessClient) Patch204HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post200 - Post bollean value true in request that returns a 200
@@ -518,7 +518,7 @@ func (client *HTTPSuccessClient) Post200HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post201 - Post true Boolean value in request returns 201 (Created)
@@ -554,7 +554,7 @@ func (client *HTTPSuccessClient) Post201HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post202 - Post true Boolean value in request returns 202 (Accepted)
@@ -590,7 +590,7 @@ func (client *HTTPSuccessClient) Post202HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Post204 - Post true Boolean value in request returns 204 (no content)
@@ -626,7 +626,7 @@ func (client *HTTPSuccessClient) Post204HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put200 - Put boolean value true returning 200 success
@@ -662,7 +662,7 @@ func (client *HTTPSuccessClient) Put200HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put201 - Put true Boolean value in request returns 201
@@ -698,7 +698,7 @@ func (client *HTTPSuccessClient) Put201HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put202 - Put true Boolean value in request returns 202 (Accepted)
@@ -734,7 +734,7 @@ func (client *HTTPSuccessClient) Put202HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Put204 - Put true Boolean value in request returns 204 (no content)
@@ -770,5 +770,5 @@ func (client *HTTPSuccessClient) Put204HandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -161,7 +161,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHa
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
@@ -216,7 +216,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHa
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -271,7 +271,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHa
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -317,7 +317,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
@@ -363,7 +363,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
@@ -409,7 +409,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneH
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
@@ -455,7 +455,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
@@ -501,7 +501,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
@@ -548,9 +548,9 @@ func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleError(resp *a
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
@@ -597,9 +597,9 @@ func (client *MultipleResponsesClient) Get200ModelA200NoneHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
@@ -646,9 +646,9 @@ func (client *MultipleResponsesClient) Get200ModelA200ValidHandleError(resp *azc
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -706,7 +706,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
@@ -764,7 +764,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -822,7 +822,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
@@ -880,7 +880,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
@@ -927,9 +927,9 @@ func (client *MultipleResponsesClient) Get200ModelA202ValidHandleError(resp *azc
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
@@ -976,9 +976,9 @@ func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleError(resp *a
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
@@ -1025,9 +1025,9 @@ func (client *MultipleResponsesClient) Get200ModelA400NoneHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
@@ -1074,9 +1074,9 @@ func (client *MultipleResponsesClient) Get200ModelA400ValidHandleError(resp *azc
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
@@ -1112,7 +1112,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneHandl
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
@@ -1148,7 +1148,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneHandl
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
@@ -1184,7 +1184,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidHand
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
@@ -1220,9 +1220,9 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidHan
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
@@ -1258,9 +1258,9 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneHandle
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
@@ -1296,9 +1296,9 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidHan
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
@@ -1334,9 +1334,9 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneHandle
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultModelA200None - Send a 200 response with no payload
@@ -1383,9 +1383,9 @@ func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleError(resp *
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -1432,9 +1432,9 @@ func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultModelA400None - Send a 400 response with no payload
@@ -1470,7 +1470,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400NoneHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
@@ -1506,7 +1506,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400ValidHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDefaultNone200Invalid - Send a 200 response with invalid payload: {'statusCode': '200'}
@@ -1542,9 +1542,9 @@ func (client *MultipleResponsesClient) GetDefaultNone200InvalidHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultNone200None - Send a 200 response with no payload
@@ -1580,9 +1580,9 @@ func (client *MultipleResponsesClient) GetDefaultNone200NoneHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
@@ -1618,9 +1618,9 @@ func (client *MultipleResponsesClient) GetDefaultNone400InvalidHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetDefaultNone400None - Send a 400 response with no payload
@@ -1656,7 +1656,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400NoneHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/integergroup/zz_generated_client.go
+++ b/test/autorest/integergroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-integergroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -103,7 +103,7 @@ func (client *IntClient) GetInvalidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalidUnixTime - Get invalid Unix time value
@@ -150,7 +150,7 @@ func (client *IntClient) GetInvalidUnixTimeHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null Int value
@@ -196,7 +196,7 @@ func (client *IntClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNullUnixTime - Get null Unix time value
@@ -243,7 +243,7 @@ func (client *IntClient) GetNullUnixTimeHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetOverflowInt32 - Get overflow Int32 value
@@ -289,7 +289,7 @@ func (client *IntClient) GetOverflowInt32HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetOverflowInt64 - Get overflow Int64 value
@@ -335,7 +335,7 @@ func (client *IntClient) GetOverflowInt64HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUnderflowInt32 - Get underflow Int32 value
@@ -381,7 +381,7 @@ func (client *IntClient) GetUnderflowInt32HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUnderflowInt64 - Get underflow Int64 value
@@ -427,7 +427,7 @@ func (client *IntClient) GetUnderflowInt64HandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUnixTime - Get datetime encoded as Unix time value
@@ -474,7 +474,7 @@ func (client *IntClient) GetUnixTimeHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMax32 - Put max int32 value
@@ -510,7 +510,7 @@ func (client *IntClient) PutMax32HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMax64 - Put max int64 value
@@ -546,7 +546,7 @@ func (client *IntClient) PutMax64HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMin32 - Put min int32 value
@@ -582,7 +582,7 @@ func (client *IntClient) PutMin32HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMin64 - Put min int64 value
@@ -618,7 +618,7 @@ func (client *IntClient) PutMin64HandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutUnixTimeDate - Put datetime encoded as Unix time
@@ -655,5 +655,5 @@ func (client *IntClient) PutUnixTimeDateHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -183,9 +183,15 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -233,9 +239,15 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -478,9 +490,15 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -537,9 +555,15 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -643,9 +667,15 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -754,9 +784,15 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -903,9 +939,15 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 
@@ -957,9 +999,15 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 	if res != nil {
 		t.Fatal("expected a nil response from the polling operation")
 	}
-	var cloudErr CloudError
-	if !errors.Is(err, cloudErr) {
+	var cloudErr *CloudError
+	if !errors.As(err, &cloudErr) {
 		t.Fatal("expected a CloudError but did not receive one")
+	}
+	var httpResp azcore.HTTPResponse
+	if !errors.As(err, &httpResp) {
+		t.Fatal("expected azcore.HTTPResponse error")
+	} else if sc := httpResp.RawResponse().StatusCode; sc != http.StatusOK {
+		t.Fatalf("unexpected status code %d", sc)
 	}
 }
 

--- a/test/autorest/lrogroup/zz_generated_client.go
+++ b/test/autorest/lrogroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-lrogroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -128,7 +128,7 @@ func (client *LroRetrysClient) Delete202Retry200HandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -198,7 +198,7 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error) {
@@ -274,7 +274,7 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginPost202Retry200(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*HTTPPollerResponse, error) {
@@ -347,7 +347,7 @@ func (client *LroRetrysClient) Post202Retry200HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error) {
@@ -420,7 +420,7 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginPut201CreatingSucceeded200(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
@@ -499,7 +499,7 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200HandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LroRetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -578,5 +578,5 @@ func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -270,7 +270,7 @@ func (client *LrOSClient) Delete202NoRetry204HandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDelete202Retry200(ctx context.Context) (*ProductPollerResponse, error) {
@@ -346,7 +346,7 @@ func (client *LrOSClient) Delete202Retry200HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -416,7 +416,7 @@ func (client *LrOSClient) Delete204SucceededHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -486,7 +486,7 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -556,7 +556,7 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteAsyncRetryFailed(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -626,7 +626,7 @@ func (client *LrOSClient) DeleteAsyncRetryFailedHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -696,7 +696,7 @@ func (client *LrOSClient) DeleteAsyncRetrySucceededHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteAsyncRetrycanceled(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -766,7 +766,7 @@ func (client *LrOSClient) DeleteAsyncRetrycanceledHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -836,7 +836,7 @@ func (client *LrOSClient) DeleteNoHeaderInRetryHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error) {
@@ -912,7 +912,7 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleError(r
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context) (*ProductPollerResponse, error) {
@@ -988,7 +988,7 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context) (*ProductPollerResponse, error) {
@@ -1064,7 +1064,7 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPost200WithPayload(ctx context.Context) (*SKUPollerResponse, error) {
@@ -1140,7 +1140,7 @@ func (client *LrOSClient) Post200WithPayloadHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPost202List(ctx context.Context) (*ProductArrayPollerResponse, error) {
@@ -1216,7 +1216,7 @@ func (client *LrOSClient) Post202ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPost202NoRetry204(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*ProductPollerResponse, error) {
@@ -1295,7 +1295,7 @@ func (client *LrOSClient) Post202NoRetry204HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPost202Retry200(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*HTTPPollerResponse, error) {
@@ -1368,7 +1368,7 @@ func (client *LrOSClient) Post202Retry200HandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -1447,7 +1447,7 @@ func (client *LrOSClient) PostAsyncNoRetrySucceededHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostAsyncRetryFailed(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*HTTPPollerResponse, error) {
@@ -1520,7 +1520,7 @@ func (client *LrOSClient) PostAsyncRetryFailedHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -1599,7 +1599,7 @@ func (client *LrOSClient) PostAsyncRetrySucceededHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostAsyncRetrycanceled(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*HTTPPollerResponse, error) {
@@ -1672,7 +1672,7 @@ func (client *LrOSClient) PostAsyncRetrycanceledHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context) (*ProductPollerResponse, error) {
@@ -1748,7 +1748,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context) (*ProductPollerResponse, error) {
@@ -1824,7 +1824,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context) (*ProductPollerResponse, error) {
@@ -1900,7 +1900,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut200Acceptedcanceled200(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*ProductPollerResponse, error) {
@@ -1979,7 +1979,7 @@ func (client *LrOSClient) Put200Acceptedcanceled200HandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut200Succeeded(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*ProductPollerResponse, error) {
@@ -2058,7 +2058,7 @@ func (client *LrOSClient) Put200SucceededHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut200SucceededNoState(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*ProductPollerResponse, error) {
@@ -2137,7 +2137,7 @@ func (client *LrOSClient) Put200SucceededNoStateHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut200UpdatingSucceeded204(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*ProductPollerResponse, error) {
@@ -2216,7 +2216,7 @@ func (client *LrOSClient) Put200UpdatingSucceeded204HandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut201CreatingFailed200(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*ProductPollerResponse, error) {
@@ -2295,7 +2295,7 @@ func (client *LrOSClient) Put201CreatingFailed200HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
@@ -2374,7 +2374,7 @@ func (client *LrOSClient) Put201CreatingSucceeded200HandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut201Succeeded(ctx context.Context, lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*ProductPollerResponse, error) {
@@ -2453,7 +2453,7 @@ func (client *LrOSClient) Put201SucceededHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPut202Retry200(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*ProductPollerResponse, error) {
@@ -2532,7 +2532,7 @@ func (client *LrOSClient) Put202Retry200HandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
@@ -2611,7 +2611,7 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -2690,7 +2690,7 @@ func (client *LrOSClient) PutAsyncNoRetrySucceededHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*ProductPollerResponse, error) {
@@ -2769,7 +2769,7 @@ func (client *LrOSClient) PutAsyncNoRetrycanceledHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncNonResource(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*SKUPollerResponse, error) {
@@ -2848,7 +2848,7 @@ func (client *LrOSClient) PutAsyncNonResourceHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*ProductPollerResponse, error) {
@@ -2927,7 +2927,7 @@ func (client *LrOSClient) PutAsyncRetryFailedHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -3006,7 +3006,7 @@ func (client *LrOSClient) PutAsyncRetrySucceededHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutAsyncSubResource(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*SubProductPollerResponse, error) {
@@ -3085,7 +3085,7 @@ func (client *LrOSClient) PutAsyncSubResourceHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
@@ -3164,7 +3164,7 @@ func (client *LrOSClient) PutNoHeaderInRetryHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutNonResource(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*SKUPollerResponse, error) {
@@ -3243,7 +3243,7 @@ func (client *LrOSClient) PutNonResourceHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSClient) BeginPutSubResource(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*SubProductPollerResponse, error) {
@@ -3322,5 +3322,5 @@ func (client *LrOSClient) PutSubResourceHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -204,7 +204,7 @@ func (client *LrosaDsClient) Delete202NonRetry400HandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDelete202RetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -274,7 +274,7 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -344,7 +344,7 @@ func (client *LrosaDsClient) Delete204SucceededHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -414,7 +414,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -484,7 +484,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -554,7 +554,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -624,7 +624,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginDeleteNonRetry400(ctx context.Context) (*HTTPPollerResponse, error) {
@@ -694,7 +694,7 @@ func (client *LrosaDsClient) DeleteNonRetry400HandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPost202NoLocation(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*HTTPPollerResponse, error) {
@@ -767,7 +767,7 @@ func (client *LrosaDsClient) Post202NoLocationHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPost202NonRetry400(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*HTTPPollerResponse, error) {
@@ -840,7 +840,7 @@ func (client *LrosaDsClient) Post202NonRetry400HandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPost202RetryInvalidHeader(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
@@ -913,7 +913,7 @@ func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPostAsyncRelativeRetry400(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*HTTPPollerResponse, error) {
@@ -986,7 +986,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
@@ -1059,7 +1059,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error) {
@@ -1132,7 +1132,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*HTTPPollerResponse, error) {
@@ -1205,7 +1205,7 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPostNonRetry400(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*HTTPPollerResponse, error) {
@@ -1278,7 +1278,7 @@ func (client *LrosaDsClient) PostNonRetry400HandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPut200InvalidJSON(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*ProductPollerResponse, error) {
@@ -1357,7 +1357,7 @@ func (client *LrosaDsClient) Put200InvalidJSONHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*ProductPollerResponse, error) {
@@ -1436,7 +1436,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*ProductPollerResponse, error) {
@@ -1515,7 +1515,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*ProductPollerResponse, error) {
@@ -1594,7 +1594,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*ProductPollerResponse, error) {
@@ -1673,7 +1673,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*ProductPollerResponse, error) {
@@ -1752,7 +1752,7 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutError201NoProvisioningStatePayload(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*ProductPollerResponse, error) {
@@ -1831,7 +1831,7 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutNonRetry201Creating400(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*ProductPollerResponse, error) {
@@ -1910,7 +1910,7 @@ func (client *LrosaDsClient) PutNonRetry201Creating400HandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*ProductPollerResponse, error) {
@@ -1989,7 +1989,7 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrosaDsClient) BeginPutNonRetry400(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*ProductPollerResponse, error) {
@@ -2068,5 +2068,5 @@ func (client *LrosaDsClient) PutNonRetry400HandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -119,7 +119,7 @@ func (client *LrOSCustomHeaderClient) Post202Retry200HandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*HTTPPollerResponse, error) {
@@ -192,7 +192,7 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
@@ -271,7 +271,7 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LrOSCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
@@ -350,5 +350,5 @@ func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/mediatypesgroup/zz_generated_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-mediatypesgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -86,9 +86,9 @@ func (client *MediaTypesClient) AnalyzeBodyHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // AnalyzeBodyWithSourcePath - Analyze body, that could be different media types.
@@ -138,9 +138,9 @@ func (client *MediaTypesClient) AnalyzeBodyWithSourcePathHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ContentTypeWithEncoding - Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter
@@ -188,7 +188,7 @@ func (client *MediaTypesClient) ContentTypeWithEncodingHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/migroup/zz_generated_client.go
+++ b/test/autorest/migroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-migroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -97,7 +97,7 @@ func (client *MultipleInheritanceServiceClient) GetCatHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetFeline - Get a feline where meows and hisses are true
@@ -143,7 +143,7 @@ func (client *MultipleInheritanceServiceClient) GetFelineHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetHorse - Get a horse with name 'Fred' and isAShowHorse true
@@ -189,7 +189,7 @@ func (client *MultipleInheritanceServiceClient) GetHorseHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
@@ -235,7 +235,7 @@ func (client *MultipleInheritanceServiceClient) GetKittenHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPet - Get a pet with name 'Peanut'
@@ -281,7 +281,7 @@ func (client *MultipleInheritanceServiceClient) GetPetHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutCat - Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true
@@ -328,9 +328,9 @@ func (client *MultipleInheritanceServiceClient) PutCatHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutFeline - Put a feline who hisses and doesn't meow
@@ -377,9 +377,9 @@ func (client *MultipleInheritanceServiceClient) PutFelineHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutHorse - Put a horse with name 'General' and isAShowHorse false
@@ -426,9 +426,9 @@ func (client *MultipleInheritanceServiceClient) PutHorseHandleError(resp *azcore
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutKitten - Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true
@@ -475,9 +475,9 @@ func (client *MultipleInheritanceServiceClient) PutKittenHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutPet - Put a pet with name 'Butter'
@@ -524,7 +524,7 @@ func (client *MultipleInheritanceServiceClient) PutPetHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/morecustombaseurigroup/zz_generated_client.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-morecustombaseurigroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -58,7 +56,7 @@ func NewClient(dnsSuffix *string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(dnsSuffix, p)
 }
 

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths.go
@@ -80,5 +80,5 @@ func (client *PathsClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-nonstringenumgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -82,9 +82,9 @@ func (client *FloatClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Put - Put a float enum
@@ -134,7 +134,7 @@ func (client *FloatClient) PutHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -82,9 +82,9 @@ func (client *IntClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Put - Put an int enum
@@ -134,7 +134,7 @@ func (client *IntClient) PutHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/numbergroup/zz_generated_client.go
+++ b/test/autorest/numbergroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-numbergroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -122,7 +122,7 @@ func (client *NumberClient) GetBigDecimalHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
@@ -168,7 +168,7 @@ func (client *NumberClient) GetBigDecimalNegativeDecimalHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
@@ -214,7 +214,7 @@ func (client *NumberClient) GetBigDecimalPositiveDecimalHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigDouble - Get big double value 2.5976931e+101
@@ -260,7 +260,7 @@ func (client *NumberClient) GetBigDoubleHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigDoubleNegativeDecimal - Get big double value -99999999.99
@@ -306,7 +306,7 @@ func (client *NumberClient) GetBigDoubleNegativeDecimalHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigDoublePositiveDecimal - Get big double value 99999999.99
@@ -352,7 +352,7 @@ func (client *NumberClient) GetBigDoublePositiveDecimalHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBigFloat - Get big float value 3.402823e+20
@@ -398,7 +398,7 @@ func (client *NumberClient) GetBigFloatHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalidDecimal - Get invalid decimal Number value
@@ -444,7 +444,7 @@ func (client *NumberClient) GetInvalidDecimalHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalidDouble - Get invalid double Number value
@@ -490,7 +490,7 @@ func (client *NumberClient) GetInvalidDoubleHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetInvalidFloat - Get invalid float Number value
@@ -536,7 +536,7 @@ func (client *NumberClient) GetInvalidFloatHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null Number value
@@ -582,7 +582,7 @@ func (client *NumberClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSmallDecimal - Get small decimal value 2.5976931e-101
@@ -628,7 +628,7 @@ func (client *NumberClient) GetSmallDecimalHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSmallDouble - Get big double value 2.5976931e-101
@@ -674,7 +674,7 @@ func (client *NumberClient) GetSmallDoubleHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSmallFloat - Get big double value 3.402823e-20
@@ -720,7 +720,7 @@ func (client *NumberClient) GetSmallFloatHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDecimal - Put big decimal value 2.5976931e+101
@@ -756,7 +756,7 @@ func (client *NumberClient) PutBigDecimalHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
@@ -792,7 +792,7 @@ func (client *NumberClient) PutBigDecimalNegativeDecimalHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
@@ -828,7 +828,7 @@ func (client *NumberClient) PutBigDecimalPositiveDecimalHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDouble - Put big double value 2.5976931e+101
@@ -864,7 +864,7 @@ func (client *NumberClient) PutBigDoubleHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDoubleNegativeDecimal - Put big double value -99999999.99
@@ -900,7 +900,7 @@ func (client *NumberClient) PutBigDoubleNegativeDecimalHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigDoublePositiveDecimal - Put big double value 99999999.99
@@ -936,7 +936,7 @@ func (client *NumberClient) PutBigDoublePositiveDecimalHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBigFloat - Put big float value 3.402823e+20
@@ -972,7 +972,7 @@ func (client *NumberClient) PutBigFloatHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutSmallDecimal - Put small decimal value 2.5976931e-101
@@ -1008,7 +1008,7 @@ func (client *NumberClient) PutSmallDecimalHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutSmallDouble - Put small double value 2.5976931e-101
@@ -1044,7 +1044,7 @@ func (client *NumberClient) PutSmallDoubleHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutSmallFloat - Put small float value 3.402823e-20
@@ -1080,5 +1080,5 @@ func (client *NumberClient) PutSmallFloatHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/optionalgroup/zz_generated_client.go
+++ b/test/autorest/optionalgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-optionalgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -113,7 +113,7 @@ func (client *ExplicitClient) PostOptionalArrayHeaderHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalArrayParameter - Test explicitly optional array. Please put null.
@@ -152,7 +152,7 @@ func (client *ExplicitClient) PostOptionalArrayParameterHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalArrayProperty - Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
@@ -191,7 +191,7 @@ func (client *ExplicitClient) PostOptionalArrayPropertyHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalClassParameter - Test explicitly optional complex object. Please put null.
@@ -230,7 +230,7 @@ func (client *ExplicitClient) PostOptionalClassParameterHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalClassProperty - Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
@@ -269,7 +269,7 @@ func (client *ExplicitClient) PostOptionalClassPropertyHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalIntegerHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
@@ -308,7 +308,7 @@ func (client *ExplicitClient) PostOptionalIntegerHeaderHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalIntegerParameter - Test explicitly optional integer. Please put null.
@@ -347,7 +347,7 @@ func (client *ExplicitClient) PostOptionalIntegerParameterHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalIntegerProperty - Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
@@ -386,7 +386,7 @@ func (client *ExplicitClient) PostOptionalIntegerPropertyHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalStringHeader - Test explicitly optional string. Please put a header 'headerParameter' => null.
@@ -425,7 +425,7 @@ func (client *ExplicitClient) PostOptionalStringHeaderHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalStringParameter - Test explicitly optional string. Please put null.
@@ -464,7 +464,7 @@ func (client *ExplicitClient) PostOptionalStringParameterHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptionalStringProperty - Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
@@ -503,7 +503,7 @@ func (client *ExplicitClient) PostOptionalStringPropertyHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredArrayHeader - Test explicitly required array. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -540,7 +540,7 @@ func (client *ExplicitClient) PostRequiredArrayHeaderHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredArrayParameter - Test explicitly required array. Please put null and the client library should throw before the request is sent.
@@ -576,7 +576,7 @@ func (client *ExplicitClient) PostRequiredArrayParameterHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredArrayProperty - Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -612,7 +612,7 @@ func (client *ExplicitClient) PostRequiredArrayPropertyHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredClassParameter - Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
@@ -648,7 +648,7 @@ func (client *ExplicitClient) PostRequiredClassParameterHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredClassProperty - Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -684,7 +684,7 @@ func (client *ExplicitClient) PostRequiredClassPropertyHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredIntegerHeader - Test explicitly required integer. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -721,7 +721,7 @@ func (client *ExplicitClient) PostRequiredIntegerHeaderHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredIntegerParameter - Test explicitly required integer. Please put null and the client library should throw before the request is sent.
@@ -757,7 +757,7 @@ func (client *ExplicitClient) PostRequiredIntegerParameterHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredIntegerProperty - Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -793,7 +793,7 @@ func (client *ExplicitClient) PostRequiredIntegerPropertyHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredStringHeader - Test explicitly required string. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
@@ -830,7 +830,7 @@ func (client *ExplicitClient) PostRequiredStringHeaderHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredStringParameter - Test explicitly required string. Please put null and the client library should throw before the request is sent.
@@ -866,7 +866,7 @@ func (client *ExplicitClient) PostRequiredStringParameterHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequiredStringProperty - Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
@@ -902,5 +902,5 @@ func (client *ExplicitClient) PostRequiredStringPropertyHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -89,7 +89,7 @@ func (client *ImplicitClient) GetOptionalGlobalQueryHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetRequiredGlobalPath - Test implicitly required path parameter
@@ -126,7 +126,7 @@ func (client *ImplicitClient) GetRequiredGlobalPathHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetRequiredGlobalQuery - Test implicitly required query parameter
@@ -165,7 +165,7 @@ func (client *ImplicitClient) GetRequiredGlobalQueryHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetRequiredPath - Test implicitly required path parameter
@@ -202,7 +202,7 @@ func (client *ImplicitClient) GetRequiredPathHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutOptionalBody - Test implicitly optional body parameter
@@ -241,7 +241,7 @@ func (client *ImplicitClient) PutOptionalBodyHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutOptionalHeader - Test implicitly optional header parameter
@@ -280,7 +280,7 @@ func (client *ImplicitClient) PutOptionalHeaderHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutOptionalQuery - Test implicitly optional query parameter
@@ -321,5 +321,5 @@ func (client *ImplicitClient) PutOptionalQueryHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/paginggroup/zz_generated_client.go
+++ b/test/autorest/paginggroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-paginggroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -121,9 +121,9 @@ func (client *PagingClient) GetMultiplePagesHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
@@ -165,9 +165,9 @@ func (client *PagingClient) GetMultiplePagesFailureHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
@@ -209,9 +209,9 @@ func (client *PagingClient) GetMultiplePagesFailureURIHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
@@ -257,9 +257,9 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLinkHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesFragmentWithGroupingNextLink - A paging operation that doesn't return a full URL, just a fragment with parameters grouped
@@ -305,9 +305,9 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleEr
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*ProductResultPagerPollerResponse, error) {
@@ -403,9 +403,9 @@ func (client *PagingClient) GetMultiplePagesLroHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
@@ -447,9 +447,9 @@ func (client *PagingClient) GetMultiplePagesRetryFirstHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
@@ -491,9 +491,9 @@ func (client *PagingClient) GetMultiplePagesRetrySecondHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
@@ -545,9 +545,9 @@ func (client *PagingClient) GetMultiplePagesWithOffsetHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
@@ -589,9 +589,9 @@ func (client *PagingClient) GetNoItemNamePagesHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
@@ -638,9 +638,9 @@ func (client *PagingClient) GetNullNextLinkNamePagesHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
@@ -691,9 +691,9 @@ func (client *PagingClient) GetOdataMultiplePagesHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetPagingModelWithItemNameWithXmsClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
@@ -735,9 +735,9 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleErr
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
@@ -779,9 +779,9 @@ func (client *PagingClient) GetSinglePagesHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
@@ -823,9 +823,9 @@ func (client *PagingClient) GetSinglePagesFailureHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
@@ -871,9 +871,9 @@ func (client *PagingClient) GetWithQueryParamsHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // NextFragmentCreateRequest creates the NextFragment request.
@@ -905,9 +905,9 @@ func (client *PagingClient) NextFragmentHandleError(resp *azcore.Response) error
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // NextFragmentWithGroupingCreateRequest creates the NextFragmentWithGrouping request.
@@ -939,9 +939,9 @@ func (client *PagingClient) NextFragmentWithGroupingHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // NextOperationWithQueryParamsCreateRequest creates the NextOperationWithQueryParams request.
@@ -971,7 +971,7 @@ func (client *PagingClient) NextOperationWithQueryParamsHandleError(resp *azcore
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/autorest/paramgroupinggroup/zz_generated_client.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-paramgroupinggroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
@@ -89,7 +89,7 @@ func (client *ParameterGroupingClient) PostMultiParamGroupsHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostOptional - Post a bunch of optional parameters grouped
@@ -133,7 +133,7 @@ func (client *ParameterGroupingClient) PostOptionalHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostRequired - Post a bunch of required parameters grouped
@@ -178,7 +178,7 @@ func (client *ParameterGroupingClient) PostRequiredHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
@@ -222,5 +222,5 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObjectHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -83,7 +83,7 @@ func (client *AutoRestReportServiceClient) GetOptionalReportHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetReport - Get test coverage report
@@ -134,5 +134,5 @@ func (client *AutoRestReportServiceClient) GetReportHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/reportgroup/zz_generated_client.go
+++ b/test/autorest/reportgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-reportgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/stringgroup/zz_generated_client.go
+++ b/test/autorest/stringgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-stringgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -86,7 +86,7 @@ func (client *EnumClient) GetNotExpandableHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -132,7 +132,7 @@ func (client *EnumClient) GetReferencedHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetReferencedConstant - Get value 'green-color' from the constant.
@@ -178,7 +178,7 @@ func (client *EnumClient) GetReferencedConstantHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
@@ -214,7 +214,7 @@ func (client *EnumClient) PutNotExpandableHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
@@ -250,7 +250,7 @@ func (client *EnumClient) PutReferencedHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutReferencedConstant - Sends value 'green-color' from a constant
@@ -286,5 +286,5 @@ func (client *EnumClient) PutReferencedConstantHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -100,7 +100,7 @@ func (client *StringClient) GetBase64EncodedHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBase64URLEncoded - Get value that is base64url encoded
@@ -146,7 +146,7 @@ func (client *StringClient) GetBase64URLEncodedHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEmpty - Get empty string value value ''
@@ -192,7 +192,7 @@ func (client *StringClient) GetEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
@@ -238,7 +238,7 @@ func (client *StringClient) GetMBCSHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotProvided - Get String value when no string value is sent in response payload
@@ -284,7 +284,7 @@ func (client *StringClient) GetNotProvidedHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNull - Get null string value value
@@ -330,7 +330,7 @@ func (client *StringClient) GetNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
@@ -376,7 +376,7 @@ func (client *StringClient) GetNullBase64URLEncodedHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
@@ -422,7 +422,7 @@ func (client *StringClient) GetWhitespaceHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutBase64URLEncoded - Put value that is base64url encoded
@@ -458,7 +458,7 @@ func (client *StringClient) PutBase64URLEncodedHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutEmpty - Set string value empty ''
@@ -494,7 +494,7 @@ func (client *StringClient) PutEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
@@ -530,7 +530,7 @@ func (client *StringClient) PutMBCSHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutNull - Set string value null
@@ -569,7 +569,7 @@ func (client *StringClient) PutNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
@@ -605,5 +605,5 @@ func (client *StringClient) PutWhitespaceHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/urlgroup/zz_generated_client.go
+++ b/test/autorest/urlgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-urlgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/urlgroup/zz_generated_pathitems.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems.go
@@ -90,7 +90,7 @@ func (client *PathItemsClient) GetAllWithValuesHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
@@ -140,7 +140,7 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
@@ -190,7 +190,7 @@ func (client *PathItemsClient) GetGlobalQueryNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
@@ -240,5 +240,5 @@ func (client *PathItemsClient) GetLocalPathItemQueryNullHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/urlgroup/zz_generated_paths.go
+++ b/test/autorest/urlgroup/zz_generated_paths.go
@@ -123,7 +123,7 @@ func (client *PathsClient) ArrayCSVInPathHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
@@ -160,7 +160,7 @@ func (client *PathsClient) Base64URLHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteEmpty - Get '' as byte array
@@ -197,7 +197,7 @@ func (client *PathsClient) ByteEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
@@ -234,7 +234,7 @@ func (client *PathsClient) ByteMultiByteHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteNull - Get null as byte array (should throw)
@@ -271,7 +271,7 @@ func (client *PathsClient) ByteNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
@@ -308,7 +308,7 @@ func (client *PathsClient) DateNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
@@ -345,7 +345,7 @@ func (client *PathsClient) DateTimeNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
@@ -382,7 +382,7 @@ func (client *PathsClient) DateTimeValidHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateValid - Get '2012-01-01' as date
@@ -419,7 +419,7 @@ func (client *PathsClient) DateValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
@@ -456,7 +456,7 @@ func (client *PathsClient) DoubleDecimalNegativeHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
@@ -493,7 +493,7 @@ func (client *PathsClient) DoubleDecimalPositiveHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // EnumNull - Get null (should throw on the client before the request is sent on wire)
@@ -530,7 +530,7 @@ func (client *PathsClient) EnumNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // EnumValid - Get using uri with 'green color' in path parameter
@@ -567,7 +567,7 @@ func (client *PathsClient) EnumValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
@@ -604,7 +604,7 @@ func (client *PathsClient) FloatScientificNegativeHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
@@ -641,7 +641,7 @@ func (client *PathsClient) FloatScientificPositiveHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanFalse - Get false Boolean value on path
@@ -678,7 +678,7 @@ func (client *PathsClient) GetBooleanFalseHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanTrue - Get true Boolean value on path
@@ -715,7 +715,7 @@ func (client *PathsClient) GetBooleanTrueHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
@@ -752,7 +752,7 @@ func (client *PathsClient) GetIntNegativeOneMillionHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntOneMillion - Get '1000000' integer value
@@ -789,7 +789,7 @@ func (client *PathsClient) GetIntOneMillionHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
@@ -826,7 +826,7 @@ func (client *PathsClient) GetNegativeTenBillionHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
@@ -863,7 +863,7 @@ func (client *PathsClient) GetTenBillionHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringEmpty - Get ''
@@ -900,7 +900,7 @@ func (client *PathsClient) StringEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringNull - Get null (should throw)
@@ -937,7 +937,7 @@ func (client *PathsClient) StringNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
@@ -974,7 +974,7 @@ func (client *PathsClient) StringURLEncodedHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringURLNonEncoded - https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded
@@ -1011,7 +1011,7 @@ func (client *PathsClient) StringURLNonEncodedHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
@@ -1048,7 +1048,7 @@ func (client *PathsClient) StringUnicodeHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
@@ -1085,5 +1085,5 @@ func (client *PathsClient) UnixTimeURLHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/urlgroup/zz_generated_queries.go
+++ b/test/autorest/urlgroup/zz_generated_queries.go
@@ -143,7 +143,7 @@ func (client *QueriesClient) ArrayStringCSVEmptyHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
@@ -184,7 +184,7 @@ func (client *QueriesClient) ArrayStringCSVNullHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
@@ -225,7 +225,7 @@ func (client *QueriesClient) ArrayStringCSVValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringNoCollectionFormatEmpty - Array query has no defined collection format, should default to csv. Pass in ['hello', 'nihao', 'bonjour'] for the 'arrayQuery' parameter to the service
@@ -266,7 +266,7 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
@@ -307,7 +307,7 @@ func (client *QueriesClient) ArrayStringPipesValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
@@ -348,7 +348,7 @@ func (client *QueriesClient) ArrayStringSsvValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
@@ -389,7 +389,7 @@ func (client *QueriesClient) ArrayStringTsvValidHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteEmpty - Get '' as byte array
@@ -428,7 +428,7 @@ func (client *QueriesClient) ByteEmptyHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
@@ -469,7 +469,7 @@ func (client *QueriesClient) ByteMultiByteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ByteNull - Get null as byte array (no query parameters in uri)
@@ -510,7 +510,7 @@ func (client *QueriesClient) ByteNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateNull - Get null as date - this should result in no query parameters in uri
@@ -551,7 +551,7 @@ func (client *QueriesClient) DateNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
@@ -592,7 +592,7 @@ func (client *QueriesClient) DateTimeNullHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
@@ -631,7 +631,7 @@ func (client *QueriesClient) DateTimeValidHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DateValid - Get '2012-01-01' as date
@@ -670,7 +670,7 @@ func (client *QueriesClient) DateValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
@@ -709,7 +709,7 @@ func (client *QueriesClient) DoubleDecimalNegativeHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
@@ -748,7 +748,7 @@ func (client *QueriesClient) DoubleDecimalPositiveHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DoubleNull - Get null numeric value (no query parameter)
@@ -789,7 +789,7 @@ func (client *QueriesClient) DoubleNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // EnumNull - Get null (no query parameter in url)
@@ -830,7 +830,7 @@ func (client *QueriesClient) EnumNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // EnumValid - Get using uri with query parameter 'green color'
@@ -871,7 +871,7 @@ func (client *QueriesClient) EnumValidHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // FloatNull - Get null numeric value (no query parameter)
@@ -912,7 +912,7 @@ func (client *QueriesClient) FloatNullHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
@@ -951,7 +951,7 @@ func (client *QueriesClient) FloatScientificNegativeHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
@@ -990,7 +990,7 @@ func (client *QueriesClient) FloatScientificPositiveHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanFalse - Get false Boolean value on path
@@ -1029,7 +1029,7 @@ func (client *QueriesClient) GetBooleanFalseHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
@@ -1070,7 +1070,7 @@ func (client *QueriesClient) GetBooleanNullHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBooleanTrue - Get true Boolean value on path
@@ -1109,7 +1109,7 @@ func (client *QueriesClient) GetBooleanTrueHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
@@ -1148,7 +1148,7 @@ func (client *QueriesClient) GetIntNegativeOneMillionHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntNull - Get null integer value (no query parameter)
@@ -1189,7 +1189,7 @@ func (client *QueriesClient) GetIntNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetIntOneMillion - Get '1000000' integer value
@@ -1228,7 +1228,7 @@ func (client *QueriesClient) GetIntOneMillionHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
@@ -1269,7 +1269,7 @@ func (client *QueriesClient) GetLongNullHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
@@ -1308,7 +1308,7 @@ func (client *QueriesClient) GetNegativeTenBillionHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
@@ -1347,7 +1347,7 @@ func (client *QueriesClient) GetTenBillionHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringEmpty - Get ''
@@ -1386,7 +1386,7 @@ func (client *QueriesClient) StringEmptyHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringNull - Get null (no query parameter in url)
@@ -1427,7 +1427,7 @@ func (client *QueriesClient) StringNullHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
@@ -1466,7 +1466,7 @@ func (client *QueriesClient) StringURLEncodedHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
@@ -1505,5 +1505,5 @@ func (client *QueriesClient) StringUnicodeHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/urlmultigroup/zz_generated_client.go
+++ b/test/autorest/urlmultigroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-urlmultigroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/urlmultigroup/zz_generated_queries.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries.go
@@ -77,7 +77,7 @@ func (client *QueriesClient) ArrayStringMultiEmptyHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringMultiNull - Get a null array of string using the multi-array format
@@ -120,7 +120,7 @@ func (client *QueriesClient) ArrayStringMultiNullHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ArrayStringMultiValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format
@@ -163,5 +163,5 @@ func (client *QueriesClient) ArrayStringMultiValidHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -77,9 +77,9 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPathHandleError(res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error) {
@@ -129,9 +129,9 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleError(re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ValidationOfBody - Validates body parameters on the method. See swagger for details.
@@ -186,7 +186,7 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
@@ -238,5 +238,5 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParametersHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/autorest/validationgroup/zz_generated_client.go
+++ b/test/autorest/validationgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-validationgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/xmlgroup/zz_generated_client.go
+++ b/test/autorest/xmlgroup/zz_generated_client.go
@@ -16,8 +16,6 @@ const telemetryInfo = "azsdk-go-xmlgroup/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -66,7 +64,7 @@ func NewClient(endpoint string, options *ClientOptions) *Client {
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return NewClientWithPipeline(endpoint, p)
 }
 

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -143,9 +143,9 @@ func (client *XMLClient) GetACLsHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
@@ -192,9 +192,9 @@ func (client *XMLClient) GetComplexTypeRefNoMetaHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
@@ -241,9 +241,9 @@ func (client *XMLClient) GetComplexTypeRefWithMetaHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetEmptyChildElement - Gets an XML document with an empty child element.
@@ -290,9 +290,9 @@ func (client *XMLClient) GetEmptyChildElementHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetEmptyList - Get an empty list.
@@ -339,9 +339,9 @@ func (client *XMLClient) GetEmptyListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetEmptyRootList - Gets an empty list as the root element.
@@ -388,9 +388,9 @@ func (client *XMLClient) GetEmptyRootListHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetEmptyWrappedLists - Gets some empty wrapped lists.
@@ -437,9 +437,9 @@ func (client *XMLClient) GetEmptyWrappedListsHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetHeaders - Get strongly-typed response headers.
@@ -488,9 +488,9 @@ func (client *XMLClient) GetHeadersHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetRootList - Gets a list as the root element.
@@ -537,9 +537,9 @@ func (client *XMLClient) GetRootListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetRootListSingleItem - Gets a list with a single item.
@@ -586,9 +586,9 @@ func (client *XMLClient) GetRootListSingleItemHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetServiceProperties - Gets storage service properties.
@@ -639,9 +639,9 @@ func (client *XMLClient) GetServicePropertiesHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSimple - Get a simple XML document
@@ -687,7 +687,7 @@ func (client *XMLClient) GetSimpleHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetWrappedLists - Get an XML document with multiple wrapped lists
@@ -734,9 +734,9 @@ func (client *XMLClient) GetWrappedListsHandleError(resp *azcore.Response) error
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetXMSText - Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language' property being 'english' and its 'content' property being 'I am text'
@@ -783,9 +783,9 @@ func (client *XMLClient) GetXMSTextHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
@@ -821,9 +821,9 @@ func (client *XMLClient) JSONInputHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
@@ -870,9 +870,9 @@ func (client *XMLClient) JSONOutputHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListBlobs - Lists blobs in a storage container.
@@ -923,9 +923,9 @@ func (client *XMLClient) ListBlobsHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListContainers - Lists containers in a storage account.
@@ -975,9 +975,9 @@ func (client *XMLClient) ListContainersHandleError(resp *azcore.Response) error 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutACLs - Puts storage ACLs for a container.
@@ -1021,9 +1021,9 @@ func (client *XMLClient) PutACLsHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
@@ -1059,9 +1059,9 @@ func (client *XMLClient) PutComplexTypeRefNoMetaHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
@@ -1097,9 +1097,9 @@ func (client *XMLClient) PutComplexTypeRefWithMetaHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutEmptyChildElement - Puts a value with an empty child element.
@@ -1135,9 +1135,9 @@ func (client *XMLClient) PutEmptyChildElementHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutEmptyList - Puts an empty list.
@@ -1173,9 +1173,9 @@ func (client *XMLClient) PutEmptyListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutEmptyRootList - Puts an empty list as the root element.
@@ -1215,9 +1215,9 @@ func (client *XMLClient) PutEmptyRootListHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutEmptyWrappedLists - Puts some empty wrapped lists.
@@ -1253,9 +1253,9 @@ func (client *XMLClient) PutEmptyWrappedListsHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutRootList - Puts a list as the root element.
@@ -1295,9 +1295,9 @@ func (client *XMLClient) PutRootListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutRootListSingleItem - Puts a list with a single item.
@@ -1337,9 +1337,9 @@ func (client *XMLClient) PutRootListSingleItemHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutServiceProperties - Puts storage service properties.
@@ -1379,9 +1379,9 @@ func (client *XMLClient) PutServicePropertiesHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // PutSimple - Put a simple XML document
@@ -1417,7 +1417,7 @@ func (client *XMLClient) PutSimpleHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // PutWrappedLists - Put an XML document with multiple wrapped lists
@@ -1453,5 +1453,5 @@ func (client *XMLClient) PutWrappedListsHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -3,6 +3,6 @@ module armcompute
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0
 )

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0 h1:F3EP1u00kFoix2wrlzubZhuiPR5WzFRgP3OHGeodE3g=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0/go.mod h1:hVEinPYJ+JgbgwsYBzNYuaDOWVNMiBVWmk6jpqUdoXw=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0 h1:bicoLZMjsxg6LqSFRpLaAmVGqZtOS9hrCVi0KdqcCco=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2 h1:Qla5Ge2580gwYCktnRto/atGRkcMaVQR7rqjh2UT8bk=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2/go.mod h1:ugWu3ac7JyLkOwhLb8Wbrk1ulIH0n97on8qzSyQTMV8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0 h1:OhkQQEj0+3Kq3ufXVRggYeJ7dPECSjK1JR+wCsdLBfw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
@@ -101,9 +101,9 @@ func (client *AvailabilitySetsClient) CreateOrUpdateHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Delete - Delete an availability set.
@@ -145,9 +145,9 @@ func (client *AvailabilitySetsClient) DeleteHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about an availability set.
@@ -200,9 +200,9 @@ func (client *AvailabilitySetsClient) GetHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Lists all availability sets in a resource group.
@@ -249,9 +249,9 @@ func (client *AvailabilitySetsClient) ListHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListAvailableSizes - Lists all available virtual machine sizes that can be used to create a new virtual machine in an existing availability set.
@@ -304,9 +304,9 @@ func (client *AvailabilitySetsClient) ListAvailableSizesHandleError(resp *azcore
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListBySubscription - Lists all availability sets in a subscription.
@@ -355,9 +355,9 @@ func (client *AvailabilitySetsClient) ListBySubscriptionHandleError(resp *azcore
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Update - Update an availability set.
@@ -410,7 +410,7 @@ func (client *AvailabilitySetsClient) UpdateHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_client.go
@@ -18,8 +18,6 @@ const telemetryInfo = "azsdk-go-armcompute/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -75,7 +73,7 @@ func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) 
 	policies = append(policies,
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	p := azcore.NewPipeline(options.HTTPClient, policies...)
 	return NewClientWithPipeline(endpoint, p)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
@@ -133,9 +133,9 @@ func (client *ContainerServicesClient) CreateOrUpdateHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string) (*HTTPPollerResponse, error) {
@@ -211,9 +211,9 @@ func (client *ContainerServicesClient) DeleteHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
@@ -266,9 +266,9 @@ func (client *ContainerServicesClient) GetHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets a list of container services in the specified subscription. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
@@ -314,9 +314,9 @@ func (client *ContainerServicesClient) ListHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Gets a list of container services in the specified subscription and resource group. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
@@ -363,7 +363,7 @@ func (client *ContainerServicesClient) ListByResourceGroupHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
@@ -99,9 +99,9 @@ func (client *DedicatedHostGroupsClient) CreateOrUpdateHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Delete - Delete a dedicated host group.
@@ -143,9 +143,9 @@ func (client *DedicatedHostGroupsClient) DeleteHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about a dedicated host group.
@@ -198,9 +198,9 @@ func (client *DedicatedHostGroupsClient) GetHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Lists all of the dedicated host groups in the specified resource group. Use the nextLink property in the response to get the next page of dedicated host groups.
@@ -247,9 +247,9 @@ func (client *DedicatedHostGroupsClient) ListByResourceGroupHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListBySubscription - Lists all of the dedicated host groups in the subscription. Use the nextLink property in the response to get the next page of dedicated host groups.
@@ -295,9 +295,9 @@ func (client *DedicatedHostGroupsClient) ListBySubscriptionHandleError(resp *azc
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Update - Update an dedicated host group.
@@ -350,7 +350,7 @@ func (client *DedicatedHostGroupsClient) UpdateHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
@@ -136,9 +136,9 @@ func (client *DedicatedHostsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string) (*HTTPPollerResponse, error) {
@@ -215,9 +215,9 @@ func (client *DedicatedHostsClient) DeleteHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about a dedicated host.
@@ -274,9 +274,9 @@ func (client *DedicatedHostsClient) GetHandleError(resp *azcore.Response) error 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByHostGroup - Lists all of the dedicated hosts in the specified dedicated host group. Use the nextLink property in the response to get the next page of dedicated hosts.
@@ -324,9 +324,9 @@ func (client *DedicatedHostsClient) ListByHostGroupHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate) (*DedicatedHostPollerResponse, error) {
@@ -410,7 +410,7 @@ func (client *DedicatedHostsClient) UpdateHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
@@ -133,7 +133,7 @@ func (client *DiskEncryptionSetsClient) CreateOrUpdateHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*HTTPPollerResponse, error) {
@@ -209,7 +209,7 @@ func (client *DiskEncryptionSetsClient) DeleteHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about a disk encryption set.
@@ -261,7 +261,7 @@ func (client *DiskEncryptionSetsClient) GetHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the disk encryption sets under a subscription.
@@ -306,7 +306,7 @@ func (client *DiskEncryptionSetsClient) ListHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the disk encryption sets under a resource group.
@@ -352,7 +352,7 @@ func (client *DiskEncryptionSetsClient) ListByResourceGroupHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate) (*DiskEncryptionSetPollerResponse, error) {
@@ -434,5 +434,5 @@ func (client *DiskEncryptionSetsClient) UpdateHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks.go
@@ -145,9 +145,9 @@ func (client *DisksClient) CreateOrUpdateHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error) {
@@ -223,9 +223,9 @@ func (client *DisksClient) DeleteHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Gets information about a disk.
@@ -278,9 +278,9 @@ func (client *DisksClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error) {
@@ -363,9 +363,9 @@ func (client *DisksClient) GrantAccessHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Lists all the disks under a subscription.
@@ -411,9 +411,9 @@ func (client *DisksClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Lists all the disks under a resource group.
@@ -460,9 +460,9 @@ func (client *DisksClient) ListByResourceGroupHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error) {
@@ -538,9 +538,9 @@ func (client *DisksClient) RevokeAccessHandleError(resp *azcore.Response) error 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate) (*DiskPollerResponse, error) {
@@ -623,7 +623,7 @@ func (client *DisksClient) UpdateHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
@@ -133,7 +133,7 @@ func (client *GalleriesClient) CreateOrUpdateHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string) (*HTTPPollerResponse, error) {
@@ -209,7 +209,7 @@ func (client *GalleriesClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves information about a Shared Image Gallery.
@@ -261,7 +261,7 @@ func (client *GalleriesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - List galleries under a subscription.
@@ -306,7 +306,7 @@ func (client *GalleriesClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - List galleries under a resource group.
@@ -352,7 +352,7 @@ func (client *GalleriesClient) ListByResourceGroupHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate) (*GalleryPollerResponse, error) {
@@ -434,5 +434,5 @@ func (client *GalleriesClient) UpdateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
@@ -132,7 +132,7 @@ func (client *GalleryApplicationsClient) CreateOrUpdateHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*HTTPPollerResponse, error) {
@@ -209,7 +209,7 @@ func (client *GalleryApplicationsClient) DeleteHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves information about a gallery Application Definition.
@@ -262,7 +262,7 @@ func (client *GalleryApplicationsClient) GetHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByGallery - List gallery Application Definitions in a gallery.
@@ -309,7 +309,7 @@ func (client *GalleryApplicationsClient) ListByGalleryHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate) (*GalleryApplicationPollerResponse, error) {
@@ -392,5 +392,5 @@ func (client *GalleryApplicationsClient) UpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
@@ -133,7 +133,7 @@ func (client *GalleryApplicationVersionsClient) CreateOrUpdateHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string) (*HTTPPollerResponse, error) {
@@ -211,7 +211,7 @@ func (client *GalleryApplicationVersionsClient) DeleteHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves information about a gallery Application Version.
@@ -268,7 +268,7 @@ func (client *GalleryApplicationVersionsClient) GetHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByGalleryApplication - List gallery Application Versions in a gallery Application Definition.
@@ -316,7 +316,7 @@ func (client *GalleryApplicationVersionsClient) ListByGalleryApplicationHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate) (*GalleryApplicationVersionPollerResponse, error) {
@@ -400,5 +400,5 @@ func (client *GalleryApplicationVersionsClient) UpdateHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
@@ -132,7 +132,7 @@ func (client *GalleryImagesClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*HTTPPollerResponse, error) {
@@ -209,7 +209,7 @@ func (client *GalleryImagesClient) DeleteHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves information about a gallery Image Definition.
@@ -262,7 +262,7 @@ func (client *GalleryImagesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByGallery - List gallery Image Definitions in a gallery.
@@ -309,7 +309,7 @@ func (client *GalleryImagesClient) ListByGalleryHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate) (*GalleryImagePollerResponse, error) {
@@ -392,5 +392,5 @@ func (client *GalleryImagesClient) UpdateHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
@@ -133,7 +133,7 @@ func (client *GalleryImageVersionsClient) CreateOrUpdateHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string) (*HTTPPollerResponse, error) {
@@ -211,7 +211,7 @@ func (client *GalleryImageVersionsClient) DeleteHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves information about a gallery Image Version.
@@ -268,7 +268,7 @@ func (client *GalleryImageVersionsClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByGalleryImage - List gallery Image Versions in a gallery Image Definition.
@@ -316,7 +316,7 @@ func (client *GalleryImageVersionsClient) ListByGalleryImageHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate) (*GalleryImageVersionPollerResponse, error) {
@@ -400,5 +400,5 @@ func (client *GalleryImageVersionsClient) UpdateHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_images.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images.go
@@ -137,9 +137,9 @@ func (client *ImagesClient) CreateOrUpdateHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, imageName string) (*HTTPPollerResponse, error) {
@@ -215,9 +215,9 @@ func (client *ImagesClient) DeleteHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Gets an image.
@@ -273,9 +273,9 @@ func (client *ImagesClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets the list of Images in the subscription. Use nextLink property in the response to get the next page of Images. Do this till nextLink is null to fetch all the Images.
@@ -321,9 +321,9 @@ func (client *ImagesClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Gets the list of images under a resource group.
@@ -370,9 +370,9 @@ func (client *ImagesClient) ListByResourceGroupHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate) (*ImagePollerResponse, error) {
@@ -455,7 +455,7 @@ func (client *ImagesClient) UpdateHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
@@ -126,9 +126,9 @@ func (client *LogAnalyticsClient) ExportRequestRateByIntervalHandleError(resp *a
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase) (*LogAnalyticsOperationResultPollerResponse, error) {
@@ -210,7 +210,7 @@ func (client *LogAnalyticsClient) ExportThrottledRequestsHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations.go
@@ -83,7 +83,7 @@ func (client *OperationsClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
@@ -99,9 +99,9 @@ func (client *ProximityPlacementGroupsClient) CreateOrUpdateHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Delete - Delete a proximity placement group.
@@ -143,9 +143,9 @@ func (client *ProximityPlacementGroupsClient) DeleteHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about a proximity placement group .
@@ -201,9 +201,9 @@ func (client *ProximityPlacementGroupsClient) GetHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Lists all proximity placement groups in a resource group.
@@ -250,9 +250,9 @@ func (client *ProximityPlacementGroupsClient) ListByResourceGroupHandleError(res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListBySubscription - Lists all proximity placement groups in a subscription.
@@ -298,9 +298,9 @@ func (client *ProximityPlacementGroupsClient) ListBySubscriptionHandleError(resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Update - Update a proximity placement group.
@@ -353,7 +353,7 @@ func (client *ProximityPlacementGroupsClient) UpdateHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
@@ -85,7 +85,7 @@ func (client *ResourceSKUsClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
@@ -145,9 +145,9 @@ func (client *SnapshotsClient) CreateOrUpdateHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error) {
@@ -223,9 +223,9 @@ func (client *SnapshotsClient) DeleteHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Gets information about a snapshot.
@@ -278,9 +278,9 @@ func (client *SnapshotsClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error) {
@@ -363,9 +363,9 @@ func (client *SnapshotsClient) GrantAccessHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Lists snapshots under a subscription.
@@ -411,9 +411,9 @@ func (client *SnapshotsClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Lists snapshots under a resource group.
@@ -460,9 +460,9 @@ func (client *SnapshotsClient) ListByResourceGroupHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error) {
@@ -538,9 +538,9 @@ func (client *SnapshotsClient) RevokeAccessHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate) (*SnapshotPollerResponse, error) {
@@ -623,7 +623,7 @@ func (client *SnapshotsClient) UpdateHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
@@ -101,9 +101,9 @@ func (client *SSHPublicKeysClient) CreateHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Delete - Delete an SSH public key.
@@ -145,9 +145,9 @@ func (client *SSHPublicKeysClient) DeleteHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GenerateKeyPair - Generates and returns a public/private key pair and populates the SSH public key resource with the public key. The length of the key will be 3072 bits. This operation can only be performed once per SSH public key resource.
@@ -200,9 +200,9 @@ func (client *SSHPublicKeysClient) GenerateKeyPairHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about an SSH public key.
@@ -255,9 +255,9 @@ func (client *SSHPublicKeysClient) GetHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByResourceGroup - Lists all of the SSH public keys in the specified resource group. Use the nextLink property in the response to get the next page of SSH public keys.
@@ -304,9 +304,9 @@ func (client *SSHPublicKeysClient) ListByResourceGroupHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListBySubscription - Lists all of the SSH public keys in the subscription. Use the nextLink property in the response to get the next page of SSH public keys.
@@ -352,9 +352,9 @@ func (client *SSHPublicKeysClient) ListBySubscriptionHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Update - Updates a new SSH public key resource.
@@ -407,7 +407,7 @@ func (client *SSHPublicKeysClient) UpdateHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage.go
@@ -83,7 +83,7 @@ func (client *UsageClient) ListHandleError(resp *azcore.Response) error {
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
@@ -96,9 +96,9 @@ func (client *VirtualMachineExtensionImagesClient) GetHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListTypes - Gets a list of virtual machine extension image types.
@@ -151,9 +151,9 @@ func (client *VirtualMachineExtensionImagesClient) ListTypesHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListVersions - Gets a list of virtual machine extension image versions.
@@ -216,7 +216,7 @@ func (client *VirtualMachineExtensionImagesClient) ListVersionsHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
@@ -136,9 +136,9 @@ func (client *VirtualMachineExtensionsClient) CreateOrUpdateHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string) (*HTTPPollerResponse, error) {
@@ -215,9 +215,9 @@ func (client *VirtualMachineExtensionsClient) DeleteHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - The operation to get the extension.
@@ -274,9 +274,9 @@ func (client *VirtualMachineExtensionsClient) GetHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - The operation to get all extensions of a Virtual Machine.
@@ -332,9 +332,9 @@ func (client *VirtualMachineExtensionsClient) ListHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error) {
@@ -418,7 +418,7 @@ func (client *VirtualMachineExtensionsClient) UpdateHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
@@ -101,9 +101,9 @@ func (client *VirtualMachineImagesClient) GetHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets a list of all virtual machine image versions for the specified location, publisher, offer, and SKU.
@@ -167,9 +167,9 @@ func (client *VirtualMachineImagesClient) ListHandleError(resp *azcore.Response)
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListOffers - Gets a list of virtual machine image offers for the specified location and publisher.
@@ -222,9 +222,9 @@ func (client *VirtualMachineImagesClient) ListOffersHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListPublishers - Gets a list of virtual machine image publishers for the specified Azure location.
@@ -276,9 +276,9 @@ func (client *VirtualMachineImagesClient) ListPublishersHandleError(resp *azcore
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListSKUs - Gets a list of virtual machine image SKUs for the specified location, publisher, and offer.
@@ -332,7 +332,7 @@ func (client *VirtualMachineImagesClient) ListSKUsHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
@@ -91,9 +91,9 @@ func (client *VirtualMachineRunCommandsClient) GetHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Lists all available run commands for a subscription in a location.
@@ -140,7 +140,7 @@ func (client *VirtualMachineRunCommandsClient) ListHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -192,9 +192,9 @@ func (client *VirtualMachinesClient) CaptureHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -270,9 +270,9 @@ func (client *VirtualMachinesClient) ConvertToManagedDisksHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine) (*VirtualMachinePollerResponse, error) {
@@ -355,9 +355,9 @@ func (client *VirtualMachinesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -433,9 +433,9 @@ func (client *VirtualMachinesClient) DeallocateHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -511,9 +511,9 @@ func (client *VirtualMachinesClient) DeleteHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Generalize - Sets the OS state of the virtual machine to generalized. It is recommended to sysprep the virtual machine before performing this operation. <br>For Windows, please refer to [Create a managed image of a generalized VM in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource).<br>For Linux, please refer to [How to create an image of a virtual machine or VHD](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/capture-image).
@@ -555,9 +555,9 @@ func (client *VirtualMachinesClient) GeneralizeHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Retrieves information about the model view or the instance view of a virtual machine.
@@ -613,9 +613,9 @@ func (client *VirtualMachinesClient) GetHandleError(resp *azcore.Response) error
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // InstanceView - Retrieves information about the run-time state of a virtual machine.
@@ -668,9 +668,9 @@ func (client *VirtualMachinesClient) InstanceViewHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Lists all of the virtual machines in the specified resource group. Use the nextLink property in the response to get the next page of virtual machines.
@@ -717,9 +717,9 @@ func (client *VirtualMachinesClient) ListHandleError(resp *azcore.Response) erro
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListAll - Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines.
@@ -768,9 +768,9 @@ func (client *VirtualMachinesClient) ListAllHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListAvailableSizes - Lists all available virtual machine sizes to which the specified virtual machine can be resized.
@@ -823,9 +823,9 @@ func (client *VirtualMachinesClient) ListAvailableSizesHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListByLocation - Gets all the virtual machines under the specified subscription for the specified location.
@@ -872,9 +872,9 @@ func (client *VirtualMachinesClient) ListByLocationHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -950,9 +950,9 @@ func (client *VirtualMachinesClient) PerformMaintenanceHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesPowerOffOptions *VirtualMachinesPowerOffOptions) (*HTTPPollerResponse, error) {
@@ -1031,9 +1031,9 @@ func (client *VirtualMachinesClient) PowerOffHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -1109,7 +1109,7 @@ func (client *VirtualMachinesClient) ReapplyHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -1185,9 +1185,9 @@ func (client *VirtualMachinesClient) RedeployHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesReimageOptions *VirtualMachinesReimageOptions) (*HTTPPollerResponse, error) {
@@ -1266,9 +1266,9 @@ func (client *VirtualMachinesClient) ReimageHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -1344,9 +1344,9 @@ func (client *VirtualMachinesClient) RestartHandleError(resp *azcore.Response) e
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error) {
@@ -1429,9 +1429,9 @@ func (client *VirtualMachinesClient) RunCommandHandleError(resp *azcore.Response
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // SimulateEviction - The operation to simulate the eviction of spot virtual machine. The eviction will occur within 30 minutes of calling the API
@@ -1473,9 +1473,9 @@ func (client *VirtualMachinesClient) SimulateEvictionHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
@@ -1551,9 +1551,9 @@ func (client *VirtualMachinesClient) StartHandleError(resp *azcore.Response) err
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate) (*VirtualMachinePollerResponse, error) {
@@ -1636,7 +1636,7 @@ func (client *VirtualMachinesClient) UpdateHandleError(resp *azcore.Response) er
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
@@ -136,9 +136,9 @@ func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdateHandleError(
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string) (*HTTPPollerResponse, error) {
@@ -215,9 +215,9 @@ func (client *VirtualMachineScaleSetExtensionsClient) DeleteHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - The operation to get the extension.
@@ -274,9 +274,9 @@ func (client *VirtualMachineScaleSetExtensionsClient) GetHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets a list of all extensions in a VM scale set.
@@ -324,9 +324,9 @@ func (client *VirtualMachineScaleSetExtensionsClient) ListHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate) (*VirtualMachineScaleSetExtensionPollerResponse, error) {
@@ -410,7 +410,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) UpdateHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
@@ -126,9 +126,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) CancelHandleError(res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetLatest - Gets the status of the latest virtual machine scale set rolling upgrade.
@@ -181,9 +181,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatestHandleError(
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
@@ -259,9 +259,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
@@ -337,7 +337,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgradeHandleE
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
@@ -151,9 +151,9 @@ func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroupHandle
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet) (*VirtualMachineScaleSetPollerResponse, error) {
@@ -236,9 +236,9 @@ func (client *VirtualMachineScaleSetsClient) CreateOrUpdateHandleError(resp *azc
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsDeallocateOptions *VirtualMachineScaleSetsDeallocateOptions) (*HTTPPollerResponse, error) {
@@ -317,9 +317,9 @@ func (client *VirtualMachineScaleSetsClient) DeallocateHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
@@ -395,9 +395,9 @@ func (client *VirtualMachineScaleSetsClient) DeleteHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error) {
@@ -473,9 +473,9 @@ func (client *VirtualMachineScaleSetsClient) DeleteInstancesHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ForceRecoveryServiceFabricPlatformUpdateDomainWalk - Manual platform update domain walk to update virtual machines in a service fabric virtual machine scale set.
@@ -529,9 +529,9 @@ func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformU
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Display information about a virtual machine scale set.
@@ -584,9 +584,9 @@ func (client *VirtualMachineScaleSetsClient) GetHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetInstanceView - Gets the status of a VM scale set instance.
@@ -639,9 +639,9 @@ func (client *VirtualMachineScaleSetsClient) GetInstanceViewHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetOSUpgradeHistory - Gets list of OS upgrades on a VM scale set instance.
@@ -689,9 +689,9 @@ func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistoryHandleError(resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets a list of all VM scale sets under a resource group.
@@ -738,9 +738,9 @@ func (client *VirtualMachineScaleSetsClient) ListHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListAll - Gets a list of all VM Scale Sets in the subscription, regardless of the associated resource group. Use nextLink property in the response to get the next page of VM Scale Sets. Do this till nextLink is null to fetch all the VM Scale Sets.
@@ -786,9 +786,9 @@ func (client *VirtualMachineScaleSetsClient) ListAllHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ListSKUs - Gets a list of SKUs available for your VM scale set, including the minimum and maximum VM instances allowed for each SKU.
@@ -836,9 +836,9 @@ func (client *VirtualMachineScaleSetsClient) ListSKUsHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPerformMaintenanceOptions *VirtualMachineScaleSetsPerformMaintenanceOptions) (*HTTPPollerResponse, error) {
@@ -917,9 +917,9 @@ func (client *VirtualMachineScaleSetsClient) PerformMaintenanceHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPowerOffOptions *VirtualMachineScaleSetsPowerOffOptions) (*HTTPPollerResponse, error) {
@@ -1001,9 +1001,9 @@ func (client *VirtualMachineScaleSetsClient) PowerOffHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRedeployOptions *VirtualMachineScaleSetsRedeployOptions) (*HTTPPollerResponse, error) {
@@ -1082,9 +1082,9 @@ func (client *VirtualMachineScaleSetsClient) RedeployHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageOptions *VirtualMachineScaleSetsReimageOptions) (*HTTPPollerResponse, error) {
@@ -1163,9 +1163,9 @@ func (client *VirtualMachineScaleSetsClient) ReimageHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageAllOptions *VirtualMachineScaleSetsReimageAllOptions) (*HTTPPollerResponse, error) {
@@ -1244,9 +1244,9 @@ func (client *VirtualMachineScaleSetsClient) ReimageAllHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRestartOptions *VirtualMachineScaleSetsRestartOptions) (*HTTPPollerResponse, error) {
@@ -1325,9 +1325,9 @@ func (client *VirtualMachineScaleSetsClient) RestartHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput) (*HTTPPollerResponse, error) {
@@ -1403,9 +1403,9 @@ func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceStateHandleE
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsStartOptions *VirtualMachineScaleSetsStartOptions) (*HTTPPollerResponse, error) {
@@ -1484,9 +1484,9 @@ func (client *VirtualMachineScaleSetsClient) StartHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate) (*VirtualMachineScaleSetPollerResponse, error) {
@@ -1569,9 +1569,9 @@ func (client *VirtualMachineScaleSetsClient) UpdateHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error) {
@@ -1647,7 +1647,7 @@ func (client *VirtualMachineScaleSetsClient) UpdateInstancesHandleError(resp *az
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
@@ -133,7 +133,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdateHandleErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string) (*HTTPPollerResponse, error) {
@@ -211,7 +211,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) DeleteHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - The operation to get the VMSS VM extension.
@@ -268,7 +268,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) GetHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - The operation to get all extensions of an instance in Virtual Machine Scaleset.
@@ -324,7 +324,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ListHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error) {
@@ -408,5 +408,5 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) UpdateHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
@@ -166,9 +166,9 @@ func (client *VirtualMachineScaleSetVMSClient) DeallocateHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -245,9 +245,9 @@ func (client *VirtualMachineScaleSetVMSClient) DeleteHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // Get - Gets a virtual machine from a VM scale set.
@@ -304,9 +304,9 @@ func (client *VirtualMachineScaleSetVMSClient) GetHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetInstanceView - Gets the status of a virtual machine from a VM scale set.
@@ -360,9 +360,9 @@ func (client *VirtualMachineScaleSetVMSClient) GetInstanceViewHandleError(resp *
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // List - Gets a list of all virtual machines in a VM scale sets.
@@ -419,9 +419,9 @@ func (client *VirtualMachineScaleSetVMSClient) ListHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -498,9 +498,9 @@ func (client *VirtualMachineScaleSetVMSClient) PerformMaintenanceHandleError(res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsPowerOffOptions *VirtualMachineScaleSetVMSPowerOffOptions) (*HTTPPollerResponse, error) {
@@ -580,9 +580,9 @@ func (client *VirtualMachineScaleSetVMSClient) PowerOffHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -659,9 +659,9 @@ func (client *VirtualMachineScaleSetVMSClient) RedeployHandleError(resp *azcore.
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsReimageOptions *VirtualMachineScaleSetVMSReimageOptions) (*HTTPPollerResponse, error) {
@@ -741,9 +741,9 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -820,9 +820,9 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageAllHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -899,9 +899,9 @@ func (client *VirtualMachineScaleSetVMSClient) RestartHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error) {
@@ -985,9 +985,9 @@ func (client *VirtualMachineScaleSetVMSClient) RunCommandHandleError(resp *azcor
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // SimulateEviction - The operation to simulate the eviction of spot virtual machine in a VM scale set. The eviction will occur within 30 minutes of calling the API
@@ -1030,9 +1030,9 @@ func (client *VirtualMachineScaleSetVMSClient) SimulateEvictionHandleError(resp 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
@@ -1109,9 +1109,9 @@ func (client *VirtualMachineScaleSetVMSClient) StartHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 func (client *VirtualMachineScaleSetVMSClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM) (*VirtualMachineScaleSetVMPollerResponse, error) {
@@ -1195,7 +1195,7 @@ func (client *VirtualMachineScaleSetVMSClient) UpdateHandleError(resp *azcore.Re
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
@@ -88,7 +88,7 @@ func (client *VirtualMachineSizesClient) ListHandleError(resp *azcore.Response) 
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module generatortests
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0 h1:F3EP1u00kFoix2wrlzubZhuiPR5WzFRgP3OHGeodE3g=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0/go.mod h1:hVEinPYJ+JgbgwsYBzNYuaDOWVNMiBVWmk6jpqUdoXw=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0 h1:bicoLZMjsxg6LqSFRpLaAmVGqZtOS9hrCVi0KdqcCco=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2 h1:Qla5Ge2580gwYCktnRto/atGRkcMaVQR7rqjh2UT8bk=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2/go.mod h1:ugWu3ac7JyLkOwhLb8Wbrk1ulIH0n97on8qzSyQTMV8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0 h1:OhkQQEj0+3Kq3ufXVRggYeJ7dPECSjK1JR+wCsdLBfw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 github.com/Azure/azure-sdk-for-go/sdk/to v0.1.1 h1:xfQtpQrdXC5By+/gOhE6rLRevCw17TLfjSWzkGkT58Y=

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -3,6 +3,6 @@ module armnetwork
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0
 )

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0 h1:F3EP1u00kFoix2wrlzubZhuiPR5WzFRgP3OHGeodE3g=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.0/go.mod h1:hVEinPYJ+JgbgwsYBzNYuaDOWVNMiBVWmk6jpqUdoXw=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0 h1:bicoLZMjsxg6LqSFRpLaAmVGqZtOS9hrCVi0KdqcCco=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2 h1:Qla5Ge2580gwYCktnRto/atGRkcMaVQR7rqjh2UT8bk=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.3.2/go.mod h1:ugWu3ac7JyLkOwhLb8Wbrk1ulIH0n97on8qzSyQTMV8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0 h1:OhkQQEj0+3Kq3ufXVRggYeJ7dPECSjK1JR+wCsdLBfw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0/go.mod h1:R+GJZ0mj7yxXtTENNLTzwkwro5zWzrEiZOdpIiN7Ypc=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0 h1:l7b+GcynB+tNmqq4yrQG2mMzp34gNu65CC5iGTKVlOA=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.3.0/go.mod h1:Q+TCQnSr+clUU0JU+xrHZ3slYCxw17AOFdvWFpQXjAY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -164,7 +164,7 @@ func (client *ApplicationGatewaysClient) BackendHealthHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error) {
@@ -249,7 +249,7 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*ApplicationGatewayPollerResponse, error) {
@@ -331,7 +331,7 @@ func (client *ApplicationGatewaysClient) CreateOrUpdateHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
@@ -407,7 +407,7 @@ func (client *ApplicationGatewaysClient) DeleteHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified application gateway.
@@ -459,7 +459,7 @@ func (client *ApplicationGatewaysClient) GetHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSslPredefinedPolicy - Gets Ssl predefined policy with the specified policy name.
@@ -510,7 +510,7 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all application gateways in a resource group.
@@ -556,7 +556,7 @@ func (client *ApplicationGatewaysClient) ListHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the application gateways in a subscription.
@@ -601,7 +601,7 @@ func (client *ApplicationGatewaysClient) ListAllHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableRequestHeaders - Lists all available request headers.
@@ -651,7 +651,7 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableResponseHeaders - Lists all available response headers.
@@ -701,7 +701,7 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableServerVariables - Lists all available server variables.
@@ -751,7 +751,7 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableSslOptions - Lists available Ssl options for configuring Ssl policy.
@@ -801,7 +801,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableSslPredefinedPolicies - Lists all SSL predefined policies for configuring Ssl policy.
@@ -846,7 +846,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandl
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAvailableWafRuleSets - Lists all available web application firewall rule sets.
@@ -896,7 +896,7 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
@@ -972,7 +972,7 @@ func (client *ApplicationGatewaysClient) StartHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
@@ -1048,7 +1048,7 @@ func (client *ApplicationGatewaysClient) StopHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates the specified application gateway tags.
@@ -1100,5 +1100,5 @@ func (client *ApplicationGatewaysClient) UpdateTagsHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -131,7 +131,7 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *ApplicationSecurityGroupsClient) DeleteHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified application security group.
@@ -259,7 +259,7 @@ func (client *ApplicationSecurityGroupsClient) GetHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the application security groups in a resource group.
@@ -305,7 +305,7 @@ func (client *ApplicationSecurityGroupsClient) ListHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all application security groups in a subscription.
@@ -350,7 +350,7 @@ func (client *ApplicationSecurityGroupsClient) ListAllHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates an application security group's tags.
@@ -402,5 +402,5 @@ func (client *ApplicationSecurityGroupsClient) UpdateTagsHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -79,5 +79,5 @@ func (client *AvailableDelegationsClient) ListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -79,5 +79,5 @@ func (client *AvailableEndpointServicesClient) ListHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -81,7 +81,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.
@@ -128,5 +128,5 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupHandleErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -80,5 +80,5 @@ func (client *AvailableResourceGroupDelegationsClient) ListHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -81,7 +81,7 @@ func (client *AvailableServiceAliasesClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all available service aliases for this resource group in this region.
@@ -128,5 +128,5 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroupHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -78,5 +78,5 @@ func (client *AzureFirewallFqdnTagsClient) ListAllHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -133,7 +133,7 @@ func (client *AzureFirewallsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string) (*HTTPPollerResponse, error) {
@@ -209,7 +209,7 @@ func (client *AzureFirewallsClient) DeleteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Azure Firewall.
@@ -261,7 +261,7 @@ func (client *AzureFirewallsClient) GetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all Azure Firewalls in a resource group.
@@ -307,7 +307,7 @@ func (client *AzureFirewallsClient) ListHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the Azure Firewalls in a subscription.
@@ -352,7 +352,7 @@ func (client *AzureFirewallsClient) ListAllHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject) (*AzureFirewallPollerResponse, error) {
@@ -434,5 +434,5 @@ func (client *AzureFirewallsClient) UpdateTagsHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -129,7 +129,7 @@ func (client *BastionHostsClient) CreateOrUpdateHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *BastionHostsClient) DeleteHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Bastion Host.
@@ -257,7 +257,7 @@ func (client *BastionHostsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all Bastion Hosts in a subscription.
@@ -302,7 +302,7 @@ func (client *BastionHostsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all Bastion Hosts in a resource group.
@@ -348,5 +348,5 @@ func (client *BastionHostsClient) ListByResourceGroupHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -78,5 +78,5 @@ func (client *BgpServiceCommunitiesClient) ListHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_client.go
@@ -18,8 +18,6 @@ const telemetryInfo = "azsdk-go-armnetwork/<version>"
 type ClientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -75,7 +73,7 @@ func NewClient(endpoint string, cred azcore.Credential, options *ClientOptions) 
 	policies = append(policies,
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	p := azcore.NewPipeline(options.HTTPClient, policies...)
 	return NewClientWithPipeline(endpoint, p)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -142,7 +142,7 @@ func (client *ConnectionMonitorsClient) CreateOrUpdateHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
@@ -219,7 +219,7 @@ func (client *ConnectionMonitorsClient) DeleteHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets a connection monitor by name.
@@ -272,7 +272,7 @@ func (client *ConnectionMonitorsClient) GetHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all connection monitors for the specified Network Watcher.
@@ -324,7 +324,7 @@ func (client *ConnectionMonitorsClient) ListHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*ConnectionMonitorQueryResultPollerResponse, error) {
@@ -407,7 +407,7 @@ func (client *ConnectionMonitorsClient) QueryHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
@@ -484,7 +484,7 @@ func (client *ConnectionMonitorsClient) StartHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
@@ -561,7 +561,7 @@ func (client *ConnectionMonitorsClient) StopHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Update tags of the specified connection monitor.
@@ -614,5 +614,5 @@ func (client *ConnectionMonitorsClient) UpdateTagsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -127,7 +127,7 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*HTTPPollerResponse, error) {
@@ -203,7 +203,7 @@ func (client *DdosCustomPoliciesClient) DeleteHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified DDoS custom policy.
@@ -255,7 +255,7 @@ func (client *DdosCustomPoliciesClient) GetHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Update a DDoS custom policy tags.
@@ -307,5 +307,5 @@ func (client *DdosCustomPoliciesClient) UpdateTagsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -131,7 +131,7 @@ func (client *DdosProtectionPlansClient) CreateOrUpdateHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *DdosProtectionPlansClient) DeleteHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified DDoS protection plan.
@@ -259,7 +259,7 @@ func (client *DdosProtectionPlansClient) GetHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all DDoS protection plans in a subscription.
@@ -304,7 +304,7 @@ func (client *DdosProtectionPlansClient) ListHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all the DDoS protection plans in a resource group.
@@ -350,7 +350,7 @@ func (client *DdosProtectionPlansClient) ListByResourceGroupHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Update a DDoS protection plan tags.
@@ -402,5 +402,5 @@ func (client *DdosProtectionPlansClient) UpdateTagsHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -88,7 +88,7 @@ func (client *DefaultSecurityRulesClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all default security rules in a network security group.
@@ -135,5 +135,5 @@ func (client *DefaultSecurityRulesClient) ListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -128,7 +128,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified authorization from the specified express route circuit.
@@ -258,7 +258,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all authorizations in an express route circuit.
@@ -305,5 +305,5 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ListHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -129,7 +129,7 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Express Route Circuit Connection from the specified express route circuit.
@@ -261,7 +261,7 @@ func (client *ExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all global reach connections associated with a private peering in an express route circuit.
@@ -309,5 +309,5 @@ func (client *ExpressRouteCircuitConnectionsClient) ListHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -128,7 +128,7 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified peering for the express route circuit.
@@ -258,7 +258,7 @@ func (client *ExpressRouteCircuitPeeringsClient) GetHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all peerings in a specified express route circuit.
@@ -305,5 +305,5 @@ func (client *ExpressRouteCircuitPeeringsClient) ListHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -147,7 +147,7 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string) (*HTTPPollerResponse, error) {
@@ -223,7 +223,7 @@ func (client *ExpressRouteCircuitsClient) DeleteHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified express route circuit.
@@ -275,7 +275,7 @@ func (client *ExpressRouteCircuitsClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPeeringStats - Gets all stats from an express route circuit in a resource group.
@@ -328,7 +328,7 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStats - Gets all the stats from an express route circuit in a resource group.
@@ -380,7 +380,7 @@ func (client *ExpressRouteCircuitsClient) GetStatsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the express route circuits in a resource group.
@@ -426,7 +426,7 @@ func (client *ExpressRouteCircuitsClient) ListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the express route circuits in a subscription.
@@ -471,7 +471,7 @@ func (client *ExpressRouteCircuitsClient) ListAllHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
@@ -555,7 +555,7 @@ func (client *ExpressRouteCircuitsClient) ListArpTableHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
@@ -639,7 +639,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error) {
@@ -723,7 +723,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates an express route circuit tags.
@@ -775,5 +775,5 @@ func (client *ExpressRouteCircuitsClient) UpdateTagsHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -128,7 +128,7 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ExpressRouteConnectionsClient) DeleteHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified ExpressRouteConnection.
@@ -258,7 +258,7 @@ func (client *ExpressRouteConnectionsClient) GetHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists ExpressRouteConnections.
@@ -310,5 +310,5 @@ func (client *ExpressRouteConnectionsClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -128,7 +128,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified peering for the ExpressRouteCrossConnection.
@@ -258,7 +258,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all peerings in a specified ExpressRouteCrossConnection.
@@ -305,5 +305,5 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ListHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -139,7 +139,7 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets details about the specified ExpressRouteCrossConnection.
@@ -191,7 +191,7 @@ func (client *ExpressRouteCrossConnectionsClient) GetHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Retrieves all the ExpressRouteCrossConnections in a subscription.
@@ -236,7 +236,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
@@ -320,7 +320,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Retrieves all the ExpressRouteCrossConnections in a resource group.
@@ -366,7 +366,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
@@ -450,7 +450,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error) {
@@ -534,7 +534,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates an express route cross connection tags.
@@ -586,5 +586,5 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTagsHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -129,7 +129,7 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ExpressRouteGatewaysClient) DeleteHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Fetches the details of a ExpressRoute gateway in a resource group.
@@ -257,7 +257,7 @@ func (client *ExpressRouteGatewaysClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists ExpressRoute gateways in a given resource group.
@@ -308,7 +308,7 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListBySubscription - Lists ExpressRoute gateways under a given subscription.
@@ -358,5 +358,5 @@ func (client *ExpressRouteGatewaysClient) ListBySubscriptionHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -88,7 +88,7 @@ func (client *ExpressRouteLinksClient) GetHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Retrieve the ExpressRouteLink sub-resources of the specified ExpressRoutePort resource.
@@ -135,5 +135,5 @@ func (client *ExpressRouteLinksClient) ListHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -131,7 +131,7 @@ func (client *ExpressRoutePortsClient) CreateOrUpdateHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *ExpressRoutePortsClient) DeleteHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the requested ExpressRoutePort resource.
@@ -259,7 +259,7 @@ func (client *ExpressRoutePortsClient) GetHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - List all the ExpressRoutePort resources in the specified subscription.
@@ -304,7 +304,7 @@ func (client *ExpressRoutePortsClient) ListHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - List all the ExpressRoutePort resources in the specified resource group.
@@ -350,7 +350,7 @@ func (client *ExpressRoutePortsClient) ListByResourceGroupHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Update ExpressRoutePort tags.
@@ -402,5 +402,5 @@ func (client *ExpressRoutePortsClient) UpdateTagsHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -86,7 +86,7 @@ func (client *ExpressRoutePortsLocationsClient) GetHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.
@@ -131,5 +131,5 @@ func (client *ExpressRoutePortsLocationsClient) ListHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -78,5 +78,5 @@ func (client *ExpressRouteServiceProvidersClient) ListHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -129,7 +129,7 @@ func (client *FirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *FirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Firewall Policy.
@@ -260,7 +260,7 @@ func (client *FirewallPoliciesClient) GetHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all Firewall Policies in a resource group.
@@ -306,7 +306,7 @@ func (client *FirewallPoliciesClient) ListHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the Firewall Policies in a subscription.
@@ -351,5 +351,5 @@ func (client *FirewallPoliciesClient) ListAllHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -128,7 +128,7 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *FirewallPolicyRuleGroupsClient) DeleteHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified FirewallPolicyRuleGroup.
@@ -258,7 +258,7 @@ func (client *FirewallPolicyRuleGroupsClient) GetHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all FirewallPolicyRuleGroups in a FirewallPolicy resource.
@@ -305,5 +305,5 @@ func (client *FirewallPolicyRuleGroupsClient) ListHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -128,7 +128,7 @@ func (client *FlowLogsClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *FlowLogsClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets a flow log resource by name.
@@ -258,7 +258,7 @@ func (client *FlowLogsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all flow log resources for the specified Network Watcher.
@@ -305,5 +305,5 @@ func (client *FlowLogsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -88,7 +88,7 @@ func (client *HubVirtualNetworkConnectionsClient) GetHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Retrieves the details of all HubVirtualNetworkConnections.
@@ -135,5 +135,5 @@ func (client *HubVirtualNetworkConnectionsClient) ListHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -128,7 +128,7 @@ func (client *InboundNatRulesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *InboundNatRulesClient) DeleteHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified load balancer inbound nat rule.
@@ -261,7 +261,7 @@ func (client *InboundNatRulesClient) GetHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the inbound nat rules in a load balancer.
@@ -308,5 +308,5 @@ func (client *InboundNatRulesClient) ListHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -131,7 +131,7 @@ func (client *IPAllocationsClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *IPAllocationsClient) DeleteHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified IpAllocation by resource group.
@@ -262,7 +262,7 @@ func (client *IPAllocationsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all IpAllocations in a subscription.
@@ -307,7 +307,7 @@ func (client *IPAllocationsClient) ListHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all IpAllocations in a resource group.
@@ -353,7 +353,7 @@ func (client *IPAllocationsClient) ListByResourceGroupHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a IpAllocation tags.
@@ -405,5 +405,5 @@ func (client *IPAllocationsClient) UpdateTagsHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -131,7 +131,7 @@ func (client *IPGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *IPGroupsClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified ipGroups.
@@ -262,7 +262,7 @@ func (client *IPGroupsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all IpGroups in a subscription.
@@ -307,7 +307,7 @@ func (client *IPGroupsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all IpGroups in a resource group.
@@ -353,7 +353,7 @@ func (client *IPGroupsClient) ListByResourceGroupHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateGroups - Updates tags of an IpGroups resource.
@@ -405,5 +405,5 @@ func (client *IPGroupsClient) UpdateGroupsHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -88,7 +88,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) GetHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the load balancer backed address pools.
@@ -135,5 +135,5 @@ func (client *LoadBalancerBackendAddressPoolsClient) ListHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -88,7 +88,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the load balancer frontend IP configurations.
@@ -135,5 +135,5 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) ListHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -88,7 +88,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) GetHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the load balancing rules in a load balancer.
@@ -135,5 +135,5 @@ func (client *LoadBalancerLoadBalancingRulesClient) ListHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -80,5 +80,5 @@ func (client *LoadBalancerNetworkInterfacesClient) ListHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -88,7 +88,7 @@ func (client *LoadBalancerOutboundRulesClient) GetHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the outbound rules in a load balancer.
@@ -135,5 +135,5 @@ func (client *LoadBalancerOutboundRulesClient) ListHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -88,7 +88,7 @@ func (client *LoadBalancerProbesClient) GetHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the load balancer probes.
@@ -135,5 +135,5 @@ func (client *LoadBalancerProbesClient) ListHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -131,7 +131,7 @@ func (client *LoadBalancersClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *LoadBalancersClient) DeleteHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified load balancer.
@@ -262,7 +262,7 @@ func (client *LoadBalancersClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the load balancers in a resource group.
@@ -308,7 +308,7 @@ func (client *LoadBalancersClient) ListHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the load balancers in a subscription.
@@ -353,7 +353,7 @@ func (client *LoadBalancersClient) ListAllHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a load balancer tags.
@@ -405,5 +405,5 @@ func (client *LoadBalancersClient) UpdateTagsHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -129,7 +129,7 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *LocalNetworkGatewaysClient) DeleteHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified local network gateway in a resource group.
@@ -257,7 +257,7 @@ func (client *LocalNetworkGatewaysClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the local network gateways in a resource group.
@@ -303,7 +303,7 @@ func (client *LocalNetworkGatewaysClient) ListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a local network gateway tags.
@@ -355,5 +355,5 @@ func (client *LocalNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -131,7 +131,7 @@ func (client *NatGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *NatGatewaysClient) DeleteHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified nat gateway in a specified resource group.
@@ -262,7 +262,7 @@ func (client *NatGatewaysClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all nat gateways in a resource group.
@@ -308,7 +308,7 @@ func (client *NatGatewaysClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the Nat Gateways in a subscription.
@@ -353,7 +353,7 @@ func (client *NatGatewaysClient) ListAllHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates nat gateway tags.
@@ -405,5 +405,5 @@ func (client *NatGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -88,7 +88,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) GetHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Get all ip configurations in a network interface.
@@ -135,5 +135,5 @@ func (client *NetworkInterfaceIPConfigurationsClient) ListHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -80,5 +80,5 @@ func (client *NetworkInterfaceLoadBalancersClient) ListHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -149,7 +149,7 @@ func (client *NetworkInterfacesClient) CreateOrUpdateHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*HTTPPollerResponse, error) {
@@ -225,7 +225,7 @@ func (client *NetworkInterfacesClient) DeleteHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified network interface.
@@ -280,7 +280,7 @@ func (client *NetworkInterfacesClient) GetHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveRouteListResultPollerResponse, error) {
@@ -362,7 +362,7 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetVirtualMachineScaleSetIPConfiguration - Get the specified network interface ip configuration in a virtual machine scale set.
@@ -420,7 +420,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationH
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetVirtualMachineScaleSetNetworkInterface - Get the specified network interface in a virtual machine scale set.
@@ -477,7 +477,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all network interfaces in a resource group.
@@ -523,7 +523,7 @@ func (client *NetworkInterfacesClient) ListHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all network interfaces in a subscription.
@@ -568,7 +568,7 @@ func (client *NetworkInterfacesClient) ListAllHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error) {
@@ -650,7 +650,7 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleE
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListVirtualMachineScaleSetIPConfigurations - Get the specified network interface ip configuration in a virtual machine scale set.
@@ -702,7 +702,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListVirtualMachineScaleSetNetworkInterfaces - Gets all network interfaces in a virtual machine scale set.
@@ -749,7 +749,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfaces - Gets information about all network interfaces in a virtual machine in a virtual machine scale set.
@@ -797,7 +797,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a network interface tags.
@@ -849,5 +849,5 @@ func (client *NetworkInterfacesClient) UpdateTagsHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -128,7 +128,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Get the specified tap configuration on a network interface.
@@ -258,7 +258,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) GetHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Get all Tap configurations in a network interface.
@@ -305,5 +305,5 @@ func (client *NetworkInterfaceTapConfigurationsClient) ListHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -109,7 +109,7 @@ func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*HTTPPollerResponse, error) {
@@ -185,7 +185,7 @@ func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DisconnectActiveSessions - Returns the list of currently active sessions on the Bastion.
@@ -232,7 +232,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessionsHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*VpnProfileResponsePollerResponse, error) {
@@ -314,7 +314,7 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string) (*BastionActiveSessionListResultPagerPollerResponse, error) {
@@ -406,7 +406,7 @@ func (client *NetworkManagementClient) GetActiveSessionsHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBastionShareableLink - Return the Bastion Shareable Links for all the VMs specified in the request.
@@ -453,7 +453,7 @@ func (client *NetworkManagementClient) GetBastionShareableLinkHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*BastionShareableLinkListResultPagerPollerResponse, error) {
@@ -545,7 +545,7 @@ func (client *NetworkManagementClient) PutBastionShareableLinkHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SupportedSecurityProviders - Gives the supported security providers for the virtual wan.
@@ -597,5 +597,5 @@ func (client *NetworkManagementClient) SupportedSecurityProvidersHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -99,7 +99,7 @@ func (client *NetworkProfilesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string) (*HTTPPollerResponse, error) {
@@ -175,7 +175,7 @@ func (client *NetworkProfilesClient) DeleteHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified network profile in a specified resource group.
@@ -230,7 +230,7 @@ func (client *NetworkProfilesClient) GetHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all network profiles in a resource group.
@@ -276,7 +276,7 @@ func (client *NetworkProfilesClient) ListHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the network profiles in a subscription.
@@ -321,7 +321,7 @@ func (client *NetworkProfilesClient) ListAllHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates network profile tags.
@@ -373,5 +373,5 @@ func (client *NetworkProfilesClient) UpdateTagsHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -131,7 +131,7 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *NetworkSecurityGroupsClient) DeleteHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified network security group.
@@ -262,7 +262,7 @@ func (client *NetworkSecurityGroupsClient) GetHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all network security groups in a resource group.
@@ -308,7 +308,7 @@ func (client *NetworkSecurityGroupsClient) ListHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all network security groups in a subscription.
@@ -353,7 +353,7 @@ func (client *NetworkSecurityGroupsClient) ListAllHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a network security group tags.
@@ -405,5 +405,5 @@ func (client *NetworkSecurityGroupsClient) UpdateTagsHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -131,7 +131,7 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *NetworkVirtualAppliancesClient) DeleteHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Network Virtual Appliance.
@@ -262,7 +262,7 @@ func (client *NetworkVirtualAppliancesClient) GetHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all Network Virtual Appliances in a subscription.
@@ -307,7 +307,7 @@ func (client *NetworkVirtualAppliancesClient) ListHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all Network Virtual Appliances in a resource group.
@@ -353,7 +353,7 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a Network Virtual Appliance.
@@ -405,5 +405,5 @@ func (client *NetworkVirtualAppliancesClient) UpdateTagsHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -175,7 +175,7 @@ func (client *NetworkWatchersClient) CheckConnectivityHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateOrUpdate - Creates or updates a network watcher in the specified resource group.
@@ -227,7 +227,7 @@ func (client *NetworkWatchersClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string) (*HTTPPollerResponse, error) {
@@ -303,7 +303,7 @@ func (client *NetworkWatchersClient) DeleteHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified network watcher by resource group.
@@ -355,7 +355,7 @@ func (client *NetworkWatchersClient) GetHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*AzureReachabilityReportPollerResponse, error) {
@@ -437,7 +437,7 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*FlowLogInformationPollerResponse, error) {
@@ -519,7 +519,7 @@ func (client *NetworkWatchersClient) GetFlowLogStatusHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*NetworkConfigurationDiagnosticResponsePollerResponse, error) {
@@ -601,7 +601,7 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleErro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*NextHopResultPollerResponse, error) {
@@ -683,7 +683,7 @@ func (client *NetworkWatchersClient) GetNextHopHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTopology - Gets the current network topology by resource group.
@@ -735,7 +735,7 @@ func (client *NetworkWatchersClient) GetTopologyHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*TroubleshootingResultPollerResponse, error) {
@@ -817,7 +817,7 @@ func (client *NetworkWatchersClient) GetTroubleshootingHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*TroubleshootingResultPollerResponse, error) {
@@ -899,7 +899,7 @@ func (client *NetworkWatchersClient) GetTroubleshootingResultHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*SecurityGroupViewResultPollerResponse, error) {
@@ -981,7 +981,7 @@ func (client *NetworkWatchersClient) GetVMSecurityRulesHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all network watchers by resource group.
@@ -1032,7 +1032,7 @@ func (client *NetworkWatchersClient) ListHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all network watchers by subscription.
@@ -1082,7 +1082,7 @@ func (client *NetworkWatchersClient) ListAllHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*AvailableProvidersListPollerResponse, error) {
@@ -1164,7 +1164,7 @@ func (client *NetworkWatchersClient) ListAvailableProvidersHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*FlowLogInformationPollerResponse, error) {
@@ -1246,7 +1246,7 @@ func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a network watcher tags.
@@ -1298,7 +1298,7 @@ func (client *NetworkWatchersClient) UpdateTagsHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*VerificationIPFlowResultPollerResponse, error) {
@@ -1380,5 +1380,5 @@ func (client *NetworkWatchersClient) VerifyIPFlowHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -74,5 +74,5 @@ func (client *OperationsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -147,7 +147,7 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *P2SVpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error) {
@@ -223,7 +223,7 @@ func (client *P2SVpnGatewaysClient) DeleteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *P2SVpnGatewaysClient) BeginDisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error) {
@@ -299,7 +299,7 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *P2SVpnGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*VpnProfileResponsePollerResponse, error) {
@@ -381,7 +381,7 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a virtual wan p2s vpn gateway.
@@ -433,7 +433,7 @@ func (client *P2SVpnGatewaysClient) GetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string) (*P2SVpnGatewayPollerResponse, error) {
@@ -515,7 +515,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*P2SVpnConnectionHealthPollerResponse, error) {
@@ -597,7 +597,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the P2SVpnGateways in a subscription.
@@ -642,7 +642,7 @@ func (client *P2SVpnGatewaysClient) ListHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the P2SVpnGateways in a resource group.
@@ -688,7 +688,7 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates virtual wan p2s vpn gateway tags.
@@ -740,5 +740,5 @@ func (client *P2SVpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -136,7 +136,7 @@ func (client *PacketCapturesClient) CreateHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error) {
@@ -213,7 +213,7 @@ func (client *PacketCapturesClient) DeleteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets a packet capture session by name.
@@ -266,7 +266,7 @@ func (client *PacketCapturesClient) GetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*PacketCaptureQueryStatusResultPollerResponse, error) {
@@ -349,7 +349,7 @@ func (client *PacketCapturesClient) GetStatusHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all packet capture sessions within the specified resource group.
@@ -401,7 +401,7 @@ func (client *PacketCapturesClient) ListHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error) {
@@ -478,5 +478,5 @@ func (client *PacketCapturesClient) StopHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -89,7 +89,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all global reach peer connections associated with a private peering in an express route circuit.
@@ -137,5 +137,5 @@ func (client *PeerExpressRouteCircuitConnectionsClient) ListHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -128,7 +128,7 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *PrivateDNSZoneGroupsClient) DeleteHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the private dns zone group resource by specified private dns zone group name.
@@ -258,7 +258,7 @@ func (client *PrivateDNSZoneGroupsClient) GetHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all private dns zone groups in a private endpoint.
@@ -305,5 +305,5 @@ func (client *PrivateDNSZoneGroupsClient) ListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -129,7 +129,7 @@ func (client *PrivateEndpointsClient) CreateOrUpdateHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *PrivateEndpointsClient) DeleteHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified private endpoint by resource group.
@@ -260,7 +260,7 @@ func (client *PrivateEndpointsClient) GetHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all private endpoints in a resource group.
@@ -306,7 +306,7 @@ func (client *PrivateEndpointsClient) ListHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListBySubscription - Gets all private endpoints in a subscription.
@@ -351,5 +351,5 @@ func (client *PrivateEndpointsClient) ListBySubscriptionHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -150,7 +150,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandle
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*PrivateLinkServiceVisibilityPollerResponse, error) {
@@ -232,7 +232,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService) (*PrivateLinkServicePollerResponse, error) {
@@ -314,7 +314,7 @@ func (client *PrivateLinkServicesClient) CreateOrUpdateHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceName string) (*HTTPPollerResponse, error) {
@@ -390,7 +390,7 @@ func (client *PrivateLinkServicesClient) DeleteHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string) (*HTTPPollerResponse, error) {
@@ -467,7 +467,7 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified private link service by resource group.
@@ -522,7 +522,7 @@ func (client *PrivateLinkServicesClient) GetHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPrivateEndpointConnection - Get the specific private end point connection by specific private link service in the resource group.
@@ -578,7 +578,7 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleError
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all private link services in a resource group.
@@ -624,7 +624,7 @@ func (client *PrivateLinkServicesClient) ListHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAutoApprovedPrivateLinkServices - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
@@ -670,7 +670,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHand
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroup - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
@@ -717,7 +717,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListBySubscription - Gets all private link service in a subscription.
@@ -762,7 +762,7 @@ func (client *PrivateLinkServicesClient) ListBySubscriptionHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListPrivateEndpointConnections - Gets all private end point connections for a specific private link service.
@@ -809,7 +809,7 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdatePrivateEndpointConnection - Approve or reject private end point connection for a private link service in a subscription.
@@ -862,5 +862,5 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -137,7 +137,7 @@ func (client *PublicIPAddressesClient) CreateOrUpdateHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string) (*HTTPPollerResponse, error) {
@@ -213,7 +213,7 @@ func (client *PublicIPAddressesClient) DeleteHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified public IP address in a specified resource group.
@@ -268,7 +268,7 @@ func (client *PublicIPAddressesClient) GetHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetVirtualMachineScaleSetPublicIPAddress - Get the specified public IP address in a virtual machine scale set.
@@ -327,7 +327,7 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressH
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all public IP addresses in a resource group.
@@ -373,7 +373,7 @@ func (client *PublicIPAddressesClient) ListHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the public IP addresses in a subscription.
@@ -418,7 +418,7 @@ func (client *PublicIPAddressesClient) ListAllHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListVirtualMachineScaleSetPublicIPAddresses - Gets information about all public IP addresses on a virtual machine scale set level.
@@ -465,7 +465,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListVirtualMachineScaleSetVMPublicIPaddresses - Gets information about all public IP addresses in a virtual machine IP configuration in a virtual machine scale set.
@@ -515,7 +515,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates public IP address tags.
@@ -567,5 +567,5 @@ func (client *PublicIPAddressesClient) UpdateTagsHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -131,7 +131,7 @@ func (client *PublicIPPrefixesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *PublicIPPrefixesClient) DeleteHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified public IP prefix in a specified resource group.
@@ -262,7 +262,7 @@ func (client *PublicIPPrefixesClient) GetHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all public IP prefixes in a resource group.
@@ -308,7 +308,7 @@ func (client *PublicIPPrefixesClient) ListHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the public IP prefixes in a subscription.
@@ -353,7 +353,7 @@ func (client *PublicIPPrefixesClient) ListAllHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates public IP prefix tags.
@@ -405,5 +405,5 @@ func (client *PublicIPPrefixesClient) UpdateTagsHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -86,5 +86,5 @@ func (client *ResourceNavigationLinksClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -128,7 +128,7 @@ func (client *RouteFilterRulesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *RouteFilterRulesClient) DeleteHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified rule from a route filter.
@@ -258,7 +258,7 @@ func (client *RouteFilterRulesClient) GetHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByRouteFilter - Gets all RouteFilterRules in a route filter.
@@ -305,5 +305,5 @@ func (client *RouteFilterRulesClient) ListByRouteFilterHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -131,7 +131,7 @@ func (client *RouteFiltersClient) CreateOrUpdateHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *RouteFiltersClient) DeleteHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified route filter.
@@ -262,7 +262,7 @@ func (client *RouteFiltersClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all route filters in a subscription.
@@ -307,7 +307,7 @@ func (client *RouteFiltersClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all route filters in a resource group.
@@ -353,7 +353,7 @@ func (client *RouteFiltersClient) ListByResourceGroupHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates tags of a route filter.
@@ -405,5 +405,5 @@ func (client *RouteFiltersClient) UpdateTagsHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -128,7 +128,7 @@ func (client *RoutesClient) CreateOrUpdateHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *RoutesClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified route from a route table.
@@ -258,7 +258,7 @@ func (client *RoutesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all routes in a route table.
@@ -305,5 +305,5 @@ func (client *RoutesClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -131,7 +131,7 @@ func (client *RouteTablesClient) CreateOrUpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *RouteTablesClient) DeleteHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified route table.
@@ -262,7 +262,7 @@ func (client *RouteTablesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all route tables in a resource group.
@@ -308,7 +308,7 @@ func (client *RouteTablesClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all route tables in a subscription.
@@ -353,7 +353,7 @@ func (client *RouteTablesClient) ListAllHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a route table tags.
@@ -405,5 +405,5 @@ func (client *RouteTablesClient) UpdateTagsHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -131,7 +131,7 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *SecurityPartnerProvidersClient) DeleteHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Security Partner Provider.
@@ -259,7 +259,7 @@ func (client *SecurityPartnerProvidersClient) GetHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the Security Partner Providers in a subscription.
@@ -304,7 +304,7 @@ func (client *SecurityPartnerProvidersClient) ListHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all Security Partner Providers in a resource group.
@@ -350,7 +350,7 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates tags of a Security Partner Provider resource.
@@ -402,5 +402,5 @@ func (client *SecurityPartnerProvidersClient) UpdateTagsHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -128,7 +128,7 @@ func (client *SecurityRulesClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *SecurityRulesClient) DeleteHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Get the specified network security rule.
@@ -258,7 +258,7 @@ func (client *SecurityRulesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all security rules in a network security group.
@@ -305,5 +305,5 @@ func (client *SecurityRulesClient) ListHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -86,5 +86,5 @@ func (client *ServiceAssociationLinksClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -131,7 +131,7 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *ServiceEndpointPoliciesClient) DeleteHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified service Endpoint Policies in a specified resource group.
@@ -262,7 +262,7 @@ func (client *ServiceEndpointPoliciesClient) GetHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the service endpoint policies in a subscription.
@@ -307,7 +307,7 @@ func (client *ServiceEndpointPoliciesClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all service endpoint Policies in a resource group.
@@ -353,7 +353,7 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates tags of a service endpoint policy.
@@ -405,5 +405,5 @@ func (client *ServiceEndpointPoliciesClient) UpdateTagsHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -128,7 +128,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Get the specified service endpoint policy definitions from service endpoint policy.
@@ -258,7 +258,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all service endpoint policy definitions in a service end point policy.
@@ -305,5 +305,5 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupHandleE
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -84,5 +84,5 @@ func (client *ServiceTagsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -136,7 +136,7 @@ func (client *SubnetsClient) CreateOrUpdateHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*HTTPPollerResponse, error) {
@@ -213,7 +213,7 @@ func (client *SubnetsClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified subnet by virtual network and resource group.
@@ -269,7 +269,7 @@ func (client *SubnetsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all subnets in a virtual network.
@@ -316,7 +316,7 @@ func (client *SubnetsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*HTTPPollerResponse, error) {
@@ -393,7 +393,7 @@ func (client *SubnetsClient) PrepareNetworkPoliciesHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*HTTPPollerResponse, error) {
@@ -470,5 +470,5 @@ func (client *SubnetsClient) UnprepareNetworkPoliciesHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -79,5 +79,5 @@ func (client *UsagesClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -128,7 +128,7 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *VirtualHubRouteTableV2SClient) DeleteHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a VirtualHubRouteTableV2.
@@ -258,7 +258,7 @@ func (client *VirtualHubRouteTableV2SClient) GetHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Retrieves the details of all VirtualHubRouteTableV2s.
@@ -305,5 +305,5 @@ func (client *VirtualHubRouteTableV2SClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -131,7 +131,7 @@ func (client *VirtualHubsClient) CreateOrUpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *VirtualHubsClient) DeleteHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a VirtualHub.
@@ -259,7 +259,7 @@ func (client *VirtualHubsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the VirtualHubs in a subscription.
@@ -304,7 +304,7 @@ func (client *VirtualHubsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the VirtualHubs in a resource group.
@@ -350,7 +350,7 @@ func (client *VirtualHubsClient) ListByResourceGroupHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates VirtualHub tags.
@@ -402,5 +402,5 @@ func (client *VirtualHubsClient) UpdateTagsHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -149,7 +149,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*HTTPPollerResponse, error) {
@@ -225,7 +225,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified virtual network gateway connection by resource group.
@@ -277,7 +277,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSharedKey - The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves information about the specified virtual network gateway connection shared key through Network resource provider.
@@ -329,7 +329,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections created.
@@ -375,7 +375,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) ListHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*ConnectionResetSharedKeyPollerResponse, error) {
@@ -457,7 +457,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*ConnectionSharedKeyPollerResponse, error) {
@@ -539,7 +539,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*StringPollerResponse, error) {
@@ -624,7 +624,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error) {
@@ -706,7 +706,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
@@ -788,5 +788,5 @@ func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -193,7 +193,7 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error) {
@@ -269,7 +269,7 @@ func (client *VirtualNetworkGatewaysClient) DeleteHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error) {
@@ -345,7 +345,7 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error) {
@@ -427,7 +427,7 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error) {
@@ -509,7 +509,7 @@ func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified virtual network gateway by resource group.
@@ -561,7 +561,7 @@ func (client *VirtualNetworkGatewaysClient) GetHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string) (*GatewayRouteListResultPollerResponse, error) {
@@ -644,7 +644,7 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*BgpPeerStatusListResultPollerResponse, error) {
@@ -729,7 +729,7 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*GatewayRouteListResultPollerResponse, error) {
@@ -811,7 +811,7 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleError(resp *az
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*StringPollerResponse, error) {
@@ -893,7 +893,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleError(r
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientConnectionHealthDetailListResultPollerResponse, error) {
@@ -975,7 +975,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientIPsecParametersPollerResponse, error) {
@@ -1057,7 +1057,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all virtual network gateways by resource group.
@@ -1103,7 +1103,7 @@ func (client *VirtualNetworkGatewaysClient) ListHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListConnections - Gets all the connections in a virtual network gateway.
@@ -1150,7 +1150,7 @@ func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*VirtualNetworkGatewayPollerResponse, error) {
@@ -1235,7 +1235,7 @@ func (client *VirtualNetworkGatewaysClient) ResetHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error) {
@@ -1311,7 +1311,7 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleError(r
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*VpnClientIPsecParametersPollerResponse, error) {
@@ -1393,7 +1393,7 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleErr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*StringPollerResponse, error) {
@@ -1478,7 +1478,7 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error) {
@@ -1560,7 +1560,7 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SupportedVpnDevices - Gets a xml format representation for supported vpn devices.
@@ -1612,7 +1612,7 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*VirtualNetworkGatewayPollerResponse, error) {
@@ -1694,7 +1694,7 @@ func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // VpnDeviceConfigurationScript - Gets a xml format representation for vpn device configuration script.
@@ -1746,5 +1746,5 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -128,7 +128,7 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *VirtualNetworkPeeringsClient) DeleteHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified virtual network peering.
@@ -258,7 +258,7 @@ func (client *VirtualNetworkPeeringsClient) GetHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all virtual network peerings in a virtual network.
@@ -305,5 +305,5 @@ func (client *VirtualNetworkPeeringsClient) ListHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -106,7 +106,7 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*VirtualNetworkPollerResponse, error) {
@@ -188,7 +188,7 @@ func (client *VirtualNetworksClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*HTTPPollerResponse, error) {
@@ -264,7 +264,7 @@ func (client *VirtualNetworksClient) DeleteHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified virtual network by resource group.
@@ -319,7 +319,7 @@ func (client *VirtualNetworksClient) GetHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all virtual networks in a resource group.
@@ -365,7 +365,7 @@ func (client *VirtualNetworksClient) ListHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all virtual networks in a subscription.
@@ -410,7 +410,7 @@ func (client *VirtualNetworksClient) ListAllHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListUsage - Lists usage stats.
@@ -457,7 +457,7 @@ func (client *VirtualNetworksClient) ListUsageHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a virtual network tags.
@@ -509,5 +509,5 @@ func (client *VirtualNetworksClient) UpdateTagsHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -131,7 +131,7 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourceGroupName string, tapName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *VirtualNetworkTapsClient) DeleteHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets information about the specified virtual network tap.
@@ -259,7 +259,7 @@ func (client *VirtualNetworkTapsClient) GetHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the VirtualNetworkTaps in a subscription.
@@ -304,7 +304,7 @@ func (client *VirtualNetworkTapsClient) ListAllHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Gets all the VirtualNetworkTaps in a subscription.
@@ -350,7 +350,7 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates an VirtualNetworkTap tags.
@@ -402,5 +402,5 @@ func (client *VirtualNetworkTapsClient) UpdateTagsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -128,7 +128,7 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *VirtualRouterPeeringsClient) DeleteHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Virtual Router Peering.
@@ -258,7 +258,7 @@ func (client *VirtualRouterPeeringsClient) GetHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all Virtual Router Peerings in a Virtual Router resource.
@@ -305,5 +305,5 @@ func (client *VirtualRouterPeeringsClient) ListHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -129,7 +129,7 @@ func (client *VirtualRoutersClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *VirtualRoutersClient) DeleteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Gets the specified Virtual Router.
@@ -260,7 +260,7 @@ func (client *VirtualRoutersClient) GetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Gets all the Virtual Routers in a subscription.
@@ -305,7 +305,7 @@ func (client *VirtualRoutersClient) ListHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all Virtual Routers in a resource group.
@@ -351,5 +351,5 @@ func (client *VirtualRoutersClient) ListByResourceGroupHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -131,7 +131,7 @@ func (client *VirtualWansClient) CreateOrUpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualWanName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *VirtualWansClient) DeleteHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a VirtualWAN.
@@ -259,7 +259,7 @@ func (client *VirtualWansClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the VirtualWANs in a subscription.
@@ -304,7 +304,7 @@ func (client *VirtualWansClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the VirtualWANs in a resource group.
@@ -350,7 +350,7 @@ func (client *VirtualWansClient) ListByResourceGroupHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates a VirtualWAN tags.
@@ -402,5 +402,5 @@ func (client *VirtualWansClient) UpdateTagsHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -128,7 +128,7 @@ func (client *VpnConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VpnConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*HTTPPollerResponse, error) {
@@ -205,7 +205,7 @@ func (client *VpnConnectionsClient) DeleteHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a vpn connection.
@@ -258,7 +258,7 @@ func (client *VpnConnectionsClient) GetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByVpnGateway - Retrieves all vpn connections for a particular virtual wan vpn gateway.
@@ -305,5 +305,5 @@ func (client *VpnConnectionsClient) ListByVpnGatewayHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -135,7 +135,7 @@ func (client *VpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error) {
@@ -211,7 +211,7 @@ func (client *VpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a virtual wan vpn gateway.
@@ -263,7 +263,7 @@ func (client *VpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the VpnGateways in a subscription.
@@ -308,7 +308,7 @@ func (client *VpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the VpnGateways in a resource group.
@@ -354,7 +354,7 @@ func (client *VpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VpnGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, gatewayName string) (*VpnGatewayPollerResponse, error) {
@@ -436,7 +436,7 @@ func (client *VpnGatewaysClient) ResetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates virtual wan vpn gateway tags.
@@ -488,5 +488,5 @@ func (client *VpnGatewaysClient) UpdateTagsHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -81,5 +81,5 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnectionHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -131,7 +131,7 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VpnServerConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *VpnServerConfigurationsClient) DeleteHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a VpnServerConfiguration.
@@ -259,7 +259,7 @@ func (client *VpnServerConfigurationsClient) GetHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the VpnServerConfigurations in a subscription.
@@ -304,7 +304,7 @@ func (client *VpnServerConfigurationsClient) ListHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the vpnServerConfigurations in a resource group.
@@ -350,7 +350,7 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates VpnServerConfiguration tags.
@@ -402,5 +402,5 @@ func (client *VpnServerConfigurationsClient) UpdateTagsHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -119,5 +119,5 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListHandleE
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -87,5 +87,5 @@ func (client *VpnSiteLinkConnectionsClient) GetHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -88,7 +88,7 @@ func (client *VpnSiteLinksClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByVpnSite - Lists all the vpnSiteLinks in a resource group for a vpn site.
@@ -135,5 +135,5 @@ func (client *VpnSiteLinksClient) ListByVpnSiteHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -131,7 +131,7 @@ func (client *VpnSitesClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *VpnSitesClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string) (*HTTPPollerResponse, error) {
@@ -207,7 +207,7 @@ func (client *VpnSitesClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieves the details of a VPN site.
@@ -259,7 +259,7 @@ func (client *VpnSitesClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all the VpnSites in a subscription.
@@ -304,7 +304,7 @@ func (client *VpnSitesClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListByResourceGroup - Lists all the vpnSites in a resource group.
@@ -350,7 +350,7 @@ func (client *VpnSitesClient) ListByResourceGroupHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateTags - Updates VpnSite tags.
@@ -402,5 +402,5 @@ func (client *VpnSitesClient) UpdateTagsHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
@@ -113,5 +113,5 @@ func (client *VpnSitesConfigurationClient) DownloadHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -97,7 +97,7 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleError(re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, policyName string) (*HTTPPollerResponse, error) {
@@ -173,7 +173,7 @@ func (client *WebApplicationFirewallPoliciesClient) DeleteHandleError(resp *azco
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Get - Retrieve protection policy with specified name within a resource group.
@@ -225,7 +225,7 @@ func (client *WebApplicationFirewallPoliciesClient) GetHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - Lists all of the protection policies within a resource group.
@@ -271,7 +271,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListAll - Gets all the WAF policies in a subscription.
@@ -316,5 +316,5 @@ func (client *WebApplicationFirewallPoliciesClient) ListAllHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/go.mod
+++ b/test/storage/2019-07-07/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -180,7 +180,7 @@ func (client *appendBlobClient) AppendBlockHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // AppendBlockFromURL - The Append Block operation commits a new block of data to the end of an existing append blob where the contents are read from a source url. The Append Block operation is permitted only if the blob was created with x-ms-blob-type set to AppendBlob. Append Block is supported only on version 2015-02-21 version or later.
@@ -355,7 +355,7 @@ func (client *appendBlobClient) AppendBlockFromURLHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Create - The Create Append Blob operation creates a new append blob.
@@ -507,5 +507,5 @@ func (client *appendBlobClient) CreateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -99,7 +99,7 @@ func (client *blobClient) AbortCopyFromURLHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // AcquireLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -202,7 +202,7 @@ func (client *blobClient) AcquireLeaseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // BreakLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -307,7 +307,7 @@ func (client *blobClient) BreakLeaseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ChangeLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -406,7 +406,7 @@ func (client *blobClient) ChangeLeaseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CopyFromURL - The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.
@@ -546,7 +546,7 @@ func (client *blobClient) CopyFromURLHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateSnapshot - The Create Snapshot operation creates a read-only snapshot of a blob
@@ -669,7 +669,7 @@ func (client *blobClient) CreateSnapshotHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete - If the storage account's soft delete feature is disabled then, when a blob is deleted, it is permanently removed from the storage account. If the storage account's soft delete feature is enabled, then, when a blob is deleted, it is marked for deletion and becomes inaccessible immediately. However, the blob service retains the blob or snapshot for the number of days specified by the DeleteRetentionPolicy section of [Storage service properties] (Set-Blob-Service-Properties.md). After the specified number of days has passed, the blob's data is permanently removed from the storage account. Note that you continue to be charged for the soft-deleted blob's storage until it is permanently removed. Use the List Blobs API and specify the "include=deleted" query parameter to discover which blobs and snapshots have been soft deleted. You can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot causes the service to return an HTTP status code of 404 (ResourceNotFound).
@@ -760,7 +760,7 @@ func (client *blobClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Download - The Download operation reads or downloads a blob from the system, including its metadata and properties. You can also call Download to read a snapshot.
@@ -996,7 +996,7 @@ func (client *blobClient) DownloadHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a blob.
@@ -1104,7 +1104,7 @@ func (client *blobClient) GetAccessControlHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetAccountInfo - Returns the sku name and account kind
@@ -1176,7 +1176,7 @@ func (client *blobClient) GetAccountInfoHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetProperties - The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob.
@@ -1422,7 +1422,7 @@ func (client *blobClient) GetPropertiesHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ReleaseLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -1517,7 +1517,7 @@ func (client *blobClient) ReleaseLeaseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Rename - Rename a blob/file.  By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken.  This operation supports conditional HTTP requests.  For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).  To fail if the destination already exists, use a conditional request with If-None-Match: "*".
@@ -1662,7 +1662,7 @@ func (client *blobClient) RenameHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // RenewLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
@@ -1760,7 +1760,7 @@ func (client *blobClient) RenewLeaseHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a blob.
@@ -1865,7 +1865,7 @@ func (client *blobClient) SetAccessControlHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetHTTPHeaders - The Set HTTP Headers operation sets system properties on the blob
@@ -1986,7 +1986,7 @@ func (client *blobClient) SetHTTPHeadersHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetMetadata - The Set Blob Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs
@@ -2112,7 +2112,7 @@ func (client *blobClient) SetMetadataHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetTier - The Set Tier operation sets the tier on a blob. The operation is allowed on a page blob in a premium storage account and on a block blob in a blob storage account (locally redundant storage only). A premium page blob's tier determines the allowed size, IOPS, and bandwidth of the blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.
@@ -2183,7 +2183,7 @@ func (client *blobClient) SetTierHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StartCopyFromURL - The Start Copy From URL operation copies a blob or an internet resource to a new blob.
@@ -2308,7 +2308,7 @@ func (client *blobClient) StartCopyFromURLHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Undelete - Undelete a blob that was previously soft deleted
@@ -2379,5 +2379,5 @@ func (client *blobClient) UndeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -188,7 +188,7 @@ func (client *blockBlobClient) CommitBlockListHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetBlockList - The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob
@@ -286,7 +286,7 @@ func (client *blockBlobClient) GetBlockListHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StageBlock - The Stage Block operation creates a new block to be committed as part of a blob
@@ -407,7 +407,7 @@ func (client *blockBlobClient) StageBlockHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StageBlockFromURL - The Stage Block operation creates a new block to be committed as part of a blob where the contents are read from a URL.
@@ -544,7 +544,7 @@ func (client *blockBlobClient) StageBlockFromURLHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Upload - The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.
@@ -702,5 +702,5 @@ func (client *blockBlobClient) UploadHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_client.go
@@ -17,8 +17,6 @@ const telemetryInfo = "azsdk-go-azblob/<version>"
 type clientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -59,7 +57,7 @@ func newClient(endpoint string, cred azcore.Credential, options *clientOptions) 
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return newClientWithPipeline(endpoint, p)
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -120,7 +120,7 @@ func (client *containerClient) AcquireLeaseHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // BreakLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -220,7 +220,7 @@ func (client *containerClient) BreakLeaseHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ChangeLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -314,7 +314,7 @@ func (client *containerClient) ChangeLeaseHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Create - creates a new container under the specified account. If the container with the same name already exists, the operation fails
@@ -409,7 +409,7 @@ func (client *containerClient) CreateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete - operation marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection
@@ -489,7 +489,7 @@ func (client *containerClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetAccessPolicy - gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
@@ -577,7 +577,7 @@ func (client *containerClient) GetAccessPolicyHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetAccountInfo - Returns the sku name and account kind
@@ -649,7 +649,7 @@ func (client *containerClient) GetAccountInfoHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetProperties - returns all user-defined metadata and system properties for the specified container. The data returned does not include the container's list of blobs
@@ -777,7 +777,7 @@ func (client *containerClient) GetPropertiesHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListBlobFlatSegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
@@ -859,7 +859,7 @@ func (client *containerClient) ListBlobFlatSegmentHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListBlobHierarchySegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
@@ -942,7 +942,7 @@ func (client *containerClient) ListBlobHierarchySegmentHandleError(resp *azcore.
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ReleaseLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -1032,7 +1032,7 @@ func (client *containerClient) ReleaseLeaseHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // RenewLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
@@ -1125,7 +1125,7 @@ func (client *containerClient) RenewLeaseHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetAccessPolicy - sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed publicly.
@@ -1226,7 +1226,7 @@ func (client *containerClient) SetAccessPolicyHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetMetadata - operation sets one or more user-defined name-value pairs for the specified container.
@@ -1319,5 +1319,5 @@ func (client *containerClient) SetMetadataHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -147,7 +147,7 @@ func (client *directoryClient) CreateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Delete - Deletes the directory
@@ -239,7 +239,7 @@ func (client *directoryClient) DeleteHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a directory.
@@ -347,7 +347,7 @@ func (client *directoryClient) GetAccessControlHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Rename - Rename a directory. By default, the destination is overwritten and if the destination already exists and has a lease the lease is broken. This operation supports conditional HTTP requests. For more information, see [Specifying Conditional Headers for Blob Service Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations). To fail if the destination already exists, use a conditional request with If-None-Match: "*".
@@ -498,7 +498,7 @@ func (client *directoryClient) RenameHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a directory.
@@ -603,5 +603,5 @@ func (client *directoryClient) SetAccessControlHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -164,7 +164,7 @@ func (client *pageBlobClient) ClearPagesHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CopyIncremental - The Copy Incremental operation copies a snapshot of the source page blob to a destination page blob. The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination. The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported since REST version 2016-05-31.
@@ -264,7 +264,7 @@ func (client *pageBlobClient) CopyIncrementalHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Create - The Create operation creates a new page blob.
@@ -423,7 +423,7 @@ func (client *pageBlobClient) CreateHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPageRanges - The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page blob
@@ -532,7 +532,7 @@ func (client *pageBlobClient) GetPageRangesHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPageRangesDiff - The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob that were changed between target blob and previous snapshot.
@@ -647,7 +647,7 @@ func (client *pageBlobClient) GetPageRangesDiffHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // Resize - Resize the Blob
@@ -763,7 +763,7 @@ func (client *pageBlobClient) ResizeHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UpdateSequenceNumber - Update the sequence number of the blob
@@ -870,7 +870,7 @@ func (client *pageBlobClient) UpdateSequenceNumberHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UploadPages - The Upload Pages operation writes a range of pages to a page blob
@@ -1032,7 +1032,7 @@ func (client *pageBlobClient) UploadPagesHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UploadPagesFromURL - The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL
@@ -1203,5 +1203,5 @@ func (client *pageBlobClient) UploadPagesFromURLHandleError(resp *azcore.Respons
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -91,7 +91,7 @@ func (client *serviceClient) GetAccountInfoHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetProperties - gets the properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
@@ -156,7 +156,7 @@ func (client *serviceClient) GetPropertiesHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetStatistics - Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
@@ -228,7 +228,7 @@ func (client *serviceClient) GetStatisticsHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetUserDelegationKey - Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
@@ -300,7 +300,7 @@ func (client *serviceClient) GetUserDelegationKeyHandleError(resp *azcore.Respon
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ListContainersSegment - The List Containers Segment operation returns a list of the containers under the specified account
@@ -371,7 +371,7 @@ func (client *serviceClient) ListContainersSegmentHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SetProperties - Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
@@ -436,7 +436,7 @@ func (client *serviceClient) SetPropertiesHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SubmitBatch - The Batch operation allows multiple API calls to be embedded into a single HTTP request.
@@ -503,5 +503,5 @@ func (client *serviceClient) SubmitBatchHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsXML(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -2,4 +2,4 @@ module azartifacts
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
@@ -69,7 +69,7 @@ func (client *bigDataPoolsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - List Big Data Pools
@@ -118,5 +118,5 @@ func (client *bigDataPoolsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_client.go
@@ -17,8 +17,6 @@ const telemetryInfo = "azsdk-go-azartifacts/<version>"
 type clientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -59,7 +57,7 @@ func newClient(endpoint string, cred azcore.Credential, options *clientOptions) 
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
 		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return newClientWithPipeline(endpoint, p)
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
@@ -68,7 +68,7 @@ func (client *dataFlowClient) CreateOrUpdateDataFlowHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteDataFlow - Deletes a data flow.
@@ -108,7 +108,7 @@ func (client *dataFlowClient) DeleteDataFlowHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDataFlow - Gets a data flow.
@@ -161,7 +161,7 @@ func (client *dataFlowClient) GetDataFlowHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDataFlowsByWorkspace - Lists data flows.
@@ -205,5 +205,5 @@ func (client *dataFlowClient) GetDataFlowsByWorkspaceHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
@@ -66,7 +66,7 @@ func (client *dataFlowDebugSessionClient) AddDataFlowHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreateDataFlowDebugSession - Creates a data flow debug session.
@@ -111,7 +111,7 @@ func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSessionHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteDataFlowDebugSession - Deletes a data flow debug session.
@@ -150,7 +150,7 @@ func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSessionHandleError(
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ExecuteCommand - Execute a data flow debug command.
@@ -195,7 +195,7 @@ func (client *dataFlowDebugSessionClient) ExecuteCommandHandleError(resp *azcore
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // QueryDataFlowDebugSessionsByWorkspace - Query all active data flow debug sessions.
@@ -239,5 +239,5 @@ func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspaceH
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
@@ -68,7 +68,7 @@ func (client *datasetClient) CreateOrUpdateDatasetHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteDataset - Deletes a dataset.
@@ -108,7 +108,7 @@ func (client *datasetClient) DeleteDatasetHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDataset - Gets a dataset.
@@ -161,7 +161,7 @@ func (client *datasetClient) GetDatasetHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetDatasetsByWorkspace - Lists datasets.
@@ -205,5 +205,5 @@ func (client *datasetClient) GetDatasetsByWorkspaceHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
@@ -69,7 +69,7 @@ func (client *integrationRuntimesClient) GetHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - List Integration Runtimes
@@ -118,5 +118,5 @@ func (client *integrationRuntimesClient) ListHandleError(resp *azcore.Response) 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
@@ -68,7 +68,7 @@ func (client *linkedServiceClient) CreateOrUpdateLinkedServiceHandleError(resp *
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteLinkedService - Deletes a linked service.
@@ -108,7 +108,7 @@ func (client *linkedServiceClient) DeleteLinkedServiceHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLinkedService - Gets a linked service.
@@ -161,7 +161,7 @@ func (client *linkedServiceClient) GetLinkedServiceHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetLinkedServicesByWorkspace - Lists linked services.
@@ -205,5 +205,5 @@ func (client *linkedServiceClient) GetLinkedServicesByWorkspaceHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
@@ -68,7 +68,7 @@ func (client *notebookClient) CreateOrUpdateNotebookHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteNotebook - Deletes a Note book.
@@ -108,7 +108,7 @@ func (client *notebookClient) DeleteNotebookHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotebook - Gets a Note Book.
@@ -161,7 +161,7 @@ func (client *notebookClient) GetNotebookHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotebookSummaryByWorkSpace - Lists a summary of Notebooks.
@@ -205,7 +205,7 @@ func (client *notebookClient) GetNotebookSummaryByWorkSpaceHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetNotebooksByWorkspace - Lists Notebooks.
@@ -249,5 +249,5 @@ func (client *notebookClient) GetNotebooksByWorkspaceHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
@@ -69,7 +69,7 @@ func (client *pipelineClient) CreateOrUpdatePipelineHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // CreatePipelineRun - Creates a run of a pipeline.
@@ -131,7 +131,7 @@ func (client *pipelineClient) CreatePipelineRunHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeletePipeline - Deletes a pipeline.
@@ -171,7 +171,7 @@ func (client *pipelineClient) DeletePipelineHandleError(resp *azcore.Response) e
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPipeline - Gets a pipeline.
@@ -224,7 +224,7 @@ func (client *pipelineClient) GetPipelineHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPipelinesByWorkspace - Lists pipelines.
@@ -268,5 +268,5 @@ func (client *pipelineClient) GetPipelinesByWorkspaceHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
@@ -63,7 +63,7 @@ func (client *pipelineRunClient) CancelPipelineRunHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetPipelineRun - Get a pipeline run by its run ID.
@@ -113,7 +113,7 @@ func (client *pipelineRunClient) GetPipelineRunHandleError(resp *azcore.Response
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // QueryActivityRuns - Query activity runs based on input filter conditions.
@@ -164,7 +164,7 @@ func (client *pipelineRunClient) QueryActivityRunsHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // QueryPipelineRunsByWorkspace - Query pipeline runs in the workspace based on input filter conditions.
@@ -213,5 +213,5 @@ func (client *pipelineRunClient) QueryPipelineRunsByWorkspaceHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
@@ -72,7 +72,7 @@ func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinitionHandleEr
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DebugSparkJobDefinition - Debug the spark job definition.
@@ -117,7 +117,7 @@ func (client *sparkJobDefinitionClient) DebugSparkJobDefinitionHandleError(resp 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteSparkJobDefinition - Deletes a Spark Job Definition.
@@ -157,7 +157,7 @@ func (client *sparkJobDefinitionClient) DeleteSparkJobDefinitionHandleError(resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // ExecuteSparkJobDefinition - Executes the spark job definition.
@@ -203,7 +203,7 @@ func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinitionHandleError(res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSparkJobDefinition - Gets a Spark Job Definition.
@@ -256,7 +256,7 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionHandleError(resp *a
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSparkJobDefinitionsByWorkspace - Lists spark job definitions.
@@ -300,5 +300,5 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspaceHandleE
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
@@ -69,7 +69,7 @@ func (client *sqlPoolsClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // List - List Sql Pools
@@ -118,5 +118,5 @@ func (client *sqlPoolsClient) ListHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
@@ -72,7 +72,7 @@ func (client *sqlScriptClient) CreateOrUpdateSQLScriptHandleError(resp *azcore.R
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteSQLScript - Deletes a Sql Script.
@@ -112,7 +112,7 @@ func (client *sqlScriptClient) DeleteSQLScriptHandleError(resp *azcore.Response)
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSQLScript - Gets a sql script.
@@ -165,7 +165,7 @@ func (client *sqlScriptClient) GetSQLScriptHandleError(resp *azcore.Response) er
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetSQLScriptsByWorkspace - Lists sql scripts.
@@ -209,5 +209,5 @@ func (client *sqlScriptClient) GetSQLScriptsByWorkspaceHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
@@ -68,7 +68,7 @@ func (client *triggerClient) CreateOrUpdateTriggerHandleError(resp *azcore.Respo
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // DeleteTrigger - Deletes a trigger.
@@ -108,7 +108,7 @@ func (client *triggerClient) DeleteTriggerHandleError(resp *azcore.Response) err
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetEventSubscriptionStatus - Get a trigger's event subscription status.
@@ -158,7 +158,7 @@ func (client *triggerClient) GetEventSubscriptionStatusHandleError(resp *azcore.
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTrigger - Gets a trigger.
@@ -211,7 +211,7 @@ func (client *triggerClient) GetTriggerHandleError(resp *azcore.Response) error 
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // GetTriggersByWorkspace - Lists triggers.
@@ -255,7 +255,7 @@ func (client *triggerClient) GetTriggersByWorkspaceHandleError(resp *azcore.Resp
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StartTrigger - Starts a trigger.
@@ -295,7 +295,7 @@ func (client *triggerClient) StartTriggerHandleError(resp *azcore.Response) erro
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // StopTrigger - Stops a trigger.
@@ -335,7 +335,7 @@ func (client *triggerClient) StopTriggerHandleError(resp *azcore.Response) error
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // SubscribeTriggerToEvents - Subscribe event trigger to events.
@@ -381,7 +381,7 @@ func (client *triggerClient) SubscribeTriggerToEventsHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // UnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.
@@ -427,5 +427,5 @@ func (client *triggerClient) UnsubscribeTriggerFromEventsHandleError(resp *azcor
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
@@ -60,7 +60,7 @@ func (client *triggerRunClient) CancelTriggerInstanceHandleError(resp *azcore.Re
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // QueryTriggerRunsByWorkspace - Query trigger runs.
@@ -109,7 +109,7 @@ func (client *triggerRunClient) QueryTriggerRunsByWorkspaceHandleError(resp *azc
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }
 
 // RerunTriggerInstance - Rerun single trigger instance by runId.
@@ -150,5 +150,5 @@ func (client *triggerRunClient) RerunTriggerInstanceHandleError(resp *azcore.Res
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
@@ -66,5 +66,5 @@ func (client *workspaceClient) GetHandleError(resp *azcore.Response) error {
 	if err := resp.UnmarshalAsJSON(&err); err != nil {
 		return err
 	}
-	return err
+	return azcore.NewResponseError(&err, resp.Response)
 }

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -2,4 +2,4 @@ module azspark
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.10.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.11.0

--- a/test/synapse/2019-06-01/azspark/zz_generated_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_client.go
@@ -17,8 +17,6 @@ const telemetryInfo = "azsdk-go-azspark/<version>"
 type clientOptions struct {
 	// HTTPClient sets the transport for making HTTP requests.
 	HTTPClient azcore.Transport
-	// LogOptions configures the built-in request logging policy behavior.
-	LogOptions azcore.RequestLogOptions
 	// Retry configures the built-in retry policy behavior.
 	Retry azcore.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -58,7 +56,7 @@ func newClient(endpoint string, livyAPIVersion *string, sparkPoolName string, op
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
 		azcore.NewUniqueRequestIDPolicy(),
 		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewRequestLogPolicy(options.LogOptions))
+		azcore.NewRequestLogPolicy(nil))
 	return newClientWithPipeline(endpoint, livyAPIVersion, sparkPoolName, p)
 }
 

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
@@ -60,9 +60,9 @@ func (client *sparkBatchClient) CancelSparkBatchJobHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // CreateSparkBatchJob - Create new spark batch job.
@@ -114,9 +114,9 @@ func (client *sparkBatchClient) CreateSparkBatchJobHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkBatchJob - Gets a single spark batch job.
@@ -169,9 +169,9 @@ func (client *sparkBatchClient) GetSparkBatchJobHandleError(resp *azcore.Respons
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkBatchJobs - List all spark batch jobs which are running under a particular spark pool.
@@ -229,7 +229,7 @@ func (client *sparkBatchClient) GetSparkBatchJobsHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
@@ -60,9 +60,9 @@ func (client *sparkSessionClient) CancelSparkSessionHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // CancelSparkStatement - Kill a statement within a session.
@@ -111,9 +111,9 @@ func (client *sparkSessionClient) CancelSparkStatementHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // CreateSparkSession - Create new spark session.
@@ -165,9 +165,9 @@ func (client *sparkSessionClient) CreateSparkSessionHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // CreateSparkStatement - Create statement within a spark session.
@@ -215,9 +215,9 @@ func (client *sparkSessionClient) CreateSparkStatementHandleError(resp *azcore.R
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkSession - Gets a single spark session.
@@ -270,9 +270,9 @@ func (client *sparkSessionClient) GetSparkSessionHandleError(resp *azcore.Respon
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkSessions - List all spark sessions which are running under a particular spark pool.
@@ -330,9 +330,9 @@ func (client *sparkSessionClient) GetSparkSessionsHandleError(resp *azcore.Respo
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkStatement - Gets a single statement within a spark session.
@@ -381,9 +381,9 @@ func (client *sparkSessionClient) GetSparkStatementHandleError(resp *azcore.Resp
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // GetSparkStatements - Gets a list of statements within a spark session.
@@ -431,9 +431,9 @@ func (client *sparkSessionClient) GetSparkStatementsHandleError(resp *azcore.Res
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
 // ResetSparkSessionTimeout - Sends a keep alive call to the current session to reset the session timeout.
@@ -470,7 +470,7 @@ func (client *sparkSessionClient) ResetSparkSessionTimeoutHandleError(resp *azco
 		return fmt.Errorf("%s; failed to read response body: %w", resp.Status, err)
 	}
 	if len(body) == 0 {
-		return errors.New(resp.Status)
+		return azcore.NewResponseError(errors.New(resp.Status), resp.Response)
 	}
-	return errors.New(string(body))
+	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }


### PR DESCRIPTION
Wrap API errors in azcore.NewResponseError() so callers have access to
the raw HTTP response.
Return error with schemas as pointer-to-type.
Remove azcore.RequestLogOptions per azcore breaking changes.