### PR TITLE
Add optional params placeholder struct to operations

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -128,6 +128,11 @@ export function getMethodParameters(op: Operation): Parameter[] {
     }
     params.push(param);
   }
+  // this handles the case where the operation has no optional params
+  // but has the optional params placeholder type.
+  if (paramGroups.length === 0 && op.language.go!.optionalParamGroup) {
+    paramGroups.push(op.language.go!.optionalParamGroup);
+  }
   // move global optional params to the end of the slice
   params.sort(sortParametersByRequired);
   // add any parameter groups.  optional group goes last
@@ -141,9 +146,9 @@ export function getMethodParameters(op: Operation): Parameter[] {
     return 1;
   })
   for (const paramGroup of values(paramGroups)) {
-    let name = camelCase(paramGroup.language.go!.name);
-    if (!paramGroup.required) {
-      name = 'options';
+    // if there's only one optional param group, name the param "options" instead of its (long) type name
+    if (!paramGroup.required && paramGroups.length === 1) {
+      paramGroup.language.go!.name = 'options';
     }
     params.push(paramGroup);
   }

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -25,7 +25,7 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   }
   const paramGroups = <Array<GroupProperty>>session.model.language.go!.parameterGroups;
   for (const paramGroup of values(paramGroups)) {
-    structs.push(generateParamGroupStruct(paramGroup.language.go!, paramGroup.originalParameter));
+    structs.push(generateParamGroupStruct(paramGroup.schema.language.go!, paramGroup.originalParameter));
   }
 
   // imports
@@ -92,6 +92,10 @@ class StructDef {
     }
     // used to track when to add an extra \n between fields that have comments
     let first = true;
+    if (this.Properties === undefined && this.Parameters?.length === 0) {
+      // this is an optional params placeholder struct
+      text += '\t// placeholder for future optional parameters\n';
+    }
     for (const prop of values(this.Properties)) {
       if (hasDescription(prop.language.go!)) {
         if (!first) {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -329,6 +329,10 @@ function processOperationRequests(session: Session<CodeModel>) {
         }
         // create an optional params struct even if the operation contains no optional params.
         // this provides version resiliency in case optional params are added in the future.
+        // don't do this for paging next link operation as this isn't part of the public API
+        if (op.language.go!.paging && op.language.go!.paging.isNextOp) {
+          continue;
+        }
         // create a type named <OperationGroup><Operation>Options
         const paramGroupName = `${group.language.go!.name}${op.language.go!.name}Options`;
         if (!paramGroups.has(paramGroupName)) {

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -27,7 +27,7 @@ func TestCreateApInProperties(t *testing.T) {
 			"weight":   599,
 			"footsize": 11.5,
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestCreateApInPropertiesWithApstring(t *testing.T) {
 			"weight":   599,
 			"footsize": 11.5,
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestCreateApObject(t *testing.T) {
 			},
 			"picture": base64.StdEncoding.EncodeToString([]byte{255, 255, 255, 255, 254}),
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestCreateApString(t *testing.T) {
 			"weight": "10 kg",
 			"city":   "Bombay",
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestCreateApTrue(t *testing.T) {
 				"color": "Red",
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestCreateCatApTrue(t *testing.T) {
 			},
 		},
 		Friendly: to.BoolPtr(true),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -432,3 +432,34 @@ type PetApTrueResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
+
+// PetsCreateApInPropertiesOptions contains the optional parameters for the Pets.CreateApInProperties method.
+type PetsCreateApInPropertiesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetsCreateApInPropertiesWithApstringOptions contains the optional parameters for the Pets.CreateApInPropertiesWithApstring
+// method.
+type PetsCreateApInPropertiesWithApstringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetsCreateApObjectOptions contains the optional parameters for the Pets.CreateApObject method.
+type PetsCreateApObjectOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetsCreateApStringOptions contains the optional parameters for the Pets.CreateApString method.
+type PetsCreateApStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetsCreateApTrueOptions contains the optional parameters for the Pets.CreateApTrue method.
+type PetsCreateApTrueOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetsCreateCatApTrueOptions contains the optional parameters for the Pets.CreateCatApTrue method.
+type PetsCreateCatApTrueOptions struct {
+	// placeholder for future optional parameters
+}

--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -14,17 +14,17 @@ import (
 // PetsOperations contains the methods for the Pets group.
 type PetsOperations interface {
 	// CreateApInProperties - Create a Pet which contains more properties than what is defined.
-	CreateApInProperties(ctx context.Context, createParameters PetApInProperties) (*PetApInPropertiesResponse, error)
+	CreateApInProperties(ctx context.Context, createParameters PetApInProperties, options *PetsCreateApInPropertiesOptions) (*PetApInPropertiesResponse, error)
 	// CreateApInPropertiesWithApstring - Create a Pet which contains more properties than what is defined.
-	CreateApInPropertiesWithApstring(ctx context.Context, createParameters PetApInPropertiesWithApstring) (*PetApInPropertiesWithApstringResponse, error)
+	CreateApInPropertiesWithApstring(ctx context.Context, createParameters PetApInPropertiesWithApstring, options *PetsCreateApInPropertiesWithApstringOptions) (*PetApInPropertiesWithApstringResponse, error)
 	// CreateApObject - Create a Pet which contains more properties than what is defined.
-	CreateApObject(ctx context.Context, createParameters PetApObject) (*PetApObjectResponse, error)
+	CreateApObject(ctx context.Context, createParameters PetApObject, options *PetsCreateApObjectOptions) (*PetApObjectResponse, error)
 	// CreateApString - Create a Pet which contains more properties than what is defined.
-	CreateApString(ctx context.Context, createParameters PetApString) (*PetApStringResponse, error)
+	CreateApString(ctx context.Context, createParameters PetApString, options *PetsCreateApStringOptions) (*PetApStringResponse, error)
 	// CreateApTrue - Create a Pet which contains more properties than what is defined.
-	CreateApTrue(ctx context.Context, createParameters PetApTrue) (*PetApTrueResponse, error)
+	CreateApTrue(ctx context.Context, createParameters PetApTrue, options *PetsCreateApTrueOptions) (*PetApTrueResponse, error)
 	// CreateCatApTrue - Create a CatAPTrue which contains more properties than what is defined.
-	CreateCatApTrue(ctx context.Context, createParameters CatApTrue) (*CatApTrueResponse, error)
+	CreateCatApTrue(ctx context.Context, createParameters CatApTrue, options *PetsCreateCatApTrueOptions) (*CatApTrueResponse, error)
 }
 
 // PetsClient implements the PetsOperations interface.
@@ -44,8 +44,8 @@ func (client *PetsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // CreateApInProperties - Create a Pet which contains more properties than what is defined.
-func (client *PetsClient) CreateApInProperties(ctx context.Context, createParameters PetApInProperties) (*PetApInPropertiesResponse, error) {
-	req, err := client.CreateApInPropertiesCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateApInProperties(ctx context.Context, createParameters PetApInProperties, options *PetsCreateApInPropertiesOptions) (*PetApInPropertiesResponse, error) {
+	req, err := client.CreateApInPropertiesCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *PetsClient) CreateApInProperties(ctx context.Context, createParame
 }
 
 // CreateApInPropertiesCreateRequest creates the CreateApInProperties request.
-func (client *PetsClient) CreateApInPropertiesCreateRequest(ctx context.Context, createParameters PetApInProperties) (*azcore.Request, error) {
+func (client *PetsClient) CreateApInPropertiesCreateRequest(ctx context.Context, createParameters PetApInProperties, options *PetsCreateApInPropertiesOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/in/properties"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -90,8 +90,8 @@ func (client *PetsClient) CreateApInPropertiesHandleError(resp *azcore.Response)
 }
 
 // CreateApInPropertiesWithApstring - Create a Pet which contains more properties than what is defined.
-func (client *PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, createParameters PetApInPropertiesWithApstring) (*PetApInPropertiesWithApstringResponse, error) {
-	req, err := client.CreateApInPropertiesWithApstringCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, createParameters PetApInPropertiesWithApstring, options *PetsCreateApInPropertiesWithApstringOptions) (*PetApInPropertiesWithApstringResponse, error) {
+	req, err := client.CreateApInPropertiesWithApstringCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, 
 }
 
 // CreateApInPropertiesWithApstringCreateRequest creates the CreateApInPropertiesWithApstring request.
-func (client *PetsClient) CreateApInPropertiesWithApstringCreateRequest(ctx context.Context, createParameters PetApInPropertiesWithApstring) (*azcore.Request, error) {
+func (client *PetsClient) CreateApInPropertiesWithApstringCreateRequest(ctx context.Context, createParameters PetApInPropertiesWithApstring, options *PetsCreateApInPropertiesWithApstringOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/in/properties/with/additionalProperties/string"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *PetsClient) CreateApInPropertiesWithApstringHandleError(resp *azco
 }
 
 // CreateApObject - Create a Pet which contains more properties than what is defined.
-func (client *PetsClient) CreateApObject(ctx context.Context, createParameters PetApObject) (*PetApObjectResponse, error) {
-	req, err := client.CreateApObjectCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateApObject(ctx context.Context, createParameters PetApObject, options *PetsCreateApObjectOptions) (*PetApObjectResponse, error) {
+	req, err := client.CreateApObjectCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *PetsClient) CreateApObject(ctx context.Context, createParameters P
 }
 
 // CreateApObjectCreateRequest creates the CreateApObject request.
-func (client *PetsClient) CreateApObjectCreateRequest(ctx context.Context, createParameters PetApObject) (*azcore.Request, error) {
+func (client *PetsClient) CreateApObjectCreateRequest(ctx context.Context, createParameters PetApObject, options *PetsCreateApObjectOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/type/object"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -182,8 +182,8 @@ func (client *PetsClient) CreateApObjectHandleError(resp *azcore.Response) error
 }
 
 // CreateApString - Create a Pet which contains more properties than what is defined.
-func (client *PetsClient) CreateApString(ctx context.Context, createParameters PetApString) (*PetApStringResponse, error) {
-	req, err := client.CreateApStringCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateApString(ctx context.Context, createParameters PetApString, options *PetsCreateApStringOptions) (*PetApStringResponse, error) {
+	req, err := client.CreateApStringCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *PetsClient) CreateApString(ctx context.Context, createParameters P
 }
 
 // CreateApStringCreateRequest creates the CreateApString request.
-func (client *PetsClient) CreateApStringCreateRequest(ctx context.Context, createParameters PetApString) (*azcore.Request, error) {
+func (client *PetsClient) CreateApStringCreateRequest(ctx context.Context, createParameters PetApString, options *PetsCreateApStringOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/type/string"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -228,8 +228,8 @@ func (client *PetsClient) CreateApStringHandleError(resp *azcore.Response) error
 }
 
 // CreateApTrue - Create a Pet which contains more properties than what is defined.
-func (client *PetsClient) CreateApTrue(ctx context.Context, createParameters PetApTrue) (*PetApTrueResponse, error) {
-	req, err := client.CreateApTrueCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateApTrue(ctx context.Context, createParameters PetApTrue, options *PetsCreateApTrueOptions) (*PetApTrueResponse, error) {
+	req, err := client.CreateApTrueCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (client *PetsClient) CreateApTrue(ctx context.Context, createParameters Pet
 }
 
 // CreateApTrueCreateRequest creates the CreateApTrue request.
-func (client *PetsClient) CreateApTrueCreateRequest(ctx context.Context, createParameters PetApTrue) (*azcore.Request, error) {
+func (client *PetsClient) CreateApTrueCreateRequest(ctx context.Context, createParameters PetApTrue, options *PetsCreateApTrueOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/true"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -274,8 +274,8 @@ func (client *PetsClient) CreateApTrueHandleError(resp *azcore.Response) error {
 }
 
 // CreateCatApTrue - Create a CatAPTrue which contains more properties than what is defined.
-func (client *PetsClient) CreateCatApTrue(ctx context.Context, createParameters CatApTrue) (*CatApTrueResponse, error) {
-	req, err := client.CreateCatApTrueCreateRequest(ctx, createParameters)
+func (client *PetsClient) CreateCatApTrue(ctx context.Context, createParameters CatApTrue, options *PetsCreateCatApTrueOptions) (*CatApTrueResponse, error) {
+	req, err := client.CreateCatApTrueCreateRequest(ctx, createParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (client *PetsClient) CreateCatApTrue(ctx context.Context, createParameters 
 }
 
 // CreateCatApTrueCreateRequest creates the CreateCatApTrue request.
-func (client *PetsClient) CreateCatApTrueCreateRequest(ctx context.Context, createParameters CatApTrue) (*azcore.Request, error) {
+func (client *PetsClient) CreateCatApTrueCreateRequest(ctx context.Context, createParameters CatApTrue, options *PetsCreateCatApTrueOptions) (*azcore.Request, error) {
 	urlPath := "/additionalProperties/true-subclass"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -20,7 +20,7 @@ func newArrayClient() ArrayOperations {
 // GetArrayEmpty - Get an empty array []
 func TestGetArrayEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetArrayEmpty(context.Background())
+	resp, err := client.GetArrayEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestGetArrayEmpty(t *testing.T) {
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
 func TestGetArrayItemEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetArrayItemEmpty(context.Background())
+	resp, err := client.GetArrayItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
 func TestGetArrayItemNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetArrayItemNull(context.Background())
+	resp, err := client.GetArrayItemNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestGetArrayItemNull(t *testing.T) {
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetArrayNull(context.Background())
+	resp, err := client.GetArrayNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,7 +75,7 @@ func TestGetArrayNull(t *testing.T) {
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestGetArrayValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetArrayValid(context.Background())
+	resp, err := client.GetArrayValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestGetArrayValid(t *testing.T) {
 func TestGetBase64URL(t *testing.T) {
 	t.Skip("decoding fails")
 	client := newArrayClient()
-	resp, err := client.GetBase64URL(context.Background())
+	resp, err := client.GetBase64URL(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestGetBase64URL(t *testing.T) {
 func TestGetBooleanInvalidNull(t *testing.T) {
 	t.Skip("unmarshalling succeeds")
 	client := newArrayClient()
-	resp, err := client.GetBooleanInvalidNull(context.Background())
+	resp, err := client.GetBooleanInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -117,7 +117,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
 func TestGetBooleanInvalidString(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetBooleanInvalidString(context.Background())
+	resp, err := client.GetBooleanInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -129,7 +129,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
 func TestGetBooleanTfft(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetBooleanTfft(context.Background())
+	resp, err := client.GetBooleanTfft(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestGetBooleanTfft(t *testing.T) {
 func TestGetByteInvalidNull(t *testing.T) {
 	t.Skip("needs investigation")
 	client := newArrayClient()
-	resp, err := client.GetByteInvalidNull(context.Background())
+	resp, err := client.GetByteInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -152,7 +152,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetByteValid(context.Background())
+	resp, err := client.GetByteValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestGetByteValid(t *testing.T) {
 // GetComplexEmpty - Get empty array of complex type []
 func TestGetComplexEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetComplexEmpty(context.Background())
+	resp, err := client.GetComplexEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestGetComplexEmpty(t *testing.T) {
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 func TestGetComplexItemEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetComplexItemEmpty(context.Background())
+	resp, err := client.GetComplexItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +205,7 @@ func TestGetComplexNull(t *testing.T) {
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestGetComplexValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetComplexValid(context.Background())
+	resp, err := client.GetComplexValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestGetComplexValid(t *testing.T) {
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
 func TestGetDateInvalidChars(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDateInvalidChars(context.Background())
+	resp, err := client.GetDateInvalidChars(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -236,7 +236,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
 func TestGetDateTimeInvalidChars(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDateTimeInvalidChars(context.Background())
+	resp, err := client.GetDateTimeInvalidChars(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -248,7 +248,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
 func TestGetDateTimeInvalidNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDateTimeInvalidNull(context.Background())
+	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -260,7 +260,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDateTimeRFC1123Valid(context.Background())
+	resp, err := client.GetDateTimeRFC1123Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,7 +277,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 func TestGetDateTimeValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDateTimeValid(context.Background())
+	resp, err := client.GetDateTimeValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +295,7 @@ func TestGetDateTimeValid(t *testing.T) {
 func TestGetDateValid(t *testing.T) {
 	t.Skip("needs codegen fix")
 	client := newArrayClient()
-	resp, err := client.GetDateValid(context.Background())
+	resp, err := client.GetDateValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestGetDateValid(t *testing.T) {
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
 func TestGetDictionaryEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDictionaryEmpty(context.Background())
+	resp, err := client.GetDictionaryEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDictionaryItemEmpty(context.Background())
+	resp, err := client.GetDictionaryItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +341,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDictionaryItemNull(context.Background())
+	resp, err := client.GetDictionaryItemNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func TestGetDictionaryItemNull(t *testing.T) {
 // GetDictionaryNull - Get an array of Dictionaries with value null
 func TestGetDictionaryNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDictionaryNull(context.Background())
+	resp, err := client.GetDictionaryNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +375,7 @@ func TestGetDictionaryNull(t *testing.T) {
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDictionaryValid(context.Background())
+	resp, err := client.GetDictionaryValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -402,7 +402,7 @@ func TestGetDictionaryValid(t *testing.T) {
 func TestGetDoubleInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
 	client := newArrayClient()
-	resp, err := client.GetDoubleInvalidNull(context.Background())
+	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -414,7 +414,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetDoubleInvalidString(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDoubleInvalidString(context.Background())
+	resp, err := client.GetDoubleInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -426,7 +426,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetDoubleValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDoubleValid(context.Background())
+	resp, err := client.GetDoubleValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +436,7 @@ func TestGetDoubleValid(t *testing.T) {
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestGetDurationValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetDurationValid(context.Background())
+	resp, err := client.GetDurationValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +446,7 @@ func TestGetDurationValid(t *testing.T) {
 // GetEmpty - Get empty array value []
 func TestGetEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetEmpty(context.Background())
+	resp, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -461,7 +461,7 @@ func TestGetEmpty(t *testing.T) {
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetEnumValid(context.Background())
+	resp, err := client.GetEnumValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ func TestGetEnumValid(t *testing.T) {
 func TestGetFloatInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
 	client := newArrayClient()
-	resp, err := client.GetFloatInvalidNull(context.Background())
+	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -484,7 +484,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetFloatInvalidString(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetFloatInvalidString(context.Background())
+	resp, err := client.GetFloatInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -496,7 +496,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetFloatValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetFloatValid(context.Background())
+	resp, err := client.GetFloatValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func TestGetFloatValid(t *testing.T) {
 func TestGetIntInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
 	client := newArrayClient()
-	resp, err := client.GetIntInvalidNull(context.Background())
+	resp, err := client.GetIntInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -519,7 +519,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
 func TestGetIntInvalidString(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetIntInvalidString(context.Background())
+	resp, err := client.GetIntInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -531,7 +531,7 @@ func TestGetIntInvalidString(t *testing.T) {
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
 func TestGetIntegerValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetIntegerValid(context.Background())
+	resp, err := client.GetIntegerValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -541,7 +541,7 @@ func TestGetIntegerValid(t *testing.T) {
 // GetInvalid - Get invalid array [1, 2, 3
 func TestGetInvalid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetInvalid(context.Background())
+	resp, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -554,7 +554,7 @@ func TestGetInvalid(t *testing.T) {
 func TestGetLongInvalidNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
 	client := newArrayClient()
-	resp, err := client.GetLongInvalidNull(context.Background())
+	resp, err := client.GetLongInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -566,7 +566,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
 func TestGetLongInvalidString(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetLongInvalidString(context.Background())
+	resp, err := client.GetLongInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -578,7 +578,7 @@ func TestGetLongInvalidString(t *testing.T) {
 // GetLongValid - Get integer array value [1, -1, 3, 300]
 func TestGetLongValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetLongValid(context.Background())
+	resp, err := client.GetLongValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,7 +588,7 @@ func TestGetLongValid(t *testing.T) {
 // GetNull - Get null array value
 func TestGetNull(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetNull(context.Background())
+	resp, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,7 +600,7 @@ func TestGetNull(t *testing.T) {
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetStringEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetStringEnumValid(context.Background())
+	resp, err := client.GetStringEnumValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -610,7 +610,7 @@ func TestGetStringEnumValid(t *testing.T) {
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
 func TestGetStringValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetStringValid(context.Background())
+	resp, err := client.GetStringValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,7 +620,7 @@ func TestGetStringValid(t *testing.T) {
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
 func TestGetStringWithInvalid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetStringWithInvalid(context.Background())
+	resp, err := client.GetStringWithInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -633,7 +633,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 func TestGetStringWithNull(t *testing.T) {
 	t.Skip("arrays with nil elements")
 	client := newArrayClient()
-	resp, err := client.GetStringWithNull(context.Background())
+	resp, err := client.GetStringWithNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -650,7 +650,7 @@ func TestGetUUIDInvalidChars(t *testing.T) {
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestGetUUIDValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.GetUUIDValid(context.Background())
+	resp, err := client.GetUUIDValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,7 +664,7 @@ func TestPutArrayValid(t *testing.T) {
 		[]string{"1", "2", "3"},
 		[]string{"4", "5", "6"},
 		[]string{"7", "8", "9"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -674,7 +674,7 @@ func TestPutArrayValid(t *testing.T) {
 // PutBooleanTfft - Set array value empty [true, false, false, true]
 func TestPutBooleanTfft(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutBooleanTfft(context.Background(), []bool{true, false, false, true})
+	resp, err := client.PutBooleanTfft(context.Background(), []bool{true, false, false, true}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,7 +688,7 @@ func TestPutByteValid(t *testing.T) {
 		[]byte{0xFF, 0xFF, 0xFF, 0xFA},
 		[]byte{0x01, 0x02, 0x03},
 		[]byte{0x25, 0x29, 0x43},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -702,7 +702,7 @@ func TestPutComplexValid(t *testing.T) {
 		Product{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		Product{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		Product{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -715,7 +715,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), []time.Time{v1, v2, v3})
+	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), []time.Time{v1, v2, v3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -728,7 +728,7 @@ func TestPutDateTimeValid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35Z")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01Z")
-	resp, err := client.PutDateTimeValid(context.Background(), []time.Time{v1, v2, v3})
+	resp, err := client.PutDateTimeValid(context.Background(), []time.Time{v1, v2, v3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,7 +759,7 @@ func TestPutDictionaryValid(t *testing.T) {
 			"8": "eight",
 			"9": "nine",
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +769,7 @@ func TestPutDictionaryValid(t *testing.T) {
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
 func TestPutDoubleValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDoubleValid(context.Background(), []float64{0, -0.01, -1.2e20})
+	resp, err := client.PutDoubleValid(context.Background(), []float64{0, -0.01, -1.2e20}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -779,7 +779,7 @@ func TestPutDoubleValid(t *testing.T) {
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestPutDurationValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDurationValid(context.Background(), []string{"P123DT22H14M12.011S", "P5DT1H"})
+	resp, err := client.PutDurationValid(context.Background(), []string{"P123DT22H14M12.011S", "P5DT1H"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +789,7 @@ func TestPutDurationValid(t *testing.T) {
 // PutEmpty - Set array value empty []
 func TestPutEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutEmpty(context.Background(), []string{})
+	resp, err := client.PutEmpty(context.Background(), []string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -799,7 +799,7 @@ func TestPutEmpty(t *testing.T) {
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutEnumValid(context.Background(), []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3})
+	resp, err := client.PutEnumValid(context.Background(), []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -809,7 +809,7 @@ func TestPutEnumValid(t *testing.T) {
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
 func TestPutFloatValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutFloatValid(context.Background(), []float32{0, -0.01, -1.2e20})
+	resp, err := client.PutFloatValid(context.Background(), []float32{0, -0.01, -1.2e20}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -819,7 +819,7 @@ func TestPutFloatValid(t *testing.T) {
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
 func TestPutIntegerValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutIntegerValid(context.Background(), []int32{1, -1, 3, 300})
+	resp, err := client.PutIntegerValid(context.Background(), []int32{1, -1, 3, 300}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -829,7 +829,7 @@ func TestPutIntegerValid(t *testing.T) {
 // PutLongValid - Set array value empty [1, -1, 3, 300]
 func TestPutLongValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutLongValid(context.Background(), []int64{1, -1, 3, 300})
+	resp, err := client.PutLongValid(context.Background(), []int64{1, -1, 3, 300}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,7 +839,7 @@ func TestPutLongValid(t *testing.T) {
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutStringEnumValid(context.Background(), []Enum1{Enum1Foo1, Enum1Foo2, Enum1Foo3})
+	resp, err := client.PutStringEnumValid(context.Background(), []Enum1{Enum1Foo1, Enum1Foo2, Enum1Foo3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -849,7 +849,7 @@ func TestPutStringEnumValid(t *testing.T) {
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutStringValid(context.Background(), []string{"foo1", "foo2", "foo3"})
+	resp, err := client.PutStringValid(context.Background(), []string{"foo1", "foo2", "foo3"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -859,7 +859,7 @@ func TestPutStringValid(t *testing.T) {
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestPutUUIDValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutUUIDValid(context.Background(), []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"})
+	resp, err := client.PutUUIDValid(context.Background(), []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -15,143 +15,143 @@ import (
 // ArrayOperations contains the methods for the Array group.
 type ArrayOperations interface {
 	// GetArrayEmpty - Get an empty array []
-	GetArrayEmpty(ctx context.Context) (*StringArrayArrayResponse, error)
+	GetArrayEmpty(ctx context.Context, options *ArrayGetArrayEmptyOptions) (*StringArrayArrayResponse, error)
 	// GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
-	GetArrayItemEmpty(ctx context.Context) (*StringArrayArrayResponse, error)
+	GetArrayItemEmpty(ctx context.Context, options *ArrayGetArrayItemEmptyOptions) (*StringArrayArrayResponse, error)
 	// GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
-	GetArrayItemNull(ctx context.Context) (*StringArrayArrayResponse, error)
+	GetArrayItemNull(ctx context.Context, options *ArrayGetArrayItemNullOptions) (*StringArrayArrayResponse, error)
 	// GetArrayNull - Get a null array
-	GetArrayNull(ctx context.Context) (*StringArrayArrayResponse, error)
+	GetArrayNull(ctx context.Context, options *ArrayGetArrayNullOptions) (*StringArrayArrayResponse, error)
 	// GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-	GetArrayValid(ctx context.Context) (*StringArrayArrayResponse, error)
+	GetArrayValid(ctx context.Context, options *ArrayGetArrayValidOptions) (*StringArrayArrayResponse, error)
 	// GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
-	GetBase64URL(ctx context.Context) (*ByteArrayArrayResponse, error)
+	GetBase64URL(ctx context.Context, options *ArrayGetBase64URLOptions) (*ByteArrayArrayResponse, error)
 	// GetBooleanInvalidNull - Get boolean array value [true, null, false]
-	GetBooleanInvalidNull(ctx context.Context) (*BoolArrayResponse, error)
+	GetBooleanInvalidNull(ctx context.Context, options *ArrayGetBooleanInvalidNullOptions) (*BoolArrayResponse, error)
 	// GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
-	GetBooleanInvalidString(ctx context.Context) (*BoolArrayResponse, error)
+	GetBooleanInvalidString(ctx context.Context, options *ArrayGetBooleanInvalidStringOptions) (*BoolArrayResponse, error)
 	// GetBooleanTfft - Get boolean array value [true, false, false, true]
-	GetBooleanTfft(ctx context.Context) (*BoolArrayResponse, error)
+	GetBooleanTfft(ctx context.Context, options *ArrayGetBooleanTfftOptions) (*BoolArrayResponse, error)
 	// GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
-	GetByteInvalidNull(ctx context.Context) (*ByteArrayArrayResponse, error)
+	GetByteInvalidNull(ctx context.Context, options *ArrayGetByteInvalidNullOptions) (*ByteArrayArrayResponse, error)
 	// GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
-	GetByteValid(ctx context.Context) (*ByteArrayArrayResponse, error)
+	GetByteValid(ctx context.Context, options *ArrayGetByteValidOptions) (*ByteArrayArrayResponse, error)
 	// GetComplexEmpty - Get empty array of complex type []
-	GetComplexEmpty(ctx context.Context) (*ProductArrayResponse, error)
+	GetComplexEmpty(ctx context.Context, options *ArrayGetComplexEmptyOptions) (*ProductArrayResponse, error)
 	// GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
-	GetComplexItemEmpty(ctx context.Context) (*ProductArrayResponse, error)
+	GetComplexItemEmpty(ctx context.Context, options *ArrayGetComplexItemEmptyOptions) (*ProductArrayResponse, error)
 	// GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
-	GetComplexItemNull(ctx context.Context) (*ProductArrayResponse, error)
+	GetComplexItemNull(ctx context.Context, options *ArrayGetComplexItemNullOptions) (*ProductArrayResponse, error)
 	// GetComplexNull - Get array of complex type null value
-	GetComplexNull(ctx context.Context) (*ProductArrayResponse, error)
+	GetComplexNull(ctx context.Context, options *ArrayGetComplexNullOptions) (*ProductArrayResponse, error)
 	// GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
-	GetComplexValid(ctx context.Context) (*ProductArrayResponse, error)
+	GetComplexValid(ctx context.Context, options *ArrayGetComplexValidOptions) (*ProductArrayResponse, error)
 	// GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
-	GetDateInvalidChars(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateInvalidChars(ctx context.Context, options *ArrayGetDateInvalidCharsOptions) (*TimeArrayResponse, error)
 	// GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
-	GetDateInvalidNull(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateInvalidNull(ctx context.Context, options *ArrayGetDateInvalidNullOptions) (*TimeArrayResponse, error)
 	// GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
-	GetDateTimeInvalidChars(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateTimeInvalidChars(ctx context.Context, options *ArrayGetDateTimeInvalidCharsOptions) (*TimeArrayResponse, error)
 	// GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
-	GetDateTimeInvalidNull(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateTimeInvalidNull(ctx context.Context, options *ArrayGetDateTimeInvalidNullOptions) (*TimeArrayResponse, error)
 	// GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
-	GetDateTimeRFC1123Valid(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateTimeRFC1123Valid(ctx context.Context, options *ArrayGetDateTimeRFC1123ValidOptions) (*TimeArrayResponse, error)
 	// GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-	GetDateTimeValid(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateTimeValid(ctx context.Context, options *ArrayGetDateTimeValidOptions) (*TimeArrayResponse, error)
 	// GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
-	GetDateValid(ctx context.Context) (*TimeArrayResponse, error)
+	GetDateValid(ctx context.Context, options *ArrayGetDateValidOptions) (*TimeArrayResponse, error)
 	// GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
-	GetDictionaryEmpty(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetDictionaryEmpty(ctx context.Context, options *ArrayGetDictionaryEmptyOptions) (*MapOfStringArrayResponse, error)
 	// GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-	GetDictionaryItemEmpty(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetDictionaryItemEmpty(ctx context.Context, options *ArrayGetDictionaryItemEmptyOptions) (*MapOfStringArrayResponse, error)
 	// GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-	GetDictionaryItemNull(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetDictionaryItemNull(ctx context.Context, options *ArrayGetDictionaryItemNullOptions) (*MapOfStringArrayResponse, error)
 	// GetDictionaryNull - Get an array of Dictionaries with value null
-	GetDictionaryNull(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetDictionaryNull(ctx context.Context, options *ArrayGetDictionaryNullOptions) (*MapOfStringArrayResponse, error)
 	// GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-	GetDictionaryValid(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetDictionaryValid(ctx context.Context, options *ArrayGetDictionaryValidOptions) (*MapOfStringArrayResponse, error)
 	// GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
-	GetDoubleInvalidNull(ctx context.Context) (*Float64ArrayResponse, error)
+	GetDoubleInvalidNull(ctx context.Context, options *ArrayGetDoubleInvalidNullOptions) (*Float64ArrayResponse, error)
 	// GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
-	GetDoubleInvalidString(ctx context.Context) (*Float64ArrayResponse, error)
+	GetDoubleInvalidString(ctx context.Context, options *ArrayGetDoubleInvalidStringOptions) (*Float64ArrayResponse, error)
 	// GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
-	GetDoubleValid(ctx context.Context) (*Float64ArrayResponse, error)
+	GetDoubleValid(ctx context.Context, options *ArrayGetDoubleValidOptions) (*Float64ArrayResponse, error)
 	// GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-	GetDurationValid(ctx context.Context) (*StringArrayResponse, error)
+	GetDurationValid(ctx context.Context, options *ArrayGetDurationValidOptions) (*StringArrayResponse, error)
 	// GetEmpty - Get empty array value []
-	GetEmpty(ctx context.Context) (*Int32ArrayResponse, error)
+	GetEmpty(ctx context.Context, options *ArrayGetEmptyOptions) (*Int32ArrayResponse, error)
 	// GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
-	GetEnumValid(ctx context.Context) (*FooEnumArrayResponse, error)
+	GetEnumValid(ctx context.Context, options *ArrayGetEnumValidOptions) (*FooEnumArrayResponse, error)
 	// GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
-	GetFloatInvalidNull(ctx context.Context) (*Float32ArrayResponse, error)
+	GetFloatInvalidNull(ctx context.Context, options *ArrayGetFloatInvalidNullOptions) (*Float32ArrayResponse, error)
 	// GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
-	GetFloatInvalidString(ctx context.Context) (*Float32ArrayResponse, error)
+	GetFloatInvalidString(ctx context.Context, options *ArrayGetFloatInvalidStringOptions) (*Float32ArrayResponse, error)
 	// GetFloatValid - Get float array value [0, -0.01, 1.2e20]
-	GetFloatValid(ctx context.Context) (*Float32ArrayResponse, error)
+	GetFloatValid(ctx context.Context, options *ArrayGetFloatValidOptions) (*Float32ArrayResponse, error)
 	// GetIntInvalidNull - Get integer array value [1, null, 0]
-	GetIntInvalidNull(ctx context.Context) (*Int32ArrayResponse, error)
+	GetIntInvalidNull(ctx context.Context, options *ArrayGetIntInvalidNullOptions) (*Int32ArrayResponse, error)
 	// GetIntInvalidString - Get integer array value [1, 'integer', 0]
-	GetIntInvalidString(ctx context.Context) (*Int32ArrayResponse, error)
+	GetIntInvalidString(ctx context.Context, options *ArrayGetIntInvalidStringOptions) (*Int32ArrayResponse, error)
 	// GetIntegerValid - Get integer array value [1, -1, 3, 300]
-	GetIntegerValid(ctx context.Context) (*Int32ArrayResponse, error)
+	GetIntegerValid(ctx context.Context, options *ArrayGetIntegerValidOptions) (*Int32ArrayResponse, error)
 	// GetInvalid - Get invalid array [1, 2, 3
-	GetInvalid(ctx context.Context) (*Int32ArrayResponse, error)
+	GetInvalid(ctx context.Context, options *ArrayGetInvalidOptions) (*Int32ArrayResponse, error)
 	// GetLongInvalidNull - Get long array value [1, null, 0]
-	GetLongInvalidNull(ctx context.Context) (*Int64ArrayResponse, error)
+	GetLongInvalidNull(ctx context.Context, options *ArrayGetLongInvalidNullOptions) (*Int64ArrayResponse, error)
 	// GetLongInvalidString - Get long array value [1, 'integer', 0]
-	GetLongInvalidString(ctx context.Context) (*Int64ArrayResponse, error)
+	GetLongInvalidString(ctx context.Context, options *ArrayGetLongInvalidStringOptions) (*Int64ArrayResponse, error)
 	// GetLongValid - Get integer array value [1, -1, 3, 300]
-	GetLongValid(ctx context.Context) (*Int64ArrayResponse, error)
+	GetLongValid(ctx context.Context, options *ArrayGetLongValidOptions) (*Int64ArrayResponse, error)
 	// GetNull - Get null array value
-	GetNull(ctx context.Context) (*Int32ArrayResponse, error)
+	GetNull(ctx context.Context, options *ArrayGetNullOptions) (*Int32ArrayResponse, error)
 	// GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
-	GetStringEnumValid(ctx context.Context) (*Enum0ArrayResponse, error)
+	GetStringEnumValid(ctx context.Context, options *ArrayGetStringEnumValidOptions) (*Enum0ArrayResponse, error)
 	// GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
-	GetStringValid(ctx context.Context) (*StringArrayResponse, error)
+	GetStringValid(ctx context.Context, options *ArrayGetStringValidOptions) (*StringArrayResponse, error)
 	// GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
-	GetStringWithInvalid(ctx context.Context) (*StringArrayResponse, error)
+	GetStringWithInvalid(ctx context.Context, options *ArrayGetStringWithInvalidOptions) (*StringArrayResponse, error)
 	// GetStringWithNull - Get string array value ['foo', null, 'foo2']
-	GetStringWithNull(ctx context.Context) (*StringArrayResponse, error)
+	GetStringWithNull(ctx context.Context, options *ArrayGetStringWithNullOptions) (*StringArrayResponse, error)
 	// GetUUIDInvalidChars - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
-	GetUUIDInvalidChars(ctx context.Context) (*StringArrayResponse, error)
+	GetUUIDInvalidChars(ctx context.Context, options *ArrayGetUUIDInvalidCharsOptions) (*StringArrayResponse, error)
 	// GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-	GetUUIDValid(ctx context.Context) (*StringArrayResponse, error)
+	GetUUIDValid(ctx context.Context, options *ArrayGetUUIDValidOptions) (*StringArrayResponse, error)
 	// PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-	PutArrayValid(ctx context.Context, arrayBody [][]string) (*http.Response, error)
+	PutArrayValid(ctx context.Context, arrayBody [][]string, options *ArrayPutArrayValidOptions) (*http.Response, error)
 	// PutBooleanTfft - Set array value empty [true, false, false, true]
-	PutBooleanTfft(ctx context.Context, arrayBody []bool) (*http.Response, error)
+	PutBooleanTfft(ctx context.Context, arrayBody []bool, options *ArrayPutBooleanTfftOptions) (*http.Response, error)
 	// PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
-	PutByteValid(ctx context.Context, arrayBody [][]byte) (*http.Response, error)
+	PutByteValid(ctx context.Context, arrayBody [][]byte, options *ArrayPutByteValidOptions) (*http.Response, error)
 	// PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
-	PutComplexValid(ctx context.Context, arrayBody []Product) (*http.Response, error)
+	PutComplexValid(ctx context.Context, arrayBody []Product, options *ArrayPutComplexValidOptions) (*http.Response, error)
 	// PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
-	PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []time.Time) (*http.Response, error)
+	PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*http.Response, error)
 	// PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-	PutDateTimeValid(ctx context.Context, arrayBody []time.Time) (*http.Response, error)
+	PutDateTimeValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeValidOptions) (*http.Response, error)
 	// PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
-	PutDateValid(ctx context.Context, arrayBody []time.Time) (*http.Response, error)
+	PutDateValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateValidOptions) (*http.Response, error)
 	// PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-	PutDictionaryValid(ctx context.Context, arrayBody []map[string]string) (*http.Response, error)
+	PutDictionaryValid(ctx context.Context, arrayBody []map[string]string, options *ArrayPutDictionaryValidOptions) (*http.Response, error)
 	// PutDoubleValid - Set array value [0, -0.01, 1.2e20]
-	PutDoubleValid(ctx context.Context, arrayBody []float64) (*http.Response, error)
+	PutDoubleValid(ctx context.Context, arrayBody []float64, options *ArrayPutDoubleValidOptions) (*http.Response, error)
 	// PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-	PutDurationValid(ctx context.Context, arrayBody []string) (*http.Response, error)
+	PutDurationValid(ctx context.Context, arrayBody []string, options *ArrayPutDurationValidOptions) (*http.Response, error)
 	// PutEmpty - Set array value empty []
-	PutEmpty(ctx context.Context, arrayBody []string) (*http.Response, error)
+	PutEmpty(ctx context.Context, arrayBody []string, options *ArrayPutEmptyOptions) (*http.Response, error)
 	// PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-	PutEnumValid(ctx context.Context, arrayBody []FooEnum) (*http.Response, error)
+	PutEnumValid(ctx context.Context, arrayBody []FooEnum, options *ArrayPutEnumValidOptions) (*http.Response, error)
 	// PutFloatValid - Set array value [0, -0.01, 1.2e20]
-	PutFloatValid(ctx context.Context, arrayBody []float32) (*http.Response, error)
+	PutFloatValid(ctx context.Context, arrayBody []float32, options *ArrayPutFloatValidOptions) (*http.Response, error)
 	// PutIntegerValid - Set array value empty [1, -1, 3, 300]
-	PutIntegerValid(ctx context.Context, arrayBody []int32) (*http.Response, error)
+	PutIntegerValid(ctx context.Context, arrayBody []int32, options *ArrayPutIntegerValidOptions) (*http.Response, error)
 	// PutLongValid - Set array value empty [1, -1, 3, 300]
-	PutLongValid(ctx context.Context, arrayBody []int64) (*http.Response, error)
+	PutLongValid(ctx context.Context, arrayBody []int64, options *ArrayPutLongValidOptions) (*http.Response, error)
 	// PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-	PutStringEnumValid(ctx context.Context, arrayBody []Enum1) (*http.Response, error)
+	PutStringEnumValid(ctx context.Context, arrayBody []Enum1, options *ArrayPutStringEnumValidOptions) (*http.Response, error)
 	// PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
-	PutStringValid(ctx context.Context, arrayBody []string) (*http.Response, error)
+	PutStringValid(ctx context.Context, arrayBody []string, options *ArrayPutStringValidOptions) (*http.Response, error)
 	// PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-	PutUUIDValid(ctx context.Context, arrayBody []string) (*http.Response, error)
+	PutUUIDValid(ctx context.Context, arrayBody []string, options *ArrayPutUUIDValidOptions) (*http.Response, error)
 }
 
 // ArrayClient implements the ArrayOperations interface.
@@ -171,8 +171,8 @@ func (client *ArrayClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetArrayEmpty - Get an empty array []
-func (client *ArrayClient) GetArrayEmpty(ctx context.Context) (*StringArrayArrayResponse, error) {
-	req, err := client.GetArrayEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetArrayEmpty(ctx context.Context, options *ArrayGetArrayEmptyOptions) (*StringArrayArrayResponse, error) {
+	req, err := client.GetArrayEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (client *ArrayClient) GetArrayEmpty(ctx context.Context) (*StringArrayArray
 }
 
 // GetArrayEmptyCreateRequest creates the GetArrayEmpty request.
-func (client *ArrayClient) GetArrayEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetArrayEmptyCreateRequest(ctx context.Context, options *ArrayGetArrayEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -217,8 +217,8 @@ func (client *ArrayClient) GetArrayEmptyHandleError(resp *azcore.Response) error
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
-func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context) (*StringArrayArrayResponse, error) {
-	req, err := client.GetArrayItemEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context, options *ArrayGetArrayItemEmptyOptions) (*StringArrayArrayResponse, error) {
+	req, err := client.GetArrayItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context) (*StringArrayA
 }
 
 // GetArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
-func (client *ArrayClient) GetArrayItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetArrayItemEmptyCreateRequest(ctx context.Context, options *ArrayGetArrayItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -263,8 +263,8 @@ func (client *ArrayClient) GetArrayItemEmptyHandleError(resp *azcore.Response) e
 }
 
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
-func (client *ArrayClient) GetArrayItemNull(ctx context.Context) (*StringArrayArrayResponse, error) {
-	req, err := client.GetArrayItemNullCreateRequest(ctx)
+func (client *ArrayClient) GetArrayItemNull(ctx context.Context, options *ArrayGetArrayItemNullOptions) (*StringArrayArrayResponse, error) {
+	req, err := client.GetArrayItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func (client *ArrayClient) GetArrayItemNull(ctx context.Context) (*StringArrayAr
 }
 
 // GetArrayItemNullCreateRequest creates the GetArrayItemNull request.
-func (client *ArrayClient) GetArrayItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetArrayItemNullCreateRequest(ctx context.Context, options *ArrayGetArrayItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -309,8 +309,8 @@ func (client *ArrayClient) GetArrayItemNullHandleError(resp *azcore.Response) er
 }
 
 // GetArrayNull - Get a null array
-func (client *ArrayClient) GetArrayNull(ctx context.Context) (*StringArrayArrayResponse, error) {
-	req, err := client.GetArrayNullCreateRequest(ctx)
+func (client *ArrayClient) GetArrayNull(ctx context.Context, options *ArrayGetArrayNullOptions) (*StringArrayArrayResponse, error) {
+	req, err := client.GetArrayNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (client *ArrayClient) GetArrayNull(ctx context.Context) (*StringArrayArrayR
 }
 
 // GetArrayNullCreateRequest creates the GetArrayNull request.
-func (client *ArrayClient) GetArrayNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetArrayNullCreateRequest(ctx context.Context, options *ArrayGetArrayNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -355,8 +355,8 @@ func (client *ArrayClient) GetArrayNullHandleError(resp *azcore.Response) error 
 }
 
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-func (client *ArrayClient) GetArrayValid(ctx context.Context) (*StringArrayArrayResponse, error) {
-	req, err := client.GetArrayValidCreateRequest(ctx)
+func (client *ArrayClient) GetArrayValid(ctx context.Context, options *ArrayGetArrayValidOptions) (*StringArrayArrayResponse, error) {
+	req, err := client.GetArrayValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (client *ArrayClient) GetArrayValid(ctx context.Context) (*StringArrayArray
 }
 
 // GetArrayValidCreateRequest creates the GetArrayValid request.
-func (client *ArrayClient) GetArrayValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetArrayValidCreateRequest(ctx context.Context, options *ArrayGetArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -401,8 +401,8 @@ func (client *ArrayClient) GetArrayValidHandleError(resp *azcore.Response) error
 }
 
 // GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
-func (client *ArrayClient) GetBase64URL(ctx context.Context) (*ByteArrayArrayResponse, error) {
-	req, err := client.GetBase64URLCreateRequest(ctx)
+func (client *ArrayClient) GetBase64URL(ctx context.Context, options *ArrayGetBase64URLOptions) (*ByteArrayArrayResponse, error) {
+	req, err := client.GetBase64URLCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -421,7 +421,7 @@ func (client *ArrayClient) GetBase64URL(ctx context.Context) (*ByteArrayArrayRes
 }
 
 // GetBase64URLCreateRequest creates the GetBase64URL request.
-func (client *ArrayClient) GetBase64URLCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetBase64URLCreateRequest(ctx context.Context, options *ArrayGetBase64URLOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/base64url/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -447,8 +447,8 @@ func (client *ArrayClient) GetBase64URLHandleError(resp *azcore.Response) error 
 }
 
 // GetBooleanInvalidNull - Get boolean array value [true, null, false]
-func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context) (*BoolArrayResponse, error) {
-	req, err := client.GetBooleanInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context, options *ArrayGetBooleanInvalidNullOptions) (*BoolArrayResponse, error) {
+	req, err := client.GetBooleanInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -467,7 +467,7 @@ func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context) (*BoolArra
 }
 
 // GetBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
-func (client *ArrayClient) GetBooleanInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetBooleanInvalidNullCreateRequest(ctx context.Context, options *ArrayGetBooleanInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/true.null.false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -493,8 +493,8 @@ func (client *ArrayClient) GetBooleanInvalidNullHandleError(resp *azcore.Respons
 }
 
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
-func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context) (*BoolArrayResponse, error) {
-	req, err := client.GetBooleanInvalidStringCreateRequest(ctx)
+func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context, options *ArrayGetBooleanInvalidStringOptions) (*BoolArrayResponse, error) {
+	req, err := client.GetBooleanInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +513,7 @@ func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context) (*BoolAr
 }
 
 // GetBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
-func (client *ArrayClient) GetBooleanInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetBooleanInvalidStringCreateRequest(ctx context.Context, options *ArrayGetBooleanInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/true.boolean.false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -539,8 +539,8 @@ func (client *ArrayClient) GetBooleanInvalidStringHandleError(resp *azcore.Respo
 }
 
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
-func (client *ArrayClient) GetBooleanTfft(ctx context.Context) (*BoolArrayResponse, error) {
-	req, err := client.GetBooleanTfftCreateRequest(ctx)
+func (client *ArrayClient) GetBooleanTfft(ctx context.Context, options *ArrayGetBooleanTfftOptions) (*BoolArrayResponse, error) {
+	req, err := client.GetBooleanTfftCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (client *ArrayClient) GetBooleanTfft(ctx context.Context) (*BoolArrayRespon
 }
 
 // GetBooleanTfftCreateRequest creates the GetBooleanTfft request.
-func (client *ArrayClient) GetBooleanTfftCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetBooleanTfftCreateRequest(ctx context.Context, options *ArrayGetBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -585,8 +585,8 @@ func (client *ArrayClient) GetBooleanTfftHandleError(resp *azcore.Response) erro
 }
 
 // GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
-func (client *ArrayClient) GetByteInvalidNull(ctx context.Context) (*ByteArrayArrayResponse, error) {
-	req, err := client.GetByteInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetByteInvalidNull(ctx context.Context, options *ArrayGetByteInvalidNullOptions) (*ByteArrayArrayResponse, error) {
+	req, err := client.GetByteInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +605,7 @@ func (client *ArrayClient) GetByteInvalidNull(ctx context.Context) (*ByteArrayAr
 }
 
 // GetByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
-func (client *ArrayClient) GetByteInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetByteInvalidNullCreateRequest(ctx context.Context, options *ArrayGetByteInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -631,8 +631,8 @@ func (client *ArrayClient) GetByteInvalidNullHandleError(resp *azcore.Response) 
 }
 
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
-func (client *ArrayClient) GetByteValid(ctx context.Context) (*ByteArrayArrayResponse, error) {
-	req, err := client.GetByteValidCreateRequest(ctx)
+func (client *ArrayClient) GetByteValid(ctx context.Context, options *ArrayGetByteValidOptions) (*ByteArrayArrayResponse, error) {
+	req, err := client.GetByteValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (client *ArrayClient) GetByteValid(ctx context.Context) (*ByteArrayArrayRes
 }
 
 // GetByteValidCreateRequest creates the GetByteValid request.
-func (client *ArrayClient) GetByteValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetByteValidCreateRequest(ctx context.Context, options *ArrayGetByteValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -677,8 +677,8 @@ func (client *ArrayClient) GetByteValidHandleError(resp *azcore.Response) error 
 }
 
 // GetComplexEmpty - Get empty array of complex type []
-func (client *ArrayClient) GetComplexEmpty(ctx context.Context) (*ProductArrayResponse, error) {
-	req, err := client.GetComplexEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetComplexEmpty(ctx context.Context, options *ArrayGetComplexEmptyOptions) (*ProductArrayResponse, error) {
+	req, err := client.GetComplexEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +697,7 @@ func (client *ArrayClient) GetComplexEmpty(ctx context.Context) (*ProductArrayRe
 }
 
 // GetComplexEmptyCreateRequest creates the GetComplexEmpty request.
-func (client *ArrayClient) GetComplexEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetComplexEmptyCreateRequest(ctx context.Context, options *ArrayGetComplexEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -723,8 +723,8 @@ func (client *ArrayClient) GetComplexEmptyHandleError(resp *azcore.Response) err
 }
 
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
-func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context) (*ProductArrayResponse, error) {
-	req, err := client.GetComplexItemEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context, options *ArrayGetComplexItemEmptyOptions) (*ProductArrayResponse, error) {
+	req, err := client.GetComplexItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +743,7 @@ func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context) (*ProductArr
 }
 
 // GetComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
-func (client *ArrayClient) GetComplexItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetComplexItemEmptyCreateRequest(ctx context.Context, options *ArrayGetComplexItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -769,8 +769,8 @@ func (client *ArrayClient) GetComplexItemEmptyHandleError(resp *azcore.Response)
 }
 
 // GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
-func (client *ArrayClient) GetComplexItemNull(ctx context.Context) (*ProductArrayResponse, error) {
-	req, err := client.GetComplexItemNullCreateRequest(ctx)
+func (client *ArrayClient) GetComplexItemNull(ctx context.Context, options *ArrayGetComplexItemNullOptions) (*ProductArrayResponse, error) {
+	req, err := client.GetComplexItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +789,7 @@ func (client *ArrayClient) GetComplexItemNull(ctx context.Context) (*ProductArra
 }
 
 // GetComplexItemNullCreateRequest creates the GetComplexItemNull request.
-func (client *ArrayClient) GetComplexItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetComplexItemNullCreateRequest(ctx context.Context, options *ArrayGetComplexItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -815,8 +815,8 @@ func (client *ArrayClient) GetComplexItemNullHandleError(resp *azcore.Response) 
 }
 
 // GetComplexNull - Get array of complex type null value
-func (client *ArrayClient) GetComplexNull(ctx context.Context) (*ProductArrayResponse, error) {
-	req, err := client.GetComplexNullCreateRequest(ctx)
+func (client *ArrayClient) GetComplexNull(ctx context.Context, options *ArrayGetComplexNullOptions) (*ProductArrayResponse, error) {
+	req, err := client.GetComplexNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +835,7 @@ func (client *ArrayClient) GetComplexNull(ctx context.Context) (*ProductArrayRes
 }
 
 // GetComplexNullCreateRequest creates the GetComplexNull request.
-func (client *ArrayClient) GetComplexNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetComplexNullCreateRequest(ctx context.Context, options *ArrayGetComplexNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -861,8 +861,8 @@ func (client *ArrayClient) GetComplexNullHandleError(resp *azcore.Response) erro
 }
 
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
-func (client *ArrayClient) GetComplexValid(ctx context.Context) (*ProductArrayResponse, error) {
-	req, err := client.GetComplexValidCreateRequest(ctx)
+func (client *ArrayClient) GetComplexValid(ctx context.Context, options *ArrayGetComplexValidOptions) (*ProductArrayResponse, error) {
+	req, err := client.GetComplexValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -881,7 +881,7 @@ func (client *ArrayClient) GetComplexValid(ctx context.Context) (*ProductArrayRe
 }
 
 // GetComplexValidCreateRequest creates the GetComplexValid request.
-func (client *ArrayClient) GetComplexValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetComplexValidCreateRequest(ctx context.Context, options *ArrayGetComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -907,8 +907,8 @@ func (client *ArrayClient) GetComplexValidHandleError(resp *azcore.Response) err
 }
 
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
-func (client *ArrayClient) GetDateInvalidChars(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateInvalidCharsCreateRequest(ctx)
+func (client *ArrayClient) GetDateInvalidChars(ctx context.Context, options *ArrayGetDateInvalidCharsOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateInvalidCharsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -927,7 +927,7 @@ func (client *ArrayClient) GetDateInvalidChars(ctx context.Context) (*TimeArrayR
 }
 
 // GetDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
-func (client *ArrayClient) GetDateInvalidCharsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateInvalidCharsCreateRequest(ctx context.Context, options *ArrayGetDateInvalidCharsOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/invalidchars"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -953,8 +953,8 @@ func (client *ArrayClient) GetDateInvalidCharsHandleError(resp *azcore.Response)
 }
 
 // GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
-func (client *ArrayClient) GetDateInvalidNull(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetDateInvalidNull(ctx context.Context, options *ArrayGetDateInvalidNullOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +973,7 @@ func (client *ArrayClient) GetDateInvalidNull(ctx context.Context) (*TimeArrayRe
 }
 
 // GetDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
-func (client *ArrayClient) GetDateInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateInvalidNullCreateRequest(ctx context.Context, options *ArrayGetDateInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -999,8 +999,8 @@ func (client *ArrayClient) GetDateInvalidNullHandleError(resp *azcore.Response) 
 }
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
-func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateTimeInvalidCharsCreateRequest(ctx)
+func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context, options *ArrayGetDateTimeInvalidCharsOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateTimeInvalidCharsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,7 +1019,7 @@ func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context) (*TimeAr
 }
 
 // GetDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
-func (client *ArrayClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Context, options *ArrayGetDateTimeInvalidCharsOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/invalidchars"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1052,8 +1052,8 @@ func (client *ArrayClient) GetDateTimeInvalidCharsHandleError(resp *azcore.Respo
 }
 
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
-func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateTimeInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context, options *ArrayGetDateTimeInvalidNullOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateTimeInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,7 +1072,7 @@ func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context) (*TimeArr
 }
 
 // GetDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
-func (client *ArrayClient) GetDateTimeInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateTimeInvalidNullCreateRequest(ctx context.Context, options *ArrayGetDateTimeInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1105,8 +1105,8 @@ func (client *ArrayClient) GetDateTimeInvalidNullHandleError(resp *azcore.Respon
 }
 
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
-func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateTimeRFC1123ValidCreateRequest(ctx)
+func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context, options *ArrayGetDateTimeRFC1123ValidOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateTimeRFC1123ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1125,7 @@ func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context) (*TimeAr
 }
 
 // GetDateTimeRFC1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
-func (client *ArrayClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Context, options *ArrayGetDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1158,8 +1158,8 @@ func (client *ArrayClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.Respo
 }
 
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-func (client *ArrayClient) GetDateTimeValid(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateTimeValidCreateRequest(ctx)
+func (client *ArrayClient) GetDateTimeValid(ctx context.Context, options *ArrayGetDateTimeValidOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateTimeValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1178,7 +1178,7 @@ func (client *ArrayClient) GetDateTimeValid(ctx context.Context) (*TimeArrayResp
 }
 
 // GetDateTimeValidCreateRequest creates the GetDateTimeValid request.
-func (client *ArrayClient) GetDateTimeValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateTimeValidCreateRequest(ctx context.Context, options *ArrayGetDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1211,8 +1211,8 @@ func (client *ArrayClient) GetDateTimeValidHandleError(resp *azcore.Response) er
 }
 
 // GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
-func (client *ArrayClient) GetDateValid(ctx context.Context) (*TimeArrayResponse, error) {
-	req, err := client.GetDateValidCreateRequest(ctx)
+func (client *ArrayClient) GetDateValid(ctx context.Context, options *ArrayGetDateValidOptions) (*TimeArrayResponse, error) {
+	req, err := client.GetDateValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1231,7 +1231,7 @@ func (client *ArrayClient) GetDateValid(ctx context.Context) (*TimeArrayResponse
 }
 
 // GetDateValidCreateRequest creates the GetDateValid request.
-func (client *ArrayClient) GetDateValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDateValidCreateRequest(ctx context.Context, options *ArrayGetDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1257,8 +1257,8 @@ func (client *ArrayClient) GetDateValidHandleError(resp *azcore.Response) error 
 }
 
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
-func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetDictionaryEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context, options *ArrayGetDictionaryEmptyOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetDictionaryEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1277,7 +1277,7 @@ func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context) (*MapOfString
 }
 
 // GetDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
-func (client *ArrayClient) GetDictionaryEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDictionaryEmptyCreateRequest(ctx context.Context, options *ArrayGetDictionaryEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1303,8 +1303,8 @@ func (client *ArrayClient) GetDictionaryEmptyHandleError(resp *azcore.Response) 
 }
 
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetDictionaryItemEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context, options *ArrayGetDictionaryItemEmptyOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetDictionaryItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1323,7 +1323,7 @@ func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context) (*MapOfSt
 }
 
 // GetDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
-func (client *ArrayClient) GetDictionaryItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDictionaryItemEmptyCreateRequest(ctx context.Context, options *ArrayGetDictionaryItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1349,8 +1349,8 @@ func (client *ArrayClient) GetDictionaryItemEmptyHandleError(resp *azcore.Respon
 }
 
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetDictionaryItemNullCreateRequest(ctx)
+func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context, options *ArrayGetDictionaryItemNullOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetDictionaryItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1369,7 +1369,7 @@ func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context) (*MapOfStr
 }
 
 // GetDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
-func (client *ArrayClient) GetDictionaryItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDictionaryItemNullCreateRequest(ctx context.Context, options *ArrayGetDictionaryItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1395,8 +1395,8 @@ func (client *ArrayClient) GetDictionaryItemNullHandleError(resp *azcore.Respons
 }
 
 // GetDictionaryNull - Get an array of Dictionaries with value null
-func (client *ArrayClient) GetDictionaryNull(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetDictionaryNullCreateRequest(ctx)
+func (client *ArrayClient) GetDictionaryNull(ctx context.Context, options *ArrayGetDictionaryNullOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetDictionaryNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1415,7 +1415,7 @@ func (client *ArrayClient) GetDictionaryNull(ctx context.Context) (*MapOfStringA
 }
 
 // GetDictionaryNullCreateRequest creates the GetDictionaryNull request.
-func (client *ArrayClient) GetDictionaryNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDictionaryNullCreateRequest(ctx context.Context, options *ArrayGetDictionaryNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1441,8 +1441,8 @@ func (client *ArrayClient) GetDictionaryNullHandleError(resp *azcore.Response) e
 }
 
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-func (client *ArrayClient) GetDictionaryValid(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetDictionaryValidCreateRequest(ctx)
+func (client *ArrayClient) GetDictionaryValid(ctx context.Context, options *ArrayGetDictionaryValidOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetDictionaryValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1461,7 +1461,7 @@ func (client *ArrayClient) GetDictionaryValid(ctx context.Context) (*MapOfString
 }
 
 // GetDictionaryValidCreateRequest creates the GetDictionaryValid request.
-func (client *ArrayClient) GetDictionaryValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDictionaryValidCreateRequest(ctx context.Context, options *ArrayGetDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1487,8 +1487,8 @@ func (client *ArrayClient) GetDictionaryValidHandleError(resp *azcore.Response) 
 }
 
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
-func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context) (*Float64ArrayResponse, error) {
-	req, err := client.GetDoubleInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context, options *ArrayGetDoubleInvalidNullOptions) (*Float64ArrayResponse, error) {
+	req, err := client.GetDoubleInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1507,7 +1507,7 @@ func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context) (*Float64Ar
 }
 
 // GetDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
-func (client *ArrayClient) GetDoubleInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDoubleInvalidNullCreateRequest(ctx context.Context, options *ArrayGetDoubleInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0.0-null-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1533,8 +1533,8 @@ func (client *ArrayClient) GetDoubleInvalidNullHandleError(resp *azcore.Response
 }
 
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
-func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context) (*Float64ArrayResponse, error) {
-	req, err := client.GetDoubleInvalidStringCreateRequest(ctx)
+func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context, options *ArrayGetDoubleInvalidStringOptions) (*Float64ArrayResponse, error) {
+	req, err := client.GetDoubleInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1553,7 +1553,7 @@ func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context) (*Float64
 }
 
 // GetDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
-func (client *ArrayClient) GetDoubleInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDoubleInvalidStringCreateRequest(ctx context.Context, options *ArrayGetDoubleInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/1.number.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1579,8 +1579,8 @@ func (client *ArrayClient) GetDoubleInvalidStringHandleError(resp *azcore.Respon
 }
 
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) GetDoubleValid(ctx context.Context) (*Float64ArrayResponse, error) {
-	req, err := client.GetDoubleValidCreateRequest(ctx)
+func (client *ArrayClient) GetDoubleValid(ctx context.Context, options *ArrayGetDoubleValidOptions) (*Float64ArrayResponse, error) {
+	req, err := client.GetDoubleValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1599,7 +1599,7 @@ func (client *ArrayClient) GetDoubleValid(ctx context.Context) (*Float64ArrayRes
 }
 
 // GetDoubleValidCreateRequest creates the GetDoubleValid request.
-func (client *ArrayClient) GetDoubleValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDoubleValidCreateRequest(ctx context.Context, options *ArrayGetDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1625,8 +1625,8 @@ func (client *ArrayClient) GetDoubleValidHandleError(resp *azcore.Response) erro
 }
 
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-func (client *ArrayClient) GetDurationValid(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetDurationValidCreateRequest(ctx)
+func (client *ArrayClient) GetDurationValid(ctx context.Context, options *ArrayGetDurationValidOptions) (*StringArrayResponse, error) {
+	req, err := client.GetDurationValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1645,7 +1645,7 @@ func (client *ArrayClient) GetDurationValid(ctx context.Context) (*StringArrayRe
 }
 
 // GetDurationValidCreateRequest creates the GetDurationValid request.
-func (client *ArrayClient) GetDurationValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetDurationValidCreateRequest(ctx context.Context, options *ArrayGetDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1671,8 +1671,8 @@ func (client *ArrayClient) GetDurationValidHandleError(resp *azcore.Response) er
 }
 
 // GetEmpty - Get empty array value []
-func (client *ArrayClient) GetEmpty(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetEmpty(ctx context.Context, options *ArrayGetEmptyOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1691,7 +1691,7 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*Int32ArrayResponse, e
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context, options *ArrayGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1717,8 +1717,8 @@ func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
 }
 
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) GetEnumValid(ctx context.Context) (*FooEnumArrayResponse, error) {
-	req, err := client.GetEnumValidCreateRequest(ctx)
+func (client *ArrayClient) GetEnumValid(ctx context.Context, options *ArrayGetEnumValidOptions) (*FooEnumArrayResponse, error) {
+	req, err := client.GetEnumValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1737,7 +1737,7 @@ func (client *ArrayClient) GetEnumValid(ctx context.Context) (*FooEnumArrayRespo
 }
 
 // GetEnumValidCreateRequest creates the GetEnumValid request.
-func (client *ArrayClient) GetEnumValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetEnumValidCreateRequest(ctx context.Context, options *ArrayGetEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1763,8 +1763,8 @@ func (client *ArrayClient) GetEnumValidHandleError(resp *azcore.Response) error 
 }
 
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
-func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context) (*Float32ArrayResponse, error) {
-	req, err := client.GetFloatInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context, options *ArrayGetFloatInvalidNullOptions) (*Float32ArrayResponse, error) {
+	req, err := client.GetFloatInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1783,7 +1783,7 @@ func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context) (*Float32Arr
 }
 
 // GetFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
-func (client *ArrayClient) GetFloatInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetFloatInvalidNullCreateRequest(ctx context.Context, options *ArrayGetFloatInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0.0-null-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1809,8 +1809,8 @@ func (client *ArrayClient) GetFloatInvalidNullHandleError(resp *azcore.Response)
 }
 
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
-func (client *ArrayClient) GetFloatInvalidString(ctx context.Context) (*Float32ArrayResponse, error) {
-	req, err := client.GetFloatInvalidStringCreateRequest(ctx)
+func (client *ArrayClient) GetFloatInvalidString(ctx context.Context, options *ArrayGetFloatInvalidStringOptions) (*Float32ArrayResponse, error) {
+	req, err := client.GetFloatInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1829,7 +1829,7 @@ func (client *ArrayClient) GetFloatInvalidString(ctx context.Context) (*Float32A
 }
 
 // GetFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
-func (client *ArrayClient) GetFloatInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetFloatInvalidStringCreateRequest(ctx context.Context, options *ArrayGetFloatInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/1.number.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1855,8 +1855,8 @@ func (client *ArrayClient) GetFloatInvalidStringHandleError(resp *azcore.Respons
 }
 
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) GetFloatValid(ctx context.Context) (*Float32ArrayResponse, error) {
-	req, err := client.GetFloatValidCreateRequest(ctx)
+func (client *ArrayClient) GetFloatValid(ctx context.Context, options *ArrayGetFloatValidOptions) (*Float32ArrayResponse, error) {
+	req, err := client.GetFloatValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1875,7 +1875,7 @@ func (client *ArrayClient) GetFloatValid(ctx context.Context) (*Float32ArrayResp
 }
 
 // GetFloatValidCreateRequest creates the GetFloatValid request.
-func (client *ArrayClient) GetFloatValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetFloatValidCreateRequest(ctx context.Context, options *ArrayGetFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1901,8 +1901,8 @@ func (client *ArrayClient) GetFloatValidHandleError(resp *azcore.Response) error
 }
 
 // GetIntInvalidNull - Get integer array value [1, null, 0]
-func (client *ArrayClient) GetIntInvalidNull(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetIntInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetIntInvalidNull(ctx context.Context, options *ArrayGetIntInvalidNullOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetIntInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1921,7 +1921,7 @@ func (client *ArrayClient) GetIntInvalidNull(ctx context.Context) (*Int32ArrayRe
 }
 
 // GetIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
-func (client *ArrayClient) GetIntInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetIntInvalidNullCreateRequest(ctx context.Context, options *ArrayGetIntInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.null.zero"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1947,8 +1947,8 @@ func (client *ArrayClient) GetIntInvalidNullHandleError(resp *azcore.Response) e
 }
 
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
-func (client *ArrayClient) GetIntInvalidString(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetIntInvalidStringCreateRequest(ctx)
+func (client *ArrayClient) GetIntInvalidString(ctx context.Context, options *ArrayGetIntInvalidStringOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetIntInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1967,7 +1967,7 @@ func (client *ArrayClient) GetIntInvalidString(ctx context.Context) (*Int32Array
 }
 
 // GetIntInvalidStringCreateRequest creates the GetIntInvalidString request.
-func (client *ArrayClient) GetIntInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetIntInvalidStringCreateRequest(ctx context.Context, options *ArrayGetIntInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.integer.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1993,8 +1993,8 @@ func (client *ArrayClient) GetIntInvalidStringHandleError(resp *azcore.Response)
 }
 
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
-func (client *ArrayClient) GetIntegerValid(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetIntegerValidCreateRequest(ctx)
+func (client *ArrayClient) GetIntegerValid(ctx context.Context, options *ArrayGetIntegerValidOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetIntegerValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2013,7 +2013,7 @@ func (client *ArrayClient) GetIntegerValid(ctx context.Context) (*Int32ArrayResp
 }
 
 // GetIntegerValidCreateRequest creates the GetIntegerValid request.
-func (client *ArrayClient) GetIntegerValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetIntegerValidCreateRequest(ctx context.Context, options *ArrayGetIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2039,8 +2039,8 @@ func (client *ArrayClient) GetIntegerValidHandleError(resp *azcore.Response) err
 }
 
 // GetInvalid - Get invalid array [1, 2, 3
-func (client *ArrayClient) GetInvalid(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *ArrayClient) GetInvalid(ctx context.Context, options *ArrayGetInvalidOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2059,7 +2059,7 @@ func (client *ArrayClient) GetInvalid(ctx context.Context) (*Int32ArrayResponse,
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *ArrayClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetInvalidCreateRequest(ctx context.Context, options *ArrayGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/array/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2085,8 +2085,8 @@ func (client *ArrayClient) GetInvalidHandleError(resp *azcore.Response) error {
 }
 
 // GetLongInvalidNull - Get long array value [1, null, 0]
-func (client *ArrayClient) GetLongInvalidNull(ctx context.Context) (*Int64ArrayResponse, error) {
-	req, err := client.GetLongInvalidNullCreateRequest(ctx)
+func (client *ArrayClient) GetLongInvalidNull(ctx context.Context, options *ArrayGetLongInvalidNullOptions) (*Int64ArrayResponse, error) {
+	req, err := client.GetLongInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2105,7 +2105,7 @@ func (client *ArrayClient) GetLongInvalidNull(ctx context.Context) (*Int64ArrayR
 }
 
 // GetLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
-func (client *ArrayClient) GetLongInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetLongInvalidNullCreateRequest(ctx context.Context, options *ArrayGetLongInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.null.zero"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2131,8 +2131,8 @@ func (client *ArrayClient) GetLongInvalidNullHandleError(resp *azcore.Response) 
 }
 
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
-func (client *ArrayClient) GetLongInvalidString(ctx context.Context) (*Int64ArrayResponse, error) {
-	req, err := client.GetLongInvalidStringCreateRequest(ctx)
+func (client *ArrayClient) GetLongInvalidString(ctx context.Context, options *ArrayGetLongInvalidStringOptions) (*Int64ArrayResponse, error) {
+	req, err := client.GetLongInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2151,7 +2151,7 @@ func (client *ArrayClient) GetLongInvalidString(ctx context.Context) (*Int64Arra
 }
 
 // GetLongInvalidStringCreateRequest creates the GetLongInvalidString request.
-func (client *ArrayClient) GetLongInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetLongInvalidStringCreateRequest(ctx context.Context, options *ArrayGetLongInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.integer.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2177,8 +2177,8 @@ func (client *ArrayClient) GetLongInvalidStringHandleError(resp *azcore.Response
 }
 
 // GetLongValid - Get integer array value [1, -1, 3, 300]
-func (client *ArrayClient) GetLongValid(ctx context.Context) (*Int64ArrayResponse, error) {
-	req, err := client.GetLongValidCreateRequest(ctx)
+func (client *ArrayClient) GetLongValid(ctx context.Context, options *ArrayGetLongValidOptions) (*Int64ArrayResponse, error) {
+	req, err := client.GetLongValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2197,7 +2197,7 @@ func (client *ArrayClient) GetLongValid(ctx context.Context) (*Int64ArrayRespons
 }
 
 // GetLongValidCreateRequest creates the GetLongValid request.
-func (client *ArrayClient) GetLongValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetLongValidCreateRequest(ctx context.Context, options *ArrayGetLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2223,8 +2223,8 @@ func (client *ArrayClient) GetLongValidHandleError(resp *azcore.Response) error 
 }
 
 // GetNull - Get null array value
-func (client *ArrayClient) GetNull(ctx context.Context) (*Int32ArrayResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *ArrayClient) GetNull(ctx context.Context, options *ArrayGetNullOptions) (*Int32ArrayResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2243,7 +2243,7 @@ func (client *ArrayClient) GetNull(ctx context.Context) (*Int32ArrayResponse, er
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *ArrayClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetNullCreateRequest(ctx context.Context, options *ArrayGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2269,8 +2269,8 @@ func (client *ArrayClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) GetStringEnumValid(ctx context.Context) (*Enum0ArrayResponse, error) {
-	req, err := client.GetStringEnumValidCreateRequest(ctx)
+func (client *ArrayClient) GetStringEnumValid(ctx context.Context, options *ArrayGetStringEnumValidOptions) (*Enum0ArrayResponse, error) {
+	req, err := client.GetStringEnumValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2289,7 +2289,7 @@ func (client *ArrayClient) GetStringEnumValid(ctx context.Context) (*Enum0ArrayR
 }
 
 // GetStringEnumValidCreateRequest creates the GetStringEnumValid request.
-func (client *ArrayClient) GetStringEnumValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetStringEnumValidCreateRequest(ctx context.Context, options *ArrayGetStringEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2315,8 +2315,8 @@ func (client *ArrayClient) GetStringEnumValidHandleError(resp *azcore.Response) 
 }
 
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) GetStringValid(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetStringValidCreateRequest(ctx)
+func (client *ArrayClient) GetStringValid(ctx context.Context, options *ArrayGetStringValidOptions) (*StringArrayResponse, error) {
+	req, err := client.GetStringValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2335,7 +2335,7 @@ func (client *ArrayClient) GetStringValid(ctx context.Context) (*StringArrayResp
 }
 
 // GetStringValidCreateRequest creates the GetStringValid request.
-func (client *ArrayClient) GetStringValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetStringValidCreateRequest(ctx context.Context, options *ArrayGetStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2361,8 +2361,8 @@ func (client *ArrayClient) GetStringValidHandleError(resp *azcore.Response) erro
 }
 
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
-func (client *ArrayClient) GetStringWithInvalid(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetStringWithInvalidCreateRequest(ctx)
+func (client *ArrayClient) GetStringWithInvalid(ctx context.Context, options *ArrayGetStringWithInvalidOptions) (*StringArrayResponse, error) {
+	req, err := client.GetStringWithInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2381,7 +2381,7 @@ func (client *ArrayClient) GetStringWithInvalid(ctx context.Context) (*StringArr
 }
 
 // GetStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
-func (client *ArrayClient) GetStringWithInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetStringWithInvalidCreateRequest(ctx context.Context, options *ArrayGetStringWithInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo.123.foo2"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2407,8 +2407,8 @@ func (client *ArrayClient) GetStringWithInvalidHandleError(resp *azcore.Response
 }
 
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
-func (client *ArrayClient) GetStringWithNull(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetStringWithNullCreateRequest(ctx)
+func (client *ArrayClient) GetStringWithNull(ctx context.Context, options *ArrayGetStringWithNullOptions) (*StringArrayResponse, error) {
+	req, err := client.GetStringWithNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2427,7 +2427,7 @@ func (client *ArrayClient) GetStringWithNull(ctx context.Context) (*StringArrayR
 }
 
 // GetStringWithNullCreateRequest creates the GetStringWithNull request.
-func (client *ArrayClient) GetStringWithNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetStringWithNullCreateRequest(ctx context.Context, options *ArrayGetStringWithNullOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo.null.foo2"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2453,8 +2453,8 @@ func (client *ArrayClient) GetStringWithNullHandleError(resp *azcore.Response) e
 }
 
 // GetUUIDInvalidChars - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
-func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetUUIDInvalidCharsCreateRequest(ctx)
+func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context, options *ArrayGetUUIDInvalidCharsOptions) (*StringArrayResponse, error) {
+	req, err := client.GetUUIDInvalidCharsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2473,7 +2473,7 @@ func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context) (*StringArra
 }
 
 // GetUUIDInvalidCharsCreateRequest creates the GetUUIDInvalidChars request.
-func (client *ArrayClient) GetUUIDInvalidCharsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetUUIDInvalidCharsCreateRequest(ctx context.Context, options *ArrayGetUUIDInvalidCharsOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/invalidchars"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2499,8 +2499,8 @@ func (client *ArrayClient) GetUUIDInvalidCharsHandleError(resp *azcore.Response)
 }
 
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-func (client *ArrayClient) GetUUIDValid(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.GetUUIDValidCreateRequest(ctx)
+func (client *ArrayClient) GetUUIDValid(ctx context.Context, options *ArrayGetUUIDValidOptions) (*StringArrayResponse, error) {
+	req, err := client.GetUUIDValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2519,7 +2519,7 @@ func (client *ArrayClient) GetUUIDValid(ctx context.Context) (*StringArrayRespon
 }
 
 // GetUUIDValidCreateRequest creates the GetUUIDValid request.
-func (client *ArrayClient) GetUUIDValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetUUIDValidCreateRequest(ctx context.Context, options *ArrayGetUUIDValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2545,8 +2545,8 @@ func (client *ArrayClient) GetUUIDValidHandleError(resp *azcore.Response) error 
 }
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]string) (*http.Response, error) {
-	req, err := client.PutArrayValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]string, options *ArrayPutArrayValidOptions) (*http.Response, error) {
+	req, err := client.PutArrayValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2561,7 +2561,7 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]stri
 }
 
 // PutArrayValidCreateRequest creates the PutArrayValid request.
-func (client *ArrayClient) PutArrayValidCreateRequest(ctx context.Context, arrayBody [][]string) (*azcore.Request, error) {
+func (client *ArrayClient) PutArrayValidCreateRequest(ctx context.Context, arrayBody [][]string, options *ArrayPutArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2581,8 +2581,8 @@ func (client *ArrayClient) PutArrayValidHandleError(resp *azcore.Response) error
 }
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
-func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool) (*http.Response, error) {
-	req, err := client.PutBooleanTfftCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool, options *ArrayPutBooleanTfftOptions) (*http.Response, error) {
+	req, err := client.PutBooleanTfftCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2597,7 +2597,7 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool)
 }
 
 // PutBooleanTfftCreateRequest creates the PutBooleanTfft request.
-func (client *ArrayClient) PutBooleanTfftCreateRequest(ctx context.Context, arrayBody []bool) (*azcore.Request, error) {
+func (client *ArrayClient) PutBooleanTfftCreateRequest(ctx context.Context, arrayBody []bool, options *ArrayPutBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2617,8 +2617,8 @@ func (client *ArrayClient) PutBooleanTfftHandleError(resp *azcore.Response) erro
 }
 
 // PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
-func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte) (*http.Response, error) {
-	req, err := client.PutByteValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte, options *ArrayPutByteValidOptions) (*http.Response, error) {
+	req, err := client.PutByteValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2633,7 +2633,7 @@ func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte)
 }
 
 // PutByteValidCreateRequest creates the PutByteValid request.
-func (client *ArrayClient) PutByteValidCreateRequest(ctx context.Context, arrayBody [][]byte) (*azcore.Request, error) {
+func (client *ArrayClient) PutByteValidCreateRequest(ctx context.Context, arrayBody [][]byte, options *ArrayPutByteValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/byte/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2653,8 +2653,8 @@ func (client *ArrayClient) PutByteValidHandleError(resp *azcore.Response) error 
 }
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
-func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Product) (*http.Response, error) {
-	req, err := client.PutComplexValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Product, options *ArrayPutComplexValidOptions) (*http.Response, error) {
+	req, err := client.PutComplexValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2669,7 +2669,7 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Prod
 }
 
 // PutComplexValidCreateRequest creates the PutComplexValid request.
-func (client *ArrayClient) PutComplexValidCreateRequest(ctx context.Context, arrayBody []Product) (*azcore.Request, error) {
+func (client *ArrayClient) PutComplexValidCreateRequest(ctx context.Context, arrayBody []Product, options *ArrayPutComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2689,8 +2689,8 @@ func (client *ArrayClient) PutComplexValidHandleError(resp *azcore.Response) err
 }
 
 // PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
-func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []time.Time) (*http.Response, error) {
-	req, err := client.PutDateTimeRFC1123ValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
+	req, err := client.PutDateTimeRFC1123ValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2705,7 +2705,7 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 }
 
 // PutDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
-func (client *ArrayClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody []time.Time) (*azcore.Request, error) {
+func (client *ArrayClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2729,8 +2729,8 @@ func (client *ArrayClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.Respo
 }
 
 // PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []time.Time) (*http.Response, error) {
-	req, err := client.PutDateTimeValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeValidOptions) (*http.Response, error) {
+	req, err := client.PutDateTimeValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2745,7 +2745,7 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []tim
 }
 
 // PutDateTimeValidCreateRequest creates the PutDateTimeValid request.
-func (client *ArrayClient) PutDateTimeValidCreateRequest(ctx context.Context, arrayBody []time.Time) (*azcore.Request, error) {
+func (client *ArrayClient) PutDateTimeValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2765,8 +2765,8 @@ func (client *ArrayClient) PutDateTimeValidHandleError(resp *azcore.Response) er
 }
 
 // PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
-func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Time) (*http.Response, error) {
-	req, err := client.PutDateValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateValidOptions) (*http.Response, error) {
+	req, err := client.PutDateValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2781,7 +2781,7 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Ti
 }
 
 // PutDateValidCreateRequest creates the PutDateValid request.
-func (client *ArrayClient) PutDateValidCreateRequest(ctx context.Context, arrayBody []time.Time) (*azcore.Request, error) {
+func (client *ArrayClient) PutDateValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2801,8 +2801,8 @@ func (client *ArrayClient) PutDateValidHandleError(resp *azcore.Response) error 
 }
 
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
-func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []map[string]string) (*http.Response, error) {
-	req, err := client.PutDictionaryValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []map[string]string, options *ArrayPutDictionaryValidOptions) (*http.Response, error) {
+	req, err := client.PutDictionaryValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2817,7 +2817,7 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 }
 
 // PutDictionaryValidCreateRequest creates the PutDictionaryValid request.
-func (client *ArrayClient) PutDictionaryValidCreateRequest(ctx context.Context, arrayBody []map[string]string) (*azcore.Request, error) {
+func (client *ArrayClient) PutDictionaryValidCreateRequest(ctx context.Context, arrayBody []map[string]string, options *ArrayPutDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2837,8 +2837,8 @@ func (client *ArrayClient) PutDictionaryValidHandleError(resp *azcore.Response) 
 }
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float64) (*http.Response, error) {
-	req, err := client.PutDoubleValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float64, options *ArrayPutDoubleValidOptions) (*http.Response, error) {
+	req, err := client.PutDoubleValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2853,7 +2853,7 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float
 }
 
 // PutDoubleValidCreateRequest creates the PutDoubleValid request.
-func (client *ArrayClient) PutDoubleValidCreateRequest(ctx context.Context, arrayBody []float64) (*azcore.Request, error) {
+func (client *ArrayClient) PutDoubleValidCreateRequest(ctx context.Context, arrayBody []float64, options *ArrayPutDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2873,8 +2873,8 @@ func (client *ArrayClient) PutDoubleValidHandleError(resp *azcore.Response) erro
 }
 
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []string) (*http.Response, error) {
-	req, err := client.PutDurationValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []string, options *ArrayPutDurationValidOptions) (*http.Response, error) {
+	req, err := client.PutDurationValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2889,7 +2889,7 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []str
 }
 
 // PutDurationValidCreateRequest creates the PutDurationValid request.
-func (client *ArrayClient) PutDurationValidCreateRequest(ctx context.Context, arrayBody []string) (*azcore.Request, error) {
+func (client *ArrayClient) PutDurationValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2909,8 +2909,8 @@ func (client *ArrayClient) PutDurationValidHandleError(resp *azcore.Response) er
 }
 
 // PutEmpty - Set array value empty []
-func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string) (*http.Response, error) {
-	req, err := client.PutEmptyCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string, options *ArrayPutEmptyOptions) (*http.Response, error) {
+	req, err := client.PutEmptyCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2925,7 +2925,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string) (*h
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
-func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, arrayBody []string) (*azcore.Request, error) {
+func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2945,8 +2945,8 @@ func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
 }
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum) (*http.Response, error) {
-	req, err := client.PutEnumValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum, options *ArrayPutEnumValidOptions) (*http.Response, error) {
+	req, err := client.PutEnumValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2961,7 +2961,7 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum
 }
 
 // PutEnumValidCreateRequest creates the PutEnumValid request.
-func (client *ArrayClient) PutEnumValidCreateRequest(ctx context.Context, arrayBody []FooEnum) (*azcore.Request, error) {
+func (client *ArrayClient) PutEnumValidCreateRequest(ctx context.Context, arrayBody []FooEnum, options *ArrayPutEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2981,8 +2981,8 @@ func (client *ArrayClient) PutEnumValidHandleError(resp *azcore.Response) error 
 }
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float32) (*http.Response, error) {
-	req, err := client.PutFloatValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float32, options *ArrayPutFloatValidOptions) (*http.Response, error) {
+	req, err := client.PutFloatValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2997,7 +2997,7 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float3
 }
 
 // PutFloatValidCreateRequest creates the PutFloatValid request.
-func (client *ArrayClient) PutFloatValidCreateRequest(ctx context.Context, arrayBody []float32) (*azcore.Request, error) {
+func (client *ArrayClient) PutFloatValidCreateRequest(ctx context.Context, arrayBody []float32, options *ArrayPutFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3017,8 +3017,8 @@ func (client *ArrayClient) PutFloatValidHandleError(resp *azcore.Response) error
 }
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
-func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int32) (*http.Response, error) {
-	req, err := client.PutIntegerValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int32, options *ArrayPutIntegerValidOptions) (*http.Response, error) {
+	req, err := client.PutIntegerValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3033,7 +3033,7 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int3
 }
 
 // PutIntegerValidCreateRequest creates the PutIntegerValid request.
-func (client *ArrayClient) PutIntegerValidCreateRequest(ctx context.Context, arrayBody []int32) (*azcore.Request, error) {
+func (client *ArrayClient) PutIntegerValidCreateRequest(ctx context.Context, arrayBody []int32, options *ArrayPutIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3053,8 +3053,8 @@ func (client *ArrayClient) PutIntegerValidHandleError(resp *azcore.Response) err
 }
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
-func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64) (*http.Response, error) {
-	req, err := client.PutLongValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64, options *ArrayPutLongValidOptions) (*http.Response, error) {
+	req, err := client.PutLongValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3069,7 +3069,7 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64) 
 }
 
 // PutLongValidCreateRequest creates the PutLongValid request.
-func (client *ArrayClient) PutLongValidCreateRequest(ctx context.Context, arrayBody []int64) (*azcore.Request, error) {
+func (client *ArrayClient) PutLongValidCreateRequest(ctx context.Context, arrayBody []int64, options *ArrayPutLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3089,8 +3089,8 @@ func (client *ArrayClient) PutLongValidHandleError(resp *azcore.Response) error 
 }
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []Enum1) (*http.Response, error) {
-	req, err := client.PutStringEnumValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []Enum1, options *ArrayPutStringEnumValidOptions) (*http.Response, error) {
+	req, err := client.PutStringEnumValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3105,7 +3105,7 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []E
 }
 
 // PutStringEnumValidCreateRequest creates the PutStringEnumValid request.
-func (client *ArrayClient) PutStringEnumValidCreateRequest(ctx context.Context, arrayBody []Enum1) (*azcore.Request, error) {
+func (client *ArrayClient) PutStringEnumValidCreateRequest(ctx context.Context, arrayBody []Enum1, options *ArrayPutStringEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3125,8 +3125,8 @@ func (client *ArrayClient) PutStringEnumValidHandleError(resp *azcore.Response) 
 }
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []string) (*http.Response, error) {
-	req, err := client.PutStringValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []string, options *ArrayPutStringValidOptions) (*http.Response, error) {
+	req, err := client.PutStringValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3141,7 +3141,7 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []strin
 }
 
 // PutStringValidCreateRequest creates the PutStringValid request.
-func (client *ArrayClient) PutStringValidCreateRequest(ctx context.Context, arrayBody []string) (*azcore.Request, error) {
+func (client *ArrayClient) PutStringValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3161,8 +3161,8 @@ func (client *ArrayClient) PutStringValidHandleError(resp *azcore.Response) erro
 }
 
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string) (*http.Response, error) {
-	req, err := client.PutUUIDValidCreateRequest(ctx, arrayBody)
+func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string, options *ArrayPutUUIDValidOptions) (*http.Response, error) {
+	req, err := client.PutUUIDValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3177,7 +3177,7 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string)
 }
 
 // PutUUIDValidCreateRequest creates the PutUUIDValid request.
-func (client *ArrayClient) PutUUIDValidCreateRequest(ctx context.Context, arrayBody []string) (*azcore.Request, error) {
+func (client *ArrayClient) PutUUIDValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutUUIDValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/arraygroup/zz_generated_models.go
+++ b/test/autorest/arraygroup/zz_generated_models.go
@@ -11,6 +11,351 @@ import (
 	"time"
 )
 
+// ArrayGetArrayEmptyOptions contains the optional parameters for the Array.GetArrayEmpty method.
+type ArrayGetArrayEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetArrayItemEmptyOptions contains the optional parameters for the Array.GetArrayItemEmpty method.
+type ArrayGetArrayItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetArrayItemNullOptions contains the optional parameters for the Array.GetArrayItemNull method.
+type ArrayGetArrayItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetArrayNullOptions contains the optional parameters for the Array.GetArrayNull method.
+type ArrayGetArrayNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetArrayValidOptions contains the optional parameters for the Array.GetArrayValid method.
+type ArrayGetArrayValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetBase64URLOptions contains the optional parameters for the Array.GetBase64URL method.
+type ArrayGetBase64URLOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetBooleanInvalidNullOptions contains the optional parameters for the Array.GetBooleanInvalidNull method.
+type ArrayGetBooleanInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetBooleanInvalidStringOptions contains the optional parameters for the Array.GetBooleanInvalidString method.
+type ArrayGetBooleanInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetBooleanTfftOptions contains the optional parameters for the Array.GetBooleanTfft method.
+type ArrayGetBooleanTfftOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetByteInvalidNullOptions contains the optional parameters for the Array.GetByteInvalidNull method.
+type ArrayGetByteInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetByteValidOptions contains the optional parameters for the Array.GetByteValid method.
+type ArrayGetByteValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetComplexEmptyOptions contains the optional parameters for the Array.GetComplexEmpty method.
+type ArrayGetComplexEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetComplexItemEmptyOptions contains the optional parameters for the Array.GetComplexItemEmpty method.
+type ArrayGetComplexItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetComplexItemNullOptions contains the optional parameters for the Array.GetComplexItemNull method.
+type ArrayGetComplexItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetComplexNullOptions contains the optional parameters for the Array.GetComplexNull method.
+type ArrayGetComplexNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetComplexValidOptions contains the optional parameters for the Array.GetComplexValid method.
+type ArrayGetComplexValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateInvalidCharsOptions contains the optional parameters for the Array.GetDateInvalidChars method.
+type ArrayGetDateInvalidCharsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateInvalidNullOptions contains the optional parameters for the Array.GetDateInvalidNull method.
+type ArrayGetDateInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateTimeInvalidCharsOptions contains the optional parameters for the Array.GetDateTimeInvalidChars method.
+type ArrayGetDateTimeInvalidCharsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateTimeInvalidNullOptions contains the optional parameters for the Array.GetDateTimeInvalidNull method.
+type ArrayGetDateTimeInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateTimeRFC1123ValidOptions contains the optional parameters for the Array.GetDateTimeRFC1123Valid method.
+type ArrayGetDateTimeRFC1123ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateTimeValidOptions contains the optional parameters for the Array.GetDateTimeValid method.
+type ArrayGetDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDateValidOptions contains the optional parameters for the Array.GetDateValid method.
+type ArrayGetDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDictionaryEmptyOptions contains the optional parameters for the Array.GetDictionaryEmpty method.
+type ArrayGetDictionaryEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDictionaryItemEmptyOptions contains the optional parameters for the Array.GetDictionaryItemEmpty method.
+type ArrayGetDictionaryItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDictionaryItemNullOptions contains the optional parameters for the Array.GetDictionaryItemNull method.
+type ArrayGetDictionaryItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDictionaryNullOptions contains the optional parameters for the Array.GetDictionaryNull method.
+type ArrayGetDictionaryNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDictionaryValidOptions contains the optional parameters for the Array.GetDictionaryValid method.
+type ArrayGetDictionaryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDoubleInvalidNullOptions contains the optional parameters for the Array.GetDoubleInvalidNull method.
+type ArrayGetDoubleInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDoubleInvalidStringOptions contains the optional parameters for the Array.GetDoubleInvalidString method.
+type ArrayGetDoubleInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDoubleValidOptions contains the optional parameters for the Array.GetDoubleValid method.
+type ArrayGetDoubleValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetDurationValidOptions contains the optional parameters for the Array.GetDurationValid method.
+type ArrayGetDurationValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetEmptyOptions contains the optional parameters for the Array.GetEmpty method.
+type ArrayGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetEnumValidOptions contains the optional parameters for the Array.GetEnumValid method.
+type ArrayGetEnumValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetFloatInvalidNullOptions contains the optional parameters for the Array.GetFloatInvalidNull method.
+type ArrayGetFloatInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetFloatInvalidStringOptions contains the optional parameters for the Array.GetFloatInvalidString method.
+type ArrayGetFloatInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetFloatValidOptions contains the optional parameters for the Array.GetFloatValid method.
+type ArrayGetFloatValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetIntInvalidNullOptions contains the optional parameters for the Array.GetIntInvalidNull method.
+type ArrayGetIntInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetIntInvalidStringOptions contains the optional parameters for the Array.GetIntInvalidString method.
+type ArrayGetIntInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetIntegerValidOptions contains the optional parameters for the Array.GetIntegerValid method.
+type ArrayGetIntegerValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetInvalidOptions contains the optional parameters for the Array.GetInvalid method.
+type ArrayGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetLongInvalidNullOptions contains the optional parameters for the Array.GetLongInvalidNull method.
+type ArrayGetLongInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetLongInvalidStringOptions contains the optional parameters for the Array.GetLongInvalidString method.
+type ArrayGetLongInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetLongValidOptions contains the optional parameters for the Array.GetLongValid method.
+type ArrayGetLongValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetNullOptions contains the optional parameters for the Array.GetNull method.
+type ArrayGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetStringEnumValidOptions contains the optional parameters for the Array.GetStringEnumValid method.
+type ArrayGetStringEnumValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetStringValidOptions contains the optional parameters for the Array.GetStringValid method.
+type ArrayGetStringValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetStringWithInvalidOptions contains the optional parameters for the Array.GetStringWithInvalid method.
+type ArrayGetStringWithInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetStringWithNullOptions contains the optional parameters for the Array.GetStringWithNull method.
+type ArrayGetStringWithNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetUUIDInvalidCharsOptions contains the optional parameters for the Array.GetUUIDInvalidChars method.
+type ArrayGetUUIDInvalidCharsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetUUIDValidOptions contains the optional parameters for the Array.GetUUIDValid method.
+type ArrayGetUUIDValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutArrayValidOptions contains the optional parameters for the Array.PutArrayValid method.
+type ArrayPutArrayValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutBooleanTfftOptions contains the optional parameters for the Array.PutBooleanTfft method.
+type ArrayPutBooleanTfftOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutByteValidOptions contains the optional parameters for the Array.PutByteValid method.
+type ArrayPutByteValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutComplexValidOptions contains the optional parameters for the Array.PutComplexValid method.
+type ArrayPutComplexValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDateTimeRFC1123ValidOptions contains the optional parameters for the Array.PutDateTimeRFC1123Valid method.
+type ArrayPutDateTimeRFC1123ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDateTimeValidOptions contains the optional parameters for the Array.PutDateTimeValid method.
+type ArrayPutDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDateValidOptions contains the optional parameters for the Array.PutDateValid method.
+type ArrayPutDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDictionaryValidOptions contains the optional parameters for the Array.PutDictionaryValid method.
+type ArrayPutDictionaryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDoubleValidOptions contains the optional parameters for the Array.PutDoubleValid method.
+type ArrayPutDoubleValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutDurationValidOptions contains the optional parameters for the Array.PutDurationValid method.
+type ArrayPutDurationValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutEmptyOptions contains the optional parameters for the Array.PutEmpty method.
+type ArrayPutEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutEnumValidOptions contains the optional parameters for the Array.PutEnumValid method.
+type ArrayPutEnumValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutFloatValidOptions contains the optional parameters for the Array.PutFloatValid method.
+type ArrayPutFloatValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutIntegerValidOptions contains the optional parameters for the Array.PutIntegerValid method.
+type ArrayPutIntegerValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutLongValidOptions contains the optional parameters for the Array.PutLongValid method.
+type ArrayPutLongValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutStringEnumValidOptions contains the optional parameters for the Array.PutStringEnumValid method.
+type ArrayPutStringEnumValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutStringValidOptions contains the optional parameters for the Array.PutStringValid method.
+type ArrayPutStringValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutUUIDValidOptions contains the optional parameters for the Array.PutUUIDValid method.
+type ArrayPutUUIDValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 // BoolArrayResponse is the response envelope for operations that return a []bool type.
 type BoolArrayResponse struct {
 	// The array value [true, false, false, true]

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -14,7 +14,7 @@ import (
 // AutoRestReportServiceForAzureOperations contains the methods for the AutoRestReportServiceForAzure group.
 type AutoRestReportServiceForAzureOperations interface {
 	// GetReport - Get test coverage report
-	GetReport(ctx context.Context, autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error)
+	GetReport(ctx context.Context, options *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error)
 }
 
 // AutoRestReportServiceForAzureClient implements the AutoRestReportServiceForAzureOperations interface.
@@ -34,8 +34,8 @@ func (client *AutoRestReportServiceForAzureClient) Do(req *azcore.Request) (*azc
 }
 
 // GetReport - Get test coverage report
-func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context, autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.GetReportCreateRequest(ctx, autoRestReportServiceForAzureGetReportOptions)
+func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context, options *AutoRestReportServiceForAzureGetReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetReportCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -54,15 +54,15 @@ func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context
 }
 
 // GetReportCreateRequest creates the GetReport request.
-func (client *AutoRestReportServiceForAzureClient) GetReportCreateRequest(ctx context.Context, autoRestReportServiceForAzureGetReportOptions *AutoRestReportServiceForAzureGetReportOptions) (*azcore.Request, error) {
+func (client *AutoRestReportServiceForAzureClient) GetReportCreateRequest(ctx context.Context, options *AutoRestReportServiceForAzureGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/azure"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if autoRestReportServiceForAzureGetReportOptions != nil && autoRestReportServiceForAzureGetReportOptions.Qualifier != nil {
-		query.Set("qualifier", *autoRestReportServiceForAzureGetReportOptions.Qualifier)
+	if options != nil && options.Qualifier != nil {
+		query.Set("qualifier", *options.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -17,7 +17,7 @@ func newAPIVersionDefaultClient() APIVersionDefaultOperations {
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
 	client := newAPIVersionDefaultClient()
-	result, err := client.GetMethodGlobalNotProvidedValid(context.Background())
+	result, err := client.GetMethodGlobalNotProvidedValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,7 +27,7 @@ func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalValid(t *testing.T) {
 	client := newAPIVersionDefaultClient()
-	result, err := client.GetMethodGlobalValid(context.Background())
+	result, err := client.GetMethodGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGetMethodGlobalValid(t *testing.T) {
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
 func TestGetPathGlobalValid(t *testing.T) {
 	client := newAPIVersionDefaultClient()
-	result, err := client.GetPathGlobalValid(context.Background())
+	result, err := client.GetPathGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestGetPathGlobalValid(t *testing.T) {
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
 func TestGetSwaggerGlobalValid(t *testing.T) {
 	client := newAPIVersionDefaultClient()
-	result, err := client.GetSwaggerGlobalValid(context.Background())
+	result, err := client.GetSwaggerGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -27,7 +27,7 @@ func TestGetMethodLocalNull(t *testing.T) {
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetMethodLocalValid(t *testing.T) {
 	client := newAPIVersionLocalClient()
-	result, err := client.GetMethodLocalValid(context.Background())
+	result, err := client.GetMethodLocalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGetMethodLocalValid(t *testing.T) {
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetPathLocalValid(t *testing.T) {
 	client := newAPIVersionLocalClient()
-	result, err := client.GetPathLocalValid(context.Background())
+	result, err := client.GetPathLocalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestGetPathLocalValid(t *testing.T) {
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetSwaggerLocalValid(t *testing.T) {
 	client := newAPIVersionLocalClient()
-	result, err := client.GetSwaggerLocalValid(context.Background())
+	result, err := client.GetSwaggerLocalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -18,7 +18,7 @@ func newHeaderClient() HeaderOperations {
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestID(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.CustomNamedRequestID(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
+	result, err := client.CustomNamedRequestID(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestCustomNamedRequestID(t *testing.T) {
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestIDHead(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.CustomNamedRequestIDHead(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
+	result, err := client.CustomNamedRequestIDHead(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -17,7 +17,7 @@ func newSkipURLEncodingClient() SkipURLEncodingOperations {
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetMethodPathValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetMethodPathValid(context.Background(), "path1/path2/path3")
+	result, err := client.GetMethodPathValid(context.Background(), "path1/path2/path3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGetMethodQueryNull(t *testing.T) {
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetMethodQueryValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetMethodQueryValid(context.Background(), "value1&q2=value2&q3=value3")
+	result, err := client.GetMethodQueryValid(context.Background(), "value1&q2=value2&q3=value3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestGetMethodQueryValid(t *testing.T) {
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetPathQueryValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetPathQueryValid(context.Background(), "value1&q2=value2&q3=value3")
+	result, err := client.GetPathQueryValid(context.Background(), "value1&q2=value2&q3=value3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestGetPathQueryValid(t *testing.T) {
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetPathValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetPathValid(context.Background(), "path1/path2/path3")
+	result, err := client.GetPathValid(context.Background(), "path1/path2/path3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestGetPathValid(t *testing.T) {
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetSwaggerPathValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetSwaggerPathValid(context.Background())
+	result, err := client.GetSwaggerPathValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestGetSwaggerPathValid(t *testing.T) {
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetSwaggerQueryValid(t *testing.T) {
 	client := newSkipURLEncodingClient()
-	result, err := client.GetSwaggerQueryValid(context.Background())
+	result, err := client.GetSwaggerQueryValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -17,7 +17,7 @@ func newSubscriptionInCredentialsClient() SubscriptionInCredentialsOperations {
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalNotProvidedValid(t *testing.T) {
 	client := newSubscriptionInCredentialsClient()
-	result, err := client.PostMethodGlobalNotProvidedValid(context.Background())
+	result, err := client.PostMethodGlobalNotProvidedValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestPostMethodGlobalNull(t *testing.T) {
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalValid(t *testing.T) {
 	client := newSubscriptionInCredentialsClient()
-	result, err := client.PostMethodGlobalValid(context.Background())
+	result, err := client.PostMethodGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestPostMethodGlobalValid(t *testing.T) {
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostPathGlobalValid(t *testing.T) {
 	client := newSubscriptionInCredentialsClient()
-	result, err := client.PostPathGlobalValid(context.Background())
+	result, err := client.PostPathGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestPostPathGlobalValid(t *testing.T) {
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostSwaggerGlobalValid(t *testing.T) {
 	client := newSubscriptionInCredentialsClient()
-	result, err := client.PostSwaggerGlobalValid(context.Background())
+	result, err := client.PostSwaggerGlobalValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -22,7 +22,7 @@ func TestPostMethodLocalNull(t *testing.T) {
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostMethodLocalValid(t *testing.T) {
 	client := newSubscriptionInMethodClient()
-	result, err := client.PostMethodLocalValid(context.Background(), "1234-5678-9012-3456")
+	result, err := client.PostMethodLocalValid(context.Background(), "1234-5678-9012-3456", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestPostMethodLocalValid(t *testing.T) {
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostPathLocalValid(t *testing.T) {
 	client := newSubscriptionInMethodClient()
-	result, err := client.PostPathLocalValid(context.Background(), "1234-5678-9012-3456")
+	result, err := client.PostPathLocalValid(context.Background(), "1234-5678-9012-3456", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestPostPathLocalValid(t *testing.T) {
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostSwaggerLocalValid(t *testing.T) {
 	client := newSubscriptionInMethodClient()
-	result, err := client.PostSwaggerLocalValid(context.Background(), "1234-5678-9012-3456")
+	result, err := client.PostSwaggerLocalValid(context.Background(), "1234-5678-9012-3456", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -19,13 +19,13 @@ func newXMSClientRequestIDClient() XMSClientRequestIDOperations {
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestGet(t *testing.T) {
 	client := newXMSClientRequestIDClient()
-	result, err := client.Get(context.Background())
+	result, err := client.Get(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
 	result, err = client.Get(azcore.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
-	}))
+	}), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestGet(t *testing.T) {
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestParamGet(t *testing.T) {
 	client := newXMSClientRequestIDClient()
-	result, err := client.ParamGet(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
+	result, err := client.ParamGet(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault.go
@@ -14,13 +14,13 @@ import (
 // APIVersionDefaultOperations contains the methods for the APIVersionDefault group.
 type APIVersionDefaultOperations interface {
 	// GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
-	GetMethodGlobalNotProvidedValid(ctx context.Context) (*http.Response, error)
+	GetMethodGlobalNotProvidedValid(ctx context.Context, options *APIVersionDefaultGetMethodGlobalNotProvidedValidOptions) (*http.Response, error)
 	// GetMethodGlobalValid - GET method with api-version modeled in global settings.
-	GetMethodGlobalValid(ctx context.Context) (*http.Response, error)
+	GetMethodGlobalValid(ctx context.Context, options *APIVersionDefaultGetMethodGlobalValidOptions) (*http.Response, error)
 	// GetPathGlobalValid - GET method with api-version modeled in global settings.
-	GetPathGlobalValid(ctx context.Context) (*http.Response, error)
+	GetPathGlobalValid(ctx context.Context, options *APIVersionDefaultGetPathGlobalValidOptions) (*http.Response, error)
 	// GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
-	GetSwaggerGlobalValid(ctx context.Context) (*http.Response, error)
+	GetSwaggerGlobalValid(ctx context.Context, options *APIVersionDefaultGetSwaggerGlobalValidOptions) (*http.Response, error)
 }
 
 // APIVersionDefaultClient implements the APIVersionDefaultOperations interface.
@@ -40,8 +40,8 @@ func (client *APIVersionDefaultClient) Do(req *azcore.Request) (*azcore.Response
 }
 
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
-func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetMethodGlobalNotProvidedValidCreateRequest(ctx)
+func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx context.Context, options *APIVersionDefaultGetMethodGlobalNotProvidedValidOptions) (*http.Response, error) {
+	req, err := client.GetMethodGlobalNotProvidedValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx conte
 }
 
 // GetMethodGlobalNotProvidedValidCreateRequest creates the GetMethodGlobalNotProvidedValid request.
-func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidCreateRequest(ctx context.Context, options *APIVersionDefaultGetMethodGlobalNotProvidedValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/globalNotProvided/2015-07-01-preview"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -79,8 +79,8 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValidHandleErro
 }
 
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
-func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetMethodGlobalValidCreateRequest(ctx)
+func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context, options *APIVersionDefaultGetMethodGlobalValidOptions) (*http.Response, error) {
+	req, err := client.GetMethodGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context)
 }
 
 // GetMethodGlobalValidCreateRequest creates the GetMethodGlobalValid request.
-func (client *APIVersionDefaultClient) GetMethodGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionDefaultClient) GetMethodGlobalValidCreateRequest(ctx context.Context, options *APIVersionDefaultGetMethodGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -118,8 +118,8 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValidHandleError(resp *azc
 }
 
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
-func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetPathGlobalValidCreateRequest(ctx)
+func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context, options *APIVersionDefaultGetPathGlobalValidOptions) (*http.Response, error) {
+	req, err := client.GetPathGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context) (
 }
 
 // GetPathGlobalValidCreateRequest creates the GetPathGlobalValid request.
-func (client *APIVersionDefaultClient) GetPathGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionDefaultClient) GetPathGlobalValidCreateRequest(ctx context.Context, options *APIVersionDefaultGetPathGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/global/2015-07-01-preview"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -157,8 +157,8 @@ func (client *APIVersionDefaultClient) GetPathGlobalValidHandleError(resp *azcor
 }
 
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
-func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetSwaggerGlobalValidCreateRequest(ctx)
+func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context, options *APIVersionDefaultGetSwaggerGlobalValidOptions) (*http.Response, error) {
+	req, err := client.GetSwaggerGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context
 }
 
 // GetSwaggerGlobalValidCreateRequest creates the GetSwaggerGlobalValid request.
-func (client *APIVersionDefaultClient) GetSwaggerGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionDefaultClient) GetSwaggerGlobalValidCreateRequest(ctx context.Context, options *APIVersionDefaultGetSwaggerGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/global/2015-07-01-preview"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal.go
@@ -14,13 +14,13 @@ import (
 // APIVersionLocalOperations contains the methods for the APIVersionLocal group.
 type APIVersionLocalOperations interface {
 	// GetMethodLocalNull - Get method with api-version modeled in the method.  pass in api-version = null to succeed
-	GetMethodLocalNull(ctx context.Context, apiVersionLocalGetMethodLocalNullOptions *APIVersionLocalGetMethodLocalNullOptions) (*http.Response, error)
+	GetMethodLocalNull(ctx context.Context, options *APIVersionLocalGetMethodLocalNullOptions) (*http.Response, error)
 	// GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-	GetMethodLocalValid(ctx context.Context) (*http.Response, error)
+	GetMethodLocalValid(ctx context.Context, options *APIVersionLocalGetMethodLocalValidOptions) (*http.Response, error)
 	// GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-	GetPathLocalValid(ctx context.Context) (*http.Response, error)
+	GetPathLocalValid(ctx context.Context, options *APIVersionLocalGetPathLocalValidOptions) (*http.Response, error)
 	// GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-	GetSwaggerLocalValid(ctx context.Context) (*http.Response, error)
+	GetSwaggerLocalValid(ctx context.Context, options *APIVersionLocalGetSwaggerLocalValidOptions) (*http.Response, error)
 }
 
 // APIVersionLocalClient implements the APIVersionLocalOperations interface.
@@ -40,8 +40,8 @@ func (client *APIVersionLocalClient) Do(req *azcore.Request) (*azcore.Response, 
 }
 
 // GetMethodLocalNull - Get method with api-version modeled in the method.  pass in api-version = null to succeed
-func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, apiVersionLocalGetMethodLocalNullOptions *APIVersionLocalGetMethodLocalNullOptions) (*http.Response, error) {
-	req, err := client.GetMethodLocalNullCreateRequest(ctx, apiVersionLocalGetMethodLocalNullOptions)
+func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, options *APIVersionLocalGetMethodLocalNullOptions) (*http.Response, error) {
+	req, err := client.GetMethodLocalNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,15 +56,15 @@ func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, api
 }
 
 // GetMethodLocalNullCreateRequest creates the GetMethodLocalNull request.
-func (client *APIVersionLocalClient) GetMethodLocalNullCreateRequest(ctx context.Context, apiVersionLocalGetMethodLocalNullOptions *APIVersionLocalGetMethodLocalNullOptions) (*azcore.Request, error) {
+func (client *APIVersionLocalClient) GetMethodLocalNullCreateRequest(ctx context.Context, options *APIVersionLocalGetMethodLocalNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if apiVersionLocalGetMethodLocalNullOptions != nil && apiVersionLocalGetMethodLocalNullOptions.ApiVersion != nil {
-		query.Set("api-version", *apiVersionLocalGetMethodLocalNullOptions.ApiVersion)
+	if options != nil && options.ApiVersion != nil {
+		query.Set("api-version", *options.ApiVersion)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -81,8 +81,8 @@ func (client *APIVersionLocalClient) GetMethodLocalNullHandleError(resp *azcore.
 }
 
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetMethodLocalValidCreateRequest(ctx)
+func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context, options *APIVersionLocalGetMethodLocalValidOptions) (*http.Response, error) {
+	req, err := client.GetMethodLocalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context) (*
 }
 
 // GetMethodLocalValidCreateRequest creates the GetMethodLocalValid request.
-func (client *APIVersionLocalClient) GetMethodLocalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionLocalClient) GetMethodLocalValidCreateRequest(ctx context.Context, options *APIVersionLocalGetMethodLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/method/string/none/query/local/2.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -120,8 +120,8 @@ func (client *APIVersionLocalClient) GetMethodLocalValidHandleError(resp *azcore
 }
 
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetPathLocalValidCreateRequest(ctx)
+func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context, options *APIVersionLocalGetPathLocalValidOptions) (*http.Response, error) {
+	req, err := client.GetPathLocalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context) (*ht
 }
 
 // GetPathLocalValidCreateRequest creates the GetPathLocalValid request.
-func (client *APIVersionLocalClient) GetPathLocalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionLocalClient) GetPathLocalValidCreateRequest(ctx context.Context, options *APIVersionLocalGetPathLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/path/string/none/query/local/2.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -159,8 +159,8 @@ func (client *APIVersionLocalClient) GetPathLocalValidHandleError(resp *azcore.R
 }
 
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
-func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetSwaggerLocalValidCreateRequest(ctx)
+func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context, options *APIVersionLocalGetSwaggerLocalValidOptions) (*http.Response, error) {
+	req, err := client.GetSwaggerLocalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context) (
 }
 
 // GetSwaggerLocalValidCreateRequest creates the GetSwaggerLocalValid request.
-func (client *APIVersionLocalClient) GetSwaggerLocalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *APIVersionLocalClient) GetSwaggerLocalValidCreateRequest(ctx context.Context, options *APIVersionLocalGetSwaggerLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/apiVersion/swagger/string/none/query/local/2.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -14,9 +14,9 @@ import (
 // HeaderOperations contains the methods for the Header group.
 type HeaderOperations interface {
 	// CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-	CustomNamedRequestID(ctx context.Context, fooClientRequestId string) (*HeaderCustomNamedRequestIDResponse, error)
+	CustomNamedRequestID(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDOptions) (*HeaderCustomNamedRequestIDResponse, error)
 	// CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-	CustomNamedRequestIDHead(ctx context.Context, fooClientRequestId string) (*HeaderCustomNamedRequestIDHeadResponse, error)
+	CustomNamedRequestIDHead(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDHeadOptions) (*HeaderCustomNamedRequestIDHeadResponse, error)
 	// CustomNamedRequestIDParamGrouping - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group
 	CustomNamedRequestIDParamGrouping(ctx context.Context, headerCustomNamedRequestIdParamGroupingParameters HeaderCustomNamedRequestIDParamGroupingParameters) (*HeaderCustomNamedRequestIDParamGroupingResponse, error)
 }
@@ -38,8 +38,8 @@ func (client *HeaderClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientRequestId string) (*HeaderCustomNamedRequestIDResponse, error) {
-	req, err := client.CustomNamedRequestIDCreateRequest(ctx, fooClientRequestId)
+func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDOptions) (*HeaderCustomNamedRequestIDResponse, error) {
+	req, err := client.CustomNamedRequestIDCreateRequest(ctx, fooClientRequestId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientR
 }
 
 // CustomNamedRequestIDCreateRequest creates the CustomNamedRequestID request.
-func (client *HeaderClient) CustomNamedRequestIDCreateRequest(ctx context.Context, fooClientRequestId string) (*azcore.Request, error) {
+func (client *HeaderClient) CustomNamedRequestIDCreateRequest(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestId"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -88,8 +88,8 @@ func (client *HeaderClient) CustomNamedRequestIDHandleError(resp *azcore.Respons
 }
 
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooClientRequestId string) (*HeaderCustomNamedRequestIDHeadResponse, error) {
-	req, err := client.CustomNamedRequestIDHeadCreateRequest(ctx, fooClientRequestId)
+func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDHeadOptions) (*HeaderCustomNamedRequestIDHeadResponse, error) {
+	req, err := client.CustomNamedRequestIDHeadCreateRequest(ctx, fooClientRequestId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooCli
 }
 
 // CustomNamedRequestIDHeadCreateRequest creates the CustomNamedRequestIDHead request.
-func (client *HeaderClient) CustomNamedRequestIDHeadCreateRequest(ctx context.Context, fooClientRequestId string) (*azcore.Request, error) {
+func (client *HeaderClient) CustomNamedRequestIDHeadCreateRequest(ctx context.Context, fooClientRequestId string, options *HeaderCustomNamedRequestIDHeadOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestIdHead"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/azurespecialsgroup/zz_generated_models.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_models.go
@@ -10,10 +10,51 @@ import (
 	"net/http"
 )
 
+// APIVersionDefaultGetMethodGlobalNotProvidedValidOptions contains the optional parameters for the APIVersionDefault.GetMethodGlobalNotProvidedValid
+// method.
+type APIVersionDefaultGetMethodGlobalNotProvidedValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIVersionDefaultGetMethodGlobalValidOptions contains the optional parameters for the APIVersionDefault.GetMethodGlobalValid
+// method.
+type APIVersionDefaultGetMethodGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIVersionDefaultGetPathGlobalValidOptions contains the optional parameters for the APIVersionDefault.GetPathGlobalValid
+// method.
+type APIVersionDefaultGetPathGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIVersionDefaultGetSwaggerGlobalValidOptions contains the optional parameters for the APIVersionDefault.GetSwaggerGlobalValid
+// method.
+type APIVersionDefaultGetSwaggerGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 // APIVersionLocalGetMethodLocalNullOptions contains the optional parameters for the APIVersionLocal.GetMethodLocalNull method.
 type APIVersionLocalGetMethodLocalNullOptions struct {
 	// This should appear as a method parameter, use value null, this should result in no serialized parameter
 	ApiVersion *string
+}
+
+// APIVersionLocalGetMethodLocalValidOptions contains the optional parameters for the APIVersionLocal.GetMethodLocalValid
+// method.
+type APIVersionLocalGetMethodLocalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIVersionLocalGetPathLocalValidOptions contains the optional parameters for the APIVersionLocal.GetPathLocalValid method.
+type APIVersionLocalGetPathLocalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIVersionLocalGetSwaggerLocalValidOptions contains the optional parameters for the APIVersionLocal.GetSwaggerLocalValid
+// method.
+type APIVersionLocalGetSwaggerLocalValidOptions struct {
+	// placeholder for future optional parameters
 }
 
 type Error struct {
@@ -40,6 +81,11 @@ func (e Error) Error() string {
 	return msg
 }
 
+// HeaderCustomNamedRequestIDHeadOptions contains the optional parameters for the Header.CustomNamedRequestIDHead method.
+type HeaderCustomNamedRequestIDHeadOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderCustomNamedRequestIDHeadResponse contains the response from method Header.CustomNamedRequestIDHead.
 type HeaderCustomNamedRequestIDHeadResponse struct {
 	// FooRequestID contains the information returned from the foo-request-id header response.
@@ -47,6 +93,17 @@ type HeaderCustomNamedRequestIDHeadResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// HeaderCustomNamedRequestIDOptions contains the optional parameters for the Header.CustomNamedRequestID method.
+type HeaderCustomNamedRequestIDOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderCustomNamedRequestIDParamGroupingOptions contains the optional parameters for the Header.CustomNamedRequestIDParamGrouping
+// method.
+type HeaderCustomNamedRequestIDParamGroupingOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderCustomNamedRequestIDParamGroupingParameters contains a group of parameters for the Header.CustomNamedRequestIDParamGrouping
@@ -89,8 +146,105 @@ type OdataGetWithFilterOptions struct {
 	Top *int32
 }
 
+// SkipURLEncodingGetMethodPathValidOptions contains the optional parameters for the SkipURLEncoding.GetMethodPathValid method.
+type SkipURLEncodingGetMethodPathValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SkipURLEncodingGetMethodQueryNullOptions contains the optional parameters for the SkipURLEncoding.GetMethodQueryNull method.
 type SkipURLEncodingGetMethodQueryNullOptions struct {
 	// Unencoded query parameter with value null
 	Q1 *string
+}
+
+// SkipURLEncodingGetMethodQueryValidOptions contains the optional parameters for the SkipURLEncoding.GetMethodQueryValid
+// method.
+type SkipURLEncodingGetMethodQueryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SkipURLEncodingGetPathQueryValidOptions contains the optional parameters for the SkipURLEncoding.GetPathQueryValid method.
+type SkipURLEncodingGetPathQueryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SkipURLEncodingGetPathValidOptions contains the optional parameters for the SkipURLEncoding.GetPathValid method.
+type SkipURLEncodingGetPathValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SkipURLEncodingGetSwaggerPathValidOptions contains the optional parameters for the SkipURLEncoding.GetSwaggerPathValid
+// method.
+type SkipURLEncodingGetSwaggerPathValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SkipURLEncodingGetSwaggerQueryValidOptions contains the optional parameters for the SkipURLEncoding.GetSwaggerQueryValid
+// method.
+type SkipURLEncodingGetSwaggerQueryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInCredentialsPostMethodGlobalNotProvidedValidOptions contains the optional parameters for the SubscriptionInCredentials.PostMethodGlobalNotProvidedValid
+// method.
+type SubscriptionInCredentialsPostMethodGlobalNotProvidedValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInCredentialsPostMethodGlobalNullOptions contains the optional parameters for the SubscriptionInCredentials.PostMethodGlobalNull
+// method.
+type SubscriptionInCredentialsPostMethodGlobalNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInCredentialsPostMethodGlobalValidOptions contains the optional parameters for the SubscriptionInCredentials.PostMethodGlobalValid
+// method.
+type SubscriptionInCredentialsPostMethodGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInCredentialsPostPathGlobalValidOptions contains the optional parameters for the SubscriptionInCredentials.PostPathGlobalValid
+// method.
+type SubscriptionInCredentialsPostPathGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInCredentialsPostSwaggerGlobalValidOptions contains the optional parameters for the SubscriptionInCredentials.PostSwaggerGlobalValid
+// method.
+type SubscriptionInCredentialsPostSwaggerGlobalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInMethodPostMethodLocalNullOptions contains the optional parameters for the SubscriptionInMethod.PostMethodLocalNull
+// method.
+type SubscriptionInMethodPostMethodLocalNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInMethodPostMethodLocalValidOptions contains the optional parameters for the SubscriptionInMethod.PostMethodLocalValid
+// method.
+type SubscriptionInMethodPostMethodLocalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInMethodPostPathLocalValidOptions contains the optional parameters for the SubscriptionInMethod.PostPathLocalValid
+// method.
+type SubscriptionInMethodPostPathLocalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubscriptionInMethodPostSwaggerLocalValidOptions contains the optional parameters for the SubscriptionInMethod.PostSwaggerLocalValid
+// method.
+type SubscriptionInMethodPostSwaggerLocalValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMSClientRequestIDGetOptions contains the optional parameters for the XMSClientRequestID.Get method.
+type XMSClientRequestIDGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMSClientRequestIDParamGetOptions contains the optional parameters for the XMSClientRequestID.ParamGet method.
+type XMSClientRequestIDParamGetOptions struct {
+	// placeholder for future optional parameters
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_odata.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata.go
@@ -15,7 +15,7 @@ import (
 // OdataOperations contains the methods for the Odata group.
 type OdataOperations interface {
 	// GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
-	GetWithFilter(ctx context.Context, odataGetWithFilterOptions *OdataGetWithFilterOptions) (*http.Response, error)
+	GetWithFilter(ctx context.Context, options *OdataGetWithFilterOptions) (*http.Response, error)
 }
 
 // OdataClient implements the OdataOperations interface.
@@ -35,8 +35,8 @@ func (client *OdataClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
-func (client *OdataClient) GetWithFilter(ctx context.Context, odataGetWithFilterOptions *OdataGetWithFilterOptions) (*http.Response, error) {
-	req, err := client.GetWithFilterCreateRequest(ctx, odataGetWithFilterOptions)
+func (client *OdataClient) GetWithFilter(ctx context.Context, options *OdataGetWithFilterOptions) (*http.Response, error) {
+	req, err := client.GetWithFilterCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -51,21 +51,21 @@ func (client *OdataClient) GetWithFilter(ctx context.Context, odataGetWithFilter
 }
 
 // GetWithFilterCreateRequest creates the GetWithFilter request.
-func (client *OdataClient) GetWithFilterCreateRequest(ctx context.Context, odataGetWithFilterOptions *OdataGetWithFilterOptions) (*azcore.Request, error) {
+func (client *OdataClient) GetWithFilterCreateRequest(ctx context.Context, options *OdataGetWithFilterOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/odata/filter"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if odataGetWithFilterOptions != nil && odataGetWithFilterOptions.Filter != nil {
-		query.Set("$filter", *odataGetWithFilterOptions.Filter)
+	if options != nil && options.Filter != nil {
+		query.Set("$filter", *options.Filter)
 	}
-	if odataGetWithFilterOptions != nil && odataGetWithFilterOptions.Top != nil {
-		query.Set("$top", strconv.FormatInt(int64(*odataGetWithFilterOptions.Top), 10))
+	if options != nil && options.Top != nil {
+		query.Set("$top", strconv.FormatInt(int64(*options.Top), 10))
 	}
-	if odataGetWithFilterOptions != nil && odataGetWithFilterOptions.Orderby != nil {
-		query.Set("$orderby", *odataGetWithFilterOptions.Orderby)
+	if options != nil && options.Orderby != nil {
+		query.Set("$orderby", *options.Orderby)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding.go
@@ -15,19 +15,19 @@ import (
 // SkipURLEncodingOperations contains the methods for the SkipURLEncoding group.
 type SkipURLEncodingOperations interface {
 	// GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-	GetMethodPathValid(ctx context.Context, unencodedPathParam string) (*http.Response, error)
+	GetMethodPathValid(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetMethodPathValidOptions) (*http.Response, error)
 	// GetMethodQueryNull - Get method with unencoded query parameter with value null
-	GetMethodQueryNull(ctx context.Context, skipUrlEncodingGetMethodQueryNullOptions *SkipURLEncodingGetMethodQueryNullOptions) (*http.Response, error)
+	GetMethodQueryNull(ctx context.Context, options *SkipURLEncodingGetMethodQueryNullOptions) (*http.Response, error)
 	// GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-	GetMethodQueryValid(ctx context.Context, q1 string) (*http.Response, error)
+	GetMethodQueryValid(ctx context.Context, q1 string, options *SkipURLEncodingGetMethodQueryValidOptions) (*http.Response, error)
 	// GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-	GetPathQueryValid(ctx context.Context, q1 string) (*http.Response, error)
+	GetPathQueryValid(ctx context.Context, q1 string, options *SkipURLEncodingGetPathQueryValidOptions) (*http.Response, error)
 	// GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-	GetPathValid(ctx context.Context, unencodedPathParam string) (*http.Response, error)
+	GetPathValid(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetPathValidOptions) (*http.Response, error)
 	// GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-	GetSwaggerPathValid(ctx context.Context) (*http.Response, error)
+	GetSwaggerPathValid(ctx context.Context, options *SkipURLEncodingGetSwaggerPathValidOptions) (*http.Response, error)
 	// GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-	GetSwaggerQueryValid(ctx context.Context) (*http.Response, error)
+	GetSwaggerQueryValid(ctx context.Context, options *SkipURLEncodingGetSwaggerQueryValidOptions) (*http.Response, error)
 }
 
 // SkipURLEncodingClient implements the SkipURLEncodingOperations interface.
@@ -47,8 +47,8 @@ func (client *SkipURLEncodingClient) Do(req *azcore.Request) (*azcore.Response, 
 }
 
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, unencodedPathParam string) (*http.Response, error) {
-	req, err := client.GetMethodPathValidCreateRequest(ctx, unencodedPathParam)
+func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetMethodPathValidOptions) (*http.Response, error) {
+	req, err := client.GetMethodPathValidCreateRequest(ctx, unencodedPathParam, options)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, une
 }
 
 // GetMethodPathValidCreateRequest creates the GetMethodPathValid request.
-func (client *SkipURLEncodingClient) GetMethodPathValidCreateRequest(ctx context.Context, unencodedPathParam string) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetMethodPathValidCreateRequest(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetMethodPathValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -84,8 +84,8 @@ func (client *SkipURLEncodingClient) GetMethodPathValidHandleError(resp *azcore.
 }
 
 // GetMethodQueryNull - Get method with unencoded query parameter with value null
-func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, skipUrlEncodingGetMethodQueryNullOptions *SkipURLEncodingGetMethodQueryNullOptions) (*http.Response, error) {
-	req, err := client.GetMethodQueryNullCreateRequest(ctx, skipUrlEncodingGetMethodQueryNullOptions)
+func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, options *SkipURLEncodingGetMethodQueryNullOptions) (*http.Response, error) {
+	req, err := client.GetMethodQueryNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,15 +100,15 @@ func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, ski
 }
 
 // GetMethodQueryNullCreateRequest creates the GetMethodQueryNull request.
-func (client *SkipURLEncodingClient) GetMethodQueryNullCreateRequest(ctx context.Context, skipUrlEncodingGetMethodQueryNullOptions *SkipURLEncodingGetMethodQueryNullOptions) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetMethodQueryNullCreateRequest(ctx context.Context, options *SkipURLEncodingGetMethodQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	unencodedParams := []string{}
-	if skipUrlEncodingGetMethodQueryNullOptions != nil && skipUrlEncodingGetMethodQueryNullOptions.Q1 != nil {
-		unencodedParams = append(unencodedParams, "q1="+*skipUrlEncodingGetMethodQueryNullOptions.Q1)
+	if options != nil && options.Q1 != nil {
+		unencodedParams = append(unencodedParams, "q1="+*options.Q1)
 	}
 	req.URL.RawQuery = strings.Join(unencodedParams, "&")
 	req.Header.Set("Accept", "application/json")
@@ -125,8 +125,8 @@ func (client *SkipURLEncodingClient) GetMethodQueryNullHandleError(resp *azcore.
 }
 
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1 string) (*http.Response, error) {
-	req, err := client.GetMethodQueryValidCreateRequest(ctx, q1)
+func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1 string, options *SkipURLEncodingGetMethodQueryValidOptions) (*http.Response, error) {
+	req, err := client.GetMethodQueryValidCreateRequest(ctx, q1, options)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1
 }
 
 // GetMethodQueryValidCreateRequest creates the GetMethodQueryValid request.
-func (client *SkipURLEncodingClient) GetMethodQueryValidCreateRequest(ctx context.Context, q1 string) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetMethodQueryValidCreateRequest(ctx context.Context, q1 string, options *SkipURLEncodingGetMethodQueryValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/method/query/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -164,8 +164,8 @@ func (client *SkipURLEncodingClient) GetMethodQueryValidHandleError(resp *azcore
 }
 
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 string) (*http.Response, error) {
-	req, err := client.GetPathQueryValidCreateRequest(ctx, q1)
+func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 string, options *SkipURLEncodingGetPathQueryValidOptions) (*http.Response, error) {
+	req, err := client.GetPathQueryValidCreateRequest(ctx, q1, options)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 s
 }
 
 // GetPathQueryValidCreateRequest creates the GetPathQueryValid request.
-func (client *SkipURLEncodingClient) GetPathQueryValidCreateRequest(ctx context.Context, q1 string) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetPathQueryValidCreateRequest(ctx context.Context, q1 string, options *SkipURLEncodingGetPathQueryValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/path/query/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -203,8 +203,8 @@ func (client *SkipURLEncodingClient) GetPathQueryValidHandleError(resp *azcore.R
 }
 
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencodedPathParam string) (*http.Response, error) {
-	req, err := client.GetPathValidCreateRequest(ctx, unencodedPathParam)
+func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetPathValidOptions) (*http.Response, error) {
+	req, err := client.GetPathValidCreateRequest(ctx, unencodedPathParam, options)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencoded
 }
 
 // GetPathValidCreateRequest creates the GetPathValid request.
-func (client *SkipURLEncodingClient) GetPathValidCreateRequest(ctx context.Context, unencodedPathParam string) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetPathValidCreateRequest(ctx context.Context, unencodedPathParam string, options *SkipURLEncodingGetPathValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/path/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", unencodedPathParam)
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -240,8 +240,8 @@ func (client *SkipURLEncodingClient) GetPathValidHandleError(resp *azcore.Respon
 }
 
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
-func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetSwaggerPathValidCreateRequest(ctx)
+func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context, options *SkipURLEncodingGetSwaggerPathValidOptions) (*http.Response, error) {
+	req, err := client.GetSwaggerPathValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context) (*
 }
 
 // GetSwaggerPathValidCreateRequest creates the GetSwaggerPathValid request.
-func (client *SkipURLEncodingClient) GetSwaggerPathValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetSwaggerPathValidCreateRequest(ctx context.Context, options *SkipURLEncodingGetSwaggerPathValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/path/valid/{unencodedPathParam}"
 	urlPath = strings.ReplaceAll(urlPath, "{unencodedPathParam}", "path1/path2/path3")
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -277,8 +277,8 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValidHandleError(resp *azcore
 }
 
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
-func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetSwaggerQueryValidCreateRequest(ctx)
+func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context, options *SkipURLEncodingGetSwaggerQueryValidOptions) (*http.Response, error) {
+	req, err := client.GetSwaggerQueryValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +293,7 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context) (
 }
 
 // GetSwaggerQueryValidCreateRequest creates the GetSwaggerQueryValid request.
-func (client *SkipURLEncodingClient) GetSwaggerQueryValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SkipURLEncodingClient) GetSwaggerQueryValidCreateRequest(ctx context.Context, options *SkipURLEncodingGetSwaggerQueryValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/skipUrlEncoding/swagger/query/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials.go
@@ -16,15 +16,15 @@ import (
 // SubscriptionInCredentialsOperations contains the methods for the SubscriptionInCredentials group.
 type SubscriptionInCredentialsOperations interface {
 	// PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-	PostMethodGlobalNotProvidedValid(ctx context.Context) (*http.Response, error)
+	PostMethodGlobalNotProvidedValid(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNotProvidedValidOptions) (*http.Response, error)
 	// PostMethodGlobalNull - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call
-	PostMethodGlobalNull(ctx context.Context) (*http.Response, error)
+	PostMethodGlobalNull(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNullOptions) (*http.Response, error)
 	// PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-	PostMethodGlobalValid(ctx context.Context) (*http.Response, error)
+	PostMethodGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalValidOptions) (*http.Response, error)
 	// PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-	PostPathGlobalValid(ctx context.Context) (*http.Response, error)
+	PostPathGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostPathGlobalValidOptions) (*http.Response, error)
 	// PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-	PostSwaggerGlobalValid(ctx context.Context) (*http.Response, error)
+	PostSwaggerGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostSwaggerGlobalValidOptions) (*http.Response, error)
 }
 
 // SubscriptionInCredentialsClient implements the SubscriptionInCredentialsOperations interface.
@@ -45,8 +45,8 @@ func (client *SubscriptionInCredentialsClient) Do(req *azcore.Request) (*azcore.
 }
 
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.PostMethodGlobalNotProvidedValidCreateRequest(ctx)
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNotProvidedValidOptions) (*http.Response, error) {
+	req, err := client.PostMethodGlobalNotProvidedValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(
 }
 
 // PostMethodGlobalNotProvidedValidCreateRequest creates the PostMethodGlobalNotProvidedValid request.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidCreateRequest(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNotProvidedValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/globalNotProvided/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -85,8 +85,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValidH
 }
 
 // PostMethodGlobalNull - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to null, and client-side validation should prevent you from making this call
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.Context) (*http.Response, error) {
-	req, err := client.PostMethodGlobalNullCreateRequest(ctx)
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNullOptions) (*http.Response, error) {
+	req, err := client.PostMethodGlobalNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.
 }
 
 // PostMethodGlobalNullCreateRequest creates the PostMethodGlobalNull request.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullCreateRequest(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -122,8 +122,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNullHandleError(r
 }
 
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.PostMethodGlobalValidCreateRequest(ctx)
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalValidOptions) (*http.Response, error) {
+	req, err := client.PostMethodGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context
 }
 
 // PostMethodGlobalValidCreateRequest creates the PostMethodGlobalValid request.
-func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidCreateRequest(ctx context.Context, options *SubscriptionInCredentialsPostMethodGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -159,8 +159,8 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValidHandleError(
 }
 
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.PostPathGlobalValidCreateRequest(ctx)
+func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostPathGlobalValidOptions) (*http.Response, error) {
+	req, err := client.PostPathGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.C
 }
 
 // PostPathGlobalValidCreateRequest creates the PostPathGlobalValid request.
-func (client *SubscriptionInCredentialsClient) PostPathGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SubscriptionInCredentialsClient) PostPathGlobalValidCreateRequest(ctx context.Context, options *SubscriptionInCredentialsPostPathGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -196,8 +196,8 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValidHandleError(re
 }
 
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.PostSwaggerGlobalValidCreateRequest(ctx)
+func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx context.Context, options *SubscriptionInCredentialsPostSwaggerGlobalValidOptions) (*http.Response, error) {
+	req, err := client.PostSwaggerGlobalValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx contex
 }
 
 // PostSwaggerGlobalValidCreateRequest creates the PostSwaggerGlobalValid request.
-func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValidCreateRequest(ctx context.Context, options *SubscriptionInCredentialsPostSwaggerGlobalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/global/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod.go
@@ -16,13 +16,13 @@ import (
 // SubscriptionInMethodOperations contains the methods for the SubscriptionInMethod group.
 type SubscriptionInMethodOperations interface {
 	// PostMethodLocalNull - POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call
-	PostMethodLocalNull(ctx context.Context, subscriptionId string) (*http.Response, error)
+	PostMethodLocalNull(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalNullOptions) (*http.Response, error)
 	// PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-	PostMethodLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error)
+	PostMethodLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalValidOptions) (*http.Response, error)
 	// PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-	PostPathLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error)
+	PostPathLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostPathLocalValidOptions) (*http.Response, error)
 	// PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-	PostSwaggerLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error)
+	PostSwaggerLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostSwaggerLocalValidOptions) (*http.Response, error)
 }
 
 // SubscriptionInMethodClient implements the SubscriptionInMethodOperations interface.
@@ -42,8 +42,8 @@ func (client *SubscriptionInMethodClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // PostMethodLocalNull - POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call
-func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Context, subscriptionId string) (*http.Response, error) {
-	req, err := client.PostMethodLocalNullCreateRequest(ctx, subscriptionId)
+func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalNullOptions) (*http.Response, error) {
+	req, err := client.PostMethodLocalNullCreateRequest(ctx, subscriptionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Contex
 }
 
 // PostMethodLocalNullCreateRequest creates the PostMethodLocalNull request.
-func (client *SubscriptionInMethodClient) PostMethodLocalNullCreateRequest(ctx context.Context, subscriptionId string) (*azcore.Request, error) {
+func (client *SubscriptionInMethodClient) PostMethodLocalNullCreateRequest(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalNullOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/null/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -79,8 +79,8 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNullHandleError(resp *a
 }
 
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error) {
-	req, err := client.PostMethodLocalValidCreateRequest(ctx, subscriptionId)
+func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalValidOptions) (*http.Response, error) {
+	req, err := client.PostMethodLocalValidCreateRequest(ctx, subscriptionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Conte
 }
 
 // PostMethodLocalValidCreateRequest creates the PostMethodLocalValid request.
-func (client *SubscriptionInMethodClient) PostMethodLocalValidCreateRequest(ctx context.Context, subscriptionId string) (*azcore.Request, error) {
+func (client *SubscriptionInMethodClient) PostMethodLocalValidCreateRequest(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostMethodLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -116,8 +116,8 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValidHandleError(resp *
 }
 
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error) {
-	req, err := client.PostPathLocalValidCreateRequest(ctx, subscriptionId)
+func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostPathLocalValidOptions) (*http.Response, error) {
+	req, err := client.PostPathLocalValidCreateRequest(ctx, subscriptionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context
 }
 
 // PostPathLocalValidCreateRequest creates the PostPathLocalValid request.
-func (client *SubscriptionInMethodClient) PostPathLocalValidCreateRequest(ctx context.Context, subscriptionId string) (*azcore.Request, error) {
+func (client *SubscriptionInMethodClient) PostPathLocalValidCreateRequest(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostPathLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/path/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -153,8 +153,8 @@ func (client *SubscriptionInMethodClient) PostPathLocalValidHandleError(resp *az
 }
 
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
-func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Context, subscriptionId string) (*http.Response, error) {
-	req, err := client.PostSwaggerLocalValidCreateRequest(ctx, subscriptionId)
+func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostSwaggerLocalValidOptions) (*http.Response, error) {
+	req, err := client.PostSwaggerLocalValidCreateRequest(ctx, subscriptionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Cont
 }
 
 // PostSwaggerLocalValidCreateRequest creates the PostSwaggerLocalValid request.
-func (client *SubscriptionInMethodClient) PostSwaggerLocalValidCreateRequest(ctx context.Context, subscriptionId string) (*azcore.Request, error) {
+func (client *SubscriptionInMethodClient) PostSwaggerLocalValidCreateRequest(ctx context.Context, subscriptionId string, options *SubscriptionInMethodPostSwaggerLocalValidOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/subscriptionId/swagger/string/none/path/local/1234-5678-9012-3456/{subscriptionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid.go
@@ -17,9 +17,9 @@ import (
 // XMSClientRequestIDOperations contains the methods for the XMSClientRequestID group.
 type XMSClientRequestIDOperations interface {
 	// Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
-	Get(ctx context.Context) (*http.Response, error)
+	Get(ctx context.Context, options *XMSClientRequestIDGetOptions) (*http.Response, error)
 	// ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
-	ParamGet(ctx context.Context, xMSClientRequestId string) (*http.Response, error)
+	ParamGet(ctx context.Context, xMSClientRequestId string, options *XMSClientRequestIDParamGetOptions) (*http.Response, error)
 }
 
 // XMSClientRequestIDClient implements the XMSClientRequestIDOperations interface.
@@ -39,8 +39,8 @@ func (client *XMSClientRequestIDClient) Do(req *azcore.Request) (*azcore.Respons
 }
 
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
-func (client *XMSClientRequestIDClient) Get(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetCreateRequest(ctx)
+func (client *XMSClientRequestIDClient) Get(ctx context.Context, options *XMSClientRequestIDGetOptions) (*http.Response, error) {
+	req, err := client.GetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (client *XMSClientRequestIDClient) Get(ctx context.Context) (*http.Response
 }
 
 // GetCreateRequest creates the Get request.
-func (client *XMSClientRequestIDClient) GetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMSClientRequestIDClient) GetCreateRequest(ctx context.Context, options *XMSClientRequestIDGetOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/method/"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -77,8 +77,8 @@ func (client *XMSClientRequestIDClient) GetHandleError(resp *azcore.Response) er
 }
 
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
-func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xMSClientRequestId string) (*http.Response, error) {
-	req, err := client.ParamGetCreateRequest(ctx, xMSClientRequestId)
+func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xMSClientRequestId string, options *XMSClientRequestIDParamGetOptions) (*http.Response, error) {
+	req, err := client.ParamGetCreateRequest(ctx, xMSClientRequestId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xMSClientR
 }
 
 // ParamGetCreateRequest creates the ParamGet request.
-func (client *XMSClientRequestIDClient) ParamGetCreateRequest(ctx context.Context, xMSClientRequestId string) (*azcore.Request, error) {
+func (client *XMSClientRequestIDClient) ParamGetCreateRequest(ctx context.Context, xMSClientRequestId string, options *XMSClientRequestIDParamGetOptions) (*azcore.Request, error) {
 	urlPath := "/azurespecials/overwrite/x-ms-client-request-id/via-param/method/"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -16,7 +16,7 @@ func newBoolClient() BoolOperations {
 
 func TestGetTrue(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.GetTrue(context.Background())
+	result, err := client.GetTrue(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetTrue: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestGetTrue(t *testing.T) {
 
 func TestGetFalse(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.GetFalse(context.Background())
+	result, err := client.GetFalse(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetFalse: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestGetFalse(t *testing.T) {
 
 func TestGetNull(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestGetNull(t *testing.T) {
 
 func TestGetInvalid(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.GetInvalid(context.Background())
+	result, err := client.GetInvalid(context.Background(), nil)
 	// TODO: verify error response is clear and actionable
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -60,7 +60,7 @@ func TestGetInvalid(t *testing.T) {
 
 func TestPutTrue(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.PutTrue(context.Background())
+	result, err := client.PutTrue(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutTrue: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestPutTrue(t *testing.T) {
 
 func TestPutFalse(t *testing.T) {
 	client := newBoolClient()
-	result, err := client.PutFalse(context.Background())
+	result, err := client.PutFalse(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutFalse: %v", err)
 	}

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -14,17 +14,17 @@ import (
 // BoolOperations contains the methods for the Bool group.
 type BoolOperations interface {
 	// GetFalse - Get false Boolean value
-	GetFalse(ctx context.Context) (*BoolResponse, error)
+	GetFalse(ctx context.Context, options *BoolGetFalseOptions) (*BoolResponse, error)
 	// GetInvalid - Get invalid Boolean value
-	GetInvalid(ctx context.Context) (*BoolResponse, error)
+	GetInvalid(ctx context.Context, options *BoolGetInvalidOptions) (*BoolResponse, error)
 	// GetNull - Get null Boolean value
-	GetNull(ctx context.Context) (*BoolResponse, error)
+	GetNull(ctx context.Context, options *BoolGetNullOptions) (*BoolResponse, error)
 	// GetTrue - Get true Boolean value
-	GetTrue(ctx context.Context) (*BoolResponse, error)
+	GetTrue(ctx context.Context, options *BoolGetTrueOptions) (*BoolResponse, error)
 	// PutFalse - Set Boolean value false
-	PutFalse(ctx context.Context) (*http.Response, error)
+	PutFalse(ctx context.Context, options *BoolPutFalseOptions) (*http.Response, error)
 	// PutTrue - Set Boolean value true
-	PutTrue(ctx context.Context) (*http.Response, error)
+	PutTrue(ctx context.Context, options *BoolPutTrueOptions) (*http.Response, error)
 }
 
 // BoolClient implements the BoolOperations interface.
@@ -44,8 +44,8 @@ func (client *BoolClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetFalse - Get false Boolean value
-func (client *BoolClient) GetFalse(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetFalseCreateRequest(ctx)
+func (client *BoolClient) GetFalse(ctx context.Context, options *BoolGetFalseOptions) (*BoolResponse, error) {
+	req, err := client.GetFalseCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *BoolClient) GetFalse(ctx context.Context) (*BoolResponse, error) {
 }
 
 // GetFalseCreateRequest creates the GetFalse request.
-func (client *BoolClient) GetFalseCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) GetFalseCreateRequest(ctx context.Context, options *BoolGetFalseOptions) (*azcore.Request, error) {
 	urlPath := "/bool/false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -90,8 +90,8 @@ func (client *BoolClient) GetFalseHandleError(resp *azcore.Response) error {
 }
 
 // GetInvalid - Get invalid Boolean value
-func (client *BoolClient) GetInvalid(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *BoolClient) GetInvalid(ctx context.Context, options *BoolGetInvalidOptions) (*BoolResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *BoolClient) GetInvalid(ctx context.Context) (*BoolResponse, error)
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *BoolClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) GetInvalidCreateRequest(ctx context.Context, options *BoolGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/bool/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *BoolClient) GetInvalidHandleError(resp *azcore.Response) error {
 }
 
 // GetNull - Get null Boolean value
-func (client *BoolClient) GetNull(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *BoolClient) GetNull(ctx context.Context, options *BoolGetNullOptions) (*BoolResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *BoolClient) GetNull(ctx context.Context) (*BoolResponse, error) {
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *BoolClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) GetNullCreateRequest(ctx context.Context, options *BoolGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/bool/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -182,8 +182,8 @@ func (client *BoolClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetTrue - Get true Boolean value
-func (client *BoolClient) GetTrue(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetTrueCreateRequest(ctx)
+func (client *BoolClient) GetTrue(ctx context.Context, options *BoolGetTrueOptions) (*BoolResponse, error) {
+	req, err := client.GetTrueCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *BoolClient) GetTrue(ctx context.Context) (*BoolResponse, error) {
 }
 
 // GetTrueCreateRequest creates the GetTrue request.
-func (client *BoolClient) GetTrueCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) GetTrueCreateRequest(ctx context.Context, options *BoolGetTrueOptions) (*azcore.Request, error) {
 	urlPath := "/bool/true"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -228,8 +228,8 @@ func (client *BoolClient) GetTrueHandleError(resp *azcore.Response) error {
 }
 
 // PutFalse - Set Boolean value false
-func (client *BoolClient) PutFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutFalseCreateRequest(ctx)
+func (client *BoolClient) PutFalse(ctx context.Context, options *BoolPutFalseOptions) (*http.Response, error) {
+	req, err := client.PutFalseCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (client *BoolClient) PutFalse(ctx context.Context) (*http.Response, error) 
 }
 
 // PutFalseCreateRequest creates the PutFalse request.
-func (client *BoolClient) PutFalseCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) PutFalseCreateRequest(ctx context.Context, options *BoolPutFalseOptions) (*azcore.Request, error) {
 	urlPath := "/bool/false"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -264,8 +264,8 @@ func (client *BoolClient) PutFalseHandleError(resp *azcore.Response) error {
 }
 
 // PutTrue - Set Boolean value true
-func (client *BoolClient) PutTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutTrueCreateRequest(ctx)
+func (client *BoolClient) PutTrue(ctx context.Context, options *BoolPutTrueOptions) (*http.Response, error) {
+	req, err := client.PutTrueCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (client *BoolClient) PutTrue(ctx context.Context) (*http.Response, error) {
 }
 
 // PutTrueCreateRequest creates the PutTrue request.
-func (client *BoolClient) PutTrueCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BoolClient) PutTrueCreateRequest(ctx context.Context, options *BoolPutTrueOptions) (*azcore.Request, error) {
 	urlPath := "/bool/true"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/booleangroup/zz_generated_models.go
+++ b/test/autorest/booleangroup/zz_generated_models.go
@@ -10,6 +10,36 @@ import (
 	"net/http"
 )
 
+// BoolGetFalseOptions contains the optional parameters for the Bool.GetFalse method.
+type BoolGetFalseOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BoolGetInvalidOptions contains the optional parameters for the Bool.GetInvalid method.
+type BoolGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BoolGetNullOptions contains the optional parameters for the Bool.GetNull method.
+type BoolGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BoolGetTrueOptions contains the optional parameters for the Bool.GetTrue method.
+type BoolGetTrueOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BoolPutFalseOptions contains the optional parameters for the Bool.PutFalse method.
+type BoolPutFalseOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BoolPutTrueOptions contains the optional parameters for the Bool.PutTrue method.
+type BoolPutTrueOptions struct {
+	// placeholder for future optional parameters
+}
+
 // BoolResponse is the response envelope for operations that return a bool type.
 type BoolResponse struct {
 	// RawResponse contains the underlying HTTP response.

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -16,7 +16,7 @@ func newByteClient() ByteOperations {
 
 func TestGetEmpty(t *testing.T) {
 	client := newByteClient()
-	result, err := client.GetEmpty(context.Background())
+	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestGetEmpty(t *testing.T) {
 
 func TestGetInvalid(t *testing.T) {
 	client := newByteClient()
-	result, err := client.GetInvalid(context.Background())
+	result, err := client.GetInvalid(context.Background(), nil)
 	// TODO: verify error response is clear and actionable
 	if err == nil {
 		t.Fatal("unexpected nil error")
@@ -38,7 +38,7 @@ func TestGetInvalid(t *testing.T) {
 
 func TestGetNonASCII(t *testing.T) {
 	client := newByteClient()
-	result, err := client.GetNonASCII(context.Background())
+	result, err := client.GetNonASCII(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNonASCII: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestGetNonASCII(t *testing.T) {
 
 func TestGetNull(t *testing.T) {
 	client := newByteClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestGetNull(t *testing.T) {
 
 func TestPutNonASCII(t *testing.T) {
 	client := newByteClient()
-	result, err := client.PutNonASCII(context.Background(), []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8, 0xF7, 0xF6})
+	result, err := client.PutNonASCII(context.Background(), []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8, 0xF7, 0xF6}, nil)
 	if err != nil {
 		t.Fatalf("PutNonASCII: %v", err)
 	}

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -14,15 +14,15 @@ import (
 // ByteOperations contains the methods for the Byte group.
 type ByteOperations interface {
 	// GetEmpty - Get empty byte value ''
-	GetEmpty(ctx context.Context) (*ByteArrayResponse, error)
+	GetEmpty(ctx context.Context, options *ByteGetEmptyOptions) (*ByteArrayResponse, error)
 	// GetInvalid - Get invalid byte value ':::SWAGGER::::'
-	GetInvalid(ctx context.Context) (*ByteArrayResponse, error)
+	GetInvalid(ctx context.Context, options *ByteGetInvalidOptions) (*ByteArrayResponse, error)
 	// GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-	GetNonASCII(ctx context.Context) (*ByteArrayResponse, error)
+	GetNonASCII(ctx context.Context, options *ByteGetNonASCIIOptions) (*ByteArrayResponse, error)
 	// GetNull - Get null byte value
-	GetNull(ctx context.Context) (*ByteArrayResponse, error)
+	GetNull(ctx context.Context, options *ByteGetNullOptions) (*ByteArrayResponse, error)
 	// PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-	PutNonASCII(ctx context.Context, byteBody []byte) (*http.Response, error)
+	PutNonASCII(ctx context.Context, byteBody []byte, options *BytePutNonASCIIOptions) (*http.Response, error)
 }
 
 // ByteClient implements the ByteOperations interface.
@@ -42,8 +42,8 @@ func (client *ByteClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmpty - Get empty byte value ''
-func (client *ByteClient) GetEmpty(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *ByteClient) GetEmpty(ctx context.Context, options *ByteGetEmptyOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (client *ByteClient) GetEmpty(ctx context.Context) (*ByteArrayResponse, err
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *ByteClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ByteClient) GetEmptyCreateRequest(ctx context.Context, options *ByteGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/byte/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -88,8 +88,8 @@ func (client *ByteClient) GetEmptyHandleError(resp *azcore.Response) error {
 }
 
 // GetInvalid - Get invalid byte value ':::SWAGGER::::'
-func (client *ByteClient) GetInvalid(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *ByteClient) GetInvalid(ctx context.Context, options *ByteGetInvalidOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (client *ByteClient) GetInvalid(ctx context.Context) (*ByteArrayResponse, e
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *ByteClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ByteClient) GetInvalidCreateRequest(ctx context.Context, options *ByteGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/byte/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -134,8 +134,8 @@ func (client *ByteClient) GetInvalidHandleError(resp *azcore.Response) error {
 }
 
 // GetNonASCII - Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-func (client *ByteClient) GetNonASCII(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetNonASCIICreateRequest(ctx)
+func (client *ByteClient) GetNonASCII(ctx context.Context, options *ByteGetNonASCIIOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetNonASCIICreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (client *ByteClient) GetNonASCII(ctx context.Context) (*ByteArrayResponse, 
 }
 
 // GetNonASCIICreateRequest creates the GetNonASCII request.
-func (client *ByteClient) GetNonASCIICreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ByteClient) GetNonASCIICreateRequest(ctx context.Context, options *ByteGetNonASCIIOptions) (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -180,8 +180,8 @@ func (client *ByteClient) GetNonASCIIHandleError(resp *azcore.Response) error {
 }
 
 // GetNull - Get null byte value
-func (client *ByteClient) GetNull(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *ByteClient) GetNull(ctx context.Context, options *ByteGetNullOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (client *ByteClient) GetNull(ctx context.Context) (*ByteArrayResponse, erro
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *ByteClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ByteClient) GetNullCreateRequest(ctx context.Context, options *ByteGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/byte/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -226,8 +226,8 @@ func (client *ByteClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // PutNonASCII - Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
-func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte) (*http.Response, error) {
-	req, err := client.PutNonASCIICreateRequest(ctx, byteBody)
+func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte, options *BytePutNonASCIIOptions) (*http.Response, error) {
+	req, err := client.PutNonASCIICreateRequest(ctx, byteBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte) (*ht
 }
 
 // PutNonASCIICreateRequest creates the PutNonASCII request.
-func (client *ByteClient) PutNonASCIICreateRequest(ctx context.Context, byteBody []byte) (*azcore.Request, error) {
+func (client *ByteClient) PutNonASCIICreateRequest(ctx context.Context, byteBody []byte, options *BytePutNonASCIIOptions) (*azcore.Request, error) {
 	urlPath := "/byte/nonAscii"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/bytegroup/zz_generated_models.go
+++ b/test/autorest/bytegroup/zz_generated_models.go
@@ -19,6 +19,31 @@ type ByteArrayResponse struct {
 	Value *[]byte
 }
 
+// ByteGetEmptyOptions contains the optional parameters for the Byte.GetEmpty method.
+type ByteGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ByteGetInvalidOptions contains the optional parameters for the Byte.GetInvalid method.
+type ByteGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ByteGetNonASCIIOptions contains the optional parameters for the Byte.GetNonASCII method.
+type ByteGetNonASCIIOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ByteGetNullOptions contains the optional parameters for the Byte.GetNull method.
+type ByteGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BytePutNonASCIIOptions contains the optional parameters for the Byte.PutNonASCII method.
+type BytePutNonASCIIOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -16,7 +16,7 @@ func newArrayClient() ArrayOperations {
 
 func TestArrayGetEmpty(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.GetEmpty(context.Background())
+	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestArrayGetEmpty(t *testing.T) {
 
 func TestArrayGetNotProvided(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.GetNotProvided(context.Background())
+	result, err := client.GetNotProvided(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestArrayGetNotProvided(t *testing.T) {
 
 func TestArrayGetValid(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestArrayGetValid(t *testing.T) {
 
 func TestArrayPutEmpty(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: &[]string{}})
+	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: &[]string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -18,7 +18,7 @@ func newBasicClient() BasicOperations {
 
 func TestBasicGetValid(t *testing.T) {
 	client := newBasicClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestBasicPutValid(t *testing.T) {
 		ID:    to.Int32Ptr(2),
 		Name:  to.StringPtr("abc"),
 		Color: CMYKColorsMagenta.ToPtr(),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestBasicPutValid(t *testing.T) {
 
 func TestBasicGetInvalid(t *testing.T) {
 	client := newBasicClient()
-	result, err := client.GetInvalid(context.Background())
+	result, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("GetInvalid expected an error")
 	}
@@ -51,7 +51,7 @@ func TestBasicGetInvalid(t *testing.T) {
 
 func TestBasicGetEmpty(t *testing.T) {
 	client := newBasicClient()
-	result, err := client.GetEmpty(context.Background())
+	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestBasicGetEmpty(t *testing.T) {
 
 func TestBasicGetNull(t *testing.T) {
 	client := newBasicClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestBasicGetNull(t *testing.T) {
 
 func TestBasicGetNotProvided(t *testing.T) {
 	client := newBasicClient()
-	result, err := client.GetNotProvided(context.Background())
+	result, err := client.GetNotProvided(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
 	}

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -16,7 +16,7 @@ func newDictionaryClient() DictionaryOperations {
 
 func TestDictionaryGetEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.GetEmpty(context.Background())
+	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestDictionaryGetEmpty(t *testing.T) {
 
 func TestDictionaryGetNotProvided(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.GetNotProvided(context.Background())
+	result, err := client.GetNotProvided(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestDictionaryGetNotProvided(t *testing.T) {
 
 func TestDictionaryGetNull(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestDictionaryGetNull(t *testing.T) {
 test is invalid, expects null values but missing x-nullable
 func TestDictionaryGetValid(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestDictionaryGetValid(t *testing.T) {
 
 func TestDictionaryPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]string{}})
+	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -18,7 +18,7 @@ func newInheritanceClient() InheritanceOperations {
 
 func TestInheritanceGetValid(t *testing.T) {
 	client := newInheritanceClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestInheritancePutValid(t *testing.T) {
 			},
 		},
 		Breed: to.StringPtr("persian"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -20,7 +20,7 @@ func newPolymorphicrecursiveClient() PolymorphicrecursiveOperations {
 // GetValid - Get complex types that are polymorphic and have recursive references
 func TestGetValid(t *testing.T) {
 	client := newPolymorphicrecursiveClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestPutValid(t *testing.T) {
 		},
 		Iswild:   to.BoolPtr(true),
 		Location: to.StringPtr("alaska"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -20,7 +20,7 @@ func newPolymorphismClient() PolymorphismOperations {
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
 func TestPolymorphismGetComplicated(t *testing.T) {
 	client := newPolymorphismClient()
-	result, err := client.GetComplicated(context.Background())
+	result, err := client.GetComplicated(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
 func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 	client := newPolymorphismClient()
-	result, err := client.GetComposedWithDiscriminator(context.Background())
+	result, err := client.GetComposedWithDiscriminator(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
 func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 	client := newPolymorphismClient()
-	result, err := client.GetComposedWithoutDiscriminator(context.Background())
+	result, err := client.GetComposedWithoutDiscriminator(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
 func TestPolymorphismGetDotSyntax(t *testing.T) {
 	client := newPolymorphismClient()
-	result, err := client.GetDotSyntax(context.Background())
+	result, err := client.GetDotSyntax(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestPolymorphismGetDotSyntax(t *testing.T) {
 // GetValid - Get complex types that are polymorphic
 func TestPolymorphismGetValid(t *testing.T) {
 	client := newPolymorphismClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 				float64(1), float64(3),
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -397,7 +397,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 		},
 		Iswild:   to.BoolPtr(true),
 		Location: to.StringPtr("alaska"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +450,7 @@ func TestPolymorphismPutValid(t *testing.T) {
 		},
 		Iswild:   to.BoolPtr(true),
 		Location: to.StringPtr("alaska"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -19,7 +19,7 @@ func newPrimitiveClient() PrimitiveOperations {
 
 func TestPrimitiveGetInt(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetInt(context.Background())
+	result, err := client.GetInt(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetInt: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestPrimitiveGetInt(t *testing.T) {
 func TestPrimitivePutInt(t *testing.T) {
 	client := newPrimitiveClient()
 	a, b := int32(-1), int32(2)
-	result, err := client.PutInt(context.Background(), IntWrapper{Field1: &a, Field2: &b})
+	result, err := client.PutInt(context.Background(), IntWrapper{Field1: &a, Field2: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutInt: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestPrimitivePutInt(t *testing.T) {
 
 func TestPrimitiveGetLong(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetLong(context.Background())
+	result, err := client.GetLong(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetLong: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestPrimitiveGetLong(t *testing.T) {
 func TestPrimitivePutLong(t *testing.T) {
 	client := newPrimitiveClient()
 	a, b := int64(1099511627775), int64(-999511627788)
-	result, err := client.PutLong(context.Background(), LongWrapper{Field1: &a, Field2: &b})
+	result, err := client.PutLong(context.Background(), LongWrapper{Field1: &a, Field2: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutLong: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestPrimitivePutLong(t *testing.T) {
 
 func TestPrimitiveGetFloat(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetFloat(context.Background())
+	result, err := client.GetFloat(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetFloat: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestPrimitiveGetFloat(t *testing.T) {
 func TestPrimitivePutFloat(t *testing.T) {
 	client := newPrimitiveClient()
 	a, b := float32(1.05), float32(-0.003)
-	result, err := client.PutFloat(context.Background(), FloatWrapper{Field1: &a, Field2: &b})
+	result, err := client.PutFloat(context.Background(), FloatWrapper{Field1: &a, Field2: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutFloat: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestPrimitivePutFloat(t *testing.T) {
 
 func TestPrimitiveGetDouble(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetDouble(context.Background())
+	result, err := client.GetDouble(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetDouble: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestPrimitiveGetDouble(t *testing.T) {
 func TestPrimitivePutDouble(t *testing.T) {
 	client := newPrimitiveClient()
 	a, b := float64(3e-100), float64(-0.000000000000000000000000000000000000000000000000000000005)
-	result, err := client.PutDouble(context.Background(), DoubleWrapper{Field1: &a, Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose: &b})
+	result, err := client.PutDouble(context.Background(), DoubleWrapper{Field1: &a, Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutDouble: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestPrimitivePutDouble(t *testing.T) {
 
 func TestPrimitiveGetBool(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetBool(context.Background())
+	result, err := client.GetBool(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBool: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestPrimitiveGetBool(t *testing.T) {
 
 func TestPrimitiveGetByte(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetByte(context.Background())
+	result, err := client.GetByte(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetByte: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestPrimitiveGetByte(t *testing.T) {
 func TestPrimitivePutBool(t *testing.T) {
 	client := newPrimitiveClient()
 	a, b := true, false
-	result, err := client.PutBool(context.Background(), BooleanWrapper{FieldTrue: &a, FieldFalse: &b})
+	result, err := client.PutBool(context.Background(), BooleanWrapper{FieldTrue: &a, FieldFalse: &b}, nil)
 	if err != nil {
 		t.Fatalf("PutBool: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestPrimitivePutBool(t *testing.T) {
 func TestPrimitivePutByte(t *testing.T) {
 	client := newPrimitiveClient()
 	val := []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}
-	result, err := client.PutByte(context.Background(), ByteWrapper{Field: &val})
+	result, err := client.PutByte(context.Background(), ByteWrapper{Field: &val}, nil)
 	if err != nil {
 		t.Fatalf("PutByte: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestPrimitivePutByte(t *testing.T) {
 
 func TestPrimitiveGetString(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetString(context.Background())
+	result, err := client.GetString(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetString: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestPrimitivePutString(t *testing.T) {
 	client := newPrimitiveClient()
 	var c *string
 	a, b, c := "goodrequest", "", nil
-	result, err := client.PutString(context.Background(), StringWrapper{Field: &a, Empty: &b, Null: c})
+	result, err := client.PutString(context.Background(), StringWrapper{Field: &a, Empty: &b, Null: c}, nil)
 	if err != nil {
 		t.Fatalf("PutString: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestPrimitivePutString(t *testing.T) {
 
 // func TestPrimitiveGetDate(t *testing.T) {
 // 	client := newPrimitiveClient()
-// 	result, err := client.GetDate(context.Background())
+// 	result, err := client.GetDate(context.Background(), nil)
 // 	if err != nil {
 // 		t.Fatalf("GetDate: %v", err)
 // 	}
@@ -209,7 +209,7 @@ func TestPrimitivePutString(t *testing.T) {
 
 func TestPrimitiveGetDuration(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetDuration(context.Background())
+	result, err := client.GetDuration(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetDuration: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestPrimitiveGetDuration(t *testing.T) {
 
 func TestPrimitivePutDuration(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.PutDuration(context.Background(), DurationWrapper{Field: to.StringPtr("P123DT22H14M12.011S")})
+	result, err := client.PutDuration(context.Background(), DurationWrapper{Field: to.StringPtr("P123DT22H14M12.011S")}, nil)
 	if err != nil {
 		t.Fatalf("PutDuration: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestPrimitivePutDuration(t *testing.T) {
 
 func TestPrimitiveGetDateTime(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetDateTime(context.Background())
+	result, err := client.GetDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetDateTime: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestPrimitiveGetDateTime(t *testing.T) {
 
 func TestPrimitiveGetDateTimeRFC1123(t *testing.T) {
 	client := newPrimitiveClient()
-	result, err := client.GetDateTimeRFC1123(context.Background())
+	result, err := client.GetDateTimeRFC1123(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetDateTimeRFC1123: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestPrimitivePutDateTime(t *testing.T) {
 	result, err := client.PutDateTime(context.Background(), DatetimeWrapper{
 		Field: &f,
 		Now:   &n,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("PutDateTime: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestPrimitivePutDateTimeRFC1123(t *testing.T) {
 	result, err := client.PutDateTimeRFC1123(context.Background(), Datetimerfc1123Wrapper{
 		Field: &f,
 		Now:   &n,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("PutDateTimeRFC1123: %v", err)
 	}

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -18,7 +18,7 @@ func newReadonlypropertyClient() ReadonlypropertyOperations {
 
 func TestReadonlypropertyGetValid(t *testing.T) {
 	client := newReadonlypropertyClient()
-	result, err := client.GetValid(context.Background())
+	result, err := client.GetValid(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetValid: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestReadonlypropertyGetValid(t *testing.T) {
 func TestReadonlypropertyPutValid(t *testing.T) {
 	client := newReadonlypropertyClient()
 	id, size := "1234", int32(2)
-	result, err := client.PutValid(context.Background(), ReadonlyObj{ID: &id, Size: &size})
+	result, err := client.PutValid(context.Background(), ReadonlyObj{ID: &id, Size: &size}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -14,15 +14,15 @@ import (
 // ArrayOperations contains the methods for the Array group.
 type ArrayOperations interface {
 	// GetEmpty - Get complex types with array property which is empty
-	GetEmpty(ctx context.Context) (*ArrayWrapperResponse, error)
+	GetEmpty(ctx context.Context, options *ArrayGetEmptyOptions) (*ArrayWrapperResponse, error)
 	// GetNotProvided - Get complex types with array property while server doesn't provide a response payload
-	GetNotProvided(ctx context.Context) (*ArrayWrapperResponse, error)
+	GetNotProvided(ctx context.Context, options *ArrayGetNotProvidedOptions) (*ArrayWrapperResponse, error)
 	// GetValid - Get complex types with array property
-	GetValid(ctx context.Context) (*ArrayWrapperResponse, error)
+	GetValid(ctx context.Context, options *ArrayGetValidOptions) (*ArrayWrapperResponse, error)
 	// PutEmpty - Put complex types with array property which is empty
-	PutEmpty(ctx context.Context, complexBody ArrayWrapper) (*http.Response, error)
+	PutEmpty(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutEmptyOptions) (*http.Response, error)
 	// PutValid - Put complex types with array property
-	PutValid(ctx context.Context, complexBody ArrayWrapper) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutValidOptions) (*http.Response, error)
 }
 
 // ArrayClient implements the ArrayOperations interface.
@@ -42,8 +42,8 @@ func (client *ArrayClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmpty - Get complex types with array property which is empty
-func (client *ArrayClient) GetEmpty(ctx context.Context) (*ArrayWrapperResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *ArrayClient) GetEmpty(ctx context.Context, options *ArrayGetEmptyOptions) (*ArrayWrapperResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (client *ArrayClient) GetEmpty(ctx context.Context) (*ArrayWrapperResponse,
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetEmptyCreateRequest(ctx context.Context, options *ArrayGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/complex/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -88,8 +88,8 @@ func (client *ArrayClient) GetEmptyHandleError(resp *azcore.Response) error {
 }
 
 // GetNotProvided - Get complex types with array property while server doesn't provide a response payload
-func (client *ArrayClient) GetNotProvided(ctx context.Context) (*ArrayWrapperResponse, error) {
-	req, err := client.GetNotProvidedCreateRequest(ctx)
+func (client *ArrayClient) GetNotProvided(ctx context.Context, options *ArrayGetNotProvidedOptions) (*ArrayWrapperResponse, error) {
+	req, err := client.GetNotProvidedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (client *ArrayClient) GetNotProvided(ctx context.Context) (*ArrayWrapperRes
 }
 
 // GetNotProvidedCreateRequest creates the GetNotProvided request.
-func (client *ArrayClient) GetNotProvidedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetNotProvidedCreateRequest(ctx context.Context, options *ArrayGetNotProvidedOptions) (*azcore.Request, error) {
 	urlPath := "/complex/array/notprovided"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -134,8 +134,8 @@ func (client *ArrayClient) GetNotProvidedHandleError(resp *azcore.Response) erro
 }
 
 // GetValid - Get complex types with array property
-func (client *ArrayClient) GetValid(ctx context.Context) (*ArrayWrapperResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *ArrayClient) GetValid(ctx context.Context, options *ArrayGetValidOptions) (*ArrayWrapperResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (client *ArrayClient) GetValid(ctx context.Context) (*ArrayWrapperResponse,
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *ArrayClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ArrayClient) GetValidCreateRequest(ctx context.Context, options *ArrayGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -180,8 +180,8 @@ func (client *ArrayClient) GetValidHandleError(resp *azcore.Response) error {
 }
 
 // PutEmpty - Put complex types with array property which is empty
-func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrapper) (*http.Response, error) {
-	req, err := client.PutEmptyCreateRequest(ctx, complexBody)
+func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutEmptyOptions) (*http.Response, error) {
+	req, err := client.PutEmptyCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrappe
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
-func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, complexBody ArrayWrapper) (*azcore.Request, error) {
+func (client *ArrayClient) PutEmptyCreateRequest(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/complex/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -216,8 +216,8 @@ func (client *ArrayClient) PutEmptyHandleError(resp *azcore.Response) error {
 }
 
 // PutValid - Put complex types with array property
-func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrapper) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrappe
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *ArrayClient) PutValidCreateRequest(ctx context.Context, complexBody ArrayWrapper) (*azcore.Request, error) {
+func (client *ArrayClient) PutValidCreateRequest(ctx context.Context, complexBody ArrayWrapper, options *ArrayPutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -14,17 +14,17 @@ import (
 // BasicOperations contains the methods for the Basic group.
 type BasicOperations interface {
 	// GetEmpty - Get a basic complex type that is empty
-	GetEmpty(ctx context.Context) (*BasicResponse, error)
+	GetEmpty(ctx context.Context, options *BasicGetEmptyOptions) (*BasicResponse, error)
 	// GetInvalid - Get a basic complex type that is invalid for the local strong type
-	GetInvalid(ctx context.Context) (*BasicResponse, error)
+	GetInvalid(ctx context.Context, options *BasicGetInvalidOptions) (*BasicResponse, error)
 	// GetNotProvided - Get a basic complex type while the server doesn't provide a response payload
-	GetNotProvided(ctx context.Context) (*BasicResponse, error)
+	GetNotProvided(ctx context.Context, options *BasicGetNotProvidedOptions) (*BasicResponse, error)
 	// GetNull - Get a basic complex type whose properties are null
-	GetNull(ctx context.Context) (*BasicResponse, error)
+	GetNull(ctx context.Context, options *BasicGetNullOptions) (*BasicResponse, error)
 	// GetValid - Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
-	GetValid(ctx context.Context) (*BasicResponse, error)
+	GetValid(ctx context.Context, options *BasicGetValidOptions) (*BasicResponse, error)
 	// PutValid - Please put {id: 2, name: 'abc', color: 'Magenta'}
-	PutValid(ctx context.Context, complexBody Basic) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody Basic, options *BasicPutValidOptions) (*http.Response, error)
 }
 
 // BasicClient implements the BasicOperations interface.
@@ -44,8 +44,8 @@ func (client *BasicClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmpty - Get a basic complex type that is empty
-func (client *BasicClient) GetEmpty(ctx context.Context) (*BasicResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *BasicClient) GetEmpty(ctx context.Context, options *BasicGetEmptyOptions) (*BasicResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *BasicClient) GetEmpty(ctx context.Context) (*BasicResponse, error)
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *BasicClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BasicClient) GetEmptyCreateRequest(ctx context.Context, options *BasicGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -90,8 +90,8 @@ func (client *BasicClient) GetEmptyHandleError(resp *azcore.Response) error {
 }
 
 // GetInvalid - Get a basic complex type that is invalid for the local strong type
-func (client *BasicClient) GetInvalid(ctx context.Context) (*BasicResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *BasicClient) GetInvalid(ctx context.Context, options *BasicGetInvalidOptions) (*BasicResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *BasicClient) GetInvalid(ctx context.Context) (*BasicResponse, erro
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *BasicClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BasicClient) GetInvalidCreateRequest(ctx context.Context, options *BasicGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *BasicClient) GetInvalidHandleError(resp *azcore.Response) error {
 }
 
 // GetNotProvided - Get a basic complex type while the server doesn't provide a response payload
-func (client *BasicClient) GetNotProvided(ctx context.Context) (*BasicResponse, error) {
-	req, err := client.GetNotProvidedCreateRequest(ctx)
+func (client *BasicClient) GetNotProvided(ctx context.Context, options *BasicGetNotProvidedOptions) (*BasicResponse, error) {
+	req, err := client.GetNotProvidedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *BasicClient) GetNotProvided(ctx context.Context) (*BasicResponse, 
 }
 
 // GetNotProvidedCreateRequest creates the GetNotProvided request.
-func (client *BasicClient) GetNotProvidedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BasicClient) GetNotProvidedCreateRequest(ctx context.Context, options *BasicGetNotProvidedOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/notprovided"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -182,8 +182,8 @@ func (client *BasicClient) GetNotProvidedHandleError(resp *azcore.Response) erro
 }
 
 // GetNull - Get a basic complex type whose properties are null
-func (client *BasicClient) GetNull(ctx context.Context) (*BasicResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *BasicClient) GetNull(ctx context.Context, options *BasicGetNullOptions) (*BasicResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *BasicClient) GetNull(ctx context.Context) (*BasicResponse, error) 
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *BasicClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BasicClient) GetNullCreateRequest(ctx context.Context, options *BasicGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -228,8 +228,8 @@ func (client *BasicClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetValid - Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
-func (client *BasicClient) GetValid(ctx context.Context) (*BasicResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *BasicClient) GetValid(ctx context.Context, options *BasicGetValidOptions) (*BasicResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (client *BasicClient) GetValid(ctx context.Context) (*BasicResponse, error)
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *BasicClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BasicClient) GetValidCreateRequest(ctx context.Context, options *BasicGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -274,8 +274,8 @@ func (client *BasicClient) GetValidHandleError(resp *azcore.Response) error {
 }
 
 // PutValid - Please put {id: 2, name: 'abc', color: 'Magenta'}
-func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic, options *BasicPutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic) (*ht
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *BasicClient) PutValidCreateRequest(ctx context.Context, complexBody Basic) (*azcore.Request, error) {
+func (client *BasicClient) PutValidCreateRequest(ctx context.Context, complexBody Basic, options *BasicPutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/basic/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -14,17 +14,17 @@ import (
 // DictionaryOperations contains the methods for the Dictionary group.
 type DictionaryOperations interface {
 	// GetEmpty - Get complex types with dictionary property which is empty
-	GetEmpty(ctx context.Context) (*DictionaryWrapperResponse, error)
+	GetEmpty(ctx context.Context, options *DictionaryGetEmptyOptions) (*DictionaryWrapperResponse, error)
 	// GetNotProvided - Get complex types with dictionary property while server doesn't provide a response payload
-	GetNotProvided(ctx context.Context) (*DictionaryWrapperResponse, error)
+	GetNotProvided(ctx context.Context, options *DictionaryGetNotProvidedOptions) (*DictionaryWrapperResponse, error)
 	// GetNull - Get complex types with dictionary property which is null
-	GetNull(ctx context.Context) (*DictionaryWrapperResponse, error)
+	GetNull(ctx context.Context, options *DictionaryGetNullOptions) (*DictionaryWrapperResponse, error)
 	// GetValid - Get complex types with dictionary property
-	GetValid(ctx context.Context) (*DictionaryWrapperResponse, error)
+	GetValid(ctx context.Context, options *DictionaryGetValidOptions) (*DictionaryWrapperResponse, error)
 	// PutEmpty - Put complex types with dictionary property which is empty
-	PutEmpty(ctx context.Context, complexBody DictionaryWrapper) (*http.Response, error)
+	PutEmpty(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutEmptyOptions) (*http.Response, error)
 	// PutValid - Put complex types with dictionary property
-	PutValid(ctx context.Context, complexBody DictionaryWrapper) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutValidOptions) (*http.Response, error)
 }
 
 // DictionaryClient implements the DictionaryOperations interface.
@@ -44,8 +44,8 @@ func (client *DictionaryClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // GetEmpty - Get complex types with dictionary property which is empty
-func (client *DictionaryClient) GetEmpty(ctx context.Context) (*DictionaryWrapperResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetEmpty(ctx context.Context, options *DictionaryGetEmptyOptions) (*DictionaryWrapperResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*DictionaryWrappe
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context, options *DictionaryGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -90,8 +90,8 @@ func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error
 }
 
 // GetNotProvided - Get complex types with dictionary property while server doesn't provide a response payload
-func (client *DictionaryClient) GetNotProvided(ctx context.Context) (*DictionaryWrapperResponse, error) {
-	req, err := client.GetNotProvidedCreateRequest(ctx)
+func (client *DictionaryClient) GetNotProvided(ctx context.Context, options *DictionaryGetNotProvidedOptions) (*DictionaryWrapperResponse, error) {
+	req, err := client.GetNotProvidedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *DictionaryClient) GetNotProvided(ctx context.Context) (*Dictionary
 }
 
 // GetNotProvidedCreateRequest creates the GetNotProvided request.
-func (client *DictionaryClient) GetNotProvidedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetNotProvidedCreateRequest(ctx context.Context, options *DictionaryGetNotProvidedOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/notprovided"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *DictionaryClient) GetNotProvidedHandleError(resp *azcore.Response)
 }
 
 // GetNull - Get complex types with dictionary property which is null
-func (client *DictionaryClient) GetNull(ctx context.Context) (*DictionaryWrapperResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *DictionaryClient) GetNull(ctx context.Context, options *DictionaryGetNullOptions) (*DictionaryWrapperResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*DictionaryWrapper
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context, options *DictionaryGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -182,8 +182,8 @@ func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error 
 }
 
 // GetValid - Get complex types with dictionary property
-func (client *DictionaryClient) GetValid(ctx context.Context) (*DictionaryWrapperResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *DictionaryClient) GetValid(ctx context.Context, options *DictionaryGetValidOptions) (*DictionaryWrapperResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (client *DictionaryClient) GetValid(ctx context.Context) (*DictionaryWrappe
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *DictionaryClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetValidCreateRequest(ctx context.Context, options *DictionaryGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -228,8 +228,8 @@ func (client *DictionaryClient) GetValidHandleError(resp *azcore.Response) error
 }
 
 // PutEmpty - Put complex types with dictionary property which is empty
-func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody DictionaryWrapper) (*http.Response, error) {
-	req, err := client.PutEmptyCreateRequest(ctx, complexBody)
+func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutEmptyOptions) (*http.Response, error) {
+	req, err := client.PutEmptyCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody Dictio
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
-func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, complexBody DictionaryWrapper) (*azcore.Request, error) {
+func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -264,8 +264,8 @@ func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error
 }
 
 // PutValid - Put complex types with dictionary property
-func (client *DictionaryClient) PutValid(ctx context.Context, complexBody DictionaryWrapper) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *DictionaryClient) PutValid(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (client *DictionaryClient) PutValid(ctx context.Context, complexBody Dictio
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *DictionaryClient) PutValidCreateRequest(ctx context.Context, complexBody DictionaryWrapper) (*azcore.Request, error) {
+func (client *DictionaryClient) PutValidCreateRequest(ctx context.Context, complexBody DictionaryWrapper, options *DictionaryPutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/dictionary/typed/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -16,7 +16,7 @@ import (
 
 // FlattencomplexOperations contains the methods for the Flattencomplex group.
 type FlattencomplexOperations interface {
-	GetValid(ctx context.Context) (*MyBaseTypeResponse, error)
+	GetValid(ctx context.Context, options *FlattencomplexGetValidOptions) (*MyBaseTypeResponse, error)
 }
 
 // FlattencomplexClient implements the FlattencomplexOperations interface.
@@ -35,8 +35,8 @@ func (client *FlattencomplexClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *FlattencomplexClient) GetValid(ctx context.Context) (*MyBaseTypeResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *FlattencomplexClient) GetValid(ctx context.Context, options *FlattencomplexGetValidOptions) (*MyBaseTypeResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (client *FlattencomplexClient) GetValid(ctx context.Context) (*MyBaseTypeRe
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *FlattencomplexClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FlattencomplexClient) GetValidCreateRequest(ctx context.Context, options *FlattencomplexGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/flatten/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -14,9 +14,9 @@ import (
 // InheritanceOperations contains the methods for the Inheritance group.
 type InheritanceOperations interface {
 	// GetValid - Get complex types that extend others
-	GetValid(ctx context.Context) (*SiameseResponse, error)
+	GetValid(ctx context.Context, options *InheritanceGetValidOptions) (*SiameseResponse, error)
 	// PutValid - Put complex types that extend others
-	PutValid(ctx context.Context, complexBody Siamese) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody Siamese, options *InheritancePutValidOptions) (*http.Response, error)
 }
 
 // InheritanceClient implements the InheritanceOperations interface.
@@ -36,8 +36,8 @@ func (client *InheritanceClient) Do(req *azcore.Request) (*azcore.Response, erro
 }
 
 // GetValid - Get complex types that extend others
-func (client *InheritanceClient) GetValid(ctx context.Context) (*SiameseResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *InheritanceClient) GetValid(ctx context.Context, options *InheritanceGetValidOptions) (*SiameseResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (client *InheritanceClient) GetValid(ctx context.Context) (*SiameseResponse
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *InheritanceClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *InheritanceClient) GetValidCreateRequest(ctx context.Context, options *InheritanceGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/inheritance/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -82,8 +82,8 @@ func (client *InheritanceClient) GetValidHandleError(resp *azcore.Response) erro
 }
 
 // PutValid - Put complex types that extend others
-func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siamese) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siamese, options *InheritancePutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siame
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *InheritanceClient) PutValidCreateRequest(ctx context.Context, complexBody Siamese) (*azcore.Request, error) {
+func (client *InheritanceClient) PutValidCreateRequest(ctx context.Context, complexBody Siamese, options *InheritancePutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/inheritance/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -12,6 +12,31 @@ import (
 	"time"
 )
 
+// ArrayGetEmptyOptions contains the optional parameters for the Array.GetEmpty method.
+type ArrayGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetNotProvidedOptions contains the optional parameters for the Array.GetNotProvided method.
+type ArrayGetNotProvidedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayGetValidOptions contains the optional parameters for the Array.GetValid method.
+type ArrayGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutEmptyOptions contains the optional parameters for the Array.PutEmpty method.
+type ArrayPutEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ArrayPutValidOptions contains the optional parameters for the Array.PutValid method.
+type ArrayPutValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 type ArrayWrapper struct {
 	Array *[]string `json:"array,omitempty"`
 }
@@ -32,6 +57,36 @@ type Basic struct {
 
 	// Name property with a very long description that does not fit on a single line and a line break.
 	Name *string `json:"name,omitempty"`
+}
+
+// BasicGetEmptyOptions contains the optional parameters for the Basic.GetEmpty method.
+type BasicGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BasicGetInvalidOptions contains the optional parameters for the Basic.GetInvalid method.
+type BasicGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BasicGetNotProvidedOptions contains the optional parameters for the Basic.GetNotProvided method.
+type BasicGetNotProvidedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BasicGetNullOptions contains the optional parameters for the Basic.GetNull method.
+type BasicGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BasicGetValidOptions contains the optional parameters for the Basic.GetValid method.
+type BasicGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BasicPutValidOptions contains the optional parameters for the Basic.PutValid method.
+type BasicPutValidOptions struct {
+	// placeholder for future optional parameters
 }
 
 // BasicResponse is the response envelope for operations that return a Basic type.
@@ -206,6 +261,36 @@ type Datetimerfc1123WrapperResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// DictionaryGetEmptyOptions contains the optional parameters for the Dictionary.GetEmpty method.
+type DictionaryGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetNotProvidedOptions contains the optional parameters for the Dictionary.GetNotProvided method.
+type DictionaryGetNotProvidedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetNullOptions contains the optional parameters for the Dictionary.GetNull method.
+type DictionaryGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetValidOptions contains the optional parameters for the Dictionary.GetValid method.
+type DictionaryGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutEmptyOptions contains the optional parameters for the Dictionary.PutEmpty method.
+type DictionaryPutEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutValidOptions contains the optional parameters for the Dictionary.PutValid method.
+type DictionaryPutValidOptions struct {
+	// placeholder for future optional parameters
 }
 
 type DictionaryWrapper struct {
@@ -530,6 +615,11 @@ func (f *FishResponse) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// FlattencomplexGetValidOptions contains the optional parameters for the Flattencomplex.GetValid method.
+type FlattencomplexGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 type FloatWrapper struct {
 	Field1 *float32 `json:"field1,omitempty"`
 	Field2 *float32 `json:"field2,omitempty"`
@@ -587,6 +677,16 @@ func (g *Goblinshark) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return g.Shark.unmarshalInternal(rawMsg)
+}
+
+// InheritanceGetValidOptions contains the optional parameters for the Inheritance.GetValid method.
+type InheritanceGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// InheritancePutValidOptions contains the optional parameters for the Inheritance.PutValid method.
+type InheritancePutValidOptions struct {
+	// placeholder for future optional parameters
 }
 
 type IntWrapper struct {
@@ -741,6 +841,175 @@ type Pet struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// PolymorphicrecursiveGetValidOptions contains the optional parameters for the Polymorphicrecursive.GetValid method.
+type PolymorphicrecursiveGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphicrecursivePutValidOptions contains the optional parameters for the Polymorphicrecursive.PutValid method.
+type PolymorphicrecursivePutValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismGetComplicatedOptions contains the optional parameters for the Polymorphism.GetComplicated method.
+type PolymorphismGetComplicatedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismGetComposedWithDiscriminatorOptions contains the optional parameters for the Polymorphism.GetComposedWithDiscriminator
+// method.
+type PolymorphismGetComposedWithDiscriminatorOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismGetComposedWithoutDiscriminatorOptions contains the optional parameters for the Polymorphism.GetComposedWithoutDiscriminator
+// method.
+type PolymorphismGetComposedWithoutDiscriminatorOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismGetDotSyntaxOptions contains the optional parameters for the Polymorphism.GetDotSyntax method.
+type PolymorphismGetDotSyntaxOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismGetValidOptions contains the optional parameters for the Polymorphism.GetValid method.
+type PolymorphismGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismPutComplicatedOptions contains the optional parameters for the Polymorphism.PutComplicated method.
+type PolymorphismPutComplicatedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismPutMissingDiscriminatorOptions contains the optional parameters for the Polymorphism.PutMissingDiscriminator
+// method.
+type PolymorphismPutMissingDiscriminatorOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismPutValidMissingRequiredOptions contains the optional parameters for the Polymorphism.PutValidMissingRequired
+// method.
+type PolymorphismPutValidMissingRequiredOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PolymorphismPutValidOptions contains the optional parameters for the Polymorphism.PutValid method.
+type PolymorphismPutValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetBoolOptions contains the optional parameters for the Primitive.GetBool method.
+type PrimitiveGetBoolOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetByteOptions contains the optional parameters for the Primitive.GetByte method.
+type PrimitiveGetByteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetDateOptions contains the optional parameters for the Primitive.GetDate method.
+type PrimitiveGetDateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetDateTimeOptions contains the optional parameters for the Primitive.GetDateTime method.
+type PrimitiveGetDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetDateTimeRFC1123Options contains the optional parameters for the Primitive.GetDateTimeRFC1123 method.
+type PrimitiveGetDateTimeRFC1123Options struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetDoubleOptions contains the optional parameters for the Primitive.GetDouble method.
+type PrimitiveGetDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetDurationOptions contains the optional parameters for the Primitive.GetDuration method.
+type PrimitiveGetDurationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetFloatOptions contains the optional parameters for the Primitive.GetFloat method.
+type PrimitiveGetFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetIntOptions contains the optional parameters for the Primitive.GetInt method.
+type PrimitiveGetIntOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetLongOptions contains the optional parameters for the Primitive.GetLong method.
+type PrimitiveGetLongOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitiveGetStringOptions contains the optional parameters for the Primitive.GetString method.
+type PrimitiveGetStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutBoolOptions contains the optional parameters for the Primitive.PutBool method.
+type PrimitivePutBoolOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutByteOptions contains the optional parameters for the Primitive.PutByte method.
+type PrimitivePutByteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutDateOptions contains the optional parameters for the Primitive.PutDate method.
+type PrimitivePutDateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutDateTimeOptions contains the optional parameters for the Primitive.PutDateTime method.
+type PrimitivePutDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutDateTimeRFC1123Options contains the optional parameters for the Primitive.PutDateTimeRFC1123 method.
+type PrimitivePutDateTimeRFC1123Options struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutDoubleOptions contains the optional parameters for the Primitive.PutDouble method.
+type PrimitivePutDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutDurationOptions contains the optional parameters for the Primitive.PutDuration method.
+type PrimitivePutDurationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutFloatOptions contains the optional parameters for the Primitive.PutFloat method.
+type PrimitivePutFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutIntOptions contains the optional parameters for the Primitive.PutInt method.
+type PrimitivePutIntOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutLongOptions contains the optional parameters for the Primitive.PutLong method.
+type PrimitivePutLongOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrimitivePutStringOptions contains the optional parameters for the Primitive.PutString method.
+type PrimitivePutStringOptions struct {
+	// placeholder for future optional parameters
+}
+
 type ReadonlyObj struct {
 	ID   *string `json:"id,omitempty" azure:"ro"`
 	Size *int32  `json:"size,omitempty"`
@@ -751,6 +1020,16 @@ type ReadonlyObjResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 	ReadonlyObj *ReadonlyObj
+}
+
+// ReadonlypropertyGetValidOptions contains the optional parameters for the Readonlyproperty.GetValid method.
+type ReadonlypropertyGetValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ReadonlypropertyPutValidOptions contains the optional parameters for the Readonlyproperty.PutValid method.
+type ReadonlypropertyPutValidOptions struct {
+	// placeholder for future optional parameters
 }
 
 // SalmonClassification provides polymorphic access to related types.

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -14,9 +14,9 @@ import (
 // PolymorphicrecursiveOperations contains the methods for the Polymorphicrecursive group.
 type PolymorphicrecursiveOperations interface {
 	// GetValid - Get complex types that are polymorphic and have recursive references
-	GetValid(ctx context.Context) (*FishResponse, error)
+	GetValid(ctx context.Context, options *PolymorphicrecursiveGetValidOptions) (*FishResponse, error)
 	// PutValid - Put complex types that are polymorphic and have recursive references
-	PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody FishClassification, options *PolymorphicrecursivePutValidOptions) (*http.Response, error)
 }
 
 // PolymorphicrecursiveClient implements the PolymorphicrecursiveOperations interface.
@@ -36,8 +36,8 @@ func (client *PolymorphicrecursiveClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // GetValid - Get complex types that are polymorphic and have recursive references
-func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context) (*FishResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context, options *PolymorphicrecursiveGetValidOptions) (*FishResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context) (*FishRe
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *PolymorphicrecursiveClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphicrecursiveClient) GetValidCreateRequest(ctx context.Context, options *PolymorphicrecursiveGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphicrecursive/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -82,8 +82,8 @@ func (client *PolymorphicrecursiveClient) GetValidHandleError(resp *azcore.Respo
 }
 
 // PutValid - Put complex types that are polymorphic and have recursive references
-func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexBody FishClassification, options *PolymorphicrecursivePutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexB
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *PolymorphicrecursiveClient) PutValidCreateRequest(ctx context.Context, complexBody FishClassification) (*azcore.Request, error) {
+func (client *PolymorphicrecursiveClient) PutValidCreateRequest(ctx context.Context, complexBody FishClassification, options *PolymorphicrecursivePutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphicrecursive/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -14,23 +14,23 @@ import (
 // PolymorphismOperations contains the methods for the Polymorphism group.
 type PolymorphismOperations interface {
 	// GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-	GetComplicated(ctx context.Context) (*SalmonResponse, error)
+	GetComplicated(ctx context.Context, options *PolymorphismGetComplicatedOptions) (*SalmonResponse, error)
 	// GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
-	GetComposedWithDiscriminator(ctx context.Context) (*DotFishMarketResponse, error)
+	GetComposedWithDiscriminator(ctx context.Context, options *PolymorphismGetComposedWithDiscriminatorOptions) (*DotFishMarketResponse, error)
 	// GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
-	GetComposedWithoutDiscriminator(ctx context.Context) (*DotFishMarketResponse, error)
+	GetComposedWithoutDiscriminator(ctx context.Context, options *PolymorphismGetComposedWithoutDiscriminatorOptions) (*DotFishMarketResponse, error)
 	// GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
-	GetDotSyntax(ctx context.Context) (*DotFishResponse, error)
+	GetDotSyntax(ctx context.Context, options *PolymorphismGetDotSyntaxOptions) (*DotFishResponse, error)
 	// GetValid - Get complex types that are polymorphic
-	GetValid(ctx context.Context) (*FishResponse, error)
+	GetValid(ctx context.Context, options *PolymorphismGetValidOptions) (*FishResponse, error)
 	// PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-	PutComplicated(ctx context.Context, complexBody SalmonClassification) (*http.Response, error)
+	PutComplicated(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutComplicatedOptions) (*http.Response, error)
 	// PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
-	PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification) (*SalmonResponse, error)
+	PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutMissingDiscriminatorOptions) (*SalmonResponse, error)
 	// PutValid - Put complex types that are polymorphic
-	PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidOptions) (*http.Response, error)
 	// PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
-	PutValidMissingRequired(ctx context.Context, complexBody FishClassification) (*http.Response, error)
+	PutValidMissingRequired(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidMissingRequiredOptions) (*http.Response, error)
 }
 
 // PolymorphismClient implements the PolymorphismOperations interface.
@@ -50,8 +50,8 @@ func (client *PolymorphismClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-func (client *PolymorphismClient) GetComplicated(ctx context.Context) (*SalmonResponse, error) {
-	req, err := client.GetComplicatedCreateRequest(ctx)
+func (client *PolymorphismClient) GetComplicated(ctx context.Context, options *PolymorphismGetComplicatedOptions) (*SalmonResponse, error) {
+	req, err := client.GetComplicatedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (client *PolymorphismClient) GetComplicated(ctx context.Context) (*SalmonRe
 }
 
 // GetComplicatedCreateRequest creates the GetComplicated request.
-func (client *PolymorphismClient) GetComplicatedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphismClient) GetComplicatedCreateRequest(ctx context.Context, options *PolymorphismGetComplicatedOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/complicated"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -96,8 +96,8 @@ func (client *PolymorphismClient) GetComplicatedHandleError(resp *azcore.Respons
 }
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
-func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Context) (*DotFishMarketResponse, error) {
-	req, err := client.GetComposedWithDiscriminatorCreateRequest(ctx)
+func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Context, options *PolymorphismGetComposedWithDiscriminatorOptions) (*DotFishMarketResponse, error) {
+	req, err := client.GetComposedWithDiscriminatorCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Conte
 }
 
 // GetComposedWithDiscriminatorCreateRequest creates the GetComposedWithDiscriminator request.
-func (client *PolymorphismClient) GetComposedWithDiscriminatorCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphismClient) GetComposedWithDiscriminatorCreateRequest(ctx context.Context, options *PolymorphismGetComposedWithDiscriminatorOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/composedWithDiscriminator"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -142,8 +142,8 @@ func (client *PolymorphismClient) GetComposedWithDiscriminatorHandleError(resp *
 }
 
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
-func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Context) (*DotFishMarketResponse, error) {
-	req, err := client.GetComposedWithoutDiscriminatorCreateRequest(ctx)
+func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Context, options *PolymorphismGetComposedWithoutDiscriminatorOptions) (*DotFishMarketResponse, error) {
+	req, err := client.GetComposedWithoutDiscriminatorCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Co
 }
 
 // GetComposedWithoutDiscriminatorCreateRequest creates the GetComposedWithoutDiscriminator request.
-func (client *PolymorphismClient) GetComposedWithoutDiscriminatorCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphismClient) GetComposedWithoutDiscriminatorCreateRequest(ctx context.Context, options *PolymorphismGetComposedWithoutDiscriminatorOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/composedWithoutDiscriminator"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -188,8 +188,8 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminatorHandleError(res
 }
 
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
-func (client *PolymorphismClient) GetDotSyntax(ctx context.Context) (*DotFishResponse, error) {
-	req, err := client.GetDotSyntaxCreateRequest(ctx)
+func (client *PolymorphismClient) GetDotSyntax(ctx context.Context, options *PolymorphismGetDotSyntaxOptions) (*DotFishResponse, error) {
+	req, err := client.GetDotSyntaxCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (client *PolymorphismClient) GetDotSyntax(ctx context.Context) (*DotFishRes
 }
 
 // GetDotSyntaxCreateRequest creates the GetDotSyntax request.
-func (client *PolymorphismClient) GetDotSyntaxCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphismClient) GetDotSyntaxCreateRequest(ctx context.Context, options *PolymorphismGetDotSyntaxOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/dotsyntax"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -234,8 +234,8 @@ func (client *PolymorphismClient) GetDotSyntaxHandleError(resp *azcore.Response)
 }
 
 // GetValid - Get complex types that are polymorphic
-func (client *PolymorphismClient) GetValid(ctx context.Context) (*FishResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *PolymorphismClient) GetValid(ctx context.Context, options *PolymorphismGetValidOptions) (*FishResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (client *PolymorphismClient) GetValid(ctx context.Context) (*FishResponse, 
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *PolymorphismClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PolymorphismClient) GetValidCreateRequest(ctx context.Context, options *PolymorphismGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -280,8 +280,8 @@ func (client *PolymorphismClient) GetValidHandleError(resp *azcore.Response) err
 }
 
 // PutComplicated - Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
-func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBody SalmonClassification) (*http.Response, error) {
-	req, err := client.PutComplicatedCreateRequest(ctx, complexBody)
+func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutComplicatedOptions) (*http.Response, error) {
+	req, err := client.PutComplicatedCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBod
 }
 
 // PutComplicatedCreateRequest creates the PutComplicated request.
-func (client *PolymorphismClient) PutComplicatedCreateRequest(ctx context.Context, complexBody SalmonClassification) (*azcore.Request, error) {
+func (client *PolymorphismClient) PutComplicatedCreateRequest(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutComplicatedOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/complicated"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -316,8 +316,8 @@ func (client *PolymorphismClient) PutComplicatedHandleError(resp *azcore.Respons
 }
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
-func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification) (*SalmonResponse, error) {
-	req, err := client.PutMissingDiscriminatorCreateRequest(ctx, complexBody)
+func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutMissingDiscriminatorOptions) (*SalmonResponse, error) {
+	req, err := client.PutMissingDiscriminatorCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, c
 }
 
 // PutMissingDiscriminatorCreateRequest creates the PutMissingDiscriminator request.
-func (client *PolymorphismClient) PutMissingDiscriminatorCreateRequest(ctx context.Context, complexBody SalmonClassification) (*azcore.Request, error) {
+func (client *PolymorphismClient) PutMissingDiscriminatorCreateRequest(ctx context.Context, complexBody SalmonClassification, options *PolymorphismPutMissingDiscriminatorOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingdiscriminator"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -362,8 +362,8 @@ func (client *PolymorphismClient) PutMissingDiscriminatorHandleError(resp *azcor
 }
 
 // PutValid - Put complex types that are polymorphic
-func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody Fish
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *PolymorphismClient) PutValidCreateRequest(ctx context.Context, complexBody FishClassification) (*azcore.Request, error) {
+func (client *PolymorphismClient) PutValidCreateRequest(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -398,8 +398,8 @@ func (client *PolymorphismClient) PutValidHandleError(resp *azcore.Response) err
 }
 
 // PutValidMissingRequired - Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client
-func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, complexBody FishClassification) (*http.Response, error) {
-	req, err := client.PutValidMissingRequiredCreateRequest(ctx, complexBody)
+func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidMissingRequiredOptions) (*http.Response, error) {
+	req, err := client.PutValidMissingRequiredCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, c
 }
 
 // PutValidMissingRequiredCreateRequest creates the PutValidMissingRequired request.
-func (client *PolymorphismClient) PutValidMissingRequiredCreateRequest(ctx context.Context, complexBody FishClassification) (*azcore.Request, error) {
+func (client *PolymorphismClient) PutValidMissingRequiredCreateRequest(ctx context.Context, complexBody FishClassification, options *PolymorphismPutValidMissingRequiredOptions) (*azcore.Request, error) {
 	urlPath := "/complex/polymorphism/missingrequired/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -14,49 +14,49 @@ import (
 // PrimitiveOperations contains the methods for the Primitive group.
 type PrimitiveOperations interface {
 	// GetBool - Get complex types with bool properties
-	GetBool(ctx context.Context) (*BooleanWrapperResponse, error)
+	GetBool(ctx context.Context, options *PrimitiveGetBoolOptions) (*BooleanWrapperResponse, error)
 	// GetByte - Get complex types with byte properties
-	GetByte(ctx context.Context) (*ByteWrapperResponse, error)
+	GetByte(ctx context.Context, options *PrimitiveGetByteOptions) (*ByteWrapperResponse, error)
 	// GetDate - Get complex types with date properties
-	GetDate(ctx context.Context) (*DateWrapperResponse, error)
+	GetDate(ctx context.Context, options *PrimitiveGetDateOptions) (*DateWrapperResponse, error)
 	// GetDateTime - Get complex types with datetime properties
-	GetDateTime(ctx context.Context) (*DatetimeWrapperResponse, error)
+	GetDateTime(ctx context.Context, options *PrimitiveGetDateTimeOptions) (*DatetimeWrapperResponse, error)
 	// GetDateTimeRFC1123 - Get complex types with datetimeRfc1123 properties
-	GetDateTimeRFC1123(ctx context.Context) (*Datetimerfc1123WrapperResponse, error)
+	GetDateTimeRFC1123(ctx context.Context, options *PrimitiveGetDateTimeRFC1123Options) (*Datetimerfc1123WrapperResponse, error)
 	// GetDouble - Get complex types with double properties
-	GetDouble(ctx context.Context) (*DoubleWrapperResponse, error)
+	GetDouble(ctx context.Context, options *PrimitiveGetDoubleOptions) (*DoubleWrapperResponse, error)
 	// GetDuration - Get complex types with duration properties
-	GetDuration(ctx context.Context) (*DurationWrapperResponse, error)
+	GetDuration(ctx context.Context, options *PrimitiveGetDurationOptions) (*DurationWrapperResponse, error)
 	// GetFloat - Get complex types with float properties
-	GetFloat(ctx context.Context) (*FloatWrapperResponse, error)
+	GetFloat(ctx context.Context, options *PrimitiveGetFloatOptions) (*FloatWrapperResponse, error)
 	// GetInt - Get complex types with integer properties
-	GetInt(ctx context.Context) (*IntWrapperResponse, error)
+	GetInt(ctx context.Context, options *PrimitiveGetIntOptions) (*IntWrapperResponse, error)
 	// GetLong - Get complex types with long properties
-	GetLong(ctx context.Context) (*LongWrapperResponse, error)
+	GetLong(ctx context.Context, options *PrimitiveGetLongOptions) (*LongWrapperResponse, error)
 	// GetString - Get complex types with string properties
-	GetString(ctx context.Context) (*StringWrapperResponse, error)
+	GetString(ctx context.Context, options *PrimitiveGetStringOptions) (*StringWrapperResponse, error)
 	// PutBool - Put complex types with bool properties
-	PutBool(ctx context.Context, complexBody BooleanWrapper) (*http.Response, error)
+	PutBool(ctx context.Context, complexBody BooleanWrapper, options *PrimitivePutBoolOptions) (*http.Response, error)
 	// PutByte - Put complex types with byte properties
-	PutByte(ctx context.Context, complexBody ByteWrapper) (*http.Response, error)
+	PutByte(ctx context.Context, complexBody ByteWrapper, options *PrimitivePutByteOptions) (*http.Response, error)
 	// PutDate - Put complex types with date properties
-	PutDate(ctx context.Context, complexBody DateWrapper) (*http.Response, error)
+	PutDate(ctx context.Context, complexBody DateWrapper, options *PrimitivePutDateOptions) (*http.Response, error)
 	// PutDateTime - Put complex types with datetime properties
-	PutDateTime(ctx context.Context, complexBody DatetimeWrapper) (*http.Response, error)
+	PutDateTime(ctx context.Context, complexBody DatetimeWrapper, options *PrimitivePutDateTimeOptions) (*http.Response, error)
 	// PutDateTimeRFC1123 - Put complex types with datetimeRfc1123 properties
-	PutDateTimeRFC1123(ctx context.Context, complexBody Datetimerfc1123Wrapper) (*http.Response, error)
+	PutDateTimeRFC1123(ctx context.Context, complexBody Datetimerfc1123Wrapper, options *PrimitivePutDateTimeRFC1123Options) (*http.Response, error)
 	// PutDouble - Put complex types with double properties
-	PutDouble(ctx context.Context, complexBody DoubleWrapper) (*http.Response, error)
+	PutDouble(ctx context.Context, complexBody DoubleWrapper, options *PrimitivePutDoubleOptions) (*http.Response, error)
 	// PutDuration - Put complex types with duration properties
-	PutDuration(ctx context.Context, complexBody DurationWrapper) (*http.Response, error)
+	PutDuration(ctx context.Context, complexBody DurationWrapper, options *PrimitivePutDurationOptions) (*http.Response, error)
 	// PutFloat - Put complex types with float properties
-	PutFloat(ctx context.Context, complexBody FloatWrapper) (*http.Response, error)
+	PutFloat(ctx context.Context, complexBody FloatWrapper, options *PrimitivePutFloatOptions) (*http.Response, error)
 	// PutInt - Put complex types with integer properties
-	PutInt(ctx context.Context, complexBody IntWrapper) (*http.Response, error)
+	PutInt(ctx context.Context, complexBody IntWrapper, options *PrimitivePutIntOptions) (*http.Response, error)
 	// PutLong - Put complex types with long properties
-	PutLong(ctx context.Context, complexBody LongWrapper) (*http.Response, error)
+	PutLong(ctx context.Context, complexBody LongWrapper, options *PrimitivePutLongOptions) (*http.Response, error)
 	// PutString - Put complex types with string properties
-	PutString(ctx context.Context, complexBody StringWrapper) (*http.Response, error)
+	PutString(ctx context.Context, complexBody StringWrapper, options *PrimitivePutStringOptions) (*http.Response, error)
 }
 
 // PrimitiveClient implements the PrimitiveOperations interface.
@@ -76,8 +76,8 @@ func (client *PrimitiveClient) Do(req *azcore.Request) (*azcore.Response, error)
 }
 
 // GetBool - Get complex types with bool properties
-func (client *PrimitiveClient) GetBool(ctx context.Context) (*BooleanWrapperResponse, error) {
-	req, err := client.GetBoolCreateRequest(ctx)
+func (client *PrimitiveClient) GetBool(ctx context.Context, options *PrimitiveGetBoolOptions) (*BooleanWrapperResponse, error) {
+	req, err := client.GetBoolCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (client *PrimitiveClient) GetBool(ctx context.Context) (*BooleanWrapperResp
 }
 
 // GetBoolCreateRequest creates the GetBool request.
-func (client *PrimitiveClient) GetBoolCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetBoolCreateRequest(ctx context.Context, options *PrimitiveGetBoolOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/bool"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -122,8 +122,8 @@ func (client *PrimitiveClient) GetBoolHandleError(resp *azcore.Response) error {
 }
 
 // GetByte - Get complex types with byte properties
-func (client *PrimitiveClient) GetByte(ctx context.Context) (*ByteWrapperResponse, error) {
-	req, err := client.GetByteCreateRequest(ctx)
+func (client *PrimitiveClient) GetByte(ctx context.Context, options *PrimitiveGetByteOptions) (*ByteWrapperResponse, error) {
+	req, err := client.GetByteCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (client *PrimitiveClient) GetByte(ctx context.Context) (*ByteWrapperRespons
 }
 
 // GetByteCreateRequest creates the GetByte request.
-func (client *PrimitiveClient) GetByteCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetByteCreateRequest(ctx context.Context, options *PrimitiveGetByteOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/byte"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -168,8 +168,8 @@ func (client *PrimitiveClient) GetByteHandleError(resp *azcore.Response) error {
 }
 
 // GetDate - Get complex types with date properties
-func (client *PrimitiveClient) GetDate(ctx context.Context) (*DateWrapperResponse, error) {
-	req, err := client.GetDateCreateRequest(ctx)
+func (client *PrimitiveClient) GetDate(ctx context.Context, options *PrimitiveGetDateOptions) (*DateWrapperResponse, error) {
+	req, err := client.GetDateCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (client *PrimitiveClient) GetDate(ctx context.Context) (*DateWrapperRespons
 }
 
 // GetDateCreateRequest creates the GetDate request.
-func (client *PrimitiveClient) GetDateCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetDateCreateRequest(ctx context.Context, options *PrimitiveGetDateOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/date"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -214,8 +214,8 @@ func (client *PrimitiveClient) GetDateHandleError(resp *azcore.Response) error {
 }
 
 // GetDateTime - Get complex types with datetime properties
-func (client *PrimitiveClient) GetDateTime(ctx context.Context) (*DatetimeWrapperResponse, error) {
-	req, err := client.GetDateTimeCreateRequest(ctx)
+func (client *PrimitiveClient) GetDateTime(ctx context.Context, options *PrimitiveGetDateTimeOptions) (*DatetimeWrapperResponse, error) {
+	req, err := client.GetDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (client *PrimitiveClient) GetDateTime(ctx context.Context) (*DatetimeWrappe
 }
 
 // GetDateTimeCreateRequest creates the GetDateTime request.
-func (client *PrimitiveClient) GetDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetDateTimeCreateRequest(ctx context.Context, options *PrimitiveGetDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetime"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -260,8 +260,8 @@ func (client *PrimitiveClient) GetDateTimeHandleError(resp *azcore.Response) err
 }
 
 // GetDateTimeRFC1123 - Get complex types with datetimeRfc1123 properties
-func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context) (*Datetimerfc1123WrapperResponse, error) {
-	req, err := client.GetDateTimeRFC1123CreateRequest(ctx)
+func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context, options *PrimitiveGetDateTimeRFC1123Options) (*Datetimerfc1123WrapperResponse, error) {
+	req, err := client.GetDateTimeRFC1123CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context) (*Datetim
 }
 
 // GetDateTimeRFC1123CreateRequest creates the GetDateTimeRFC1123 request.
-func (client *PrimitiveClient) GetDateTimeRFC1123CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetDateTimeRFC1123CreateRequest(ctx context.Context, options *PrimitiveGetDateTimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetimerfc1123"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -306,8 +306,8 @@ func (client *PrimitiveClient) GetDateTimeRFC1123HandleError(resp *azcore.Respon
 }
 
 // GetDouble - Get complex types with double properties
-func (client *PrimitiveClient) GetDouble(ctx context.Context) (*DoubleWrapperResponse, error) {
-	req, err := client.GetDoubleCreateRequest(ctx)
+func (client *PrimitiveClient) GetDouble(ctx context.Context, options *PrimitiveGetDoubleOptions) (*DoubleWrapperResponse, error) {
+	req, err := client.GetDoubleCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (client *PrimitiveClient) GetDouble(ctx context.Context) (*DoubleWrapperRes
 }
 
 // GetDoubleCreateRequest creates the GetDouble request.
-func (client *PrimitiveClient) GetDoubleCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetDoubleCreateRequest(ctx context.Context, options *PrimitiveGetDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/double"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -352,8 +352,8 @@ func (client *PrimitiveClient) GetDoubleHandleError(resp *azcore.Response) error
 }
 
 // GetDuration - Get complex types with duration properties
-func (client *PrimitiveClient) GetDuration(ctx context.Context) (*DurationWrapperResponse, error) {
-	req, err := client.GetDurationCreateRequest(ctx)
+func (client *PrimitiveClient) GetDuration(ctx context.Context, options *PrimitiveGetDurationOptions) (*DurationWrapperResponse, error) {
+	req, err := client.GetDurationCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func (client *PrimitiveClient) GetDuration(ctx context.Context) (*DurationWrappe
 }
 
 // GetDurationCreateRequest creates the GetDuration request.
-func (client *PrimitiveClient) GetDurationCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetDurationCreateRequest(ctx context.Context, options *PrimitiveGetDurationOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/duration"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -398,8 +398,8 @@ func (client *PrimitiveClient) GetDurationHandleError(resp *azcore.Response) err
 }
 
 // GetFloat - Get complex types with float properties
-func (client *PrimitiveClient) GetFloat(ctx context.Context) (*FloatWrapperResponse, error) {
-	req, err := client.GetFloatCreateRequest(ctx)
+func (client *PrimitiveClient) GetFloat(ctx context.Context, options *PrimitiveGetFloatOptions) (*FloatWrapperResponse, error) {
+	req, err := client.GetFloatCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +418,7 @@ func (client *PrimitiveClient) GetFloat(ctx context.Context) (*FloatWrapperRespo
 }
 
 // GetFloatCreateRequest creates the GetFloat request.
-func (client *PrimitiveClient) GetFloatCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetFloatCreateRequest(ctx context.Context, options *PrimitiveGetFloatOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/float"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -444,8 +444,8 @@ func (client *PrimitiveClient) GetFloatHandleError(resp *azcore.Response) error 
 }
 
 // GetInt - Get complex types with integer properties
-func (client *PrimitiveClient) GetInt(ctx context.Context) (*IntWrapperResponse, error) {
-	req, err := client.GetIntCreateRequest(ctx)
+func (client *PrimitiveClient) GetInt(ctx context.Context, options *PrimitiveGetIntOptions) (*IntWrapperResponse, error) {
+	req, err := client.GetIntCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +464,7 @@ func (client *PrimitiveClient) GetInt(ctx context.Context) (*IntWrapperResponse,
 }
 
 // GetIntCreateRequest creates the GetInt request.
-func (client *PrimitiveClient) GetIntCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetIntCreateRequest(ctx context.Context, options *PrimitiveGetIntOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/integer"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -490,8 +490,8 @@ func (client *PrimitiveClient) GetIntHandleError(resp *azcore.Response) error {
 }
 
 // GetLong - Get complex types with long properties
-func (client *PrimitiveClient) GetLong(ctx context.Context) (*LongWrapperResponse, error) {
-	req, err := client.GetLongCreateRequest(ctx)
+func (client *PrimitiveClient) GetLong(ctx context.Context, options *PrimitiveGetLongOptions) (*LongWrapperResponse, error) {
+	req, err := client.GetLongCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +510,7 @@ func (client *PrimitiveClient) GetLong(ctx context.Context) (*LongWrapperRespons
 }
 
 // GetLongCreateRequest creates the GetLong request.
-func (client *PrimitiveClient) GetLongCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetLongCreateRequest(ctx context.Context, options *PrimitiveGetLongOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/long"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -536,8 +536,8 @@ func (client *PrimitiveClient) GetLongHandleError(resp *azcore.Response) error {
 }
 
 // GetString - Get complex types with string properties
-func (client *PrimitiveClient) GetString(ctx context.Context) (*StringWrapperResponse, error) {
-	req, err := client.GetStringCreateRequest(ctx)
+func (client *PrimitiveClient) GetString(ctx context.Context, options *PrimitiveGetStringOptions) (*StringWrapperResponse, error) {
+	req, err := client.GetStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func (client *PrimitiveClient) GetString(ctx context.Context) (*StringWrapperRes
 }
 
 // GetStringCreateRequest creates the GetString request.
-func (client *PrimitiveClient) GetStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrimitiveClient) GetStringCreateRequest(ctx context.Context, options *PrimitiveGetStringOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/string"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -582,8 +582,8 @@ func (client *PrimitiveClient) GetStringHandleError(resp *azcore.Response) error
 }
 
 // PutBool - Put complex types with bool properties
-func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanWrapper) (*http.Response, error) {
-	req, err := client.PutBoolCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanWrapper, options *PrimitivePutBoolOptions) (*http.Response, error) {
+	req, err := client.PutBoolCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -598,7 +598,7 @@ func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanW
 }
 
 // PutBoolCreateRequest creates the PutBool request.
-func (client *PrimitiveClient) PutBoolCreateRequest(ctx context.Context, complexBody BooleanWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutBoolCreateRequest(ctx context.Context, complexBody BooleanWrapper, options *PrimitivePutBoolOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/bool"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -618,8 +618,8 @@ func (client *PrimitiveClient) PutBoolHandleError(resp *azcore.Response) error {
 }
 
 // PutByte - Put complex types with byte properties
-func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrapper) (*http.Response, error) {
-	req, err := client.PutByteCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrapper, options *PrimitivePutByteOptions) (*http.Response, error) {
+	req, err := client.PutByteCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -634,7 +634,7 @@ func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrap
 }
 
 // PutByteCreateRequest creates the PutByte request.
-func (client *PrimitiveClient) PutByteCreateRequest(ctx context.Context, complexBody ByteWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutByteCreateRequest(ctx context.Context, complexBody ByteWrapper, options *PrimitivePutByteOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/byte"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -654,8 +654,8 @@ func (client *PrimitiveClient) PutByteHandleError(resp *azcore.Response) error {
 }
 
 // PutDate - Put complex types with date properties
-func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrapper) (*http.Response, error) {
-	req, err := client.PutDateCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrapper, options *PrimitivePutDateOptions) (*http.Response, error) {
+	req, err := client.PutDateCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -670,7 +670,7 @@ func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrap
 }
 
 // PutDateCreateRequest creates the PutDate request.
-func (client *PrimitiveClient) PutDateCreateRequest(ctx context.Context, complexBody DateWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutDateCreateRequest(ctx context.Context, complexBody DateWrapper, options *PrimitivePutDateOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/date"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -690,8 +690,8 @@ func (client *PrimitiveClient) PutDateHandleError(resp *azcore.Response) error {
 }
 
 // PutDateTime - Put complex types with datetime properties
-func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody DatetimeWrapper) (*http.Response, error) {
-	req, err := client.PutDateTimeCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody DatetimeWrapper, options *PrimitivePutDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutDateTimeCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -706,7 +706,7 @@ func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody Date
 }
 
 // PutDateTimeCreateRequest creates the PutDateTime request.
-func (client *PrimitiveClient) PutDateTimeCreateRequest(ctx context.Context, complexBody DatetimeWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutDateTimeCreateRequest(ctx context.Context, complexBody DatetimeWrapper, options *PrimitivePutDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetime"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -726,8 +726,8 @@ func (client *PrimitiveClient) PutDateTimeHandleError(resp *azcore.Response) err
 }
 
 // PutDateTimeRFC1123 - Put complex types with datetimeRfc1123 properties
-func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBody Datetimerfc1123Wrapper) (*http.Response, error) {
-	req, err := client.PutDateTimeRFC1123CreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBody Datetimerfc1123Wrapper, options *PrimitivePutDateTimeRFC1123Options) (*http.Response, error) {
+	req, err := client.PutDateTimeRFC1123CreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +742,7 @@ func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBo
 }
 
 // PutDateTimeRFC1123CreateRequest creates the PutDateTimeRFC1123 request.
-func (client *PrimitiveClient) PutDateTimeRFC1123CreateRequest(ctx context.Context, complexBody Datetimerfc1123Wrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutDateTimeRFC1123CreateRequest(ctx context.Context, complexBody Datetimerfc1123Wrapper, options *PrimitivePutDateTimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/datetimerfc1123"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -762,8 +762,8 @@ func (client *PrimitiveClient) PutDateTimeRFC1123HandleError(resp *azcore.Respon
 }
 
 // PutDouble - Put complex types with double properties
-func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody DoubleWrapper) (*http.Response, error) {
-	req, err := client.PutDoubleCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody DoubleWrapper, options *PrimitivePutDoubleOptions) (*http.Response, error) {
+	req, err := client.PutDoubleCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -778,7 +778,7 @@ func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody Double
 }
 
 // PutDoubleCreateRequest creates the PutDouble request.
-func (client *PrimitiveClient) PutDoubleCreateRequest(ctx context.Context, complexBody DoubleWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutDoubleCreateRequest(ctx context.Context, complexBody DoubleWrapper, options *PrimitivePutDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/double"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -798,8 +798,8 @@ func (client *PrimitiveClient) PutDoubleHandleError(resp *azcore.Response) error
 }
 
 // PutDuration - Put complex types with duration properties
-func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody DurationWrapper) (*http.Response, error) {
-	req, err := client.PutDurationCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody DurationWrapper, options *PrimitivePutDurationOptions) (*http.Response, error) {
+	req, err := client.PutDurationCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +814,7 @@ func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody Dura
 }
 
 // PutDurationCreateRequest creates the PutDuration request.
-func (client *PrimitiveClient) PutDurationCreateRequest(ctx context.Context, complexBody DurationWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutDurationCreateRequest(ctx context.Context, complexBody DurationWrapper, options *PrimitivePutDurationOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/duration"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -834,8 +834,8 @@ func (client *PrimitiveClient) PutDurationHandleError(resp *azcore.Response) err
 }
 
 // PutFloat - Put complex types with float properties
-func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWrapper) (*http.Response, error) {
-	req, err := client.PutFloatCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWrapper, options *PrimitivePutFloatOptions) (*http.Response, error) {
+	req, err := client.PutFloatCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -850,7 +850,7 @@ func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWr
 }
 
 // PutFloatCreateRequest creates the PutFloat request.
-func (client *PrimitiveClient) PutFloatCreateRequest(ctx context.Context, complexBody FloatWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutFloatCreateRequest(ctx context.Context, complexBody FloatWrapper, options *PrimitivePutFloatOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/float"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -870,8 +870,8 @@ func (client *PrimitiveClient) PutFloatHandleError(resp *azcore.Response) error 
 }
 
 // PutInt - Put complex types with integer properties
-func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrapper) (*http.Response, error) {
-	req, err := client.PutIntCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrapper, options *PrimitivePutIntOptions) (*http.Response, error) {
+	req, err := client.PutIntCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +886,7 @@ func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrappe
 }
 
 // PutIntCreateRequest creates the PutInt request.
-func (client *PrimitiveClient) PutIntCreateRequest(ctx context.Context, complexBody IntWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutIntCreateRequest(ctx context.Context, complexBody IntWrapper, options *PrimitivePutIntOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/integer"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -906,8 +906,8 @@ func (client *PrimitiveClient) PutIntHandleError(resp *azcore.Response) error {
 }
 
 // PutLong - Put complex types with long properties
-func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrapper) (*http.Response, error) {
-	req, err := client.PutLongCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrapper, options *PrimitivePutLongOptions) (*http.Response, error) {
+	req, err := client.PutLongCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -922,7 +922,7 @@ func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrap
 }
 
 // PutLongCreateRequest creates the PutLong request.
-func (client *PrimitiveClient) PutLongCreateRequest(ctx context.Context, complexBody LongWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutLongCreateRequest(ctx context.Context, complexBody LongWrapper, options *PrimitivePutLongOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/long"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -942,8 +942,8 @@ func (client *PrimitiveClient) PutLongHandleError(resp *azcore.Response) error {
 }
 
 // PutString - Put complex types with string properties
-func (client *PrimitiveClient) PutString(ctx context.Context, complexBody StringWrapper) (*http.Response, error) {
-	req, err := client.PutStringCreateRequest(ctx, complexBody)
+func (client *PrimitiveClient) PutString(ctx context.Context, complexBody StringWrapper, options *PrimitivePutStringOptions) (*http.Response, error) {
+	req, err := client.PutStringCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -958,7 +958,7 @@ func (client *PrimitiveClient) PutString(ctx context.Context, complexBody String
 }
 
 // PutStringCreateRequest creates the PutString request.
-func (client *PrimitiveClient) PutStringCreateRequest(ctx context.Context, complexBody StringWrapper) (*azcore.Request, error) {
+func (client *PrimitiveClient) PutStringCreateRequest(ctx context.Context, complexBody StringWrapper, options *PrimitivePutStringOptions) (*azcore.Request, error) {
 	urlPath := "/complex/primitive/string"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -14,9 +14,9 @@ import (
 // ReadonlypropertyOperations contains the methods for the Readonlyproperty group.
 type ReadonlypropertyOperations interface {
 	// GetValid - Get complex types that have readonly properties
-	GetValid(ctx context.Context) (*ReadonlyObjResponse, error)
+	GetValid(ctx context.Context, options *ReadonlypropertyGetValidOptions) (*ReadonlyObjResponse, error)
 	// PutValid - Put complex types that have readonly properties
-	PutValid(ctx context.Context, complexBody ReadonlyObj) (*http.Response, error)
+	PutValid(ctx context.Context, complexBody ReadonlyObj, options *ReadonlypropertyPutValidOptions) (*http.Response, error)
 }
 
 // ReadonlypropertyClient implements the ReadonlypropertyOperations interface.
@@ -36,8 +36,8 @@ func (client *ReadonlypropertyClient) Do(req *azcore.Request) (*azcore.Response,
 }
 
 // GetValid - Get complex types that have readonly properties
-func (client *ReadonlypropertyClient) GetValid(ctx context.Context) (*ReadonlyObjResponse, error) {
-	req, err := client.GetValidCreateRequest(ctx)
+func (client *ReadonlypropertyClient) GetValid(ctx context.Context, options *ReadonlypropertyGetValidOptions) (*ReadonlyObjResponse, error) {
+	req, err := client.GetValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (client *ReadonlypropertyClient) GetValid(ctx context.Context) (*ReadonlyOb
 }
 
 // GetValidCreateRequest creates the GetValid request.
-func (client *ReadonlypropertyClient) GetValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ReadonlypropertyClient) GetValidCreateRequest(ctx context.Context, options *ReadonlypropertyGetValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/readonlyproperty/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -82,8 +82,8 @@ func (client *ReadonlypropertyClient) GetValidHandleError(resp *azcore.Response)
 }
 
 // PutValid - Put complex types that have readonly properties
-func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody ReadonlyObj) (*http.Response, error) {
-	req, err := client.PutValidCreateRequest(ctx, complexBody)
+func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody ReadonlyObj, options *ReadonlypropertyPutValidOptions) (*http.Response, error) {
+	req, err := client.PutValidCreateRequest(ctx, complexBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody 
 }
 
 // PutValidCreateRequest creates the PutValid request.
-func (client *ReadonlypropertyClient) PutValidCreateRequest(ctx context.Context, complexBody ReadonlyObj) (*azcore.Request, error) {
+func (client *ReadonlypropertyClient) PutValidCreateRequest(ctx context.Context, complexBody ReadonlyObj, options *ReadonlypropertyPutValidOptions) (*azcore.Request, error) {
 	urlPath := "/complex/readonlyproperty/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -14,7 +14,7 @@ func newComplexModelClient() ComplexModelClientOperations {
 
 func TestCreate(t *testing.T) {
 	client := newComplexModelClient()
-	_, err := client.Create(context.Background(), "sub", "rg", CatalogDictionaryOfArray{})
+	_, err := client.Create(context.Background(), "sub", "rg", CatalogDictionaryOfArray{}, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -22,7 +22,7 @@ func TestCreate(t *testing.T) {
 
 func TestList(t *testing.T) {
 	client := newComplexModelClient()
-	_, err := client.List(context.Background(), "")
+	_, err := client.List(context.Background(), "", nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -30,7 +30,7 @@ func TestList(t *testing.T) {
 
 func TestUpdate(t *testing.T) {
 	client := newComplexModelClient()
-	_, err := client.Update(context.Background(), "", "", CatalogArrayOfDictionary{})
+	_, err := client.Update(context.Background(), "", "", CatalogArrayOfDictionary{}, nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -16,11 +16,11 @@ import (
 // ComplexModelClientOperations contains the methods for the ComplexModelClient group.
 type ComplexModelClientOperations interface {
 	// Create - Resets products.
-	Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error)
+	Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray, options *ComplexModelClientCreateOptions) (*CatalogDictionaryResponse, error)
 	// List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
-	List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error)
+	List(ctx context.Context, resourceGroupName string, options *ComplexModelClientListOptions) (*CatalogArrayResponse, error)
 	// Update - Resets products.
-	Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error)
+	Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary, options *ComplexModelClientUpdateOptions) (*CatalogArrayResponse, error)
 }
 
 // ComplexModelClient implements the ComplexModelClientOperations interface.
@@ -40,8 +40,8 @@ func (client *ComplexModelClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // Create - Resets products.
-func (client *ComplexModelClient) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*CatalogDictionaryResponse, error) {
-	req, err := client.CreateCreateRequest(ctx, subscriptionId, resourceGroupName, bodyParameter)
+func (client *ComplexModelClient) Create(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray, options *ComplexModelClientCreateOptions) (*CatalogDictionaryResponse, error) {
+	req, err := client.CreateCreateRequest(ctx, subscriptionId, resourceGroupName, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (client *ComplexModelClient) Create(ctx context.Context, subscriptionId str
 }
 
 // CreateCreateRequest creates the Create request.
-func (client *ComplexModelClient) CreateCreateRequest(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray) (*azcore.Request, error) {
+func (client *ComplexModelClient) CreateCreateRequest(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogDictionaryOfArray, options *ComplexModelClientCreateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -91,8 +91,8 @@ func (client *ComplexModelClient) CreateHandleError(resp *azcore.Response) error
 }
 
 // List - The Products endpoint returns information about the Uber products offered at a given location. The response includes the display name and other details about each product, and lists the products in the proper display order.
-func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName string) (*CatalogArrayResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName)
+func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName string, options *ComplexModelClientListOptions) (*CatalogArrayResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName st
 }
 
 // ListCreateRequest creates the List request.
-func (client *ComplexModelClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ComplexModelClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *ComplexModelClientListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape("123456"))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -142,8 +142,8 @@ func (client *ComplexModelClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // Update - Resets products.
-func (client *ComplexModelClient) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*CatalogArrayResponse, error) {
-	req, err := client.UpdateCreateRequest(ctx, subscriptionId, resourceGroupName, bodyParameter)
+func (client *ComplexModelClient) Update(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary, options *ComplexModelClientUpdateOptions) (*CatalogArrayResponse, error) {
+	req, err := client.UpdateCreateRequest(ctx, subscriptionId, resourceGroupName, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (client *ComplexModelClient) Update(ctx context.Context, subscriptionId str
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *ComplexModelClient) UpdateCreateRequest(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary) (*azcore.Request, error) {
+func (client *ComplexModelClient) UpdateCreateRequest(ctx context.Context, subscriptionId string, resourceGroupName string, bodyParameter CatalogArrayOfDictionary, options *ComplexModelClientUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(subscriptionId))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/autorest/complexmodelgroup/zz_generated_models.go
+++ b/test/autorest/complexmodelgroup/zz_generated_models.go
@@ -46,6 +46,21 @@ type CatalogDictionaryResponse struct {
 	RawResponse *http.Response
 }
 
+// ComplexModelClientCreateOptions contains the optional parameters for the ComplexModelClient.Create method.
+type ComplexModelClientCreateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ComplexModelClientListOptions contains the optional parameters for the ComplexModelClient.List method.
+type ComplexModelClientListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ComplexModelClientUpdateOptions contains the optional parameters for the ComplexModelClient.Update method.
+type ComplexModelClientUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -19,7 +19,7 @@ func newPathsClient() PathsOperations {
 
 func TestGetEmpty(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetEmpty(context.Background(), "localhost")
+	result, err := client.GetEmpty(context.Background(), "localhost", nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}

--- a/test/autorest/custombaseurlgroup/zz_generated_models.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_models.go
@@ -26,3 +26,8 @@ func (e Error) Error() string {
 	}
 	return msg
 }
+
+// PathsGetEmptyOptions contains the optional parameters for the Paths.GetEmpty method.
+type PathsGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}

--- a/test/autorest/custombaseurlgroup/zz_generated_paths.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths.go
@@ -15,7 +15,7 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// GetEmpty - Get a 200 to test a valid base uri
-	GetEmpty(ctx context.Context, accountName string) (*http.Response, error)
+	GetEmpty(ctx context.Context, accountName string, options *PathsGetEmptyOptions) (*http.Response, error)
 }
 
 // PathsClient implements the PathsOperations interface.
@@ -35,8 +35,8 @@ func (client *PathsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
-func (client *PathsClient) GetEmpty(ctx context.Context, accountName string) (*http.Response, error) {
-	req, err := client.GetEmptyCreateRequest(ctx, accountName)
+func (client *PathsClient) GetEmpty(ctx context.Context, accountName string, options *PathsGetEmptyOptions) (*http.Response, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, accountName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, accountName string) (*h
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, accountName string) (*azcore.Request, error) {
+func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, accountName string, options *PathsGetEmptyOptions) (*azcore.Request, error) {
 	host := "http://{accountName}{host}"
 	host = strings.ReplaceAll(host, "{host}", client.host)
 	host = strings.ReplaceAll(host, "{accountName}", accountName)

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -17,7 +17,7 @@ func newDatetimeClient() DatetimeOperations {
 
 func TestGetInvalid(t *testing.T) {
 	client := newDatetimeClient()
-	_, err := client.GetInvalid(context.Background())
+	_, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -25,7 +25,7 @@ func TestGetInvalid(t *testing.T) {
 
 func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTime(context.Background())
+	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
 
 func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalNegativeOffsetMinDateTime(context.Background())
+	result, err := client.GetLocalNegativeOffsetMinDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
 
 func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTime(context.Background())
+	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
 
 func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTime(context.Background())
+	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
 
 func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalPositiveOffsetMinDateTime(context.Background())
+	result, err := client.GetLocalPositiveOffsetMinDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
 
 func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalNoOffsetMinDateTime(context.Background())
+	result, err := client.GetLocalNoOffsetMinDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
 
 func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTime(context.Background())
+	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
 
 func TestGetNull(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestGetNull(t *testing.T) {
 func TestGetOverflow(t *testing.T) {
 	t.Skip("API doesn't actually overflow")
 	client := newDatetimeClient()
-	_, err := client.GetOverflow(context.Background())
+	_, err := client.GetOverflow(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -135,7 +135,7 @@ func TestGetOverflow(t *testing.T) {
 
 func TestGetUnderflow(t *testing.T) {
 	client := newDatetimeClient()
-	_, err := client.GetUnderflow(context.Background())
+	_, err := client.GetUnderflow(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -143,7 +143,7 @@ func TestGetUnderflow(t *testing.T) {
 
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetUTCLowercaseMaxDateTime(context.Background())
+	result, err := client.GetUTCLowercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 
 func TestGetUTCMinDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetUTCMinDateTime(context.Background())
+	result, err := client.GetUTCMinDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetUTCUppercaseMaxDateTime(context.Background())
+	result, err := client.GetUTCUppercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 
 func TestGetUTCUppercaseMaxDateTime7Digits(t *testing.T) {
 	client := newDatetimeClient()
-	result, err := client.GetUTCUppercaseMaxDateTime7Digits(context.Background())
+	result, err := client.GetUTCUppercaseMaxDateTime7Digits(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutLocalNegativeOffsetMaxDateTime(context.Background(), body)
+	result, err := client.PutLocalNegativeOffsetMaxDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutLocalNegativeOffsetMinDateTime(context.Background(), body)
+	result, err := client.PutLocalNegativeOffsetMinDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutLocalPositiveOffsetMaxDateTime(context.Background(), body)
+	result, err := client.PutLocalPositiveOffsetMaxDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +238,7 @@ func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutLocalPositiveOffsetMinDateTime(context.Background(), body)
+	result, err := client.PutLocalPositiveOffsetMinDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +251,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutUTCMaxDateTime(context.Background(), body)
+	result, err := client.PutUTCMaxDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func TestPutUTCMaxDateTime7Digits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutUTCMaxDateTime7Digits(context.Background(), body)
+	result, err := client.PutUTCMaxDateTime7Digits(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -277,7 +277,7 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutUTCMinDateTime(context.Background(), body)
+	result, err := client.PutUTCMinDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -15,49 +15,49 @@ import (
 // DatetimeOperations contains the methods for the Datetime group.
 type DatetimeOperations interface {
 	// GetInvalid - Get invalid datetime value
-	GetInvalid(ctx context.Context) (*TimeResponse, error)
+	GetInvalid(ctx context.Context, options *DatetimeGetInvalidOptions) (*TimeResponse, error)
 	// GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
-	GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
-	GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalNegativeOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetMinDateTimeOptions) (*TimeResponse, error)
 	// GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
-	GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetLocalNoOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00
-	GetLocalNoOffsetMinDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalNoOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalNoOffsetMinDateTimeOptions) (*TimeResponse, error)
 	// GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
-	GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
-	GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalPositiveOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetMinDateTimeOptions) (*TimeResponse, error)
 	// GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
-	GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetNull - Get null datetime value
-	GetNull(ctx context.Context) (*TimeResponse, error)
+	GetNull(ctx context.Context, options *DatetimeGetNullOptions) (*TimeResponse, error)
 	// GetOverflow - Get overflow datetime value
-	GetOverflow(ctx context.Context) (*TimeResponse, error)
+	GetOverflow(ctx context.Context, options *DatetimeGetOverflowOptions) (*TimeResponse, error)
 	// GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
-	GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetUTCLowercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
-	GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCMinDateTime(ctx context.Context, options *DatetimeGetUTCMinDateTimeOptions) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
-	GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
-	GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*TimeResponse, error)
+	GetUTCUppercaseMaxDateTime7Digits(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTime7DigitsOptions) (*TimeResponse, error)
 	// GetUnderflow - Get underflow datetime value
-	GetUnderflow(ctx context.Context) (*TimeResponse, error)
+	GetUnderflow(ctx context.Context, options *DatetimeGetUnderflowOptions) (*TimeResponse, error)
 	// PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
-	PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMaxDateTimeOptions) (*http.Response, error)
 	// PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
-	PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMinDateTimeOptions) (*http.Response, error)
 	// PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
-	PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMaxDateTimeOptions) (*http.Response, error)
 	// PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
-	PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMinDateTimeOptions) (*http.Response, error)
 	// PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
-	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTimeOptions) (*http.Response, error)
 	// PutUTCMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
-	PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTime7DigitsOptions) (*http.Response, error)
 	// PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
-	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMinDateTimeOptions) (*http.Response, error)
 }
 
 // DatetimeClient implements the DatetimeOperations interface.
@@ -77,8 +77,8 @@ func (client *DatetimeClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // GetInvalid - Get invalid datetime value
-func (client *DatetimeClient) GetInvalid(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *DatetimeClient) GetInvalid(ctx context.Context, options *DatetimeGetInvalidOptions) (*TimeResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (client *DatetimeClient) GetInvalid(ctx context.Context) (*TimeResponse, er
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *DatetimeClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetInvalidCreateRequest(ctx context.Context, options *DatetimeGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -124,8 +124,8 @@ func (client *DatetimeClient) GetInvalidHandleError(resp *azcore.Response) error
 }
 
 // GetLocalNegativeOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999-14:00
-func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx con
 }
 
 // GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetLowercaseMaxDateTime request.
-func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/lowercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -171,8 +171,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTimeHandleEr
 }
 
 // GetLocalNegativeOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00-14:00
-func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetMinDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Cont
 }
 
 // GetLocalNegativeOffsetMinDateTimeCreateRequest creates the GetLocalNegativeOffsetMinDateTime request.
-func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalNegativeOffsetMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -218,8 +218,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTimeHandleError(resp 
 }
 
 // GetLocalNegativeOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999-14:00
-func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx con
 }
 
 // GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetUppercaseMaxDateTime request.
-func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset/uppercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -265,8 +265,8 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTimeHandleEr
 }
 
 // GetLocalNoOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00
-func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalNoOffsetMinDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalNoOffsetMinDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalNoOffsetMinDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,7 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context) (
 }
 
 // GetLocalNoOffsetMinDateTimeCreateRequest creates the GetLocalNoOffsetMinDateTime request.
-func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalNoOffsetMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnooffset"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -312,8 +312,8 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTimeHandleError(resp *azcor
 }
 
 // GetLocalPositiveOffsetLowercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31t23:59:59.999+14:00
-func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx con
 }
 
 // GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetLowercaseMaxDateTime request.
-func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/lowercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -359,8 +359,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTimeHandleEr
 }
 
 // GetLocalPositiveOffsetMinDateTime - Get min datetime value 0001-01-01T00:00:00+14:00
-func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetMinDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Cont
 }
 
 // GetLocalPositiveOffsetMinDateTimeCreateRequest creates the GetLocalPositiveOffsetMinDateTime request.
-func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalPositiveOffsetMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -406,8 +406,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTimeHandleError(resp 
 }
 
 // GetLocalPositiveOffsetUppercaseMaxDateTime - Get max datetime value with positive num offset 9999-12-31T23:59:59.999+14:00
-func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +426,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx con
 }
 
 // GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetUppercaseMaxDateTime request.
-func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset/uppercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -453,8 +453,8 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTimeHandleEr
 }
 
 // GetNull - Get null datetime value
-func (client *DatetimeClient) GetNull(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *DatetimeClient) GetNull(ctx context.Context, options *DatetimeGetNullOptions) (*TimeResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +473,7 @@ func (client *DatetimeClient) GetNull(ctx context.Context) (*TimeResponse, error
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *DatetimeClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetNullCreateRequest(ctx context.Context, options *DatetimeGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -500,8 +500,8 @@ func (client *DatetimeClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetOverflow - Get overflow datetime value
-func (client *DatetimeClient) GetOverflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetOverflowCreateRequest(ctx)
+func (client *DatetimeClient) GetOverflow(ctx context.Context, options *DatetimeGetOverflowOptions) (*TimeResponse, error) {
+	req, err := client.GetOverflowCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -520,7 +520,7 @@ func (client *DatetimeClient) GetOverflow(ctx context.Context) (*TimeResponse, e
 }
 
 // GetOverflowCreateRequest creates the GetOverflow request.
-func (client *DatetimeClient) GetOverflowCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetOverflowCreateRequest(ctx context.Context, options *DatetimeGetOverflowOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/overflow"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -547,8 +547,8 @@ func (client *DatetimeClient) GetOverflowHandleError(resp *azcore.Response) erro
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value 9999-12-31t23:59:59.999z
-func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCLowercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context, options *DatetimeGetUTCLowercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCLowercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context) (*
 }
 
 // GetUTCLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
-func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetUTCLowercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/lowercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -594,8 +594,8 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTimeHandleError(resp *azcore
 }
 
 // GetUTCMinDateTime - Get min datetime value 0001-01-01T00:00:00Z
-func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCMinDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context, options *DatetimeGetUTCMinDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCMinDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context) (*TimeRespo
 }
 
 // GetUTCMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
-func (client *DatetimeClient) GetUTCMinDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetUTCMinDateTimeCreateRequest(ctx context.Context, options *DatetimeGetUTCMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -641,8 +641,8 @@ func (client *DatetimeClient) GetUTCMinDateTimeHandleError(resp *azcore.Response
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value 9999-12-31T23:59:59.999Z
-func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCUppercaseMaxDateTimeCreateRequest(ctx)
+func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCUppercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context) (*
 }
 
 // GetUTCUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
-func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeCreateRequest(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc/uppercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -688,8 +688,8 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTimeHandleError(resp *azcore
 }
 
 // GetUTCUppercaseMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
-func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx)
+func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTime7DigitsOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Cont
 }
 
 // GetUTCUppercaseMaxDateTime7DigitsCreateRequest creates the GetUTCUppercaseMaxDateTime7Digits request.
-func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsCreateRequest(ctx context.Context, options *DatetimeGetUTCUppercaseMaxDateTime7DigitsOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms/uppercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -735,8 +735,8 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7DigitsHandleError(resp 
 }
 
 // GetUnderflow - Get underflow datetime value
-func (client *DatetimeClient) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUnderflowCreateRequest(ctx)
+func (client *DatetimeClient) GetUnderflow(ctx context.Context, options *DatetimeGetUnderflowOptions) (*TimeResponse, error) {
+	req, err := client.GetUnderflowCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +755,7 @@ func (client *DatetimeClient) GetUnderflow(ctx context.Context) (*TimeResponse, 
 }
 
 // GetUnderflowCreateRequest creates the GetUnderflow request.
-func (client *DatetimeClient) GetUnderflowCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DatetimeClient) GetUnderflowCreateRequest(ctx context.Context, options *DatetimeGetUnderflowOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/underflow"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -782,8 +782,8 @@ func (client *DatetimeClient) GetUnderflowHandleError(resp *azcore.Response) err
 }
 
 // PutLocalNegativeOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999-14:00
-func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMaxDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +798,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Cont
 }
 
 // PutLocalNegativeOffsetMaxDateTimeCreateRequest creates the PutLocalNegativeOffsetMaxDateTime request.
-func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localnegativeoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -818,8 +818,8 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTimeHandleError(resp 
 }
 
 // PutLocalNegativeOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00-14:00
-func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMinDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -834,7 +834,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Cont
 }
 
 // PutLocalNegativeOffsetMinDateTimeCreateRequest creates the PutLocalNegativeOffsetMinDateTime request.
-func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalNegativeOffsetMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localnegativeoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -854,8 +854,8 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTimeHandleError(resp 
 }
 
 // PutLocalPositiveOffsetMaxDateTime - Put max datetime value with positive numoffset 9999-12-31t23:59:59.999+14:00
-func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMaxDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -870,7 +870,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Cont
 }
 
 // PutLocalPositiveOffsetMaxDateTimeCreateRequest creates the PutLocalPositiveOffsetMaxDateTime request.
-func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/localpositiveoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -890,8 +890,8 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTimeHandleError(resp 
 }
 
 // PutLocalPositiveOffsetMinDateTime - Put min datetime value 0001-01-01T00:00:00+14:00
-func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMinDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -906,7 +906,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Cont
 }
 
 // PutLocalPositiveOffsetMinDateTimeCreateRequest creates the PutLocalPositiveOffsetMinDateTime request.
-func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutLocalPositiveOffsetMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/localpositiveoffset"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -926,8 +926,8 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTimeHandleError(resp 
 }
 
 // PutUTCMaxDateTime - Put max datetime value 9999-12-31T23:59:59.999Z
-func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutUTCMaxDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutUTCMaxDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -942,7 +942,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBod
 }
 
 // PutUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
-func (client *DatetimeClient) PutUTCMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutUTCMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -962,8 +962,8 @@ func (client *DatetimeClient) PutUTCMaxDateTimeHandleError(resp *azcore.Response
 }
 
 // PutUTCMaxDateTime7Digits - This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario
-func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutUTCMaxDateTime7DigitsCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTime7DigitsOptions) (*http.Response, error) {
+	req, err := client.PutUTCMaxDateTime7DigitsCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -978,7 +978,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, date
 }
 
 // PutUTCMaxDateTime7DigitsCreateRequest creates the PutUTCMaxDateTime7Digits request.
-func (client *DatetimeClient) PutUTCMaxDateTime7DigitsCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutUTCMaxDateTime7DigitsCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMaxDateTime7DigitsOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/max/utc7ms"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -998,8 +998,8 @@ func (client *DatetimeClient) PutUTCMaxDateTime7DigitsHandleError(resp *azcore.R
 }
 
 // PutUTCMinDateTime - Put min datetime value 0001-01-01T00:00:00Z
-func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutUTCMinDateTimeCreateRequest(ctx, datetimeBody)
+func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMinDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutUTCMinDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,7 +1014,7 @@ func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBod
 }
 
 // PutUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
-func (client *DatetimeClient) PutUTCMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *DatetimeClient) PutUTCMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *DatetimePutUTCMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetime/min/utc"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/datetimegroup/zz_generated_models.go
+++ b/test/autorest/datetimegroup/zz_generated_models.go
@@ -11,6 +11,130 @@ import (
 	"time"
 )
 
+// DatetimeGetInvalidOptions contains the optional parameters for the Datetime.GetInvalid method.
+type DatetimeGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetLocalNegativeOffsetLowercaseMaxDateTime
+// method.
+type DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalNegativeOffsetMinDateTimeOptions contains the optional parameters for the Datetime.GetLocalNegativeOffsetMinDateTime
+// method.
+type DatetimeGetLocalNegativeOffsetMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetLocalNegativeOffsetUppercaseMaxDateTime
+// method.
+type DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalNoOffsetMinDateTimeOptions contains the optional parameters for the Datetime.GetLocalNoOffsetMinDateTime
+// method.
+type DatetimeGetLocalNoOffsetMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetLocalPositiveOffsetLowercaseMaxDateTime
+// method.
+type DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalPositiveOffsetMinDateTimeOptions contains the optional parameters for the Datetime.GetLocalPositiveOffsetMinDateTime
+// method.
+type DatetimeGetLocalPositiveOffsetMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetLocalPositiveOffsetUppercaseMaxDateTime
+// method.
+type DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetNullOptions contains the optional parameters for the Datetime.GetNull method.
+type DatetimeGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetOverflowOptions contains the optional parameters for the Datetime.GetOverflow method.
+type DatetimeGetOverflowOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetUTCLowercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetUTCLowercaseMaxDateTime
+// method.
+type DatetimeGetUTCLowercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetUTCMinDateTimeOptions contains the optional parameters for the Datetime.GetUTCMinDateTime method.
+type DatetimeGetUTCMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetUTCUppercaseMaxDateTime7DigitsOptions contains the optional parameters for the Datetime.GetUTCUppercaseMaxDateTime7Digits
+// method.
+type DatetimeGetUTCUppercaseMaxDateTime7DigitsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetUTCUppercaseMaxDateTimeOptions contains the optional parameters for the Datetime.GetUTCUppercaseMaxDateTime
+// method.
+type DatetimeGetUTCUppercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimeGetUnderflowOptions contains the optional parameters for the Datetime.GetUnderflow method.
+type DatetimeGetUnderflowOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutLocalNegativeOffsetMaxDateTimeOptions contains the optional parameters for the Datetime.PutLocalNegativeOffsetMaxDateTime
+// method.
+type DatetimePutLocalNegativeOffsetMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutLocalNegativeOffsetMinDateTimeOptions contains the optional parameters for the Datetime.PutLocalNegativeOffsetMinDateTime
+// method.
+type DatetimePutLocalNegativeOffsetMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutLocalPositiveOffsetMaxDateTimeOptions contains the optional parameters for the Datetime.PutLocalPositiveOffsetMaxDateTime
+// method.
+type DatetimePutLocalPositiveOffsetMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutLocalPositiveOffsetMinDateTimeOptions contains the optional parameters for the Datetime.PutLocalPositiveOffsetMinDateTime
+// method.
+type DatetimePutLocalPositiveOffsetMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutUTCMaxDateTime7DigitsOptions contains the optional parameters for the Datetime.PutUTCMaxDateTime7Digits method.
+type DatetimePutUTCMaxDateTime7DigitsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutUTCMaxDateTimeOptions contains the optional parameters for the Datetime.PutUTCMaxDateTime method.
+type DatetimePutUTCMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DatetimePutUTCMinDateTimeOptions contains the optional parameters for the Datetime.PutUTCMinDateTime method.
+type DatetimePutUTCMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -17,7 +17,7 @@ func newDatetimerfc1123Client() Datetimerfc1123Operations {
 
 func TestGetInvalid(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	_, err := client.GetInvalid(context.Background())
+	_, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -25,7 +25,7 @@ func TestGetInvalid(t *testing.T) {
 
 func TestGetNull(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestGetNull(t *testing.T) {
 
 func TestGetOverflow(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	_, err := client.GetOverflow(context.Background())
+	_, err := client.GetOverflow(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -44,7 +44,7 @@ func TestGetOverflow(t *testing.T) {
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	result, err := client.GetUTCLowercaseMaxDateTime(context.Background())
+	result, err := client.GetUTCLowercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func TestGetUTCMinDateTime(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	result, err := client.GetUTCMinDateTime(context.Background())
+	result, err := client.GetUTCMinDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	result, err := client.GetUTCUppercaseMaxDateTime(context.Background())
+	result, err := client.GetUTCUppercaseMaxDateTime(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 
 func TestGetUnderflow(t *testing.T) {
 	client := newDatetimerfc1123Client()
-	_, err := client.GetUnderflow(context.Background())
+	_, err := client.GetUnderflow(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -98,7 +98,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutUTCMaxDateTime(context.Background(), body)
+	result, err := client.PutUTCMaxDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestPutUTCMinDateTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.PutUTCMinDateTime(context.Background(), body)
+	result, err := client.PutUTCMinDateTime(context.Background(), body, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -15,23 +15,23 @@ import (
 // Datetimerfc1123Operations contains the methods for the Datetimerfc1123 group.
 type Datetimerfc1123Operations interface {
 	// GetInvalid - Get invalid datetime value
-	GetInvalid(ctx context.Context) (*TimeResponse, error)
+	GetInvalid(ctx context.Context, options *Datetimerfc1123GetInvalidOptions) (*TimeResponse, error)
 	// GetNull - Get null datetime value
-	GetNull(ctx context.Context) (*TimeResponse, error)
+	GetNull(ctx context.Context, options *Datetimerfc1123GetNullOptions) (*TimeResponse, error)
 	// GetOverflow - Get overflow datetime value
-	GetOverflow(ctx context.Context) (*TimeResponse, error)
+	GetOverflow(ctx context.Context, options *Datetimerfc1123GetOverflowOptions) (*TimeResponse, error)
 	// GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
-	GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCLowercaseMaxDateTime(ctx context.Context, options *Datetimerfc1123GetUTCLowercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-	GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCMinDateTime(ctx context.Context, options *Datetimerfc1123GetUTCMinDateTimeOptions) (*TimeResponse, error)
 	// GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
-	GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error)
+	GetUTCUppercaseMaxDateTime(ctx context.Context, options *Datetimerfc1123GetUTCUppercaseMaxDateTimeOptions) (*TimeResponse, error)
 	// GetUnderflow - Get underflow datetime value
-	GetUnderflow(ctx context.Context) (*TimeResponse, error)
+	GetUnderflow(ctx context.Context, options *Datetimerfc1123GetUnderflowOptions) (*TimeResponse, error)
 	// PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
-	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMaxDateTimeOptions) (*http.Response, error)
 	// PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error)
+	PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMinDateTimeOptions) (*http.Response, error)
 }
 
 // Datetimerfc1123Client implements the Datetimerfc1123Operations interface.
@@ -51,8 +51,8 @@ func (client *Datetimerfc1123Client) Do(req *azcore.Request) (*azcore.Response, 
 }
 
 // GetInvalid - Get invalid datetime value
-func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context, options *Datetimerfc1123GetInvalidOptions) (*TimeResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context) (*TimeRespo
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *Datetimerfc1123Client) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetInvalidCreateRequest(ctx context.Context, options *Datetimerfc1123GetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -98,8 +98,8 @@ func (client *Datetimerfc1123Client) GetInvalidHandleError(resp *azcore.Response
 }
 
 // GetNull - Get null datetime value
-func (client *Datetimerfc1123Client) GetNull(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetNull(ctx context.Context, options *Datetimerfc1123GetNullOptions) (*TimeResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (client *Datetimerfc1123Client) GetNull(ctx context.Context) (*TimeResponse
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *Datetimerfc1123Client) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetNullCreateRequest(ctx context.Context, options *Datetimerfc1123GetNullOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -145,8 +145,8 @@ func (client *Datetimerfc1123Client) GetNullHandleError(resp *azcore.Response) e
 }
 
 // GetOverflow - Get overflow datetime value
-func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetOverflowCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context, options *Datetimerfc1123GetOverflowOptions) (*TimeResponse, error) {
+	req, err := client.GetOverflowCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context) (*TimeResp
 }
 
 // GetOverflowCreateRequest creates the GetOverflow request.
-func (client *Datetimerfc1123Client) GetOverflowCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetOverflowCreateRequest(ctx context.Context, options *Datetimerfc1123GetOverflowOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/overflow"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -192,8 +192,8 @@ func (client *Datetimerfc1123Client) GetOverflowHandleError(resp *azcore.Respons
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
-func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCLowercaseMaxDateTimeCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Context, options *Datetimerfc1123GetUTCLowercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCLowercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Cont
 }
 
 // GetUTCLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
-func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeCreateRequest(ctx context.Context, options *Datetimerfc1123GetUTCLowercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/lowercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -239,8 +239,8 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTimeHandleError(resp 
 }
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCMinDateTimeCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context, options *Datetimerfc1123GetUTCMinDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCMinDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context) (*Ti
 }
 
 // GetUTCMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
-func (client *Datetimerfc1123Client) GetUTCMinDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetUTCMinDateTimeCreateRequest(ctx context.Context, options *Datetimerfc1123GetUTCMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -286,8 +286,8 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTimeHandleError(resp *azcore.R
 }
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
-func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUTCUppercaseMaxDateTimeCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Context, options *Datetimerfc1123GetUTCUppercaseMaxDateTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUTCUppercaseMaxDateTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Cont
 }
 
 // GetUTCUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
-func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeCreateRequest(ctx context.Context, options *Datetimerfc1123GetUTCUppercaseMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max/uppercase"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -333,8 +333,8 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTimeHandleError(resp 
 }
 
 // GetUnderflow - Get underflow datetime value
-func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUnderflowCreateRequest(ctx)
+func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context, options *Datetimerfc1123GetUnderflowOptions) (*TimeResponse, error) {
+	req, err := client.GetUnderflowCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context) (*TimeRes
 }
 
 // GetUnderflowCreateRequest creates the GetUnderflow request.
-func (client *Datetimerfc1123Client) GetUnderflowCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) GetUnderflowCreateRequest(ctx context.Context, options *Datetimerfc1123GetUnderflowOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/underflow"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -380,8 +380,8 @@ func (client *Datetimerfc1123Client) GetUnderflowHandleError(resp *azcore.Respon
 }
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
-func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutUTCMaxDateTimeCreateRequest(ctx, datetimeBody)
+func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMaxDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutUTCMaxDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +396,7 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, date
 }
 
 // PutUTCMaxDateTimeCreateRequest creates the PutUTCMaxDateTime request.
-func (client *Datetimerfc1123Client) PutUTCMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) PutUTCMaxDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMaxDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/max"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -417,8 +417,8 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTimeHandleError(resp *azcore.R
 }
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
-func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time) (*http.Response, error) {
-	req, err := client.PutUTCMinDateTimeCreateRequest(ctx, datetimeBody)
+func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMinDateTimeOptions) (*http.Response, error) {
+	req, err := client.PutUTCMinDateTimeCreateRequest(ctx, datetimeBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, date
 }
 
 // PutUTCMinDateTimeCreateRequest creates the PutUTCMinDateTime request.
-func (client *Datetimerfc1123Client) PutUTCMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time) (*azcore.Request, error) {
+func (client *Datetimerfc1123Client) PutUTCMinDateTimeCreateRequest(ctx context.Context, datetimeBody time.Time, options *Datetimerfc1123PutUTCMinDateTimeOptions) (*azcore.Request, error) {
 	urlPath := "/datetimerfc1123/min"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/datetimerfc1123group/zz_generated_models.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_models.go
@@ -11,6 +11,53 @@ import (
 	"time"
 )
 
+// Datetimerfc1123GetInvalidOptions contains the optional parameters for the Datetimerfc1123.GetInvalid method.
+type Datetimerfc1123GetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetNullOptions contains the optional parameters for the Datetimerfc1123.GetNull method.
+type Datetimerfc1123GetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetOverflowOptions contains the optional parameters for the Datetimerfc1123.GetOverflow method.
+type Datetimerfc1123GetOverflowOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetUTCLowercaseMaxDateTimeOptions contains the optional parameters for the Datetimerfc1123.GetUTCLowercaseMaxDateTime
+// method.
+type Datetimerfc1123GetUTCLowercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetUTCMinDateTimeOptions contains the optional parameters for the Datetimerfc1123.GetUTCMinDateTime method.
+type Datetimerfc1123GetUTCMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetUTCUppercaseMaxDateTimeOptions contains the optional parameters for the Datetimerfc1123.GetUTCUppercaseMaxDateTime
+// method.
+type Datetimerfc1123GetUTCUppercaseMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123GetUnderflowOptions contains the optional parameters for the Datetimerfc1123.GetUnderflow method.
+type Datetimerfc1123GetUnderflowOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123PutUTCMaxDateTimeOptions contains the optional parameters for the Datetimerfc1123.PutUTCMaxDateTime method.
+type Datetimerfc1123PutUTCMaxDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// Datetimerfc1123PutUTCMinDateTimeOptions contains the optional parameters for the Datetimerfc1123.PutUTCMinDateTime method.
+type Datetimerfc1123PutUTCMinDateTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -20,7 +20,7 @@ func newDictionaryClient() DictionaryOperations {
 // GetArrayEmpty - Get an empty dictionary {}
 func TestGetArrayEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetArrayEmpty(context.Background())
+	resp, err := client.GetArrayEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestGetArrayEmpty(t *testing.T) {
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
 func TestGetArrayItemEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetArrayItemEmpty(context.Background())
+	resp, err := client.GetArrayItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
 func TestGetArrayItemNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetArrayItemNull(context.Background())
+	resp, err := client.GetArrayItemNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestGetArrayItemNull(t *testing.T) {
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetArrayNull(context.Background())
+	resp, err := client.GetArrayNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestGetArrayNull(t *testing.T) {
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestGetArrayValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetArrayValid(context.Background())
+	resp, err := client.GetArrayValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestGetBase64URL(t *testing.T) {
 func TestGetBooleanInvalidNull(t *testing.T) {
 	t.Skip("no x-nullable, should fail")
 	client := newDictionaryClient()
-	resp, err := client.GetBooleanInvalidNull(context.Background())
+	resp, err := client.GetBooleanInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -105,7 +105,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
 func TestGetBooleanInvalidString(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetBooleanInvalidString(context.Background())
+	resp, err := client.GetBooleanInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -117,7 +117,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
 func TestGetBooleanTfft(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetBooleanTfft(context.Background())
+	resp, err := client.GetBooleanTfft(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestGetBooleanTfft(t *testing.T) {
 func TestGetByteInvalidNull(t *testing.T) {
 	t.Skip("no x-nullable, should fail")
 	client := newDictionaryClient()
-	resp, err := client.GetByteInvalidNull(context.Background())
+	resp, err := client.GetByteInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -145,7 +145,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetByteValid(context.Background())
+	resp, err := client.GetByteValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestGetByteValid(t *testing.T) {
 // GetComplexEmpty - Get empty dictionary of complex type {}
 func TestGetComplexEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetComplexEmpty(context.Background())
+	resp, err := client.GetComplexEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestGetComplexEmpty(t *testing.T) {
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexItemEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetComplexItemEmpty(context.Background())
+	resp, err := client.GetComplexItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 test is invalid, expects nil value but missing x-nullable
 func TestGetComplexItemNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetComplexItemNull(context.Background())
+	resp, err := client.GetComplexItemNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestGetComplexItemNull(t *testing.T) {
 // GetComplexNull - Get dictionary of complex type null value
 func TestGetComplexNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetComplexNull(context.Background())
+	resp, err := client.GetComplexNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestGetComplexNull(t *testing.T) {
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetComplexValid(context.Background())
+	resp, err := client.GetComplexValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
 func TestGetDateTimeInvalidChars(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDateTimeInvalidChars(context.Background())
+	resp, err := client.GetDateTimeInvalidChars(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -247,7 +247,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
 func TestGetDateTimeInvalidNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDateTimeInvalidNull(context.Background())
+	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -259,7 +259,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDateTimeRFC1123Valid(context.Background())
+	resp, err := client.GetDateTimeRFC1123Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 func TestGetDateTimeValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDateTimeValid(context.Background())
+	resp, err := client.GetDateTimeValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +298,7 @@ func TestGetDateValid(t *testing.T) {
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
 func TestGetDictionaryEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDictionaryEmpty(context.Background())
+	resp, err := client.GetDictionaryEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 func TestGetDictionaryItemEmpty(t *testing.T) {
 	t.Skip("needs codegen fix")
 	client := newDictionaryClient()
-	resp, err := client.GetDictionaryItemEmpty(context.Background())
+	resp, err := client.GetDictionaryItemEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -335,7 +335,7 @@ func TestGetDictionaryValid(t *testing.T) {
 func TestGetDoubleInvalidNull(t *testing.T) {
 	t.Skip("should fail as mising x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetDoubleInvalidNull(context.Background())
+	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -347,7 +347,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetDoubleInvalidString(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDoubleInvalidString(context.Background())
+	resp, err := client.GetDoubleInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -359,7 +359,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetDoubleValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDoubleValid(context.Background())
+	resp, err := client.GetDoubleValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,7 @@ func TestGetDoubleValid(t *testing.T) {
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestGetDurationValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetDurationValid(context.Background())
+	resp, err := client.GetDurationValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -386,7 +386,7 @@ func TestGetDurationValid(t *testing.T) {
 // GetEmpty - Get empty dictionary value {}
 func TestGetEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetEmpty(context.Background())
+	resp, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,7 +398,7 @@ func TestGetEmpty(t *testing.T) {
 // GetEmptyStringKey - Get Dictionary with key as empty string
 func TestGetEmptyStringKey(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetEmptyStringKey(context.Background())
+	resp, err := client.GetEmptyStringKey(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestGetEmptyStringKey(t *testing.T) {
 func TestGetFloatInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetFloatInvalidNull(context.Background())
+	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -421,7 +421,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetFloatInvalidString(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetFloatInvalidString(context.Background())
+	resp, err := client.GetFloatInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -433,7 +433,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetFloatValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetFloatValid(context.Background())
+	resp, err := client.GetFloatValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func TestGetFloatValid(t *testing.T) {
 func TestGetIntInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetIntInvalidNull(context.Background())
+	resp, err := client.GetIntInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -460,7 +460,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetIntInvalidString(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetIntInvalidString(context.Background())
+	resp, err := client.GetIntInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -472,7 +472,7 @@ func TestGetIntInvalidString(t *testing.T) {
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetIntegerValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetIntegerValid(context.Background())
+	resp, err := client.GetIntegerValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +487,7 @@ func TestGetIntegerValid(t *testing.T) {
 // GetInvalid - Get invalid Dictionary value
 func TestGetInvalid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetInvalid(context.Background())
+	resp, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -500,7 +500,7 @@ func TestGetInvalid(t *testing.T) {
 func TestGetLongInvalidNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetLongInvalidNull(context.Background())
+	resp, err := client.GetLongInvalidNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -512,7 +512,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetLongInvalidString(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetLongInvalidString(context.Background())
+	resp, err := client.GetLongInvalidString(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -524,7 +524,7 @@ func TestGetLongInvalidString(t *testing.T) {
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetLongValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetLongValid(context.Background())
+	resp, err := client.GetLongValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,7 +539,7 @@ func TestGetLongValid(t *testing.T) {
 // GetNull - Get null dictionary value
 func TestGetNull(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetNull(context.Background())
+	resp, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -551,7 +551,7 @@ func TestGetNull(t *testing.T) {
 // GetNullKey - Get Dictionary with null key
 func TestGetNullKey(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetNullKey(context.Background())
+	resp, err := client.GetNullKey(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -564,7 +564,7 @@ func TestGetNullKey(t *testing.T) {
 func TestGetNullValue(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetNullValue(context.Background())
+	resp, err := client.GetNullValue(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -576,7 +576,7 @@ func TestGetNullValue(t *testing.T) {
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestGetStringValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetStringValid(context.Background())
+	resp, err := client.GetStringValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -590,7 +590,7 @@ func TestGetStringValid(t *testing.T) {
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
 func TestGetStringWithInvalid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.GetStringWithInvalid(context.Background())
+	resp, err := client.GetStringWithInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -603,7 +603,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 func TestGetStringWithNull(t *testing.T) {
 	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
-	resp, err := client.GetStringWithNull(context.Background())
+	resp, err := client.GetStringWithNull(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -619,7 +619,7 @@ func TestPutArrayValid(t *testing.T) {
 		"0": []string{"1", "2", "3"},
 		"1": []string{"4", "5", "6"},
 		"2": []string{"7", "8", "9"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -634,7 +634,7 @@ func TestPutBooleanTfft(t *testing.T) {
 		"1": false,
 		"2": false,
 		"3": true,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -648,7 +648,7 @@ func TestPutByteValid(t *testing.T) {
 		"0": {255, 255, 255, 250},
 		"1": {1, 2, 3},
 		"2": {37, 41, 67},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -662,7 +662,7 @@ func TestPutComplexValid(t *testing.T) {
 		"0": Widget{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": Widget{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		"2": Widget{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,7 +679,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 		"0": dt1,
 		"1": dt2,
 		"2": dt3,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestPutDateTimeValid(t *testing.T) {
 		"0": dt1,
 		"1": dt2,
 		"2": dt3,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -720,7 +720,7 @@ func TestPutDoubleValid(t *testing.T) {
 		"0": 0,
 		"1": -0.01,
 		"2": -1.2e20,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -733,7 +733,7 @@ func TestPutDurationValid(t *testing.T) {
 	resp, err := client.PutDurationValid(context.Background(), map[string]string{
 		"0": "P123DT22H14M12.011S",
 		"1": "P5DT1H",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -743,7 +743,7 @@ func TestPutDurationValid(t *testing.T) {
 // PutEmpty - Set dictionary value empty {}
 func TestPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutEmpty(context.Background(), map[string]string{})
+	resp, err := client.PutEmpty(context.Background(), map[string]string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -757,7 +757,7 @@ func TestPutFloatValid(t *testing.T) {
 		"0": 0,
 		"1": -0.01,
 		"2": -1.2e20,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -772,7 +772,7 @@ func TestPutIntegerValid(t *testing.T) {
 		"1": -1,
 		"2": 3,
 		"3": 300,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func TestPutLongValid(t *testing.T) {
 		"1": -1,
 		"2": 3,
 		"3": 300,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -801,7 +801,7 @@ func TestPutStringValid(t *testing.T) {
 		"0": "foo1",
 		"1": "foo2",
 		"2": "foo3",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -15,135 +15,135 @@ import (
 // DictionaryOperations contains the methods for the Dictionary group.
 type DictionaryOperations interface {
 	// GetArrayEmpty - Get an empty dictionary {}
-	GetArrayEmpty(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetArrayEmpty(ctx context.Context, options *DictionaryGetArrayEmptyOptions) (*MapOfStringArrayResponse, error)
 	// GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
-	GetArrayItemEmpty(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetArrayItemEmpty(ctx context.Context, options *DictionaryGetArrayItemEmptyOptions) (*MapOfStringArrayResponse, error)
 	// GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
-	GetArrayItemNull(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetArrayItemNull(ctx context.Context, options *DictionaryGetArrayItemNullOptions) (*MapOfStringArrayResponse, error)
 	// GetArrayNull - Get a null array
-	GetArrayNull(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetArrayNull(ctx context.Context, options *DictionaryGetArrayNullOptions) (*MapOfStringArrayResponse, error)
 	// GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-	GetArrayValid(ctx context.Context) (*MapOfStringArrayResponse, error)
+	GetArrayValid(ctx context.Context, options *DictionaryGetArrayValidOptions) (*MapOfStringArrayResponse, error)
 	// GetBase64URL - Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
-	GetBase64URL(ctx context.Context) (*MapOfByteArrayResponse, error)
+	GetBase64URL(ctx context.Context, options *DictionaryGetBase64URLOptions) (*MapOfByteArrayResponse, error)
 	// GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
-	GetBooleanInvalidNull(ctx context.Context) (*MapOfBoolResponse, error)
+	GetBooleanInvalidNull(ctx context.Context, options *DictionaryGetBooleanInvalidNullOptions) (*MapOfBoolResponse, error)
 	// GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
-	GetBooleanInvalidString(ctx context.Context) (*MapOfBoolResponse, error)
+	GetBooleanInvalidString(ctx context.Context, options *DictionaryGetBooleanInvalidStringOptions) (*MapOfBoolResponse, error)
 	// GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
-	GetBooleanTfft(ctx context.Context) (*MapOfBoolResponse, error)
+	GetBooleanTfft(ctx context.Context, options *DictionaryGetBooleanTfftOptions) (*MapOfBoolResponse, error)
 	// GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
-	GetByteInvalidNull(ctx context.Context) (*MapOfByteArrayResponse, error)
+	GetByteInvalidNull(ctx context.Context, options *DictionaryGetByteInvalidNullOptions) (*MapOfByteArrayResponse, error)
 	// GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
-	GetByteValid(ctx context.Context) (*MapOfByteArrayResponse, error)
+	GetByteValid(ctx context.Context, options *DictionaryGetByteValidOptions) (*MapOfByteArrayResponse, error)
 	// GetComplexEmpty - Get empty dictionary of complex type {}
-	GetComplexEmpty(ctx context.Context) (*MapOfWidgetResponse, error)
+	GetComplexEmpty(ctx context.Context, options *DictionaryGetComplexEmptyOptions) (*MapOfWidgetResponse, error)
 	// GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
-	GetComplexItemEmpty(ctx context.Context) (*MapOfWidgetResponse, error)
+	GetComplexItemEmpty(ctx context.Context, options *DictionaryGetComplexItemEmptyOptions) (*MapOfWidgetResponse, error)
 	// GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
-	GetComplexItemNull(ctx context.Context) (*MapOfWidgetResponse, error)
+	GetComplexItemNull(ctx context.Context, options *DictionaryGetComplexItemNullOptions) (*MapOfWidgetResponse, error)
 	// GetComplexNull - Get dictionary of complex type null value
-	GetComplexNull(ctx context.Context) (*MapOfWidgetResponse, error)
+	GetComplexNull(ctx context.Context, options *DictionaryGetComplexNullOptions) (*MapOfWidgetResponse, error)
 	// GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
-	GetComplexValid(ctx context.Context) (*MapOfWidgetResponse, error)
+	GetComplexValid(ctx context.Context, options *DictionaryGetComplexValidOptions) (*MapOfWidgetResponse, error)
 	// GetDateInvalidChars - Get date dictionary value {"0": "2011-03-22", "1": "date"}
-	GetDateInvalidChars(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateInvalidChars(ctx context.Context, options *DictionaryGetDateInvalidCharsOptions) (*MapOfTimeResponse, error)
 	// GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
-	GetDateInvalidNull(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateInvalidNull(ctx context.Context, options *DictionaryGetDateInvalidNullOptions) (*MapOfTimeResponse, error)
 	// GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
-	GetDateTimeInvalidChars(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateTimeInvalidChars(ctx context.Context, options *DictionaryGetDateTimeInvalidCharsOptions) (*MapOfTimeResponse, error)
 	// GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
-	GetDateTimeInvalidNull(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateTimeInvalidNull(ctx context.Context, options *DictionaryGetDateTimeInvalidNullOptions) (*MapOfTimeResponse, error)
 	// GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
-	GetDateTimeRFC1123Valid(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateTimeRFC1123Valid(ctx context.Context, options *DictionaryGetDateTimeRFC1123ValidOptions) (*MapOfTimeResponse, error)
 	// GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
-	GetDateTimeValid(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateTimeValid(ctx context.Context, options *DictionaryGetDateTimeValidOptions) (*MapOfTimeResponse, error)
 	// GetDateValid - Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-	GetDateValid(ctx context.Context) (*MapOfTimeResponse, error)
+	GetDateValid(ctx context.Context, options *DictionaryGetDateValidOptions) (*MapOfTimeResponse, error)
 	// GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
-	GetDictionaryEmpty(ctx context.Context) (*MapOfInterfaceResponse, error)
+	GetDictionaryEmpty(ctx context.Context, options *DictionaryGetDictionaryEmptyOptions) (*MapOfInterfaceResponse, error)
 	// GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-	GetDictionaryItemEmpty(ctx context.Context) (*MapOfInterfaceResponse, error)
+	GetDictionaryItemEmpty(ctx context.Context, options *DictionaryGetDictionaryItemEmptyOptions) (*MapOfInterfaceResponse, error)
 	// GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-	GetDictionaryItemNull(ctx context.Context) (*MapOfInterfaceResponse, error)
+	GetDictionaryItemNull(ctx context.Context, options *DictionaryGetDictionaryItemNullOptions) (*MapOfInterfaceResponse, error)
 	// GetDictionaryNull - Get an dictionaries of dictionaries with value null
-	GetDictionaryNull(ctx context.Context) (*MapOfInterfaceResponse, error)
+	GetDictionaryNull(ctx context.Context, options *DictionaryGetDictionaryNullOptions) (*MapOfInterfaceResponse, error)
 	// GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-	GetDictionaryValid(ctx context.Context) (*MapOfInterfaceResponse, error)
+	GetDictionaryValid(ctx context.Context, options *DictionaryGetDictionaryValidOptions) (*MapOfInterfaceResponse, error)
 	// GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
-	GetDoubleInvalidNull(ctx context.Context) (*MapOfFloat64Response, error)
+	GetDoubleInvalidNull(ctx context.Context, options *DictionaryGetDoubleInvalidNullOptions) (*MapOfFloat64Response, error)
 	// GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
-	GetDoubleInvalidString(ctx context.Context) (*MapOfFloat64Response, error)
+	GetDoubleInvalidString(ctx context.Context, options *DictionaryGetDoubleInvalidStringOptions) (*MapOfFloat64Response, error)
 	// GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	GetDoubleValid(ctx context.Context) (*MapOfFloat64Response, error)
+	GetDoubleValid(ctx context.Context, options *DictionaryGetDoubleValidOptions) (*MapOfFloat64Response, error)
 	// GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-	GetDurationValid(ctx context.Context) (*MapOfStringResponse, error)
+	GetDurationValid(ctx context.Context, options *DictionaryGetDurationValidOptions) (*MapOfStringResponse, error)
 	// GetEmpty - Get empty dictionary value {}
-	GetEmpty(ctx context.Context) (*MapOfInt32Response, error)
+	GetEmpty(ctx context.Context, options *DictionaryGetEmptyOptions) (*MapOfInt32Response, error)
 	// GetEmptyStringKey - Get Dictionary with key as empty string
-	GetEmptyStringKey(ctx context.Context) (*MapOfStringResponse, error)
+	GetEmptyStringKey(ctx context.Context, options *DictionaryGetEmptyStringKeyOptions) (*MapOfStringResponse, error)
 	// GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
-	GetFloatInvalidNull(ctx context.Context) (*MapOfFloat32Response, error)
+	GetFloatInvalidNull(ctx context.Context, options *DictionaryGetFloatInvalidNullOptions) (*MapOfFloat32Response, error)
 	// GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
-	GetFloatInvalidString(ctx context.Context) (*MapOfFloat32Response, error)
+	GetFloatInvalidString(ctx context.Context, options *DictionaryGetFloatInvalidStringOptions) (*MapOfFloat32Response, error)
 	// GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	GetFloatValid(ctx context.Context) (*MapOfFloat32Response, error)
+	GetFloatValid(ctx context.Context, options *DictionaryGetFloatValidOptions) (*MapOfFloat32Response, error)
 	// GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
-	GetIntInvalidNull(ctx context.Context) (*MapOfInt32Response, error)
+	GetIntInvalidNull(ctx context.Context, options *DictionaryGetIntInvalidNullOptions) (*MapOfInt32Response, error)
 	// GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
-	GetIntInvalidString(ctx context.Context) (*MapOfInt32Response, error)
+	GetIntInvalidString(ctx context.Context, options *DictionaryGetIntInvalidStringOptions) (*MapOfInt32Response, error)
 	// GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-	GetIntegerValid(ctx context.Context) (*MapOfInt32Response, error)
+	GetIntegerValid(ctx context.Context, options *DictionaryGetIntegerValidOptions) (*MapOfInt32Response, error)
 	// GetInvalid - Get invalid Dictionary value
-	GetInvalid(ctx context.Context) (*MapOfStringResponse, error)
+	GetInvalid(ctx context.Context, options *DictionaryGetInvalidOptions) (*MapOfStringResponse, error)
 	// GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
-	GetLongInvalidNull(ctx context.Context) (*MapOfInt64Response, error)
+	GetLongInvalidNull(ctx context.Context, options *DictionaryGetLongInvalidNullOptions) (*MapOfInt64Response, error)
 	// GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
-	GetLongInvalidString(ctx context.Context) (*MapOfInt64Response, error)
+	GetLongInvalidString(ctx context.Context, options *DictionaryGetLongInvalidStringOptions) (*MapOfInt64Response, error)
 	// GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-	GetLongValid(ctx context.Context) (*MapOfInt64Response, error)
+	GetLongValid(ctx context.Context, options *DictionaryGetLongValidOptions) (*MapOfInt64Response, error)
 	// GetNull - Get null dictionary value
-	GetNull(ctx context.Context) (*MapOfInt32Response, error)
+	GetNull(ctx context.Context, options *DictionaryGetNullOptions) (*MapOfInt32Response, error)
 	// GetNullKey - Get Dictionary with null key
-	GetNullKey(ctx context.Context) (*MapOfStringResponse, error)
+	GetNullKey(ctx context.Context, options *DictionaryGetNullKeyOptions) (*MapOfStringResponse, error)
 	// GetNullValue - Get Dictionary with null value
-	GetNullValue(ctx context.Context) (*MapOfStringResponse, error)
+	GetNullValue(ctx context.Context, options *DictionaryGetNullValueOptions) (*MapOfStringResponse, error)
 	// GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-	GetStringValid(ctx context.Context) (*MapOfStringResponse, error)
+	GetStringValid(ctx context.Context, options *DictionaryGetStringValidOptions) (*MapOfStringResponse, error)
 	// GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
-	GetStringWithInvalid(ctx context.Context) (*MapOfStringResponse, error)
+	GetStringWithInvalid(ctx context.Context, options *DictionaryGetStringWithInvalidOptions) (*MapOfStringResponse, error)
 	// GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
-	GetStringWithNull(ctx context.Context) (*MapOfStringResponse, error)
+	GetStringWithNull(ctx context.Context, options *DictionaryGetStringWithNullOptions) (*MapOfStringResponse, error)
 	// PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-	PutArrayValid(ctx context.Context, arrayBody map[string][]string) (*http.Response, error)
+	PutArrayValid(ctx context.Context, arrayBody map[string][]string, options *DictionaryPutArrayValidOptions) (*http.Response, error)
 	// PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
-	PutBooleanTfft(ctx context.Context, arrayBody map[string]bool) (*http.Response, error)
+	PutBooleanTfft(ctx context.Context, arrayBody map[string]bool, options *DictionaryPutBooleanTfftOptions) (*http.Response, error)
 	// PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
-	PutByteValid(ctx context.Context, arrayBody map[string][]byte) (*http.Response, error)
+	PutByteValid(ctx context.Context, arrayBody map[string][]byte, options *DictionaryPutByteValidOptions) (*http.Response, error)
 	// PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
-	PutComplexValid(ctx context.Context, arrayBody map[string]Widget) (*http.Response, error)
+	PutComplexValid(ctx context.Context, arrayBody map[string]Widget, options *DictionaryPutComplexValidOptions) (*http.Response, error)
 	// PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
-	PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error)
+	PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*http.Response, error)
 	// PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
-	PutDateTimeValid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error)
+	PutDateTimeValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeValidOptions) (*http.Response, error)
 	// PutDateValid - Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-	PutDateValid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error)
+	PutDateValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateValidOptions) (*http.Response, error)
 	// PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-	PutDictionaryValid(ctx context.Context, arrayBody map[string]interface{}) (*http.Response, error)
+	PutDictionaryValid(ctx context.Context, arrayBody map[string]interface{}, options *DictionaryPutDictionaryValidOptions) (*http.Response, error)
 	// PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	PutDoubleValid(ctx context.Context, arrayBody map[string]float64) (*http.Response, error)
+	PutDoubleValid(ctx context.Context, arrayBody map[string]float64, options *DictionaryPutDoubleValidOptions) (*http.Response, error)
 	// PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-	PutDurationValid(ctx context.Context, arrayBody map[string]string) (*http.Response, error)
+	PutDurationValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutDurationValidOptions) (*http.Response, error)
 	// PutEmpty - Set dictionary value empty {}
-	PutEmpty(ctx context.Context, arrayBody map[string]string) (*http.Response, error)
+	PutEmpty(ctx context.Context, arrayBody map[string]string, options *DictionaryPutEmptyOptions) (*http.Response, error)
 	// PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	PutFloatValid(ctx context.Context, arrayBody map[string]float32) (*http.Response, error)
+	PutFloatValid(ctx context.Context, arrayBody map[string]float32, options *DictionaryPutFloatValidOptions) (*http.Response, error)
 	// PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-	PutIntegerValid(ctx context.Context, arrayBody map[string]int32) (*http.Response, error)
+	PutIntegerValid(ctx context.Context, arrayBody map[string]int32, options *DictionaryPutIntegerValidOptions) (*http.Response, error)
 	// PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-	PutLongValid(ctx context.Context, arrayBody map[string]int64) (*http.Response, error)
+	PutLongValid(ctx context.Context, arrayBody map[string]int64, options *DictionaryPutLongValidOptions) (*http.Response, error)
 	// PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-	PutStringValid(ctx context.Context, arrayBody map[string]string) (*http.Response, error)
+	PutStringValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutStringValidOptions) (*http.Response, error)
 }
 
 // DictionaryClient implements the DictionaryOperations interface.
@@ -163,8 +163,8 @@ func (client *DictionaryClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // GetArrayEmpty - Get an empty dictionary {}
-func (client *DictionaryClient) GetArrayEmpty(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetArrayEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetArrayEmpty(ctx context.Context, options *DictionaryGetArrayEmptyOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetArrayEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *DictionaryClient) GetArrayEmpty(ctx context.Context) (*MapOfString
 }
 
 // GetArrayEmptyCreateRequest creates the GetArrayEmpty request.
-func (client *DictionaryClient) GetArrayEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetArrayEmptyCreateRequest(ctx context.Context, options *DictionaryGetArrayEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -209,8 +209,8 @@ func (client *DictionaryClient) GetArrayEmptyHandleError(resp *azcore.Response) 
 }
 
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
-func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetArrayItemEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context, options *DictionaryGetArrayItemEmptyOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetArrayItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context) (*MapOfSt
 }
 
 // GetArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
-func (client *DictionaryClient) GetArrayItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetArrayItemEmptyCreateRequest(ctx context.Context, options *DictionaryGetArrayItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -255,8 +255,8 @@ func (client *DictionaryClient) GetArrayItemEmptyHandleError(resp *azcore.Respon
 }
 
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
-func (client *DictionaryClient) GetArrayItemNull(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetArrayItemNullCreateRequest(ctx)
+func (client *DictionaryClient) GetArrayItemNull(ctx context.Context, options *DictionaryGetArrayItemNullOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetArrayItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (client *DictionaryClient) GetArrayItemNull(ctx context.Context) (*MapOfStr
 }
 
 // GetArrayItemNullCreateRequest creates the GetArrayItemNull request.
-func (client *DictionaryClient) GetArrayItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetArrayItemNullCreateRequest(ctx context.Context, options *DictionaryGetArrayItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -301,8 +301,8 @@ func (client *DictionaryClient) GetArrayItemNullHandleError(resp *azcore.Respons
 }
 
 // GetArrayNull - Get a null array
-func (client *DictionaryClient) GetArrayNull(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetArrayNullCreateRequest(ctx)
+func (client *DictionaryClient) GetArrayNull(ctx context.Context, options *DictionaryGetArrayNullOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetArrayNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (client *DictionaryClient) GetArrayNull(ctx context.Context) (*MapOfStringA
 }
 
 // GetArrayNullCreateRequest creates the GetArrayNull request.
-func (client *DictionaryClient) GetArrayNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetArrayNullCreateRequest(ctx context.Context, options *DictionaryGetArrayNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -347,8 +347,8 @@ func (client *DictionaryClient) GetArrayNullHandleError(resp *azcore.Response) e
 }
 
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-func (client *DictionaryClient) GetArrayValid(ctx context.Context) (*MapOfStringArrayResponse, error) {
-	req, err := client.GetArrayValidCreateRequest(ctx)
+func (client *DictionaryClient) GetArrayValid(ctx context.Context, options *DictionaryGetArrayValidOptions) (*MapOfStringArrayResponse, error) {
+	req, err := client.GetArrayValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +367,7 @@ func (client *DictionaryClient) GetArrayValid(ctx context.Context) (*MapOfString
 }
 
 // GetArrayValidCreateRequest creates the GetArrayValid request.
-func (client *DictionaryClient) GetArrayValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetArrayValidCreateRequest(ctx context.Context, options *DictionaryGetArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -393,8 +393,8 @@ func (client *DictionaryClient) GetArrayValidHandleError(resp *azcore.Response) 
 }
 
 // GetBase64URL - Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
-func (client *DictionaryClient) GetBase64URL(ctx context.Context) (*MapOfByteArrayResponse, error) {
-	req, err := client.GetBase64URLCreateRequest(ctx)
+func (client *DictionaryClient) GetBase64URL(ctx context.Context, options *DictionaryGetBase64URLOptions) (*MapOfByteArrayResponse, error) {
+	req, err := client.GetBase64URLCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (client *DictionaryClient) GetBase64URL(ctx context.Context) (*MapOfByteArr
 }
 
 // GetBase64URLCreateRequest creates the GetBase64URL request.
-func (client *DictionaryClient) GetBase64URLCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetBase64URLCreateRequest(ctx context.Context, options *DictionaryGetBase64URLOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/base64url/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -439,8 +439,8 @@ func (client *DictionaryClient) GetBase64URLHandleError(resp *azcore.Response) e
 }
 
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
-func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context) (*MapOfBoolResponse, error) {
-	req, err := client.GetBooleanInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context, options *DictionaryGetBooleanInvalidNullOptions) (*MapOfBoolResponse, error) {
+	req, err := client.GetBooleanInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context) (*Map
 }
 
 // GetBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
-func (client *DictionaryClient) GetBooleanInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetBooleanInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetBooleanInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/true.null.false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -485,8 +485,8 @@ func (client *DictionaryClient) GetBooleanInvalidNullHandleError(resp *azcore.Re
 }
 
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
-func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context) (*MapOfBoolResponse, error) {
-	req, err := client.GetBooleanInvalidStringCreateRequest(ctx)
+func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context, options *DictionaryGetBooleanInvalidStringOptions) (*MapOfBoolResponse, error) {
+	req, err := client.GetBooleanInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context) (*M
 }
 
 // GetBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
-func (client *DictionaryClient) GetBooleanInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetBooleanInvalidStringCreateRequest(ctx context.Context, options *DictionaryGetBooleanInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/true.boolean.false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -531,8 +531,8 @@ func (client *DictionaryClient) GetBooleanInvalidStringHandleError(resp *azcore.
 }
 
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
-func (client *DictionaryClient) GetBooleanTfft(ctx context.Context) (*MapOfBoolResponse, error) {
-	req, err := client.GetBooleanTfftCreateRequest(ctx)
+func (client *DictionaryClient) GetBooleanTfft(ctx context.Context, options *DictionaryGetBooleanTfftOptions) (*MapOfBoolResponse, error) {
+	req, err := client.GetBooleanTfftCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +551,7 @@ func (client *DictionaryClient) GetBooleanTfft(ctx context.Context) (*MapOfBoolR
 }
 
 // GetBooleanTfftCreateRequest creates the GetBooleanTfft request.
-func (client *DictionaryClient) GetBooleanTfftCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetBooleanTfftCreateRequest(ctx context.Context, options *DictionaryGetBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -577,8 +577,8 @@ func (client *DictionaryClient) GetBooleanTfftHandleError(resp *azcore.Response)
 }
 
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
-func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context) (*MapOfByteArrayResponse, error) {
-	req, err := client.GetByteInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context, options *DictionaryGetByteInvalidNullOptions) (*MapOfByteArrayResponse, error) {
+	req, err := client.GetByteInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +597,7 @@ func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context) (*MapOfB
 }
 
 // GetByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
-func (client *DictionaryClient) GetByteInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetByteInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetByteInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -623,8 +623,8 @@ func (client *DictionaryClient) GetByteInvalidNullHandleError(resp *azcore.Respo
 }
 
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
-func (client *DictionaryClient) GetByteValid(ctx context.Context) (*MapOfByteArrayResponse, error) {
-	req, err := client.GetByteValidCreateRequest(ctx)
+func (client *DictionaryClient) GetByteValid(ctx context.Context, options *DictionaryGetByteValidOptions) (*MapOfByteArrayResponse, error) {
+	req, err := client.GetByteValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +643,7 @@ func (client *DictionaryClient) GetByteValid(ctx context.Context) (*MapOfByteArr
 }
 
 // GetByteValidCreateRequest creates the GetByteValid request.
-func (client *DictionaryClient) GetByteValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetByteValidCreateRequest(ctx context.Context, options *DictionaryGetByteValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -669,8 +669,8 @@ func (client *DictionaryClient) GetByteValidHandleError(resp *azcore.Response) e
 }
 
 // GetComplexEmpty - Get empty dictionary of complex type {}
-func (client *DictionaryClient) GetComplexEmpty(ctx context.Context) (*MapOfWidgetResponse, error) {
-	req, err := client.GetComplexEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetComplexEmpty(ctx context.Context, options *DictionaryGetComplexEmptyOptions) (*MapOfWidgetResponse, error) {
+	req, err := client.GetComplexEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -689,7 +689,7 @@ func (client *DictionaryClient) GetComplexEmpty(ctx context.Context) (*MapOfWidg
 }
 
 // GetComplexEmptyCreateRequest creates the GetComplexEmpty request.
-func (client *DictionaryClient) GetComplexEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetComplexEmptyCreateRequest(ctx context.Context, options *DictionaryGetComplexEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -715,8 +715,8 @@ func (client *DictionaryClient) GetComplexEmptyHandleError(resp *azcore.Response
 }
 
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
-func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context) (*MapOfWidgetResponse, error) {
-	req, err := client.GetComplexItemEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context, options *DictionaryGetComplexItemEmptyOptions) (*MapOfWidgetResponse, error) {
+	req, err := client.GetComplexItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -735,7 +735,7 @@ func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context) (*MapOf
 }
 
 // GetComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
-func (client *DictionaryClient) GetComplexItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetComplexItemEmptyCreateRequest(ctx context.Context, options *DictionaryGetComplexItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -761,8 +761,8 @@ func (client *DictionaryClient) GetComplexItemEmptyHandleError(resp *azcore.Resp
 }
 
 // GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
-func (client *DictionaryClient) GetComplexItemNull(ctx context.Context) (*MapOfWidgetResponse, error) {
-	req, err := client.GetComplexItemNullCreateRequest(ctx)
+func (client *DictionaryClient) GetComplexItemNull(ctx context.Context, options *DictionaryGetComplexItemNullOptions) (*MapOfWidgetResponse, error) {
+	req, err := client.GetComplexItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -781,7 +781,7 @@ func (client *DictionaryClient) GetComplexItemNull(ctx context.Context) (*MapOfW
 }
 
 // GetComplexItemNullCreateRequest creates the GetComplexItemNull request.
-func (client *DictionaryClient) GetComplexItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetComplexItemNullCreateRequest(ctx context.Context, options *DictionaryGetComplexItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -807,8 +807,8 @@ func (client *DictionaryClient) GetComplexItemNullHandleError(resp *azcore.Respo
 }
 
 // GetComplexNull - Get dictionary of complex type null value
-func (client *DictionaryClient) GetComplexNull(ctx context.Context) (*MapOfWidgetResponse, error) {
-	req, err := client.GetComplexNullCreateRequest(ctx)
+func (client *DictionaryClient) GetComplexNull(ctx context.Context, options *DictionaryGetComplexNullOptions) (*MapOfWidgetResponse, error) {
+	req, err := client.GetComplexNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -827,7 +827,7 @@ func (client *DictionaryClient) GetComplexNull(ctx context.Context) (*MapOfWidge
 }
 
 // GetComplexNullCreateRequest creates the GetComplexNull request.
-func (client *DictionaryClient) GetComplexNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetComplexNullCreateRequest(ctx context.Context, options *DictionaryGetComplexNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -853,8 +853,8 @@ func (client *DictionaryClient) GetComplexNullHandleError(resp *azcore.Response)
 }
 
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
-func (client *DictionaryClient) GetComplexValid(ctx context.Context) (*MapOfWidgetResponse, error) {
-	req, err := client.GetComplexValidCreateRequest(ctx)
+func (client *DictionaryClient) GetComplexValid(ctx context.Context, options *DictionaryGetComplexValidOptions) (*MapOfWidgetResponse, error) {
+	req, err := client.GetComplexValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -873,7 +873,7 @@ func (client *DictionaryClient) GetComplexValid(ctx context.Context) (*MapOfWidg
 }
 
 // GetComplexValidCreateRequest creates the GetComplexValid request.
-func (client *DictionaryClient) GetComplexValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetComplexValidCreateRequest(ctx context.Context, options *DictionaryGetComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -899,8 +899,8 @@ func (client *DictionaryClient) GetComplexValidHandleError(resp *azcore.Response
 }
 
 // GetDateInvalidChars - Get date dictionary value {"0": "2011-03-22", "1": "date"}
-func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateInvalidCharsCreateRequest(ctx)
+func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context, options *DictionaryGetDateInvalidCharsOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateInvalidCharsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -919,7 +919,7 @@ func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context) (*MapOf
 }
 
 // GetDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
-func (client *DictionaryClient) GetDateInvalidCharsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateInvalidCharsCreateRequest(ctx context.Context, options *DictionaryGetDateInvalidCharsOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/invalidchars"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -945,8 +945,8 @@ func (client *DictionaryClient) GetDateInvalidCharsHandleError(resp *azcore.Resp
 }
 
 // GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
-func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context, options *DictionaryGetDateInvalidNullOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -965,7 +965,7 @@ func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context) (*MapOfT
 }
 
 // GetDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
-func (client *DictionaryClient) GetDateInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetDateInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -991,8 +991,8 @@ func (client *DictionaryClient) GetDateInvalidNullHandleError(resp *azcore.Respo
 }
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
-func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateTimeInvalidCharsCreateRequest(ctx)
+func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context, options *DictionaryGetDateTimeInvalidCharsOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateTimeInvalidCharsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1011,7 +1011,7 @@ func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context) (*M
 }
 
 // GetDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
-func (client *DictionaryClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateTimeInvalidCharsCreateRequest(ctx context.Context, options *DictionaryGetDateTimeInvalidCharsOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/invalidchars"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1044,8 +1044,8 @@ func (client *DictionaryClient) GetDateTimeInvalidCharsHandleError(resp *azcore.
 }
 
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
-func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateTimeInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context, options *DictionaryGetDateTimeInvalidNullOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateTimeInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1064,7 +1064,7 @@ func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context) (*Ma
 }
 
 // GetDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
-func (client *DictionaryClient) GetDateTimeInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateTimeInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetDateTimeInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/invalidnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1097,8 +1097,8 @@ func (client *DictionaryClient) GetDateTimeInvalidNullHandleError(resp *azcore.R
 }
 
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
-func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateTimeRFC1123ValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context, options *DictionaryGetDateTimeRFC1123ValidOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateTimeRFC1123ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1117,7 +1117,7 @@ func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context) (*M
 }
 
 // GetDateTimeRFC1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
-func (client *DictionaryClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateTimeRFC1123ValidCreateRequest(ctx context.Context, options *DictionaryGetDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1150,8 +1150,8 @@ func (client *DictionaryClient) GetDateTimeRFC1123ValidHandleError(resp *azcore.
 }
 
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
-func (client *DictionaryClient) GetDateTimeValid(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateTimeValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDateTimeValid(ctx context.Context, options *DictionaryGetDateTimeValidOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateTimeValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1170,7 +1170,7 @@ func (client *DictionaryClient) GetDateTimeValid(ctx context.Context) (*MapOfTim
 }
 
 // GetDateTimeValidCreateRequest creates the GetDateTimeValid request.
-func (client *DictionaryClient) GetDateTimeValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateTimeValidCreateRequest(ctx context.Context, options *DictionaryGetDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1203,8 +1203,8 @@ func (client *DictionaryClient) GetDateTimeValidHandleError(resp *azcore.Respons
 }
 
 // GetDateValid - Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-func (client *DictionaryClient) GetDateValid(ctx context.Context) (*MapOfTimeResponse, error) {
-	req, err := client.GetDateValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDateValid(ctx context.Context, options *DictionaryGetDateValidOptions) (*MapOfTimeResponse, error) {
+	req, err := client.GetDateValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1223,7 +1223,7 @@ func (client *DictionaryClient) GetDateValid(ctx context.Context) (*MapOfTimeRes
 }
 
 // GetDateValidCreateRequest creates the GetDateValid request.
-func (client *DictionaryClient) GetDateValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDateValidCreateRequest(ctx context.Context, options *DictionaryGetDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1249,8 +1249,8 @@ func (client *DictionaryClient) GetDateValidHandleError(resp *azcore.Response) e
 }
 
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
-func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context) (*MapOfInterfaceResponse, error) {
-	req, err := client.GetDictionaryEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context, options *DictionaryGetDictionaryEmptyOptions) (*MapOfInterfaceResponse, error) {
+	req, err := client.GetDictionaryEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1269,7 +1269,7 @@ func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context) (*MapOfI
 }
 
 // GetDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
-func (client *DictionaryClient) GetDictionaryEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDictionaryEmptyCreateRequest(ctx context.Context, options *DictionaryGetDictionaryEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1295,8 +1295,8 @@ func (client *DictionaryClient) GetDictionaryEmptyHandleError(resp *azcore.Respo
 }
 
 // GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context) (*MapOfInterfaceResponse, error) {
-	req, err := client.GetDictionaryItemEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context, options *DictionaryGetDictionaryItemEmptyOptions) (*MapOfInterfaceResponse, error) {
+	req, err := client.GetDictionaryItemEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1315,7 +1315,7 @@ func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context) (*Ma
 }
 
 // GetDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
-func (client *DictionaryClient) GetDictionaryItemEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDictionaryItemEmptyCreateRequest(ctx context.Context, options *DictionaryGetDictionaryItemEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/itemempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1341,8 +1341,8 @@ func (client *DictionaryClient) GetDictionaryItemEmptyHandleError(resp *azcore.R
 }
 
 // GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context) (*MapOfInterfaceResponse, error) {
-	req, err := client.GetDictionaryItemNullCreateRequest(ctx)
+func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context, options *DictionaryGetDictionaryItemNullOptions) (*MapOfInterfaceResponse, error) {
+	req, err := client.GetDictionaryItemNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1361,7 +1361,7 @@ func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context) (*Map
 }
 
 // GetDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
-func (client *DictionaryClient) GetDictionaryItemNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDictionaryItemNullCreateRequest(ctx context.Context, options *DictionaryGetDictionaryItemNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/itemnull"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1387,8 +1387,8 @@ func (client *DictionaryClient) GetDictionaryItemNullHandleError(resp *azcore.Re
 }
 
 // GetDictionaryNull - Get an dictionaries of dictionaries with value null
-func (client *DictionaryClient) GetDictionaryNull(ctx context.Context) (*MapOfInterfaceResponse, error) {
-	req, err := client.GetDictionaryNullCreateRequest(ctx)
+func (client *DictionaryClient) GetDictionaryNull(ctx context.Context, options *DictionaryGetDictionaryNullOptions) (*MapOfInterfaceResponse, error) {
+	req, err := client.GetDictionaryNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1407,7 +1407,7 @@ func (client *DictionaryClient) GetDictionaryNull(ctx context.Context) (*MapOfIn
 }
 
 // GetDictionaryNullCreateRequest creates the GetDictionaryNull request.
-func (client *DictionaryClient) GetDictionaryNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDictionaryNullCreateRequest(ctx context.Context, options *DictionaryGetDictionaryNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1433,8 +1433,8 @@ func (client *DictionaryClient) GetDictionaryNullHandleError(resp *azcore.Respon
 }
 
 // GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-func (client *DictionaryClient) GetDictionaryValid(ctx context.Context) (*MapOfInterfaceResponse, error) {
-	req, err := client.GetDictionaryValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDictionaryValid(ctx context.Context, options *DictionaryGetDictionaryValidOptions) (*MapOfInterfaceResponse, error) {
+	req, err := client.GetDictionaryValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1453,7 +1453,7 @@ func (client *DictionaryClient) GetDictionaryValid(ctx context.Context) (*MapOfI
 }
 
 // GetDictionaryValidCreateRequest creates the GetDictionaryValid request.
-func (client *DictionaryClient) GetDictionaryValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDictionaryValidCreateRequest(ctx context.Context, options *DictionaryGetDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1479,8 +1479,8 @@ func (client *DictionaryClient) GetDictionaryValidHandleError(resp *azcore.Respo
 }
 
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
-func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context) (*MapOfFloat64Response, error) {
-	req, err := client.GetDoubleInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context, options *DictionaryGetDoubleInvalidNullOptions) (*MapOfFloat64Response, error) {
+	req, err := client.GetDoubleInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1499,7 +1499,7 @@ func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context) (*MapO
 }
 
 // GetDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
-func (client *DictionaryClient) GetDoubleInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDoubleInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetDoubleInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0.0-null-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1525,8 +1525,8 @@ func (client *DictionaryClient) GetDoubleInvalidNullHandleError(resp *azcore.Res
 }
 
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
-func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context) (*MapOfFloat64Response, error) {
-	req, err := client.GetDoubleInvalidStringCreateRequest(ctx)
+func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context, options *DictionaryGetDoubleInvalidStringOptions) (*MapOfFloat64Response, error) {
+	req, err := client.GetDoubleInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1545,7 +1545,7 @@ func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context) (*Ma
 }
 
 // GetDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
-func (client *DictionaryClient) GetDoubleInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDoubleInvalidStringCreateRequest(ctx context.Context, options *DictionaryGetDoubleInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/1.number.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1571,8 +1571,8 @@ func (client *DictionaryClient) GetDoubleInvalidStringHandleError(resp *azcore.R
 }
 
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) GetDoubleValid(ctx context.Context) (*MapOfFloat64Response, error) {
-	req, err := client.GetDoubleValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDoubleValid(ctx context.Context, options *DictionaryGetDoubleValidOptions) (*MapOfFloat64Response, error) {
+	req, err := client.GetDoubleValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1591,7 +1591,7 @@ func (client *DictionaryClient) GetDoubleValid(ctx context.Context) (*MapOfFloat
 }
 
 // GetDoubleValidCreateRequest creates the GetDoubleValid request.
-func (client *DictionaryClient) GetDoubleValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDoubleValidCreateRequest(ctx context.Context, options *DictionaryGetDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1617,8 +1617,8 @@ func (client *DictionaryClient) GetDoubleValidHandleError(resp *azcore.Response)
 }
 
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-func (client *DictionaryClient) GetDurationValid(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetDurationValidCreateRequest(ctx)
+func (client *DictionaryClient) GetDurationValid(ctx context.Context, options *DictionaryGetDurationValidOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetDurationValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1637,7 +1637,7 @@ func (client *DictionaryClient) GetDurationValid(ctx context.Context) (*MapOfStr
 }
 
 // GetDurationValidCreateRequest creates the GetDurationValid request.
-func (client *DictionaryClient) GetDurationValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetDurationValidCreateRequest(ctx context.Context, options *DictionaryGetDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1663,8 +1663,8 @@ func (client *DictionaryClient) GetDurationValidHandleError(resp *azcore.Respons
 }
 
 // GetEmpty - Get empty dictionary value {}
-func (client *DictionaryClient) GetEmpty(ctx context.Context) (*MapOfInt32Response, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *DictionaryClient) GetEmpty(ctx context.Context, options *DictionaryGetEmptyOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1683,7 +1683,7 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context) (*MapOfInt32Respon
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetEmptyCreateRequest(ctx context.Context, options *DictionaryGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1709,8 +1709,8 @@ func (client *DictionaryClient) GetEmptyHandleError(resp *azcore.Response) error
 }
 
 // GetEmptyStringKey - Get Dictionary with key as empty string
-func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetEmptyStringKeyCreateRequest(ctx)
+func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context, options *DictionaryGetEmptyStringKeyOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetEmptyStringKeyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1729,7 +1729,7 @@ func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context) (*MapOfSt
 }
 
 // GetEmptyStringKeyCreateRequest creates the GetEmptyStringKey request.
-func (client *DictionaryClient) GetEmptyStringKeyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetEmptyStringKeyCreateRequest(ctx context.Context, options *DictionaryGetEmptyStringKeyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/keyemptystring"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1755,8 +1755,8 @@ func (client *DictionaryClient) GetEmptyStringKeyHandleError(resp *azcore.Respon
 }
 
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
-func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context) (*MapOfFloat32Response, error) {
-	req, err := client.GetFloatInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context, options *DictionaryGetFloatInvalidNullOptions) (*MapOfFloat32Response, error) {
+	req, err := client.GetFloatInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1775,7 +1775,7 @@ func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context) (*MapOf
 }
 
 // GetFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
-func (client *DictionaryClient) GetFloatInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetFloatInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetFloatInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0.0-null-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1801,8 +1801,8 @@ func (client *DictionaryClient) GetFloatInvalidNullHandleError(resp *azcore.Resp
 }
 
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
-func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context) (*MapOfFloat32Response, error) {
-	req, err := client.GetFloatInvalidStringCreateRequest(ctx)
+func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context, options *DictionaryGetFloatInvalidStringOptions) (*MapOfFloat32Response, error) {
+	req, err := client.GetFloatInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1821,7 +1821,7 @@ func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context) (*Map
 }
 
 // GetFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
-func (client *DictionaryClient) GetFloatInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetFloatInvalidStringCreateRequest(ctx context.Context, options *DictionaryGetFloatInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/1.number.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1847,8 +1847,8 @@ func (client *DictionaryClient) GetFloatInvalidStringHandleError(resp *azcore.Re
 }
 
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) GetFloatValid(ctx context.Context) (*MapOfFloat32Response, error) {
-	req, err := client.GetFloatValidCreateRequest(ctx)
+func (client *DictionaryClient) GetFloatValid(ctx context.Context, options *DictionaryGetFloatValidOptions) (*MapOfFloat32Response, error) {
+	req, err := client.GetFloatValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1867,7 +1867,7 @@ func (client *DictionaryClient) GetFloatValid(ctx context.Context) (*MapOfFloat3
 }
 
 // GetFloatValidCreateRequest creates the GetFloatValid request.
-func (client *DictionaryClient) GetFloatValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetFloatValidCreateRequest(ctx context.Context, options *DictionaryGetFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1893,8 +1893,8 @@ func (client *DictionaryClient) GetFloatValidHandleError(resp *azcore.Response) 
 }
 
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
-func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context) (*MapOfInt32Response, error) {
-	req, err := client.GetIntInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context, options *DictionaryGetIntInvalidNullOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetIntInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1913,7 +1913,7 @@ func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context) (*MapOfIn
 }
 
 // GetIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
-func (client *DictionaryClient) GetIntInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetIntInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetIntInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.null.zero"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1939,8 +1939,8 @@ func (client *DictionaryClient) GetIntInvalidNullHandleError(resp *azcore.Respon
 }
 
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
-func (client *DictionaryClient) GetIntInvalidString(ctx context.Context) (*MapOfInt32Response, error) {
-	req, err := client.GetIntInvalidStringCreateRequest(ctx)
+func (client *DictionaryClient) GetIntInvalidString(ctx context.Context, options *DictionaryGetIntInvalidStringOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetIntInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1959,7 +1959,7 @@ func (client *DictionaryClient) GetIntInvalidString(ctx context.Context) (*MapOf
 }
 
 // GetIntInvalidStringCreateRequest creates the GetIntInvalidString request.
-func (client *DictionaryClient) GetIntInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetIntInvalidStringCreateRequest(ctx context.Context, options *DictionaryGetIntInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.integer.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1985,8 +1985,8 @@ func (client *DictionaryClient) GetIntInvalidStringHandleError(resp *azcore.Resp
 }
 
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) GetIntegerValid(ctx context.Context) (*MapOfInt32Response, error) {
-	req, err := client.GetIntegerValidCreateRequest(ctx)
+func (client *DictionaryClient) GetIntegerValid(ctx context.Context, options *DictionaryGetIntegerValidOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetIntegerValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2005,7 +2005,7 @@ func (client *DictionaryClient) GetIntegerValid(ctx context.Context) (*MapOfInt3
 }
 
 // GetIntegerValidCreateRequest creates the GetIntegerValid request.
-func (client *DictionaryClient) GetIntegerValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetIntegerValidCreateRequest(ctx context.Context, options *DictionaryGetIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2031,8 +2031,8 @@ func (client *DictionaryClient) GetIntegerValidHandleError(resp *azcore.Response
 }
 
 // GetInvalid - Get invalid Dictionary value
-func (client *DictionaryClient) GetInvalid(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *DictionaryClient) GetInvalid(ctx context.Context, options *DictionaryGetInvalidOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2051,7 +2051,7 @@ func (client *DictionaryClient) GetInvalid(ctx context.Context) (*MapOfStringRes
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *DictionaryClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetInvalidCreateRequest(ctx context.Context, options *DictionaryGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2077,8 +2077,8 @@ func (client *DictionaryClient) GetInvalidHandleError(resp *azcore.Response) err
 }
 
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
-func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context) (*MapOfInt64Response, error) {
-	req, err := client.GetLongInvalidNullCreateRequest(ctx)
+func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context, options *DictionaryGetLongInvalidNullOptions) (*MapOfInt64Response, error) {
+	req, err := client.GetLongInvalidNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2097,7 +2097,7 @@ func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context) (*MapOfI
 }
 
 // GetLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
-func (client *DictionaryClient) GetLongInvalidNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetLongInvalidNullCreateRequest(ctx context.Context, options *DictionaryGetLongInvalidNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.null.zero"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2123,8 +2123,8 @@ func (client *DictionaryClient) GetLongInvalidNullHandleError(resp *azcore.Respo
 }
 
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
-func (client *DictionaryClient) GetLongInvalidString(ctx context.Context) (*MapOfInt64Response, error) {
-	req, err := client.GetLongInvalidStringCreateRequest(ctx)
+func (client *DictionaryClient) GetLongInvalidString(ctx context.Context, options *DictionaryGetLongInvalidStringOptions) (*MapOfInt64Response, error) {
+	req, err := client.GetLongInvalidStringCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2143,7 +2143,7 @@ func (client *DictionaryClient) GetLongInvalidString(ctx context.Context) (*MapO
 }
 
 // GetLongInvalidStringCreateRequest creates the GetLongInvalidString request.
-func (client *DictionaryClient) GetLongInvalidStringCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetLongInvalidStringCreateRequest(ctx context.Context, options *DictionaryGetLongInvalidStringOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.integer.0"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2169,8 +2169,8 @@ func (client *DictionaryClient) GetLongInvalidStringHandleError(resp *azcore.Res
 }
 
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) GetLongValid(ctx context.Context) (*MapOfInt64Response, error) {
-	req, err := client.GetLongValidCreateRequest(ctx)
+func (client *DictionaryClient) GetLongValid(ctx context.Context, options *DictionaryGetLongValidOptions) (*MapOfInt64Response, error) {
+	req, err := client.GetLongValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2189,7 +2189,7 @@ func (client *DictionaryClient) GetLongValid(ctx context.Context) (*MapOfInt64Re
 }
 
 // GetLongValidCreateRequest creates the GetLongValid request.
-func (client *DictionaryClient) GetLongValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetLongValidCreateRequest(ctx context.Context, options *DictionaryGetLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2215,8 +2215,8 @@ func (client *DictionaryClient) GetLongValidHandleError(resp *azcore.Response) e
 }
 
 // GetNull - Get null dictionary value
-func (client *DictionaryClient) GetNull(ctx context.Context) (*MapOfInt32Response, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *DictionaryClient) GetNull(ctx context.Context, options *DictionaryGetNullOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2235,7 +2235,7 @@ func (client *DictionaryClient) GetNull(ctx context.Context) (*MapOfInt32Respons
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetNullCreateRequest(ctx context.Context, options *DictionaryGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2261,8 +2261,8 @@ func (client *DictionaryClient) GetNullHandleError(resp *azcore.Response) error 
 }
 
 // GetNullKey - Get Dictionary with null key
-func (client *DictionaryClient) GetNullKey(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetNullKeyCreateRequest(ctx)
+func (client *DictionaryClient) GetNullKey(ctx context.Context, options *DictionaryGetNullKeyOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetNullKeyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2281,7 +2281,7 @@ func (client *DictionaryClient) GetNullKey(ctx context.Context) (*MapOfStringRes
 }
 
 // GetNullKeyCreateRequest creates the GetNullKey request.
-func (client *DictionaryClient) GetNullKeyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetNullKeyCreateRequest(ctx context.Context, options *DictionaryGetNullKeyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/nullkey"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2307,8 +2307,8 @@ func (client *DictionaryClient) GetNullKeyHandleError(resp *azcore.Response) err
 }
 
 // GetNullValue - Get Dictionary with null value
-func (client *DictionaryClient) GetNullValue(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetNullValueCreateRequest(ctx)
+func (client *DictionaryClient) GetNullValue(ctx context.Context, options *DictionaryGetNullValueOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetNullValueCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2327,7 +2327,7 @@ func (client *DictionaryClient) GetNullValue(ctx context.Context) (*MapOfStringR
 }
 
 // GetNullValueCreateRequest creates the GetNullValue request.
-func (client *DictionaryClient) GetNullValueCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetNullValueCreateRequest(ctx context.Context, options *DictionaryGetNullValueOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/nullvalue"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2353,8 +2353,8 @@ func (client *DictionaryClient) GetNullValueHandleError(resp *azcore.Response) e
 }
 
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-func (client *DictionaryClient) GetStringValid(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetStringValidCreateRequest(ctx)
+func (client *DictionaryClient) GetStringValid(ctx context.Context, options *DictionaryGetStringValidOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetStringValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2373,7 +2373,7 @@ func (client *DictionaryClient) GetStringValid(ctx context.Context) (*MapOfStrin
 }
 
 // GetStringValidCreateRequest creates the GetStringValid request.
-func (client *DictionaryClient) GetStringValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetStringValidCreateRequest(ctx context.Context, options *DictionaryGetStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2399,8 +2399,8 @@ func (client *DictionaryClient) GetStringValidHandleError(resp *azcore.Response)
 }
 
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
-func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetStringWithInvalidCreateRequest(ctx)
+func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context, options *DictionaryGetStringWithInvalidOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetStringWithInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2419,7 +2419,7 @@ func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context) (*MapO
 }
 
 // GetStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
-func (client *DictionaryClient) GetStringWithInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetStringWithInvalidCreateRequest(ctx context.Context, options *DictionaryGetStringWithInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo.123.foo2"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2445,8 +2445,8 @@ func (client *DictionaryClient) GetStringWithInvalidHandleError(resp *azcore.Res
 }
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
-func (client *DictionaryClient) GetStringWithNull(ctx context.Context) (*MapOfStringResponse, error) {
-	req, err := client.GetStringWithNullCreateRequest(ctx)
+func (client *DictionaryClient) GetStringWithNull(ctx context.Context, options *DictionaryGetStringWithNullOptions) (*MapOfStringResponse, error) {
+	req, err := client.GetStringWithNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2465,7 +2465,7 @@ func (client *DictionaryClient) GetStringWithNull(ctx context.Context) (*MapOfSt
 }
 
 // GetStringWithNullCreateRequest creates the GetStringWithNull request.
-func (client *DictionaryClient) GetStringWithNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DictionaryClient) GetStringWithNullCreateRequest(ctx context.Context, options *DictionaryGetStringWithNullOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo.null.foo2"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2491,8 +2491,8 @@ func (client *DictionaryClient) GetStringWithNullHandleError(resp *azcore.Respon
 }
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map[string][]string) (*http.Response, error) {
-	req, err := client.PutArrayValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map[string][]string, options *DictionaryPutArrayValidOptions) (*http.Response, error) {
+	req, err := client.PutArrayValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2507,7 +2507,7 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 }
 
 // PutArrayValidCreateRequest creates the PutArrayValid request.
-func (client *DictionaryClient) PutArrayValidCreateRequest(ctx context.Context, arrayBody map[string][]string) (*azcore.Request, error) {
+func (client *DictionaryClient) PutArrayValidCreateRequest(ctx context.Context, arrayBody map[string][]string, options *DictionaryPutArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2527,8 +2527,8 @@ func (client *DictionaryClient) PutArrayValidHandleError(resp *azcore.Response) 
 }
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
-func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody map[string]bool) (*http.Response, error) {
-	req, err := client.PutBooleanTfftCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody map[string]bool, options *DictionaryPutBooleanTfftOptions) (*http.Response, error) {
+	req, err := client.PutBooleanTfftCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2543,7 +2543,7 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 }
 
 // PutBooleanTfftCreateRequest creates the PutBooleanTfft request.
-func (client *DictionaryClient) PutBooleanTfftCreateRequest(ctx context.Context, arrayBody map[string]bool) (*azcore.Request, error) {
+func (client *DictionaryClient) PutBooleanTfftCreateRequest(ctx context.Context, arrayBody map[string]bool, options *DictionaryPutBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2563,8 +2563,8 @@ func (client *DictionaryClient) PutBooleanTfftHandleError(resp *azcore.Response)
 }
 
 // PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
-func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[string][]byte) (*http.Response, error) {
-	req, err := client.PutByteValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[string][]byte, options *DictionaryPutByteValidOptions) (*http.Response, error) {
+	req, err := client.PutByteValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2579,7 +2579,7 @@ func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[
 }
 
 // PutByteValidCreateRequest creates the PutByteValid request.
-func (client *DictionaryClient) PutByteValidCreateRequest(ctx context.Context, arrayBody map[string][]byte) (*azcore.Request, error) {
+func (client *DictionaryClient) PutByteValidCreateRequest(ctx context.Context, arrayBody map[string][]byte, options *DictionaryPutByteValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/byte/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2599,8 +2599,8 @@ func (client *DictionaryClient) PutByteValidHandleError(resp *azcore.Response) e
 }
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
-func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody map[string]Widget) (*http.Response, error) {
-	req, err := client.PutComplexValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody map[string]Widget, options *DictionaryPutComplexValidOptions) (*http.Response, error) {
+	req, err := client.PutComplexValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2615,7 +2615,7 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 }
 
 // PutComplexValidCreateRequest creates the PutComplexValid request.
-func (client *DictionaryClient) PutComplexValidCreateRequest(ctx context.Context, arrayBody map[string]Widget) (*azcore.Request, error) {
+func (client *DictionaryClient) PutComplexValidCreateRequest(ctx context.Context, arrayBody map[string]Widget, options *DictionaryPutComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2635,8 +2635,8 @@ func (client *DictionaryClient) PutComplexValidHandleError(resp *azcore.Response
 }
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
-func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error) {
-	req, err := client.PutDateTimeRFC1123ValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
+	req, err := client.PutDateTimeRFC1123ValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2651,7 +2651,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 }
 
 // PutDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
-func (client *DictionaryClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2675,8 +2675,8 @@ func (client *DictionaryClient) PutDateTimeRFC1123ValidHandleError(resp *azcore.
 }
 
 // PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
-func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error) {
-	req, err := client.PutDateTimeValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeValidOptions) (*http.Response, error) {
+	req, err := client.PutDateTimeValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2691,7 +2691,7 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 }
 
 // PutDateTimeValidCreateRequest creates the PutDateTimeValid request.
-func (client *DictionaryClient) PutDateTimeValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDateTimeValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2715,8 +2715,8 @@ func (client *DictionaryClient) PutDateTimeValidHandleError(resp *azcore.Respons
 }
 
 // PutDateValid - Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[string]time.Time) (*http.Response, error) {
-	req, err := client.PutDateValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateValidOptions) (*http.Response, error) {
+	req, err := client.PutDateValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2731,7 +2731,7 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 }
 
 // PutDateValidCreateRequest creates the PutDateValid request.
-func (client *DictionaryClient) PutDateValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDateValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2751,8 +2751,8 @@ func (client *DictionaryClient) PutDateValidHandleError(resp *azcore.Response) e
 }
 
 // PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBody map[string]interface{}) (*http.Response, error) {
-	req, err := client.PutDictionaryValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBody map[string]interface{}, options *DictionaryPutDictionaryValidOptions) (*http.Response, error) {
+	req, err := client.PutDictionaryValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2767,7 +2767,7 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 }
 
 // PutDictionaryValidCreateRequest creates the PutDictionaryValid request.
-func (client *DictionaryClient) PutDictionaryValidCreateRequest(ctx context.Context, arrayBody map[string]interface{}) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDictionaryValidCreateRequest(ctx context.Context, arrayBody map[string]interface{}, options *DictionaryPutDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2787,8 +2787,8 @@ func (client *DictionaryClient) PutDictionaryValidHandleError(resp *azcore.Respo
 }
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody map[string]float64) (*http.Response, error) {
-	req, err := client.PutDoubleValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody map[string]float64, options *DictionaryPutDoubleValidOptions) (*http.Response, error) {
+	req, err := client.PutDoubleValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2803,7 +2803,7 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 }
 
 // PutDoubleValidCreateRequest creates the PutDoubleValid request.
-func (client *DictionaryClient) PutDoubleValidCreateRequest(ctx context.Context, arrayBody map[string]float64) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDoubleValidCreateRequest(ctx context.Context, arrayBody map[string]float64, options *DictionaryPutDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2823,8 +2823,8 @@ func (client *DictionaryClient) PutDoubleValidHandleError(resp *azcore.Response)
 }
 
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody map[string]string) (*http.Response, error) {
-	req, err := client.PutDurationValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutDurationValidOptions) (*http.Response, error) {
+	req, err := client.PutDurationValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2839,7 +2839,7 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 }
 
 // PutDurationValidCreateRequest creates the PutDurationValid request.
-func (client *DictionaryClient) PutDurationValidCreateRequest(ctx context.Context, arrayBody map[string]string) (*azcore.Request, error) {
+func (client *DictionaryClient) PutDurationValidCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2859,8 +2859,8 @@ func (client *DictionaryClient) PutDurationValidHandleError(resp *azcore.Respons
 }
 
 // PutEmpty - Set dictionary value empty {}
-func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[string]string) (*http.Response, error) {
-	req, err := client.PutEmptyCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[string]string, options *DictionaryPutEmptyOptions) (*http.Response, error) {
+	req, err := client.PutEmptyCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2875,7 +2875,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
-func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, arrayBody map[string]string) (*azcore.Request, error) {
+func (client *DictionaryClient) PutEmptyCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2895,8 +2895,8 @@ func (client *DictionaryClient) PutEmptyHandleError(resp *azcore.Response) error
 }
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map[string]float32) (*http.Response, error) {
-	req, err := client.PutFloatValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map[string]float32, options *DictionaryPutFloatValidOptions) (*http.Response, error) {
+	req, err := client.PutFloatValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2911,7 +2911,7 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 }
 
 // PutFloatValidCreateRequest creates the PutFloatValid request.
-func (client *DictionaryClient) PutFloatValidCreateRequest(ctx context.Context, arrayBody map[string]float32) (*azcore.Request, error) {
+func (client *DictionaryClient) PutFloatValidCreateRequest(ctx context.Context, arrayBody map[string]float32, options *DictionaryPutFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2931,8 +2931,8 @@ func (client *DictionaryClient) PutFloatValidHandleError(resp *azcore.Response) 
 }
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody map[string]int32) (*http.Response, error) {
-	req, err := client.PutIntegerValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody map[string]int32, options *DictionaryPutIntegerValidOptions) (*http.Response, error) {
+	req, err := client.PutIntegerValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2947,7 +2947,7 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 }
 
 // PutIntegerValidCreateRequest creates the PutIntegerValid request.
-func (client *DictionaryClient) PutIntegerValidCreateRequest(ctx context.Context, arrayBody map[string]int32) (*azcore.Request, error) {
+func (client *DictionaryClient) PutIntegerValidCreateRequest(ctx context.Context, arrayBody map[string]int32, options *DictionaryPutIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -2967,8 +2967,8 @@ func (client *DictionaryClient) PutIntegerValidHandleError(resp *azcore.Response
 }
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[string]int64) (*http.Response, error) {
-	req, err := client.PutLongValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[string]int64, options *DictionaryPutLongValidOptions) (*http.Response, error) {
+	req, err := client.PutLongValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2983,7 +2983,7 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 }
 
 // PutLongValidCreateRequest creates the PutLongValid request.
-func (client *DictionaryClient) PutLongValidCreateRequest(ctx context.Context, arrayBody map[string]int64) (*azcore.Request, error) {
+func (client *DictionaryClient) PutLongValidCreateRequest(ctx context.Context, arrayBody map[string]int64, options *DictionaryPutLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -3003,8 +3003,8 @@ func (client *DictionaryClient) PutLongValidHandleError(resp *azcore.Response) e
 }
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody map[string]string) (*http.Response, error) {
-	req, err := client.PutStringValidCreateRequest(ctx, arrayBody)
+func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutStringValidOptions) (*http.Response, error) {
+	req, err := client.PutStringValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3019,7 +3019,7 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 }
 
 // PutStringValidCreateRequest creates the PutStringValid request.
-func (client *DictionaryClient) PutStringValidCreateRequest(ctx context.Context, arrayBody map[string]string) (*azcore.Request, error) {
+func (client *DictionaryClient) PutStringValidCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/dictionarygroup/zz_generated_models.go
+++ b/test/autorest/dictionarygroup/zz_generated_models.go
@@ -11,6 +11,331 @@ import (
 	"time"
 )
 
+// DictionaryGetArrayEmptyOptions contains the optional parameters for the Dictionary.GetArrayEmpty method.
+type DictionaryGetArrayEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetArrayItemEmptyOptions contains the optional parameters for the Dictionary.GetArrayItemEmpty method.
+type DictionaryGetArrayItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetArrayItemNullOptions contains the optional parameters for the Dictionary.GetArrayItemNull method.
+type DictionaryGetArrayItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetArrayNullOptions contains the optional parameters for the Dictionary.GetArrayNull method.
+type DictionaryGetArrayNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetArrayValidOptions contains the optional parameters for the Dictionary.GetArrayValid method.
+type DictionaryGetArrayValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetBase64URLOptions contains the optional parameters for the Dictionary.GetBase64URL method.
+type DictionaryGetBase64URLOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetBooleanInvalidNullOptions contains the optional parameters for the Dictionary.GetBooleanInvalidNull method.
+type DictionaryGetBooleanInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetBooleanInvalidStringOptions contains the optional parameters for the Dictionary.GetBooleanInvalidString method.
+type DictionaryGetBooleanInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetBooleanTfftOptions contains the optional parameters for the Dictionary.GetBooleanTfft method.
+type DictionaryGetBooleanTfftOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetByteInvalidNullOptions contains the optional parameters for the Dictionary.GetByteInvalidNull method.
+type DictionaryGetByteInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetByteValidOptions contains the optional parameters for the Dictionary.GetByteValid method.
+type DictionaryGetByteValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetComplexEmptyOptions contains the optional parameters for the Dictionary.GetComplexEmpty method.
+type DictionaryGetComplexEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetComplexItemEmptyOptions contains the optional parameters for the Dictionary.GetComplexItemEmpty method.
+type DictionaryGetComplexItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetComplexItemNullOptions contains the optional parameters for the Dictionary.GetComplexItemNull method.
+type DictionaryGetComplexItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetComplexNullOptions contains the optional parameters for the Dictionary.GetComplexNull method.
+type DictionaryGetComplexNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetComplexValidOptions contains the optional parameters for the Dictionary.GetComplexValid method.
+type DictionaryGetComplexValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateInvalidCharsOptions contains the optional parameters for the Dictionary.GetDateInvalidChars method.
+type DictionaryGetDateInvalidCharsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateInvalidNullOptions contains the optional parameters for the Dictionary.GetDateInvalidNull method.
+type DictionaryGetDateInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateTimeInvalidCharsOptions contains the optional parameters for the Dictionary.GetDateTimeInvalidChars method.
+type DictionaryGetDateTimeInvalidCharsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateTimeInvalidNullOptions contains the optional parameters for the Dictionary.GetDateTimeInvalidNull method.
+type DictionaryGetDateTimeInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateTimeRFC1123ValidOptions contains the optional parameters for the Dictionary.GetDateTimeRFC1123Valid method.
+type DictionaryGetDateTimeRFC1123ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateTimeValidOptions contains the optional parameters for the Dictionary.GetDateTimeValid method.
+type DictionaryGetDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDateValidOptions contains the optional parameters for the Dictionary.GetDateValid method.
+type DictionaryGetDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDictionaryEmptyOptions contains the optional parameters for the Dictionary.GetDictionaryEmpty method.
+type DictionaryGetDictionaryEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDictionaryItemEmptyOptions contains the optional parameters for the Dictionary.GetDictionaryItemEmpty method.
+type DictionaryGetDictionaryItemEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDictionaryItemNullOptions contains the optional parameters for the Dictionary.GetDictionaryItemNull method.
+type DictionaryGetDictionaryItemNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDictionaryNullOptions contains the optional parameters for the Dictionary.GetDictionaryNull method.
+type DictionaryGetDictionaryNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDictionaryValidOptions contains the optional parameters for the Dictionary.GetDictionaryValid method.
+type DictionaryGetDictionaryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDoubleInvalidNullOptions contains the optional parameters for the Dictionary.GetDoubleInvalidNull method.
+type DictionaryGetDoubleInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDoubleInvalidStringOptions contains the optional parameters for the Dictionary.GetDoubleInvalidString method.
+type DictionaryGetDoubleInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDoubleValidOptions contains the optional parameters for the Dictionary.GetDoubleValid method.
+type DictionaryGetDoubleValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetDurationValidOptions contains the optional parameters for the Dictionary.GetDurationValid method.
+type DictionaryGetDurationValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetEmptyOptions contains the optional parameters for the Dictionary.GetEmpty method.
+type DictionaryGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetEmptyStringKeyOptions contains the optional parameters for the Dictionary.GetEmptyStringKey method.
+type DictionaryGetEmptyStringKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetFloatInvalidNullOptions contains the optional parameters for the Dictionary.GetFloatInvalidNull method.
+type DictionaryGetFloatInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetFloatInvalidStringOptions contains the optional parameters for the Dictionary.GetFloatInvalidString method.
+type DictionaryGetFloatInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetFloatValidOptions contains the optional parameters for the Dictionary.GetFloatValid method.
+type DictionaryGetFloatValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetIntInvalidNullOptions contains the optional parameters for the Dictionary.GetIntInvalidNull method.
+type DictionaryGetIntInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetIntInvalidStringOptions contains the optional parameters for the Dictionary.GetIntInvalidString method.
+type DictionaryGetIntInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetIntegerValidOptions contains the optional parameters for the Dictionary.GetIntegerValid method.
+type DictionaryGetIntegerValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetInvalidOptions contains the optional parameters for the Dictionary.GetInvalid method.
+type DictionaryGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetLongInvalidNullOptions contains the optional parameters for the Dictionary.GetLongInvalidNull method.
+type DictionaryGetLongInvalidNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetLongInvalidStringOptions contains the optional parameters for the Dictionary.GetLongInvalidString method.
+type DictionaryGetLongInvalidStringOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetLongValidOptions contains the optional parameters for the Dictionary.GetLongValid method.
+type DictionaryGetLongValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetNullKeyOptions contains the optional parameters for the Dictionary.GetNullKey method.
+type DictionaryGetNullKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetNullOptions contains the optional parameters for the Dictionary.GetNull method.
+type DictionaryGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetNullValueOptions contains the optional parameters for the Dictionary.GetNullValue method.
+type DictionaryGetNullValueOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetStringValidOptions contains the optional parameters for the Dictionary.GetStringValid method.
+type DictionaryGetStringValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetStringWithInvalidOptions contains the optional parameters for the Dictionary.GetStringWithInvalid method.
+type DictionaryGetStringWithInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryGetStringWithNullOptions contains the optional parameters for the Dictionary.GetStringWithNull method.
+type DictionaryGetStringWithNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutArrayValidOptions contains the optional parameters for the Dictionary.PutArrayValid method.
+type DictionaryPutArrayValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutBooleanTfftOptions contains the optional parameters for the Dictionary.PutBooleanTfft method.
+type DictionaryPutBooleanTfftOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutByteValidOptions contains the optional parameters for the Dictionary.PutByteValid method.
+type DictionaryPutByteValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutComplexValidOptions contains the optional parameters for the Dictionary.PutComplexValid method.
+type DictionaryPutComplexValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDateTimeRFC1123ValidOptions contains the optional parameters for the Dictionary.PutDateTimeRFC1123Valid method.
+type DictionaryPutDateTimeRFC1123ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDateTimeValidOptions contains the optional parameters for the Dictionary.PutDateTimeValid method.
+type DictionaryPutDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDateValidOptions contains the optional parameters for the Dictionary.PutDateValid method.
+type DictionaryPutDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDictionaryValidOptions contains the optional parameters for the Dictionary.PutDictionaryValid method.
+type DictionaryPutDictionaryValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDoubleValidOptions contains the optional parameters for the Dictionary.PutDoubleValid method.
+type DictionaryPutDoubleValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutDurationValidOptions contains the optional parameters for the Dictionary.PutDurationValid method.
+type DictionaryPutDurationValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutEmptyOptions contains the optional parameters for the Dictionary.PutEmpty method.
+type DictionaryPutEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutFloatValidOptions contains the optional parameters for the Dictionary.PutFloatValid method.
+type DictionaryPutFloatValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutIntegerValidOptions contains the optional parameters for the Dictionary.PutIntegerValid method.
+type DictionaryPutIntegerValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutLongValidOptions contains the optional parameters for the Dictionary.PutLongValid method.
+type DictionaryPutLongValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DictionaryPutStringValidOptions contains the optional parameters for the Dictionary.PutStringValid method.
+type DictionaryPutStringValidOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/durationgroup/durationgroup_test.go
+++ b/test/autorest/durationgroup/durationgroup_test.go
@@ -19,7 +19,7 @@ func newDurationClient() DurationOperations {
 func TestGetInvalid(t *testing.T) {
 	t.Skip("this does not apply to us meanwhile we do not parse durations")
 	client := newDurationClient()
-	_, err := client.GetInvalid(context.Background())
+	_, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -27,7 +27,7 @@ func TestGetInvalid(t *testing.T) {
 
 func TestGetNull(t *testing.T) {
 	client := newDurationClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGetNull(t *testing.T) {
 
 func TestGetPositiveDuration(t *testing.T) {
 	client := newDurationClient()
-	result, err := client.GetPositiveDuration(context.Background())
+	result, err := client.GetPositiveDuration(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestGetPositiveDuration(t *testing.T) {
 
 func TestPutPositiveDuration(t *testing.T) {
 	client := newDurationClient()
-	result, err := client.PutPositiveDuration(context.Background(), "P123DT22H14M12.011S")
+	result, err := client.PutPositiveDuration(context.Background(), "P123DT22H14M12.011S", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -14,13 +14,13 @@ import (
 // DurationOperations contains the methods for the Duration group.
 type DurationOperations interface {
 	// GetInvalid - Get an invalid duration value
-	GetInvalid(ctx context.Context) (*StringResponse, error)
+	GetInvalid(ctx context.Context, options *DurationGetInvalidOptions) (*StringResponse, error)
 	// GetNull - Get null duration value
-	GetNull(ctx context.Context) (*StringResponse, error)
+	GetNull(ctx context.Context, options *DurationGetNullOptions) (*StringResponse, error)
 	// GetPositiveDuration - Get a positive duration value
-	GetPositiveDuration(ctx context.Context) (*StringResponse, error)
+	GetPositiveDuration(ctx context.Context, options *DurationGetPositiveDurationOptions) (*StringResponse, error)
 	// PutPositiveDuration - Put a positive duration value
-	PutPositiveDuration(ctx context.Context, durationBody string) (*http.Response, error)
+	PutPositiveDuration(ctx context.Context, durationBody string, options *DurationPutPositiveDurationOptions) (*http.Response, error)
 }
 
 // DurationClient implements the DurationOperations interface.
@@ -40,8 +40,8 @@ func (client *DurationClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // GetInvalid - Get an invalid duration value
-func (client *DurationClient) GetInvalid(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *DurationClient) GetInvalid(ctx context.Context, options *DurationGetInvalidOptions) (*StringResponse, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (client *DurationClient) GetInvalid(ctx context.Context) (*StringResponse, 
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *DurationClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DurationClient) GetInvalidCreateRequest(ctx context.Context, options *DurationGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/duration/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -86,8 +86,8 @@ func (client *DurationClient) GetInvalidHandleError(resp *azcore.Response) error
 }
 
 // GetNull - Get null duration value
-func (client *DurationClient) GetNull(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *DurationClient) GetNull(ctx context.Context, options *DurationGetNullOptions) (*StringResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (client *DurationClient) GetNull(ctx context.Context) (*StringResponse, err
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *DurationClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DurationClient) GetNullCreateRequest(ctx context.Context, options *DurationGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/duration/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -132,8 +132,8 @@ func (client *DurationClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetPositiveDuration - Get a positive duration value
-func (client *DurationClient) GetPositiveDuration(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetPositiveDurationCreateRequest(ctx)
+func (client *DurationClient) GetPositiveDuration(ctx context.Context, options *DurationGetPositiveDurationOptions) (*StringResponse, error) {
+	req, err := client.GetPositiveDurationCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (client *DurationClient) GetPositiveDuration(ctx context.Context) (*StringR
 }
 
 // GetPositiveDurationCreateRequest creates the GetPositiveDuration request.
-func (client *DurationClient) GetPositiveDurationCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DurationClient) GetPositiveDurationCreateRequest(ctx context.Context, options *DurationGetPositiveDurationOptions) (*azcore.Request, error) {
 	urlPath := "/duration/positiveduration"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -178,8 +178,8 @@ func (client *DurationClient) GetPositiveDurationHandleError(resp *azcore.Respon
 }
 
 // PutPositiveDuration - Put a positive duration value
-func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationBody string) (*http.Response, error) {
-	req, err := client.PutPositiveDurationCreateRequest(ctx, durationBody)
+func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationBody string, options *DurationPutPositiveDurationOptions) (*http.Response, error) {
+	req, err := client.PutPositiveDurationCreateRequest(ctx, durationBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationB
 }
 
 // PutPositiveDurationCreateRequest creates the PutPositiveDuration request.
-func (client *DurationClient) PutPositiveDurationCreateRequest(ctx context.Context, durationBody string) (*azcore.Request, error) {
+func (client *DurationClient) PutPositiveDurationCreateRequest(ctx context.Context, durationBody string, options *DurationPutPositiveDurationOptions) (*azcore.Request, error) {
 	urlPath := "/duration/positiveduration"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/durationgroup/zz_generated_models.go
+++ b/test/autorest/durationgroup/zz_generated_models.go
@@ -10,6 +10,26 @@ import (
 	"net/http"
 )
 
+// DurationGetInvalidOptions contains the optional parameters for the Duration.GetInvalid method.
+type DurationGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DurationGetNullOptions contains the optional parameters for the Duration.GetNull method.
+type DurationGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DurationGetPositiveDurationOptions contains the optional parameters for the Duration.GetPositiveDuration method.
+type DurationGetPositiveDurationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DurationPutPositiveDurationOptions contains the optional parameters for the Duration.PutPositiveDuration method.
+type DurationPutPositiveDurationOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -24,7 +24,7 @@ func newPetClient() PetOperations {
 // DoSomething - Asks pet to do something
 func TestDoSomethingSuccess(t *testing.T) {
 	client := newPetClient()
-	result, err := client.DoSomething(context.Background(), "stay")
+	result, err := client.DoSomething(context.Background(), "stay", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestDoSomethingSuccess(t *testing.T) {
 
 func TestDoSomethingError1(t *testing.T) {
 	client := newPetClient()
-	result, err := client.DoSomething(context.Background(), "jump")
+	result, err := client.DoSomething(context.Background(), "jump", nil)
 	var sadErr *PetSadError
 	if !errors.As(err, &sadErr) {
 		t.Fatalf("expected PetSadError: %v", err)
@@ -53,7 +53,7 @@ func TestDoSomethingError1(t *testing.T) {
 
 func TestDoSomethingError2(t *testing.T) {
 	client := newPetClient()
-	result, err := client.DoSomething(context.Background(), "fetch")
+	result, err := client.DoSomething(context.Background(), "fetch", nil)
 	var hungrErr *PetHungryOrThirstyError
 	if !errors.As(err, &hungrErr) {
 		t.Fatal("expected PetHungryOrThirstyError")
@@ -75,7 +75,7 @@ func TestDoSomethingError2(t *testing.T) {
 
 func TestDoSomethingError3(t *testing.T) {
 	client := newPetClient()
-	result, err := client.DoSomething(context.Background(), "unknown")
+	result, err := client.DoSomething(context.Background(), "unknown", nil)
 	var actErr *PetActionError
 	if !errors.As(err, &actErr) {
 		t.Fatal("expected PetActionError")
@@ -89,7 +89,7 @@ func TestDoSomethingError3(t *testing.T) {
 // GetPetByID - Gets pets by id.
 func TestGetPetByIDSuccess1(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "tommy")
+	result, err := client.GetPetByID(context.Background(), "tommy", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestGetPetByIDSuccess1(t *testing.T) {
 
 func TestGetPetByIDSuccess2(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "django")
+	result, err := client.GetPetByID(context.Background(), "django", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestGetPetByIDSuccess2(t *testing.T) {
 
 func TestGetPetByIDError1(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "coyoteUgly")
+	result, err := client.GetPetByID(context.Background(), "coyoteUgly", nil)
 	var anfe *AnimalNotFound
 	if !errors.As(err, &anfe) {
 		t.Fatal("expected AnimalNotFoundError")
@@ -134,7 +134,7 @@ func TestGetPetByIDError1(t *testing.T) {
 
 func TestGetPetByIDError2(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "weirdAlYankovic")
+	result, err := client.GetPetByID(context.Background(), "weirdAlYankovic", nil)
 	var lnfe *LinkNotFound
 	if !errors.As(err, &lnfe) {
 		t.Fatal("expected LinkNotFoundError")
@@ -156,7 +156,7 @@ func TestGetPetByIDError2(t *testing.T) {
 
 func TestGetPetByIDError3(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "ringo")
+	result, err := client.GetPetByID(context.Background(), "ringo", nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -171,7 +171,7 @@ func TestGetPetByIDError3(t *testing.T) {
 
 func TestGetPetByIDError4(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "alien123")
+	result, err := client.GetPetByID(context.Background(), "alien123", nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -186,7 +186,7 @@ func TestGetPetByIDError4(t *testing.T) {
 
 func TestGetPetByIDError5(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetPetByID(context.Background(), "unknown")
+	result, err := client.GetPetByID(context.Background(), "unknown", nil)
 	// default generic error (no schema)
 	helpers.DeepEqualOrFatal(t, err.Error(), "That's all folks!!")
 	if result != nil {

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -231,6 +231,16 @@ type PetActionResponse struct {
 	RawResponse *http.Response
 }
 
+// PetDoSomethingOptions contains the optional parameters for the Pet.DoSomething method.
+type PetDoSomethingOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PetGetPetByIDOptions contains the optional parameters for the Pet.GetPetByID method.
+type PetGetPetByIDOptions struct {
+	// placeholder for future optional parameters
+}
+
 type PetHungryOrThirstyError struct {
 	PetSadError
 	// is the pet hungry or thirsty or both

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -19,9 +19,9 @@ import (
 // PetOperations contains the methods for the Pet group.
 type PetOperations interface {
 	// DoSomething - Asks pet to do something
-	DoSomething(ctx context.Context, whatAction string) (*PetActionResponse, error)
+	DoSomething(ctx context.Context, whatAction string, options *PetDoSomethingOptions) (*PetActionResponse, error)
 	// GetPetByID - Gets pets by id.
-	GetPetByID(ctx context.Context, petId string) (*PetResponse, error)
+	GetPetByID(ctx context.Context, petId string, options *PetGetPetByIDOptions) (*PetResponse, error)
 }
 
 // PetClient implements the PetOperations interface.
@@ -41,8 +41,8 @@ func (client *PetClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // DoSomething - Asks pet to do something
-func (client *PetClient) DoSomething(ctx context.Context, whatAction string) (*PetActionResponse, error) {
-	req, err := client.DoSomethingCreateRequest(ctx, whatAction)
+func (client *PetClient) DoSomething(ctx context.Context, whatAction string, options *PetDoSomethingOptions) (*PetActionResponse, error) {
+	req, err := client.DoSomethingCreateRequest(ctx, whatAction, options)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (client *PetClient) DoSomething(ctx context.Context, whatAction string) (*P
 }
 
 // DoSomethingCreateRequest creates the DoSomething request.
-func (client *PetClient) DoSomethingCreateRequest(ctx context.Context, whatAction string) (*azcore.Request, error) {
+func (client *PetClient) DoSomethingCreateRequest(ctx context.Context, whatAction string, options *PetDoSomethingOptions) (*azcore.Request, error) {
 	urlPath := "/errorStatusCodes/Pets/doSomething/{whatAction}"
 	urlPath = strings.ReplaceAll(urlPath, "{whatAction}", url.PathEscape(whatAction))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -97,8 +97,8 @@ func (client *PetClient) DoSomethingHandleError(resp *azcore.Response) error {
 }
 
 // GetPetByID - Gets pets by id.
-func (client *PetClient) GetPetByID(ctx context.Context, petId string) (*PetResponse, error) {
-	req, err := client.GetPetByIDCreateRequest(ctx, petId)
+func (client *PetClient) GetPetByID(ctx context.Context, petId string, options *PetGetPetByIDOptions) (*PetResponse, error) {
+	req, err := client.GetPetByIDCreateRequest(ctx, petId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func (client *PetClient) GetPetByID(ctx context.Context, petId string) (*PetResp
 }
 
 // GetPetByIDCreateRequest creates the GetPetByID request.
-func (client *PetClient) GetPetByIDCreateRequest(ctx context.Context, petId string) (*azcore.Request, error) {
+func (client *PetClient) GetPetByIDCreateRequest(ctx context.Context, petId string, options *PetGetPetByIDOptions) (*azcore.Request, error) {
 	urlPath := "/errorStatusCodes/Pets/{petId}/GetPet"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/autorest/extenumsgroup/extenumsgroup_test.go
+++ b/test/autorest/extenumsgroup/extenumsgroup_test.go
@@ -32,7 +32,7 @@ func TestAddPet(t *testing.T) {
 
 func TestGetByPetIDExpected(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetByPetID(context.Background(), "tommy")
+	result, err := client.GetByPetID(context.Background(), "tommy", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +45,7 @@ func TestGetByPetIDExpected(t *testing.T) {
 
 func TestGetByPetIDUnexpected(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetByPetID(context.Background(), "casper")
+	result, err := client.GetByPetID(context.Background(), "casper", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestGetByPetIDUnexpected(t *testing.T) {
 
 func TestGetByPetIDAllowed(t *testing.T) {
 	client := newPetClient()
-	result, err := client.GetByPetID(context.Background(), "scooby")
+	result, err := client.GetByPetID(context.Background(), "scooby", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/extenumsgroup/zz_generated_models.go
+++ b/test/autorest/extenumsgroup/zz_generated_models.go
@@ -22,6 +22,11 @@ type PetAddPetOptions struct {
 	PetParam *Pet
 }
 
+// PetGetByPetIDOptions contains the optional parameters for the Pet.GetByPetID method.
+type PetGetByPetIDOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PetResponse is the response envelope for operations that return a Pet type.
 type PetResponse struct {
 	Pet *Pet

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -19,9 +19,9 @@ import (
 // PetOperations contains the methods for the Pet group.
 type PetOperations interface {
 	// AddPet - add pet
-	AddPet(ctx context.Context, petAddPetOptions *PetAddPetOptions) (*PetResponse, error)
+	AddPet(ctx context.Context, options *PetAddPetOptions) (*PetResponse, error)
 	// GetByPetID - get pet by id
-	GetByPetID(ctx context.Context, petId string) (*PetResponse, error)
+	GetByPetID(ctx context.Context, petId string, options *PetGetByPetIDOptions) (*PetResponse, error)
 }
 
 // PetClient implements the PetOperations interface.
@@ -41,8 +41,8 @@ func (client *PetClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // AddPet - add pet
-func (client *PetClient) AddPet(ctx context.Context, petAddPetOptions *PetAddPetOptions) (*PetResponse, error) {
-	req, err := client.AddPetCreateRequest(ctx, petAddPetOptions)
+func (client *PetClient) AddPet(ctx context.Context, options *PetAddPetOptions) (*PetResponse, error) {
+	req, err := client.AddPetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -61,15 +61,15 @@ func (client *PetClient) AddPet(ctx context.Context, petAddPetOptions *PetAddPet
 }
 
 // AddPetCreateRequest creates the AddPet request.
-func (client *PetClient) AddPetCreateRequest(ctx context.Context, petAddPetOptions *PetAddPetOptions) (*azcore.Request, error) {
+func (client *PetClient) AddPetCreateRequest(ctx context.Context, options *PetAddPetOptions) (*azcore.Request, error) {
 	urlPath := "/extensibleenums/pet/addPet"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if petAddPetOptions != nil {
-		return req, req.MarshalAsJSON(petAddPetOptions.PetParam)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.PetParam)
 	}
 	return req, nil
 }
@@ -93,8 +93,8 @@ func (client *PetClient) AddPetHandleError(resp *azcore.Response) error {
 }
 
 // GetByPetID - get pet by id
-func (client *PetClient) GetByPetID(ctx context.Context, petId string) (*PetResponse, error) {
-	req, err := client.GetByPetIDCreateRequest(ctx, petId)
+func (client *PetClient) GetByPetID(ctx context.Context, petId string, options *PetGetByPetIDOptions) (*PetResponse, error) {
+	req, err := client.GetByPetIDCreateRequest(ctx, petId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (client *PetClient) GetByPetID(ctx context.Context, petId string) (*PetResp
 }
 
 // GetByPetIDCreateRequest creates the GetByPetID request.
-func (client *PetClient) GetByPetIDCreateRequest(ctx context.Context, petId string) (*azcore.Request, error) {
+func (client *PetClient) GetByPetIDCreateRequest(ctx context.Context, petId string, options *PetGetByPetIDOptions) (*azcore.Request, error) {
 	urlPath := "/extensibleenums/pet/{petId}"
 	urlPath = strings.ReplaceAll(urlPath, "{petId}", url.PathEscape(petId))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -17,7 +17,7 @@ func newFilesClient() FilesOperations {
 
 func TestGetEmptyFile(t *testing.T) {
 	client := newFilesClient()
-	result, err := client.GetEmptyFile(context.Background())
+	result, err := client.GetEmptyFile(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestGetEmptyFile(t *testing.T) {
 
 func TestGetFile(t *testing.T) {
 	client := newFilesClient()
-	result, err := client.GetFile(context.Background())
+	result, err := client.GetFile(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestGetFile(t *testing.T) {
 func TestGetFileLarge(t *testing.T) {
 	t.Skip("test is unreliable, can fail when running on a machine with low memory")
 	client := newFilesClient()
-	result, err := client.GetFileLarge(context.Background())
+	result, err := client.GetFileLarge(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/filegroup/zz_generated_files.go
+++ b/test/autorest/filegroup/zz_generated_files.go
@@ -14,11 +14,11 @@ import (
 // FilesOperations contains the methods for the Files group.
 type FilesOperations interface {
 	// GetEmptyFile - Get empty file
-	GetEmptyFile(ctx context.Context) (*http.Response, error)
+	GetEmptyFile(ctx context.Context, options *FilesGetEmptyFileOptions) (*http.Response, error)
 	// GetFile - Get file
-	GetFile(ctx context.Context) (*http.Response, error)
+	GetFile(ctx context.Context, options *FilesGetFileOptions) (*http.Response, error)
 	// GetFileLarge - Get a large file
-	GetFileLarge(ctx context.Context) (*http.Response, error)
+	GetFileLarge(ctx context.Context, options *FilesGetFileLargeOptions) (*http.Response, error)
 }
 
 // FilesClient implements the FilesOperations interface.
@@ -38,8 +38,8 @@ func (client *FilesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmptyFile - Get empty file
-func (client *FilesClient) GetEmptyFile(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetEmptyFileCreateRequest(ctx)
+func (client *FilesClient) GetEmptyFile(ctx context.Context, options *FilesGetEmptyFileOptions) (*http.Response, error) {
+	req, err := client.GetEmptyFileCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (client *FilesClient) GetEmptyFile(ctx context.Context) (*http.Response, er
 }
 
 // GetEmptyFileCreateRequest creates the GetEmptyFile request.
-func (client *FilesClient) GetEmptyFileCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FilesClient) GetEmptyFileCreateRequest(ctx context.Context, options *FilesGetEmptyFileOptions) (*azcore.Request, error) {
 	urlPath := "/files/stream/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -75,8 +75,8 @@ func (client *FilesClient) GetEmptyFileHandleError(resp *azcore.Response) error 
 }
 
 // GetFile - Get file
-func (client *FilesClient) GetFile(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetFileCreateRequest(ctx)
+func (client *FilesClient) GetFile(ctx context.Context, options *FilesGetFileOptions) (*http.Response, error) {
+	req, err := client.GetFileCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (client *FilesClient) GetFile(ctx context.Context) (*http.Response, error) 
 }
 
 // GetFileCreateRequest creates the GetFile request.
-func (client *FilesClient) GetFileCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FilesClient) GetFileCreateRequest(ctx context.Context, options *FilesGetFileOptions) (*azcore.Request, error) {
 	urlPath := "/files/stream/nonempty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -112,8 +112,8 @@ func (client *FilesClient) GetFileHandleError(resp *azcore.Response) error {
 }
 
 // GetFileLarge - Get a large file
-func (client *FilesClient) GetFileLarge(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetFileLargeCreateRequest(ctx)
+func (client *FilesClient) GetFileLarge(ctx context.Context, options *FilesGetFileLargeOptions) (*http.Response, error) {
+	req, err := client.GetFileLargeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (client *FilesClient) GetFileLarge(ctx context.Context) (*http.Response, er
 }
 
 // GetFileLargeCreateRequest creates the GetFileLarge request.
-func (client *FilesClient) GetFileLargeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FilesClient) GetFileLargeCreateRequest(ctx context.Context, options *FilesGetFileLargeOptions) (*azcore.Request, error) {
 	urlPath := "/files/stream/verylarge"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/filegroup/zz_generated_models.go
+++ b/test/autorest/filegroup/zz_generated_models.go
@@ -26,3 +26,18 @@ func (e Error) Error() string {
 	}
 	return msg
 }
+
+// FilesGetEmptyFileOptions contains the optional parameters for the Files.GetEmptyFile method.
+type FilesGetEmptyFileOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FilesGetFileLargeOptions contains the optional parameters for the Files.GetFileLarge method.
+type FilesGetFileLargeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FilesGetFileOptions contains the optional parameters for the Files.GetFile method.
+type FilesGetFileOptions struct {
+	// placeholder for future optional parameters
+}

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -19,7 +19,7 @@ func newHeaderClient() HeaderOperations {
 
 // func TestHeaderCustomRequestID(t *testing.T) {
 // 	client := newHeaderClient()
-// 	result, err := client.CustomRequestID(context.Background())
+// 	result, err := client.CustomRequestID(context.Background(), nil)
 // 	if err != nil {
 // 		t.Fatalf("CustomRequestID: %v", err)
 // 	}
@@ -31,23 +31,22 @@ func newHeaderClient() HeaderOperations {
 
 func TestHeaderParamBool(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamBool(context.Background(), "true", true)
+	result, err := client.ParamBool(context.Background(), "true", true, nil)
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
-	result, err = client.ParamBool(context.Background(), "false", false)
+	result, err = client.ParamBool(context.Background(), "false", false, nil)
 	if err != nil {
 		t.Fatalf("ParamBool: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 }
 
-// TODO this required a change in the generated code so that it outputs base64.STDEncoding.EncodeToString()
 func TestHeaderParamByte(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamByte(context.Background(), "valid", []byte("啊齄丂狛狜隣郎隣兀﨩"))
+	result, err := client.ParamByte(context.Background(), "valid", []byte("啊齄丂狛狜隣郎隣兀﨩"), nil)
 	if err != nil {
 		t.Fatalf("ParamByte: %v", err)
 	}
@@ -60,7 +59,7 @@ func TestHeaderParamDate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
 	}
-	result, err := client.ParamDate(context.Background(), "valid", val)
+	result, err := client.ParamDate(context.Background(), "valid", val, nil)
 	if err != nil {
 		t.Fatalf("ParamDate: %v", err)
 	}
@@ -73,7 +72,7 @@ func TestHeaderParamDatetime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to parse time: %v", err)
 	}
-	result, err := client.ParamDatetime(context.Background(), "valid", val)
+	result, err := client.ParamDatetime(context.Background(), "valid", val, nil)
 	if err != nil {
 		t.Fatalf("ParamDatetime: %v", err)
 	}
@@ -95,13 +94,13 @@ func TestHeaderParamDatetimeRFC1123(t *testing.T) {
 
 func TestHeaderParamDouble(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamDouble(context.Background(), "positive", 7e120)
+	result, err := client.ParamDouble(context.Background(), "positive", 7e120, nil)
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
-	result, err = client.ParamDouble(context.Background(), "negative", -3.0)
+	result, err = client.ParamDouble(context.Background(), "negative", -3.0, nil)
 	if err != nil {
 		t.Fatalf("ParamDouble: %v", err)
 	}
@@ -110,7 +109,7 @@ func TestHeaderParamDouble(t *testing.T) {
 
 func TestHeaderParamDuration(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamDuration(context.Background(), "valid", "P123DT22H14M12.011S")
+	result, err := client.ParamDuration(context.Background(), "valid", "P123DT22H14M12.011S", nil)
 	if err != nil {
 		t.Fatalf("ParamDuration: %v", err)
 	}
@@ -144,13 +143,13 @@ func TestHeaderParamEnum(t *testing.T) {
 
 func TestHeaderParamFloat(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamFloat(context.Background(), "positive", 0.07)
+	result, err := client.ParamFloat(context.Background(), "positive", 0.07, nil)
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
-	result, err = client.ParamFloat(context.Background(), "negative", -3.0)
+	result, err = client.ParamFloat(context.Background(), "negative", -3.0, nil)
 	if err != nil {
 		t.Fatalf("ParamFloat: %v", err)
 	}
@@ -159,13 +158,13 @@ func TestHeaderParamFloat(t *testing.T) {
 
 func TestHeaderParamInteger(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamInteger(context.Background(), "positive", 1)
+	result, err := client.ParamInteger(context.Background(), "positive", 1, nil)
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
-	result, err = client.ParamInteger(context.Background(), "negative", -2)
+	result, err = client.ParamInteger(context.Background(), "negative", -2, nil)
 	if err != nil {
 		t.Fatalf("ParamInteger: %v", err)
 	}
@@ -174,13 +173,13 @@ func TestHeaderParamInteger(t *testing.T) {
 
 func TestHeaderParamLong(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamLong(context.Background(), "positive", 105)
+	result, err := client.ParamLong(context.Background(), "positive", 105, nil)
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result, http.StatusOK)
 
-	result, err = client.ParamLong(context.Background(), "negative", -2)
+	result, err = client.ParamLong(context.Background(), "negative", -2, nil)
 	if err != nil {
 		t.Fatalf("ParamLong: %v", err)
 	}
@@ -189,7 +188,7 @@ func TestHeaderParamLong(t *testing.T) {
 
 func TestHeaderParamProtectedKey(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ParamProtectedKey(context.Background(), "text/html")
+	result, err := client.ParamProtectedKey(context.Background(), "text/html", nil)
 	if err != nil {
 		t.Fatalf("ParamProtectedKey: %v", err)
 	}
@@ -222,7 +221,7 @@ func TestHeaderParamString(t *testing.T) {
 // TODO check why we dont check for the value returned in all of the tests below this comment
 func TestHeaderResponseBool(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseBool(context.Background(), "true")
+	result, err := client.ResponseBool(context.Background(), "true", nil)
 	if err != nil {
 		t.Fatalf("ResponseBool: %v", err)
 	}
@@ -230,7 +229,7 @@ func TestHeaderResponseBool(t *testing.T) {
 	val := true
 	expected := HeaderResponseBoolResponse{RawResponse: result.RawResponse, Value: &val}
 	helpers.DeepEqualOrFatal(t, result, &expected)
-	result, err = client.ResponseBool(context.Background(), "false")
+	result, err = client.ResponseBool(context.Background(), "false", nil)
 	if err != nil {
 		t.Fatalf("ResponseBool: %v", err)
 	}
@@ -243,7 +242,7 @@ func TestHeaderResponseBool(t *testing.T) {
 
 func TestHeaderResponseByte(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseByte(context.Background(), "valid")
+	result, err := client.ResponseByte(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseByte: %v", err)
 	}
@@ -254,7 +253,7 @@ func TestHeaderResponseByte(t *testing.T) {
 
 func TestHeaderResponseDate(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseDate(context.Background(), "valid")
+	result, err := client.ResponseDate(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseDate: %v", err)
 	}
@@ -268,7 +267,7 @@ func TestHeaderResponseDate(t *testing.T) {
 			RawResponse: result.RawResponse,
 			Value:       &val,
 		})
-	result, err = client.ResponseDate(context.Background(), "min")
+	result, err = client.ResponseDate(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDate: %v", err)
 	}
@@ -286,7 +285,7 @@ func TestHeaderResponseDate(t *testing.T) {
 
 func TestHeaderResponseDatetime(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseDatetime(context.Background(), "valid")
+	result, err := client.ResponseDatetime(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetime: %v", err)
 	}
@@ -300,7 +299,7 @@ func TestHeaderResponseDatetime(t *testing.T) {
 			RawResponse: result.RawResponse,
 			Value:       &val,
 		})
-	result, err = client.ResponseDatetime(context.Background(), "min")
+	result, err = client.ResponseDatetime(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetime: %v", err)
 	}
@@ -318,7 +317,7 @@ func TestHeaderResponseDatetime(t *testing.T) {
 
 func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseDatetimeRFC1123(context.Background(), "valid")
+	result, err := client.ResponseDatetimeRFC1123(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetimeRFC1123: %v", err)
 	}
@@ -332,7 +331,7 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 			RawResponse: result.RawResponse,
 			Value:       &val,
 		})
-	result, err = client.ResponseDatetimeRFC1123(context.Background(), "min")
+	result, err = client.ResponseDatetimeRFC1123(context.Background(), "min", nil)
 	if err != nil {
 		t.Fatalf("ResponseDatetimeRFC1123: %v", err)
 	}
@@ -350,13 +349,13 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 
 func TestHeaderResponseDouble(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseDouble(context.Background(), "positive")
+	result, err := client.ResponseDouble(context.Background(), "positive", nil)
 	if err != nil {
 		t.Fatalf("ResponseDouble: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseDouble(context.Background(), "negative")
+	result, err = client.ResponseDouble(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseDouble: %v", err)
 	}
@@ -365,7 +364,7 @@ func TestHeaderResponseDouble(t *testing.T) {
 
 func TestHeaderResponseDuration(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseDuration(context.Background(), "valid")
+	result, err := client.ResponseDuration(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseDuration: %v", err)
 	}
@@ -374,14 +373,14 @@ func TestHeaderResponseDuration(t *testing.T) {
 
 func TestHeaderResponseEnum(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseEnum(context.Background(), "valid")
+	result, err := client.ResponseEnum(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseEnum: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 	val := GreyscaleColors("GREY")
 	helpers.DeepEqualOrFatal(t, result, &HeaderResponseEnumResponse{RawResponse: result.RawResponse, Value: &val})
-	result, err = client.ResponseEnum(context.Background(), "null")
+	result, err = client.ResponseEnum(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ResponseEnum: %v", err)
 	}
@@ -390,7 +389,7 @@ func TestHeaderResponseEnum(t *testing.T) {
 
 func TestHeaderResponseExistingKey(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseExistingKey(context.Background())
+	result, err := client.ResponseExistingKey(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ResponseExistingKey: %v", err)
 	}
@@ -399,13 +398,13 @@ func TestHeaderResponseExistingKey(t *testing.T) {
 
 func TestHeaderResponseFloat(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseFloat(context.Background(), "positive")
+	result, err := client.ResponseFloat(context.Background(), "positive", nil)
 	if err != nil {
 		t.Fatalf("ResponseFloat: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseFloat(context.Background(), "negative")
+	result, err = client.ResponseFloat(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseFloat: %v", err)
 	}
@@ -414,13 +413,13 @@ func TestHeaderResponseFloat(t *testing.T) {
 
 func TestHeaderResponseInteger(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseInteger(context.Background(), "positive")
+	result, err := client.ResponseInteger(context.Background(), "positive", nil)
 	if err != nil {
 		t.Fatalf("ResponseInteger: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseInteger(context.Background(), "negative")
+	result, err = client.ResponseInteger(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseInteger: %v", err)
 	}
@@ -429,13 +428,13 @@ func TestHeaderResponseInteger(t *testing.T) {
 
 func TestHeaderResponseLong(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseLong(context.Background(), "positive")
+	result, err := client.ResponseLong(context.Background(), "positive", nil)
 	if err != nil {
 		t.Fatalf("ResponseLong: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseLong(context.Background(), "negative")
+	result, err = client.ResponseLong(context.Background(), "negative", nil)
 	if err != nil {
 		t.Fatalf("ResponseLong: %v", err)
 	}
@@ -444,7 +443,7 @@ func TestHeaderResponseLong(t *testing.T) {
 
 func TestHeaderResponseProtectedKey(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseProtectedKey(context.Background())
+	result, err := client.ResponseProtectedKey(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ResponseProtectedKey: %v", err)
 	}
@@ -453,19 +452,19 @@ func TestHeaderResponseProtectedKey(t *testing.T) {
 
 func TestHeaderResponseString(t *testing.T) {
 	client := newHeaderClient()
-	result, err := client.ResponseString(context.Background(), "valid")
+	result, err := client.ResponseString(context.Background(), "valid", nil)
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseString(context.Background(), "null")
+	result, err = client.ResponseString(context.Background(), "null", nil)
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}
 	helpers.VerifyStatusCode(t, result.RawResponse, http.StatusOK)
 
-	result, err = client.ResponseString(context.Background(), "empty")
+	result, err = client.ResponseString(context.Background(), "empty", nil)
 	if err != nil {
 		t.Fatalf("ResponseString: %v", err)
 	}

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -17,63 +17,63 @@ import (
 // HeaderOperations contains the methods for the Header group.
 type HeaderOperations interface {
 	// CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-	CustomRequestID(ctx context.Context) (*http.Response, error)
+	CustomRequestID(ctx context.Context, options *HeaderCustomRequestIDOptions) (*http.Response, error)
 	// ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
-	ParamBool(ctx context.Context, scenario string, value bool) (*http.Response, error)
+	ParamBool(ctx context.Context, scenario string, value bool, options *HeaderParamBoolOptions) (*http.Response, error)
 	// ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-	ParamByte(ctx context.Context, scenario string, value []byte) (*http.Response, error)
+	ParamByte(ctx context.Context, scenario string, value []byte, options *HeaderParamByteOptions) (*http.Response, error)
 	// ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
-	ParamDate(ctx context.Context, scenario string, value time.Time) (*http.Response, error)
+	ParamDate(ctx context.Context, scenario string, value time.Time, options *HeaderParamDateOptions) (*http.Response, error)
 	// ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
-	ParamDatetime(ctx context.Context, scenario string, value time.Time) (*http.Response, error)
+	ParamDatetime(ctx context.Context, scenario string, value time.Time, options *HeaderParamDatetimeOptions) (*http.Response, error)
 	// ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-	ParamDatetimeRFC1123(ctx context.Context, scenario string, headerParamDatetimeRfc1123Options *HeaderParamDatetimeRFC1123Options) (*http.Response, error)
+	ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*http.Response, error)
 	// ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
-	ParamDouble(ctx context.Context, scenario string, value float64) (*http.Response, error)
+	ParamDouble(ctx context.Context, scenario string, value float64, options *HeaderParamDoubleOptions) (*http.Response, error)
 	// ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-	ParamDuration(ctx context.Context, scenario string, value string) (*http.Response, error)
+	ParamDuration(ctx context.Context, scenario string, value string, options *HeaderParamDurationOptions) (*http.Response, error)
 	// ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
-	ParamEnum(ctx context.Context, scenario string, headerParamEnumOptions *HeaderParamEnumOptions) (*http.Response, error)
+	ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*http.Response, error)
 	// ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
-	ParamExistingKey(ctx context.Context, userAgent string) (*http.Response, error)
+	ParamExistingKey(ctx context.Context, userAgent string, options *HeaderParamExistingKeyOptions) (*http.Response, error)
 	// ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
-	ParamFloat(ctx context.Context, scenario string, value float32) (*http.Response, error)
+	ParamFloat(ctx context.Context, scenario string, value float32, options *HeaderParamFloatOptions) (*http.Response, error)
 	// ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
-	ParamInteger(ctx context.Context, scenario string, value int32) (*http.Response, error)
+	ParamInteger(ctx context.Context, scenario string, value int32, options *HeaderParamIntegerOptions) (*http.Response, error)
 	// ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
-	ParamLong(ctx context.Context, scenario string, value int64) (*http.Response, error)
+	ParamLong(ctx context.Context, scenario string, value int64, options *HeaderParamLongOptions) (*http.Response, error)
 	// ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
-	ParamProtectedKey(ctx context.Context, contentType string) (*http.Response, error)
+	ParamProtectedKey(ctx context.Context, contentType string, options *HeaderParamProtectedKeyOptions) (*http.Response, error)
 	// ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-	ParamString(ctx context.Context, scenario string, headerParamStringOptions *HeaderParamStringOptions) (*http.Response, error)
+	ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*http.Response, error)
 	// ResponseBool - Get a response with header value "value": true or false
-	ResponseBool(ctx context.Context, scenario string) (*HeaderResponseBoolResponse, error)
+	ResponseBool(ctx context.Context, scenario string, options *HeaderResponseBoolOptions) (*HeaderResponseBoolResponse, error)
 	// ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
-	ResponseByte(ctx context.Context, scenario string) (*HeaderResponseByteResponse, error)
+	ResponseByte(ctx context.Context, scenario string, options *HeaderResponseByteOptions) (*HeaderResponseByteResponse, error)
 	// ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
-	ResponseDate(ctx context.Context, scenario string) (*HeaderResponseDateResponse, error)
+	ResponseDate(ctx context.Context, scenario string, options *HeaderResponseDateOptions) (*HeaderResponseDateResponse, error)
 	// ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
-	ResponseDatetime(ctx context.Context, scenario string) (*HeaderResponseDatetimeResponse, error)
+	ResponseDatetime(ctx context.Context, scenario string, options *HeaderResponseDatetimeOptions) (*HeaderResponseDatetimeResponse, error)
 	// ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
-	ResponseDatetimeRFC1123(ctx context.Context, scenario string) (*HeaderResponseDatetimeRFC1123Response, error)
+	ResponseDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderResponseDatetimeRFC1123Options) (*HeaderResponseDatetimeRFC1123Response, error)
 	// ResponseDouble - Get a response with header value "value": 7e120 or -3.0
-	ResponseDouble(ctx context.Context, scenario string) (*HeaderResponseDoubleResponse, error)
+	ResponseDouble(ctx context.Context, scenario string, options *HeaderResponseDoubleOptions) (*HeaderResponseDoubleResponse, error)
 	// ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
-	ResponseDuration(ctx context.Context, scenario string) (*HeaderResponseDurationResponse, error)
+	ResponseDuration(ctx context.Context, scenario string, options *HeaderResponseDurationOptions) (*HeaderResponseDurationResponse, error)
 	// ResponseEnum - Get a response with header values "GREY" or null
-	ResponseEnum(ctx context.Context, scenario string) (*HeaderResponseEnumResponse, error)
+	ResponseEnum(ctx context.Context, scenario string, options *HeaderResponseEnumOptions) (*HeaderResponseEnumResponse, error)
 	// ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
-	ResponseExistingKey(ctx context.Context) (*HeaderResponseExistingKeyResponse, error)
+	ResponseExistingKey(ctx context.Context, options *HeaderResponseExistingKeyOptions) (*HeaderResponseExistingKeyResponse, error)
 	// ResponseFloat - Get a response with header value "value": 0.07 or -3.0
-	ResponseFloat(ctx context.Context, scenario string) (*HeaderResponseFloatResponse, error)
+	ResponseFloat(ctx context.Context, scenario string, options *HeaderResponseFloatOptions) (*HeaderResponseFloatResponse, error)
 	// ResponseInteger - Get a response with header value "value": 1 or -2
-	ResponseInteger(ctx context.Context, scenario string) (*HeaderResponseIntegerResponse, error)
+	ResponseInteger(ctx context.Context, scenario string, options *HeaderResponseIntegerOptions) (*HeaderResponseIntegerResponse, error)
 	// ResponseLong - Get a response with header value "value": 105 or -2
-	ResponseLong(ctx context.Context, scenario string) (*HeaderResponseLongResponse, error)
+	ResponseLong(ctx context.Context, scenario string, options *HeaderResponseLongOptions) (*HeaderResponseLongResponse, error)
 	// ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
-	ResponseProtectedKey(ctx context.Context) (*HeaderResponseProtectedKeyResponse, error)
+	ResponseProtectedKey(ctx context.Context, options *HeaderResponseProtectedKeyOptions) (*HeaderResponseProtectedKeyResponse, error)
 	// ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
-	ResponseString(ctx context.Context, scenario string) (*HeaderResponseStringResponse, error)
+	ResponseString(ctx context.Context, scenario string, options *HeaderResponseStringOptions) (*HeaderResponseStringResponse, error)
 }
 
 // HeaderClient implements the HeaderOperations interface.
@@ -93,8 +93,8 @@ func (client *HeaderClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
-func (client *HeaderClient) CustomRequestID(ctx context.Context) (*http.Response, error) {
-	req, err := client.CustomRequestIDCreateRequest(ctx)
+func (client *HeaderClient) CustomRequestID(ctx context.Context, options *HeaderCustomRequestIDOptions) (*http.Response, error) {
+	req, err := client.CustomRequestIDCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (client *HeaderClient) CustomRequestID(ctx context.Context) (*http.Response
 }
 
 // CustomRequestIDCreateRequest creates the CustomRequestID request.
-func (client *HeaderClient) CustomRequestIDCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HeaderClient) CustomRequestIDCreateRequest(ctx context.Context, options *HeaderCustomRequestIDOptions) (*azcore.Request, error) {
 	urlPath := "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -129,8 +129,8 @@ func (client *HeaderClient) CustomRequestIDHandleError(resp *azcore.Response) er
 }
 
 // ParamBool - Send a post request with header values "scenario": "true", "value": true or "scenario": "false", "value": false
-func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, value bool) (*http.Response, error) {
-	req, err := client.ParamBoolCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, value bool, options *HeaderParamBoolOptions) (*http.Response, error) {
+	req, err := client.ParamBoolCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, valu
 }
 
 // ParamBoolCreateRequest creates the ParamBool request.
-func (client *HeaderClient) ParamBoolCreateRequest(ctx context.Context, scenario string, value bool) (*azcore.Request, error) {
+func (client *HeaderClient) ParamBoolCreateRequest(ctx context.Context, scenario string, value bool, options *HeaderParamBoolOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/bool"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -167,8 +167,8 @@ func (client *HeaderClient) ParamBoolHandleError(resp *azcore.Response) error {
 }
 
 // ParamByte - Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, value []byte) (*http.Response, error) {
-	req, err := client.ParamByteCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, value []byte, options *HeaderParamByteOptions) (*http.Response, error) {
+	req, err := client.ParamByteCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, valu
 }
 
 // ParamByteCreateRequest creates the ParamByte request.
-func (client *HeaderClient) ParamByteCreateRequest(ctx context.Context, scenario string, value []byte) (*azcore.Request, error) {
+func (client *HeaderClient) ParamByteCreateRequest(ctx context.Context, scenario string, value []byte, options *HeaderParamByteOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/byte"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -205,8 +205,8 @@ func (client *HeaderClient) ParamByteHandleError(resp *azcore.Response) error {
 }
 
 // ParamDate - Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario": "min", "value": "0001-01-01"
-func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
-	req, err := client.ParamDateCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, value time.Time, options *HeaderParamDateOptions) (*http.Response, error) {
+	req, err := client.ParamDateCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, valu
 }
 
 // ParamDateCreateRequest creates the ParamDate request.
-func (client *HeaderClient) ParamDateCreateRequest(ctx context.Context, scenario string, value time.Time) (*azcore.Request, error) {
+func (client *HeaderClient) ParamDateCreateRequest(ctx context.Context, scenario string, value time.Time, options *HeaderParamDateOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/date"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -243,8 +243,8 @@ func (client *HeaderClient) ParamDateHandleError(resp *azcore.Response) error {
 }
 
 // ParamDatetime - Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or "scenario": "min", "value": "0001-01-01T00:00:00Z"
-func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, value time.Time) (*http.Response, error) {
-	req, err := client.ParamDatetimeCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, value time.Time, options *HeaderParamDatetimeOptions) (*http.Response, error) {
+	req, err := client.ParamDatetimeCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, 
 }
 
 // ParamDatetimeCreateRequest creates the ParamDatetime request.
-func (client *HeaderClient) ParamDatetimeCreateRequest(ctx context.Context, scenario string, value time.Time) (*azcore.Request, error) {
+func (client *HeaderClient) ParamDatetimeCreateRequest(ctx context.Context, scenario string, value time.Time, options *HeaderParamDatetimeOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetime"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -281,8 +281,8 @@ func (client *HeaderClient) ParamDatetimeHandleError(resp *azcore.Response) erro
 }
 
 // ParamDatetimeRFC1123 - Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario string, headerParamDatetimeRfc1123Options *HeaderParamDatetimeRFC1123Options) (*http.Response, error) {
-	req, err := client.ParamDatetimeRFC1123CreateRequest(ctx, scenario, headerParamDatetimeRfc1123Options)
+func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*http.Response, error) {
+	req, err := client.ParamDatetimeRFC1123CreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -297,15 +297,15 @@ func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario s
 }
 
 // ParamDatetimeRFC1123CreateRequest creates the ParamDatetimeRFC1123 request.
-func (client *HeaderClient) ParamDatetimeRFC1123CreateRequest(ctx context.Context, scenario string, headerParamDatetimeRfc1123Options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
+func (client *HeaderClient) ParamDatetimeRFC1123CreateRequest(ctx context.Context, scenario string, options *HeaderParamDatetimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/datetimerfc1123"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
-	if headerParamDatetimeRfc1123Options != nil && headerParamDatetimeRfc1123Options.Value != nil {
-		req.Header.Set("value", headerParamDatetimeRfc1123Options.Value.Format(time.RFC1123))
+	if options != nil && options.Value != nil {
+		req.Header.Set("value", options.Value.Format(time.RFC1123))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -321,8 +321,8 @@ func (client *HeaderClient) ParamDatetimeRFC1123HandleError(resp *azcore.Respons
 }
 
 // ParamDouble - Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario": "negative", "value": -3.0
-func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, value float64) (*http.Response, error) {
-	req, err := client.ParamDoubleCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, value float64, options *HeaderParamDoubleOptions) (*http.Response, error) {
+	req, err := client.ParamDoubleCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +337,7 @@ func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, va
 }
 
 // ParamDoubleCreateRequest creates the ParamDouble request.
-func (client *HeaderClient) ParamDoubleCreateRequest(ctx context.Context, scenario string, value float64) (*azcore.Request, error) {
+func (client *HeaderClient) ParamDoubleCreateRequest(ctx context.Context, scenario string, value float64, options *HeaderParamDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/double"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -359,8 +359,8 @@ func (client *HeaderClient) ParamDoubleHandleError(resp *azcore.Response) error 
 }
 
 // ParamDuration - Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, value string) (*http.Response, error) {
-	req, err := client.ParamDurationCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, value string, options *HeaderParamDurationOptions) (*http.Response, error) {
+	req, err := client.ParamDurationCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, 
 }
 
 // ParamDurationCreateRequest creates the ParamDuration request.
-func (client *HeaderClient) ParamDurationCreateRequest(ctx context.Context, scenario string, value string) (*azcore.Request, error) {
+func (client *HeaderClient) ParamDurationCreateRequest(ctx context.Context, scenario string, value string, options *HeaderParamDurationOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/duration"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -397,8 +397,8 @@ func (client *HeaderClient) ParamDurationHandleError(resp *azcore.Response) erro
 }
 
 // ParamEnum - Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null", "value": null
-func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, headerParamEnumOptions *HeaderParamEnumOptions) (*http.Response, error) {
-	req, err := client.ParamEnumCreateRequest(ctx, scenario, headerParamEnumOptions)
+func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*http.Response, error) {
+	req, err := client.ParamEnumCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -413,15 +413,15 @@ func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, head
 }
 
 // ParamEnumCreateRequest creates the ParamEnum request.
-func (client *HeaderClient) ParamEnumCreateRequest(ctx context.Context, scenario string, headerParamEnumOptions *HeaderParamEnumOptions) (*azcore.Request, error) {
+func (client *HeaderClient) ParamEnumCreateRequest(ctx context.Context, scenario string, options *HeaderParamEnumOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/enum"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
-	if headerParamEnumOptions != nil && headerParamEnumOptions.Value != nil {
-		req.Header.Set("value", string(*headerParamEnumOptions.Value))
+	if options != nil && options.Value != nil {
+		req.Header.Set("value", string(*options.Value))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -437,8 +437,8 @@ func (client *HeaderClient) ParamEnumHandleError(resp *azcore.Response) error {
 }
 
 // ParamExistingKey - Send a post request with header value "User-Agent": "overwrite"
-func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent string) (*http.Response, error) {
-	req, err := client.ParamExistingKeyCreateRequest(ctx, userAgent)
+func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent string, options *HeaderParamExistingKeyOptions) (*http.Response, error) {
+	req, err := client.ParamExistingKeyCreateRequest(ctx, userAgent, options)
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +453,7 @@ func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent stri
 }
 
 // ParamExistingKeyCreateRequest creates the ParamExistingKey request.
-func (client *HeaderClient) ParamExistingKeyCreateRequest(ctx context.Context, userAgent string) (*azcore.Request, error) {
+func (client *HeaderClient) ParamExistingKeyCreateRequest(ctx context.Context, userAgent string, options *HeaderParamExistingKeyOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/existingkey"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -474,8 +474,8 @@ func (client *HeaderClient) ParamExistingKeyHandleError(resp *azcore.Response) e
 }
 
 // ParamFloat - Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario": "negative", "value": -3.0
-func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, value float32) (*http.Response, error) {
-	req, err := client.ParamFloatCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, value float32, options *HeaderParamFloatOptions) (*http.Response, error) {
+	req, err := client.ParamFloatCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, val
 }
 
 // ParamFloatCreateRequest creates the ParamFloat request.
-func (client *HeaderClient) ParamFloatCreateRequest(ctx context.Context, scenario string, value float32) (*azcore.Request, error) {
+func (client *HeaderClient) ParamFloatCreateRequest(ctx context.Context, scenario string, value float32, options *HeaderParamFloatOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/float"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -512,8 +512,8 @@ func (client *HeaderClient) ParamFloatHandleError(resp *azcore.Response) error {
 }
 
 // ParamInteger - Send a post request with header values "scenario": "positive", "value": 1 or "scenario": "negative", "value": -2
-func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, value int32) (*http.Response, error) {
-	req, err := client.ParamIntegerCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, value int32, options *HeaderParamIntegerOptions) (*http.Response, error) {
+	req, err := client.ParamIntegerCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +528,7 @@ func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, v
 }
 
 // ParamIntegerCreateRequest creates the ParamInteger request.
-func (client *HeaderClient) ParamIntegerCreateRequest(ctx context.Context, scenario string, value int32) (*azcore.Request, error) {
+func (client *HeaderClient) ParamIntegerCreateRequest(ctx context.Context, scenario string, value int32, options *HeaderParamIntegerOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/integer"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -550,8 +550,8 @@ func (client *HeaderClient) ParamIntegerHandleError(resp *azcore.Response) error
 }
 
 // ParamLong - Send a post request with header values "scenario": "positive", "value": 105 or "scenario": "negative", "value": -2
-func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, value int64) (*http.Response, error) {
-	req, err := client.ParamLongCreateRequest(ctx, scenario, value)
+func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, value int64, options *HeaderParamLongOptions) (*http.Response, error) {
+	req, err := client.ParamLongCreateRequest(ctx, scenario, value, options)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +566,7 @@ func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, valu
 }
 
 // ParamLongCreateRequest creates the ParamLong request.
-func (client *HeaderClient) ParamLongCreateRequest(ctx context.Context, scenario string, value int64) (*azcore.Request, error) {
+func (client *HeaderClient) ParamLongCreateRequest(ctx context.Context, scenario string, value int64, options *HeaderParamLongOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/long"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -588,8 +588,8 @@ func (client *HeaderClient) ParamLongHandleError(resp *azcore.Response) error {
 }
 
 // ParamProtectedKey - Send a post request with header value "Content-Type": "text/html"
-func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType string) (*http.Response, error) {
-	req, err := client.ParamProtectedKeyCreateRequest(ctx, contentType)
+func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType string, options *HeaderParamProtectedKeyOptions) (*http.Response, error) {
+	req, err := client.ParamProtectedKeyCreateRequest(ctx, contentType, options)
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +604,7 @@ func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType s
 }
 
 // ParamProtectedKeyCreateRequest creates the ParamProtectedKey request.
-func (client *HeaderClient) ParamProtectedKeyCreateRequest(ctx context.Context, contentType string) (*azcore.Request, error) {
+func (client *HeaderClient) ParamProtectedKeyCreateRequest(ctx context.Context, contentType string, options *HeaderParamProtectedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/protectedkey"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -625,8 +625,8 @@ func (client *HeaderClient) ParamProtectedKeyHandleError(resp *azcore.Response) 
 }
 
 // ParamString - Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-func (client *HeaderClient) ParamString(ctx context.Context, scenario string, headerParamStringOptions *HeaderParamStringOptions) (*http.Response, error) {
-	req, err := client.ParamStringCreateRequest(ctx, scenario, headerParamStringOptions)
+func (client *HeaderClient) ParamString(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*http.Response, error) {
+	req, err := client.ParamStringCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -641,15 +641,15 @@ func (client *HeaderClient) ParamString(ctx context.Context, scenario string, he
 }
 
 // ParamStringCreateRequest creates the ParamString request.
-func (client *HeaderClient) ParamStringCreateRequest(ctx context.Context, scenario string, headerParamStringOptions *HeaderParamStringOptions) (*azcore.Request, error) {
+func (client *HeaderClient) ParamStringCreateRequest(ctx context.Context, scenario string, options *HeaderParamStringOptions) (*azcore.Request, error) {
 	urlPath := "/header/param/prim/string"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("scenario", scenario)
-	if headerParamStringOptions != nil && headerParamStringOptions.Value != nil {
-		req.Header.Set("value", *headerParamStringOptions.Value)
+	if options != nil && options.Value != nil {
+		req.Header.Set("value", *options.Value)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -665,8 +665,8 @@ func (client *HeaderClient) ParamStringHandleError(resp *azcore.Response) error 
 }
 
 // ResponseBool - Get a response with header value "value": true or false
-func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string) (*HeaderResponseBoolResponse, error) {
-	req, err := client.ResponseBoolCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string, options *HeaderResponseBoolOptions) (*HeaderResponseBoolResponse, error) {
+	req, err := client.ResponseBoolCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +685,7 @@ func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string) (
 }
 
 // ResponseBoolCreateRequest creates the ResponseBool request.
-func (client *HeaderClient) ResponseBoolCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseBoolCreateRequest(ctx context.Context, scenario string, options *HeaderResponseBoolOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/bool"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -719,8 +719,8 @@ func (client *HeaderClient) ResponseBoolHandleError(resp *azcore.Response) error
 }
 
 // ResponseByte - Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
-func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string) (*HeaderResponseByteResponse, error) {
-	req, err := client.ResponseByteCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string, options *HeaderResponseByteOptions) (*HeaderResponseByteResponse, error) {
+	req, err := client.ResponseByteCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string) (
 }
 
 // ResponseByteCreateRequest creates the ResponseByte request.
-func (client *HeaderClient) ResponseByteCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseByteCreateRequest(ctx context.Context, scenario string, options *HeaderResponseByteOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/byte"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -773,8 +773,8 @@ func (client *HeaderClient) ResponseByteHandleError(resp *azcore.Response) error
 }
 
 // ResponseDate - Get a response with header values "2010-01-01" or "0001-01-01"
-func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string) (*HeaderResponseDateResponse, error) {
-	req, err := client.ResponseDateCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string, options *HeaderResponseDateOptions) (*HeaderResponseDateResponse, error) {
+	req, err := client.ResponseDateCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -793,7 +793,7 @@ func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string) (
 }
 
 // ResponseDateCreateRequest creates the ResponseDate request.
-func (client *HeaderClient) ResponseDateCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseDateCreateRequest(ctx context.Context, scenario string, options *HeaderResponseDateOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/date"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -827,8 +827,8 @@ func (client *HeaderClient) ResponseDateHandleError(resp *azcore.Response) error
 }
 
 // ResponseDatetime - Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
-func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario string) (*HeaderResponseDatetimeResponse, error) {
-	req, err := client.ResponseDatetimeCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario string, options *HeaderResponseDatetimeOptions) (*HeaderResponseDatetimeResponse, error) {
+	req, err := client.ResponseDatetimeCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +847,7 @@ func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario strin
 }
 
 // ResponseDatetimeCreateRequest creates the ResponseDatetime request.
-func (client *HeaderClient) ResponseDatetimeCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseDatetimeCreateRequest(ctx context.Context, scenario string, options *HeaderResponseDatetimeOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetime"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -881,8 +881,8 @@ func (client *HeaderClient) ResponseDatetimeHandleError(resp *azcore.Response) e
 }
 
 // ResponseDatetimeRFC1123 - Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
-func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenario string) (*HeaderResponseDatetimeRFC1123Response, error) {
-	req, err := client.ResponseDatetimeRFC1123CreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenario string, options *HeaderResponseDatetimeRFC1123Options) (*HeaderResponseDatetimeRFC1123Response, error) {
+	req, err := client.ResponseDatetimeRFC1123CreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -901,7 +901,7 @@ func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenari
 }
 
 // ResponseDatetimeRFC1123CreateRequest creates the ResponseDatetimeRFC1123 request.
-func (client *HeaderClient) ResponseDatetimeRFC1123CreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseDatetimeRFC1123CreateRequest(ctx context.Context, scenario string, options *HeaderResponseDatetimeRFC1123Options) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/datetimerfc1123"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -935,8 +935,8 @@ func (client *HeaderClient) ResponseDatetimeRFC1123HandleError(resp *azcore.Resp
 }
 
 // ResponseDouble - Get a response with header value "value": 7e120 or -3.0
-func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string) (*HeaderResponseDoubleResponse, error) {
-	req, err := client.ResponseDoubleCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string, options *HeaderResponseDoubleOptions) (*HeaderResponseDoubleResponse, error) {
+	req, err := client.ResponseDoubleCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -955,7 +955,7 @@ func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string)
 }
 
 // ResponseDoubleCreateRequest creates the ResponseDouble request.
-func (client *HeaderClient) ResponseDoubleCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseDoubleCreateRequest(ctx context.Context, scenario string, options *HeaderResponseDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/double"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -989,8 +989,8 @@ func (client *HeaderClient) ResponseDoubleHandleError(resp *azcore.Response) err
 }
 
 // ResponseDuration - Get a response with header values "P123DT22H14M12.011S"
-func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario string) (*HeaderResponseDurationResponse, error) {
-	req, err := client.ResponseDurationCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario string, options *HeaderResponseDurationOptions) (*HeaderResponseDurationResponse, error) {
+	req, err := client.ResponseDurationCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1009,7 +1009,7 @@ func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario strin
 }
 
 // ResponseDurationCreateRequest creates the ResponseDuration request.
-func (client *HeaderClient) ResponseDurationCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseDurationCreateRequest(ctx context.Context, scenario string, options *HeaderResponseDurationOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/duration"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1039,8 +1039,8 @@ func (client *HeaderClient) ResponseDurationHandleError(resp *azcore.Response) e
 }
 
 // ResponseEnum - Get a response with header values "GREY" or null
-func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string) (*HeaderResponseEnumResponse, error) {
-	req, err := client.ResponseEnumCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string, options *HeaderResponseEnumOptions) (*HeaderResponseEnumResponse, error) {
+	req, err := client.ResponseEnumCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1059,7 +1059,7 @@ func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string) (
 }
 
 // ResponseEnumCreateRequest creates the ResponseEnum request.
-func (client *HeaderClient) ResponseEnumCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseEnumCreateRequest(ctx context.Context, scenario string, options *HeaderResponseEnumOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/enum"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1089,8 +1089,8 @@ func (client *HeaderClient) ResponseEnumHandleError(resp *azcore.Response) error
 }
 
 // ResponseExistingKey - Get a response with header value "User-Agent": "overwrite"
-func (client *HeaderClient) ResponseExistingKey(ctx context.Context) (*HeaderResponseExistingKeyResponse, error) {
-	req, err := client.ResponseExistingKeyCreateRequest(ctx)
+func (client *HeaderClient) ResponseExistingKey(ctx context.Context, options *HeaderResponseExistingKeyOptions) (*HeaderResponseExistingKeyResponse, error) {
+	req, err := client.ResponseExistingKeyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1109,7 +1109,7 @@ func (client *HeaderClient) ResponseExistingKey(ctx context.Context) (*HeaderRes
 }
 
 // ResponseExistingKeyCreateRequest creates the ResponseExistingKey request.
-func (client *HeaderClient) ResponseExistingKeyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseExistingKeyCreateRequest(ctx context.Context, options *HeaderResponseExistingKeyOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/existingkey"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1138,8 +1138,8 @@ func (client *HeaderClient) ResponseExistingKeyHandleError(resp *azcore.Response
 }
 
 // ResponseFloat - Get a response with header value "value": 0.07 or -3.0
-func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string) (*HeaderResponseFloatResponse, error) {
-	req, err := client.ResponseFloatCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string, options *HeaderResponseFloatOptions) (*HeaderResponseFloatResponse, error) {
+	req, err := client.ResponseFloatCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,7 +1158,7 @@ func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string) 
 }
 
 // ResponseFloatCreateRequest creates the ResponseFloat request.
-func (client *HeaderClient) ResponseFloatCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseFloatCreateRequest(ctx context.Context, scenario string, options *HeaderResponseFloatOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/float"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1193,8 +1193,8 @@ func (client *HeaderClient) ResponseFloatHandleError(resp *azcore.Response) erro
 }
 
 // ResponseInteger - Get a response with header value "value": 1 or -2
-func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string) (*HeaderResponseIntegerResponse, error) {
-	req, err := client.ResponseIntegerCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string, options *HeaderResponseIntegerOptions) (*HeaderResponseIntegerResponse, error) {
+	req, err := client.ResponseIntegerCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1213,7 +1213,7 @@ func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string
 }
 
 // ResponseIntegerCreateRequest creates the ResponseInteger request.
-func (client *HeaderClient) ResponseIntegerCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseIntegerCreateRequest(ctx context.Context, scenario string, options *HeaderResponseIntegerOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/integer"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1248,8 +1248,8 @@ func (client *HeaderClient) ResponseIntegerHandleError(resp *azcore.Response) er
 }
 
 // ResponseLong - Get a response with header value "value": 105 or -2
-func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string) (*HeaderResponseLongResponse, error) {
-	req, err := client.ResponseLongCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string, options *HeaderResponseLongOptions) (*HeaderResponseLongResponse, error) {
+	req, err := client.ResponseLongCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1268,7 +1268,7 @@ func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string) (
 }
 
 // ResponseLongCreateRequest creates the ResponseLong request.
-func (client *HeaderClient) ResponseLongCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseLongCreateRequest(ctx context.Context, scenario string, options *HeaderResponseLongOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/long"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1302,8 +1302,8 @@ func (client *HeaderClient) ResponseLongHandleError(resp *azcore.Response) error
 }
 
 // ResponseProtectedKey - Get a response with header value "Content-Type": "text/html"
-func (client *HeaderClient) ResponseProtectedKey(ctx context.Context) (*HeaderResponseProtectedKeyResponse, error) {
-	req, err := client.ResponseProtectedKeyCreateRequest(ctx)
+func (client *HeaderClient) ResponseProtectedKey(ctx context.Context, options *HeaderResponseProtectedKeyOptions) (*HeaderResponseProtectedKeyResponse, error) {
+	req, err := client.ResponseProtectedKeyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1322,7 +1322,7 @@ func (client *HeaderClient) ResponseProtectedKey(ctx context.Context) (*HeaderRe
 }
 
 // ResponseProtectedKeyCreateRequest creates the ResponseProtectedKey request.
-func (client *HeaderClient) ResponseProtectedKeyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseProtectedKeyCreateRequest(ctx context.Context, options *HeaderResponseProtectedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/protectedkey"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1351,8 +1351,8 @@ func (client *HeaderClient) ResponseProtectedKeyHandleError(resp *azcore.Respons
 }
 
 // ResponseString - Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
-func (client *HeaderClient) ResponseString(ctx context.Context, scenario string) (*HeaderResponseStringResponse, error) {
-	req, err := client.ResponseStringCreateRequest(ctx, scenario)
+func (client *HeaderClient) ResponseString(ctx context.Context, scenario string, options *HeaderResponseStringOptions) (*HeaderResponseStringResponse, error) {
+	req, err := client.ResponseStringCreateRequest(ctx, scenario, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1371,7 +1371,7 @@ func (client *HeaderClient) ResponseString(ctx context.Context, scenario string)
 }
 
 // ResponseStringCreateRequest creates the ResponseString request.
-func (client *HeaderClient) ResponseStringCreateRequest(ctx context.Context, scenario string) (*azcore.Request, error) {
+func (client *HeaderClient) ResponseStringCreateRequest(ctx context.Context, scenario string, options *HeaderResponseStringOptions) (*azcore.Request, error) {
 	urlPath := "/header/response/prim/string"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/headergroup/zz_generated_models.go
+++ b/test/autorest/headergroup/zz_generated_models.go
@@ -31,10 +31,45 @@ func (e Error) Error() string {
 	return msg
 }
 
+// HeaderCustomRequestIDOptions contains the optional parameters for the Header.CustomRequestID method.
+type HeaderCustomRequestIDOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamBoolOptions contains the optional parameters for the Header.ParamBool method.
+type HeaderParamBoolOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamByteOptions contains the optional parameters for the Header.ParamByte method.
+type HeaderParamByteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamDateOptions contains the optional parameters for the Header.ParamDate method.
+type HeaderParamDateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamDatetimeOptions contains the optional parameters for the Header.ParamDatetime method.
+type HeaderParamDatetimeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderParamDatetimeRFC1123Options contains the optional parameters for the Header.ParamDatetimeRFC1123 method.
 type HeaderParamDatetimeRFC1123Options struct {
 	// Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
 	Value *time.Time
+}
+
+// HeaderParamDoubleOptions contains the optional parameters for the Header.ParamDouble method.
+type HeaderParamDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamDurationOptions contains the optional parameters for the Header.ParamDuration method.
+type HeaderParamDurationOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderParamEnumOptions contains the optional parameters for the Header.ParamEnum method.
@@ -43,10 +78,40 @@ type HeaderParamEnumOptions struct {
 	Value *GreyscaleColors
 }
 
+// HeaderParamExistingKeyOptions contains the optional parameters for the Header.ParamExistingKey method.
+type HeaderParamExistingKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamFloatOptions contains the optional parameters for the Header.ParamFloat method.
+type HeaderParamFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamIntegerOptions contains the optional parameters for the Header.ParamInteger method.
+type HeaderParamIntegerOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamLongOptions contains the optional parameters for the Header.ParamLong method.
+type HeaderParamLongOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderParamProtectedKeyOptions contains the optional parameters for the Header.ParamProtectedKey method.
+type HeaderParamProtectedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderParamStringOptions contains the optional parameters for the Header.ParamString method.
 type HeaderParamStringOptions struct {
 	// Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
 	Value *string
+}
+
+// HeaderResponseBoolOptions contains the optional parameters for the Header.ResponseBool method.
+type HeaderResponseBoolOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseBoolResponse contains the response from method Header.ResponseBool.
@@ -58,6 +123,11 @@ type HeaderResponseBoolResponse struct {
 	Value *bool
 }
 
+// HeaderResponseByteOptions contains the optional parameters for the Header.ResponseByte method.
+type HeaderResponseByteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseByteResponse contains the response from method Header.ResponseByte.
 type HeaderResponseByteResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -67,6 +137,11 @@ type HeaderResponseByteResponse struct {
 	Value *[]byte
 }
 
+// HeaderResponseDateOptions contains the optional parameters for the Header.ResponseDate method.
+type HeaderResponseDateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseDateResponse contains the response from method Header.ResponseDate.
 type HeaderResponseDateResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -74,6 +149,16 @@ type HeaderResponseDateResponse struct {
 
 	// Value contains the information returned from the value header response.
 	Value *time.Time
+}
+
+// HeaderResponseDatetimeOptions contains the optional parameters for the Header.ResponseDatetime method.
+type HeaderResponseDatetimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HeaderResponseDatetimeRFC1123Options contains the optional parameters for the Header.ResponseDatetimeRFC1123 method.
+type HeaderResponseDatetimeRFC1123Options struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseDatetimeRFC1123Response contains the response from method Header.ResponseDatetimeRFC1123.
@@ -94,6 +179,11 @@ type HeaderResponseDatetimeResponse struct {
 	Value *time.Time
 }
 
+// HeaderResponseDoubleOptions contains the optional parameters for the Header.ResponseDouble method.
+type HeaderResponseDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseDoubleResponse contains the response from method Header.ResponseDouble.
 type HeaderResponseDoubleResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -101,6 +191,11 @@ type HeaderResponseDoubleResponse struct {
 
 	// Value contains the information returned from the value header response.
 	Value *float64
+}
+
+// HeaderResponseDurationOptions contains the optional parameters for the Header.ResponseDuration method.
+type HeaderResponseDurationOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseDurationResponse contains the response from method Header.ResponseDuration.
@@ -112,6 +207,11 @@ type HeaderResponseDurationResponse struct {
 	Value *string
 }
 
+// HeaderResponseEnumOptions contains the optional parameters for the Header.ResponseEnum method.
+type HeaderResponseEnumOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseEnumResponse contains the response from method Header.ResponseEnum.
 type HeaderResponseEnumResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -119,6 +219,11 @@ type HeaderResponseEnumResponse struct {
 
 	// Value contains the information returned from the value header response.
 	Value *GreyscaleColors
+}
+
+// HeaderResponseExistingKeyOptions contains the optional parameters for the Header.ResponseExistingKey method.
+type HeaderResponseExistingKeyOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseExistingKeyResponse contains the response from method Header.ResponseExistingKey.
@@ -130,6 +235,11 @@ type HeaderResponseExistingKeyResponse struct {
 	UserAgent *string
 }
 
+// HeaderResponseFloatOptions contains the optional parameters for the Header.ResponseFloat method.
+type HeaderResponseFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseFloatResponse contains the response from method Header.ResponseFloat.
 type HeaderResponseFloatResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -137,6 +247,11 @@ type HeaderResponseFloatResponse struct {
 
 	// Value contains the information returned from the value header response.
 	Value *float32
+}
+
+// HeaderResponseIntegerOptions contains the optional parameters for the Header.ResponseInteger method.
+type HeaderResponseIntegerOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseIntegerResponse contains the response from method Header.ResponseInteger.
@@ -148,6 +263,11 @@ type HeaderResponseIntegerResponse struct {
 	Value *int32
 }
 
+// HeaderResponseLongOptions contains the optional parameters for the Header.ResponseLong method.
+type HeaderResponseLongOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseLongResponse contains the response from method Header.ResponseLong.
 type HeaderResponseLongResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -157,6 +277,11 @@ type HeaderResponseLongResponse struct {
 	Value *int64
 }
 
+// HeaderResponseProtectedKeyOptions contains the optional parameters for the Header.ResponseProtectedKey method.
+type HeaderResponseProtectedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // HeaderResponseProtectedKeyResponse contains the response from method Header.ResponseProtectedKey.
 type HeaderResponseProtectedKeyResponse struct {
 	// ContentType contains the information returned from the Content-Type header response.
@@ -164,6 +289,11 @@ type HeaderResponseProtectedKeyResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// HeaderResponseStringOptions contains the optional parameters for the Header.ResponseString method.
+type HeaderResponseStringOptions struct {
+	// placeholder for future optional parameters
 }
 
 // HeaderResponseStringResponse contains the response from method Header.ResponseString.

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -14,7 +14,7 @@ func newHTTPClientFailureClient() HTTPClientFailureOperations {
 
 func TestHTTPClientFailureDelete400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Delete400(context.Background())
+	result, err := client.Delete400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -25,7 +25,7 @@ func TestHTTPClientFailureDelete400(t *testing.T) {
 
 func TestHTTPClientFailureDelete407(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Delete407(context.Background())
+	result, err := client.Delete407(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -36,7 +36,7 @@ func TestHTTPClientFailureDelete407(t *testing.T) {
 
 func TestHTTPClientFailureDelete417(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Delete417(context.Background())
+	result, err := client.Delete417(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -47,7 +47,7 @@ func TestHTTPClientFailureDelete417(t *testing.T) {
 
 func TestHTTPClientFailureGet400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get400(context.Background())
+	result, err := client.Get400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -58,7 +58,7 @@ func TestHTTPClientFailureGet400(t *testing.T) {
 
 func TestHTTPClientFailureGet402(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get402(context.Background())
+	result, err := client.Get402(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -69,7 +69,7 @@ func TestHTTPClientFailureGet402(t *testing.T) {
 
 func TestHTTPClientFailureGet403(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get403(context.Background())
+	result, err := client.Get403(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -80,7 +80,7 @@ func TestHTTPClientFailureGet403(t *testing.T) {
 
 func TestHTTPClientFailureGet411(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get411(context.Background())
+	result, err := client.Get411(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -91,7 +91,7 @@ func TestHTTPClientFailureGet411(t *testing.T) {
 
 func TestHTTPClientFailureGet412(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get412(context.Background())
+	result, err := client.Get412(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -102,7 +102,7 @@ func TestHTTPClientFailureGet412(t *testing.T) {
 
 func TestHTTPClientFailureGet416(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Get416(context.Background())
+	result, err := client.Get416(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -113,7 +113,7 @@ func TestHTTPClientFailureGet416(t *testing.T) {
 
 func TestHTTPClientFailureHead400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Head400(context.Background())
+	result, err := client.Head400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -124,7 +124,7 @@ func TestHTTPClientFailureHead400(t *testing.T) {
 
 func TestHTTPClientFailureHead401(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Head401(context.Background())
+	result, err := client.Head401(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -135,7 +135,7 @@ func TestHTTPClientFailureHead401(t *testing.T) {
 
 func TestHTTPClientFailureHead410(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Head410(context.Background())
+	result, err := client.Head410(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -146,7 +146,7 @@ func TestHTTPClientFailureHead410(t *testing.T) {
 
 func TestHTTPClientFailureHead429(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Head429(context.Background())
+	result, err := client.Head429(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -157,7 +157,7 @@ func TestHTTPClientFailureHead429(t *testing.T) {
 
 func TestHTTPClientFailureOptions400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Options400(context.Background())
+	result, err := client.Options400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -168,7 +168,7 @@ func TestHTTPClientFailureOptions400(t *testing.T) {
 
 func TestHTTPClientFailureOptions403(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Options403(context.Background())
+	result, err := client.Options403(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -179,7 +179,7 @@ func TestHTTPClientFailureOptions403(t *testing.T) {
 
 func TestHTTPClientFailureOptions412(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Options412(context.Background())
+	result, err := client.Options412(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -190,7 +190,7 @@ func TestHTTPClientFailureOptions412(t *testing.T) {
 
 func TestHTTPClientFailurePatch400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Patch400(context.Background())
+	result, err := client.Patch400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -201,7 +201,7 @@ func TestHTTPClientFailurePatch400(t *testing.T) {
 
 func TestHTTPClientFailurePatch405(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Patch405(context.Background())
+	result, err := client.Patch405(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -212,7 +212,7 @@ func TestHTTPClientFailurePatch405(t *testing.T) {
 
 func TestHTTPClientFailurePatch414(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Patch414(context.Background())
+	result, err := client.Patch414(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -223,7 +223,7 @@ func TestHTTPClientFailurePatch414(t *testing.T) {
 
 func TestHTTPClientFailurePost400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Post400(context.Background())
+	result, err := client.Post400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -234,7 +234,7 @@ func TestHTTPClientFailurePost400(t *testing.T) {
 
 func TestHTTPClientFailurePost406(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Post406(context.Background())
+	result, err := client.Post406(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -245,7 +245,7 @@ func TestHTTPClientFailurePost406(t *testing.T) {
 
 func TestHTTPClientFailurePost415(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Post415(context.Background())
+	result, err := client.Post415(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -256,7 +256,7 @@ func TestHTTPClientFailurePost415(t *testing.T) {
 
 func TestHTTPClientFailurePut400(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Put400(context.Background())
+	result, err := client.Put400(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -267,7 +267,7 @@ func TestHTTPClientFailurePut400(t *testing.T) {
 
 func TestHTTPClientFailurePut404(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Put404(context.Background())
+	result, err := client.Put404(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -278,7 +278,7 @@ func TestHTTPClientFailurePut404(t *testing.T) {
 
 func TestHTTPClientFailurePut409(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Put409(context.Background())
+	result, err := client.Put409(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -289,7 +289,7 @@ func TestHTTPClientFailurePut409(t *testing.T) {
 
 func TestHTTPClientFailurePut413(t *testing.T) {
 	client := newHTTPClientFailureClient()
-	result, err := client.Put413(context.Background())
+	result, err := client.Put413(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/test/autorest/httpinfrastructuregroup/httpfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpfailure_test.go
@@ -14,7 +14,7 @@ func newHTTPFailureClient() HTTPFailureOperations {
 
 func TestHTTPFailureGetEmptyError(t *testing.T) {
 	client := newHTTPFailureClient()
-	result, err := client.GetEmptyError(context.Background())
+	result, err := client.GetEmptyError(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -25,7 +25,7 @@ func TestHTTPFailureGetEmptyError(t *testing.T) {
 
 func TestHTTPFailureGetNoModelEmpty(t *testing.T) {
 	client := newHTTPFailureClient()
-	result, err := client.GetNoModelEmpty(context.Background())
+	result, err := client.GetNoModelEmpty(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -36,7 +36,7 @@ func TestHTTPFailureGetNoModelEmpty(t *testing.T) {
 
 func TestHTTPFailureGetNoModelError(t *testing.T) {
 	client := newHTTPFailureClient()
-	result, err := client.GetNoModelError(context.Background())
+	result, err := client.GetNoModelError(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -20,7 +20,7 @@ func newMultipleResponsesClient() MultipleResponsesOperations {
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model201ModelDefaultError200Valid(context.Background())
+	result, err := client.Get200Model201ModelDefaultError200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model201ModelDefaultError201Valid(context.Background())
+	result, err := client.Get200Model201ModelDefaultError201Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background())
+	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background(), nil)
 	var r *Error
 	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
@@ -73,7 +73,7 @@ func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model204NoModelDefaultError200Valid(context.Background())
+	result, err := client.Get200Model204NoModelDefaultError200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
 func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background())
+	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background(), nil)
 	var r *Error
 	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
@@ -99,7 +99,7 @@ func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
 func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model204NoModelDefaultError202None(context.Background())
+	result, err := client.Get200Model204NoModelDefaultError202None(context.Background(), nil)
 	var r *Error
 	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
@@ -113,7 +113,7 @@ func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
 func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model204NoModelDefaultError204Valid(context.Background())
+	result, err := client.Get200Model204NoModelDefaultError204Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
 func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background())
+	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background(), nil)
 	var r *Error
 	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
@@ -148,7 +148,7 @@ func TestGet200ModelA200Invalid(t *testing.T) {
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
 func TestGet200ModelA200None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA200None(context.Background())
+	result, err := client.Get200ModelA200None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestGet200ModelA200None(t *testing.T) {
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
 func TestGet200ModelA200Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA200Valid(context.Background())
+	result, err := client.Get200ModelA200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestGet200ModelA200Valid(t *testing.T) {
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background())
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background())
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background())
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background(), nil)
 	var r *Error
 	if !errors.As(err, &r) {
 		t.Fatal("unexpected error type")
@@ -221,7 +221,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background())
+	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
 func TestGet200ModelA202Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA200Valid(context.Background())
+	result, err := client.Get200ModelA200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestGet200ModelA400Invalid(t *testing.T) {
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
 func TestGet200ModelA400None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA400None(context.Background())
+	result, err := client.Get200ModelA400None(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -266,7 +266,7 @@ func TestGet200ModelA400None(t *testing.T) {
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
 func TestGet200ModelA400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get200ModelA400Valid(context.Background())
+	result, err := client.Get200ModelA400Valid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -278,7 +278,7 @@ func TestGet200ModelA400Valid(t *testing.T) {
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
 func TestGet202None204NoneDefaultError202None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultError202None(context.Background())
+	result, err := client.Get202None204NoneDefaultError202None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func TestGet202None204NoneDefaultError202None(t *testing.T) {
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultError204None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultError204None(context.Background())
+	result, err := client.Get202None204NoneDefaultError204None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +298,7 @@ func TestGet202None204NoneDefaultError204None(t *testing.T) {
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultError400Valid(context.Background())
+	result, err := client.Get202None204NoneDefaultError400Valid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -310,7 +310,7 @@ func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultNone202Invalid(context.Background())
+	result, err := client.Get202None204NoneDefaultNone202Invalid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultNone204None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultNone204None(context.Background())
+	result, err := client.Get202None204NoneDefaultNone204None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestGet202None204NoneDefaultNone204None(t *testing.T) {
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultNone400Invalid(context.Background())
+	result, err := client.Get202None204NoneDefaultNone400Invalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -342,7 +342,7 @@ func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
 func TestGet202None204NoneDefaultNone400None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.Get202None204NoneDefaultNone400None(context.Background())
+	result, err := client.Get202None204NoneDefaultNone400None(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -354,7 +354,7 @@ func TestGet202None204NoneDefaultNone400None(t *testing.T) {
 // GetDefaultModelA200None - Send a 200 response with no payload
 func TestGetDefaultModelA200None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultModelA200None(context.Background())
+	result, err := client.GetDefaultModelA200None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestGetDefaultModelA200None(t *testing.T) {
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGetDefaultModelA200Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultModelA200Valid(context.Background())
+	result, err := client.GetDefaultModelA200Valid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +378,7 @@ func TestGetDefaultModelA200Valid(t *testing.T) {
 // GetDefaultModelA400None - Send a 400 response with no payload
 func TestGetDefaultModelA400None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultModelA400None(context.Background())
+	result, err := client.GetDefaultModelA400None(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -390,7 +390,7 @@ func TestGetDefaultModelA400None(t *testing.T) {
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultModelA400Valid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultModelA400Valid(context.Background())
+	result, err := client.GetDefaultModelA400Valid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -407,7 +407,7 @@ func TestGetDefaultNone200Invalid(t *testing.T) {
 // GetDefaultNone200None - Send a 200 response with no payload
 func TestGetDefaultNone200None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultNone200None(context.Background())
+	result, err := client.GetDefaultNone200None(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestGetDefaultNone200None(t *testing.T) {
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultNone400Invalid(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultNone400Invalid(context.Background())
+	result, err := client.GetDefaultNone400Invalid(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}
@@ -429,7 +429,7 @@ func TestGetDefaultNone400Invalid(t *testing.T) {
 // GetDefaultNone400None - Send a 400 response with no payload
 func TestGetDefaultNone400None(t *testing.T) {
 	client := newMultipleResponsesClient()
-	result, err := client.GetDefaultNone400None(context.Background())
+	result, err := client.GetDefaultNone400None(context.Background(), nil)
 	if err == nil {
 		t.Fatal("unexpected nil error")
 	}

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -16,7 +16,7 @@ func newHTTPRedirectsClient() HTTPRedirectsOperations {
 
 func TestHTTPRedirectsDelete307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Delete307(context.Background())
+	result, err := client.Delete307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestHTTPRedirectsDelete307(t *testing.T) {
 func TestHTTPRedirectsGet300(t *testing.T) {
 	t.Skip("does not automatically redirect")
 	client := newHTTPRedirectsClient()
-	result, err := client.Get300(context.Background())
+	result, err := client.Get300(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestHTTPRedirectsGet300(t *testing.T) {
 
 func TestHTTPRedirectsGet301(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Get301(context.Background())
+	result, err := client.Get301(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestHTTPRedirectsGet301(t *testing.T) {
 
 func TestHTTPRedirectsGet302(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Get302(context.Background())
+	result, err := client.Get302(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestHTTPRedirectsGet302(t *testing.T) {
 
 func TestHTTPRedirectsGet307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Get307(context.Background())
+	result, err := client.Get307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestHTTPRedirectsGet307(t *testing.T) {
 func TestHTTPRedirectsHead300(t *testing.T) {
 	t.Skip("does not automatically redirect")
 	client := newHTTPRedirectsClient()
-	result, err := client.Head300(context.Background())
+	result, err := client.Head300(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestHTTPRedirectsHead300(t *testing.T) {
 
 func TestHTTPRedirectsHead301(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Head301(context.Background())
+	result, err := client.Head301(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestHTTPRedirectsHead301(t *testing.T) {
 
 func TestHTTPRedirectsHead302(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Head302(context.Background())
+	result, err := client.Head302(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestHTTPRedirectsHead302(t *testing.T) {
 
 func TestHTTPRedirectsHead307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Head307(context.Background())
+	result, err := client.Head307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestHTTPRedirectsHead307(t *testing.T) {
 func TestHTTPRedirectsOptions307(t *testing.T) {
 	t.Skip("receive a status code of 204 which is not expected")
 	client := newHTTPRedirectsClient()
-	result, err := client.Options307(context.Background())
+	result, err := client.Options307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestHTTPRedirectsOptions307(t *testing.T) {
 func TestHTTPRedirectsPatch302(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
 	client := newHTTPRedirectsClient()
-	result, err := client.Patch302(context.Background())
+	result, err := client.Patch302(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestHTTPRedirectsPatch302(t *testing.T) {
 
 func TestHTTPRedirectsPatch307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Patch307(context.Background())
+	result, err := client.Patch307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestHTTPRedirectsPatch307(t *testing.T) {
 
 func TestHTTPRedirectsPost303(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Post303(context.Background())
+	result, err := client.Post303(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestHTTPRedirectsPost303(t *testing.T) {
 
 func TestHTTPRedirectsPost307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Post307(context.Background())
+	result, err := client.Post307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestHTTPRedirectsPost307(t *testing.T) {
 func TestHTTPRedirectsPut301(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
 	client := newHTTPRedirectsClient()
-	result, err := client.Put301(context.Background())
+	result, err := client.Put301(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestHTTPRedirectsPut301(t *testing.T) {
 
 func TestHTTPRedirectsPut307(t *testing.T) {
 	client := newHTTPRedirectsClient()
-	result, err := client.Put307(context.Background())
+	result, err := client.Put307(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -34,7 +34,7 @@ func httpClientWithCookieJar() azcore.Transport {
 
 func TestHTTPRetryDelete503(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Delete503(context.Background())
+	result, err := client.Delete503(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error but received: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestHTTPRetryDelete503(t *testing.T) {
 
 func TestHTTPRetryGet502(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Get502(context.Background())
+	result, err := client.Get502(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestHTTPRetryGet502(t *testing.T) {
 
 func TestHTTPRetryHead408(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Head408(context.Background())
+	result, err := client.Head408(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestHTTPRetryHead408(t *testing.T) {
 func TestHTTPRetryOptions502(t *testing.T) {
 	t.Skip("options method not enabled by test server")
 	client := newHTTPRetryClient()
-	result, err := client.Options502(context.Background())
+	result, err := client.Options502(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestHTTPRetryOptions502(t *testing.T) {
 
 func TestHTTPRetryPatch500(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Patch500(context.Background())
+	result, err := client.Patch500(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestHTTPRetryPatch500(t *testing.T) {
 
 func TestHTTPRetryPatch504(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Patch504(context.Background())
+	result, err := client.Patch504(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestHTTPRetryPatch504(t *testing.T) {
 
 func TestHTTPRetryPost503(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Post503(context.Background())
+	result, err := client.Post503(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestHTTPRetryPost503(t *testing.T) {
 
 func TestHTTPRetryPut500(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Put500(context.Background())
+	result, err := client.Put500(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestHTTPRetryPut500(t *testing.T) {
 
 func TestHTTPRetryPut504(t *testing.T) {
 	client := newHTTPRetryClient()
-	result, err := client.Put504(context.Background())
+	result, err := client.Put504(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -14,7 +14,7 @@ func newHTTPServerFailureClient() HTTPServerFailureOperations {
 
 func TestHTTPServerFailureDelete505(t *testing.T) {
 	client := newHTTPServerFailureClient()
-	result, err := client.Delete505(context.Background())
+	result, err := client.Delete505(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -25,7 +25,7 @@ func TestHTTPServerFailureDelete505(t *testing.T) {
 
 func TestHTTPServerFailureGet501(t *testing.T) {
 	client := newHTTPServerFailureClient()
-	result, err := client.Get501(context.Background())
+	result, err := client.Get501(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -36,7 +36,7 @@ func TestHTTPServerFailureGet501(t *testing.T) {
 
 func TestHTTPServerFailureHead501(t *testing.T) {
 	client := newHTTPServerFailureClient()
-	result, err := client.Head501(context.Background())
+	result, err := client.Head501(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -47,7 +47,7 @@ func TestHTTPServerFailureHead501(t *testing.T) {
 
 func TestHTTPServerFailurePost505(t *testing.T) {
 	client := newHTTPServerFailureClient()
-	result, err := client.Post505(context.Background())
+	result, err := client.Post505(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -16,7 +16,7 @@ func newHTTPSuccessClient() HTTPSuccessOperations {
 
 func TestHTTPSuccessDelete200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Delete200(context.Background())
+	result, err := client.Delete200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestHTTPSuccessDelete200(t *testing.T) {
 
 func TestHTTPSuccessDelete202(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Delete202(context.Background())
+	result, err := client.Delete202(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestHTTPSuccessDelete202(t *testing.T) {
 
 func TestHTTPSuccessDelete204(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Delete204(context.Background())
+	result, err := client.Delete204(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestHTTPSuccessDelete204(t *testing.T) {
 
 func TestHTTPSuccessGet200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Get200(context.Background())
+	result, err := client.Get200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestHTTPSuccessGet200(t *testing.T) {
 
 func TestHTTPSuccessHead200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Head200(context.Background())
+	result, err := client.Head200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestHTTPSuccessHead200(t *testing.T) {
 
 func TestHTTPSuccessHead204(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Head204(context.Background())
+	result, err := client.Head204(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestHTTPSuccessHead204(t *testing.T) {
 
 func TestHTTPSuccessHead404(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Head404(context.Background())
+	result, err := client.Head404(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestHTTPSuccessHead404(t *testing.T) {
 func TestHTTPSuccessOptions200(t *testing.T) {
 	t.Skip("options method not enabled by test server")
 	client := newHTTPSuccessClient()
-	result, err := client.Options200(context.Background())
+	result, err := client.Options200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestHTTPSuccessOptions200(t *testing.T) {
 
 func TestHTTPSuccessPatch200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Patch200(context.Background())
+	result, err := client.Patch200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestHTTPSuccessPatch200(t *testing.T) {
 
 func TestHTTPSuccessPatch202(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Patch202(context.Background())
+	result, err := client.Patch202(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestHTTPSuccessPatch202(t *testing.T) {
 
 func TestHTTPSuccessPatch204(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Patch204(context.Background())
+	result, err := client.Patch204(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestHTTPSuccessPatch204(t *testing.T) {
 
 func TestHTTPSuccessPost200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Post200(context.Background())
+	result, err := client.Post200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestHTTPSuccessPost200(t *testing.T) {
 
 func TestHTTPSuccessPost201(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Post201(context.Background())
+	result, err := client.Post201(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestHTTPSuccessPost201(t *testing.T) {
 
 func TestHTTPSuccessPost202(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Post202(context.Background())
+	result, err := client.Post202(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestHTTPSuccessPost202(t *testing.T) {
 
 func TestHTTPSuccessPost204(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Post204(context.Background())
+	result, err := client.Post204(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestHTTPSuccessPost204(t *testing.T) {
 
 func TestHTTPSuccessPut200(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Put200(context.Background())
+	result, err := client.Put200(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -161,7 +161,7 @@ func TestHTTPSuccessPut200(t *testing.T) {
 
 func TestHTTPSuccessPut201(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Put201(context.Background())
+	result, err := client.Put201(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestHTTPSuccessPut201(t *testing.T) {
 
 func TestHTTPSuccessPut202(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Put202(context.Background())
+	result, err := client.Put202(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestHTTPSuccessPut202(t *testing.T) {
 
 func TestHTTPSuccessPut204(t *testing.T) {
 	client := newHTTPSuccessClient()
-	result, err := client.Put204(context.Background())
+	result, err := client.Put204(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Did not expect an error, but received: %v", err)
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure.go
@@ -14,57 +14,57 @@ import (
 // HTTPClientFailureOperations contains the methods for the HTTPClientFailure group.
 type HTTPClientFailureOperations interface {
 	// Delete400 - Return 400 status code - should be represented in the client as an error
-	Delete400(ctx context.Context) (*http.Response, error)
+	Delete400(ctx context.Context, options *HTTPClientFailureDelete400Options) (*http.Response, error)
 	// Delete407 - Return 407 status code - should be represented in the client as an error
-	Delete407(ctx context.Context) (*http.Response, error)
+	Delete407(ctx context.Context, options *HTTPClientFailureDelete407Options) (*http.Response, error)
 	// Delete417 - Return 417 status code - should be represented in the client as an error
-	Delete417(ctx context.Context) (*http.Response, error)
+	Delete417(ctx context.Context, options *HTTPClientFailureDelete417Options) (*http.Response, error)
 	// Get400 - Return 400 status code - should be represented in the client as an error
-	Get400(ctx context.Context) (*http.Response, error)
+	Get400(ctx context.Context, options *HTTPClientFailureGet400Options) (*http.Response, error)
 	// Get402 - Return 402 status code - should be represented in the client as an error
-	Get402(ctx context.Context) (*http.Response, error)
+	Get402(ctx context.Context, options *HTTPClientFailureGet402Options) (*http.Response, error)
 	// Get403 - Return 403 status code - should be represented in the client as an error
-	Get403(ctx context.Context) (*http.Response, error)
+	Get403(ctx context.Context, options *HTTPClientFailureGet403Options) (*http.Response, error)
 	// Get411 - Return 411 status code - should be represented in the client as an error
-	Get411(ctx context.Context) (*http.Response, error)
+	Get411(ctx context.Context, options *HTTPClientFailureGet411Options) (*http.Response, error)
 	// Get412 - Return 412 status code - should be represented in the client as an error
-	Get412(ctx context.Context) (*http.Response, error)
+	Get412(ctx context.Context, options *HTTPClientFailureGet412Options) (*http.Response, error)
 	// Get416 - Return 416 status code - should be represented in the client as an error
-	Get416(ctx context.Context) (*http.Response, error)
+	Get416(ctx context.Context, options *HTTPClientFailureGet416Options) (*http.Response, error)
 	// Head400 - Return 400 status code - should be represented in the client as an error
-	Head400(ctx context.Context) (*http.Response, error)
+	Head400(ctx context.Context, options *HTTPClientFailureHead400Options) (*http.Response, error)
 	// Head401 - Return 401 status code - should be represented in the client as an error
-	Head401(ctx context.Context) (*http.Response, error)
+	Head401(ctx context.Context, options *HTTPClientFailureHead401Options) (*http.Response, error)
 	// Head410 - Return 410 status code - should be represented in the client as an error
-	Head410(ctx context.Context) (*http.Response, error)
+	Head410(ctx context.Context, options *HTTPClientFailureHead410Options) (*http.Response, error)
 	// Head429 - Return 429 status code - should be represented in the client as an error
-	Head429(ctx context.Context) (*http.Response, error)
+	Head429(ctx context.Context, options *HTTPClientFailureHead429Options) (*http.Response, error)
 	// Options400 - Return 400 status code - should be represented in the client as an error
-	Options400(ctx context.Context) (*http.Response, error)
+	Options400(ctx context.Context, options *HTTPClientFailureOptions400Options) (*http.Response, error)
 	// Options403 - Return 403 status code - should be represented in the client as an error
-	Options403(ctx context.Context) (*http.Response, error)
+	Options403(ctx context.Context, options *HTTPClientFailureOptions403Options) (*http.Response, error)
 	// Options412 - Return 412 status code - should be represented in the client as an error
-	Options412(ctx context.Context) (*http.Response, error)
+	Options412(ctx context.Context, options *HTTPClientFailureOptions412Options) (*http.Response, error)
 	// Patch400 - Return 400 status code - should be represented in the client as an error
-	Patch400(ctx context.Context) (*http.Response, error)
+	Patch400(ctx context.Context, options *HTTPClientFailurePatch400Options) (*http.Response, error)
 	// Patch405 - Return 405 status code - should be represented in the client as an error
-	Patch405(ctx context.Context) (*http.Response, error)
+	Patch405(ctx context.Context, options *HTTPClientFailurePatch405Options) (*http.Response, error)
 	// Patch414 - Return 414 status code - should be represented in the client as an error
-	Patch414(ctx context.Context) (*http.Response, error)
+	Patch414(ctx context.Context, options *HTTPClientFailurePatch414Options) (*http.Response, error)
 	// Post400 - Return 400 status code - should be represented in the client as an error
-	Post400(ctx context.Context) (*http.Response, error)
+	Post400(ctx context.Context, options *HTTPClientFailurePost400Options) (*http.Response, error)
 	// Post406 - Return 406 status code - should be represented in the client as an error
-	Post406(ctx context.Context) (*http.Response, error)
+	Post406(ctx context.Context, options *HTTPClientFailurePost406Options) (*http.Response, error)
 	// Post415 - Return 415 status code - should be represented in the client as an error
-	Post415(ctx context.Context) (*http.Response, error)
+	Post415(ctx context.Context, options *HTTPClientFailurePost415Options) (*http.Response, error)
 	// Put400 - Return 400 status code - should be represented in the client as an error
-	Put400(ctx context.Context) (*http.Response, error)
+	Put400(ctx context.Context, options *HTTPClientFailurePut400Options) (*http.Response, error)
 	// Put404 - Return 404 status code - should be represented in the client as an error
-	Put404(ctx context.Context) (*http.Response, error)
+	Put404(ctx context.Context, options *HTTPClientFailurePut404Options) (*http.Response, error)
 	// Put409 - Return 409 status code - should be represented in the client as an error
-	Put409(ctx context.Context) (*http.Response, error)
+	Put409(ctx context.Context, options *HTTPClientFailurePut409Options) (*http.Response, error)
 	// Put413 - Return 413 status code - should be represented in the client as an error
-	Put413(ctx context.Context) (*http.Response, error)
+	Put413(ctx context.Context, options *HTTPClientFailurePut413Options) (*http.Response, error)
 }
 
 // HTTPClientFailureClient implements the HTTPClientFailureOperations interface.
@@ -84,8 +84,8 @@ func (client *HTTPClientFailureClient) Do(req *azcore.Request) (*azcore.Response
 }
 
 // Delete400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Delete400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Delete400(ctx context.Context, options *HTTPClientFailureDelete400Options) (*http.Response, error) {
+	req, err := client.Delete400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (client *HTTPClientFailureClient) Delete400(ctx context.Context) (*http.Res
 }
 
 // Delete400CreateRequest creates the Delete400 request.
-func (client *HTTPClientFailureClient) Delete400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Delete400CreateRequest(ctx context.Context, options *HTTPClientFailureDelete400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -120,8 +120,8 @@ func (client *HTTPClientFailureClient) Delete400HandleError(resp *azcore.Respons
 }
 
 // Delete407 - Return 407 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Delete407(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete407CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Delete407(ctx context.Context, options *HTTPClientFailureDelete407Options) (*http.Response, error) {
+	req, err := client.Delete407CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (client *HTTPClientFailureClient) Delete407(ctx context.Context) (*http.Res
 }
 
 // Delete407CreateRequest creates the Delete407 request.
-func (client *HTTPClientFailureClient) Delete407CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Delete407CreateRequest(ctx context.Context, options *HTTPClientFailureDelete407Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/407"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -156,8 +156,8 @@ func (client *HTTPClientFailureClient) Delete407HandleError(resp *azcore.Respons
 }
 
 // Delete417 - Return 417 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Delete417(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete417CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Delete417(ctx context.Context, options *HTTPClientFailureDelete417Options) (*http.Response, error) {
+	req, err := client.Delete417CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (client *HTTPClientFailureClient) Delete417(ctx context.Context) (*http.Res
 }
 
 // Delete417CreateRequest creates the Delete417 request.
-func (client *HTTPClientFailureClient) Delete417CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Delete417CreateRequest(ctx context.Context, options *HTTPClientFailureDelete417Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/417"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -192,8 +192,8 @@ func (client *HTTPClientFailureClient) Delete417HandleError(resp *azcore.Respons
 }
 
 // Get400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get400(ctx context.Context, options *HTTPClientFailureGet400Options) (*http.Response, error) {
+	req, err := client.Get400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (client *HTTPClientFailureClient) Get400(ctx context.Context) (*http.Respon
 }
 
 // Get400CreateRequest creates the Get400 request.
-func (client *HTTPClientFailureClient) Get400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get400CreateRequest(ctx context.Context, options *HTTPClientFailureGet400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -228,8 +228,8 @@ func (client *HTTPClientFailureClient) Get400HandleError(resp *azcore.Response) 
 }
 
 // Get402 - Return 402 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get402(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get402CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get402(ctx context.Context, options *HTTPClientFailureGet402Options) (*http.Response, error) {
+	req, err := client.Get402CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (client *HTTPClientFailureClient) Get402(ctx context.Context) (*http.Respon
 }
 
 // Get402CreateRequest creates the Get402 request.
-func (client *HTTPClientFailureClient) Get402CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get402CreateRequest(ctx context.Context, options *HTTPClientFailureGet402Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/402"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -264,8 +264,8 @@ func (client *HTTPClientFailureClient) Get402HandleError(resp *azcore.Response) 
 }
 
 // Get403 - Return 403 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get403(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get403CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get403(ctx context.Context, options *HTTPClientFailureGet403Options) (*http.Response, error) {
+	req, err := client.Get403CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (client *HTTPClientFailureClient) Get403(ctx context.Context) (*http.Respon
 }
 
 // Get403CreateRequest creates the Get403 request.
-func (client *HTTPClientFailureClient) Get403CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get403CreateRequest(ctx context.Context, options *HTTPClientFailureGet403Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/403"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -300,8 +300,8 @@ func (client *HTTPClientFailureClient) Get403HandleError(resp *azcore.Response) 
 }
 
 // Get411 - Return 411 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get411(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get411CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get411(ctx context.Context, options *HTTPClientFailureGet411Options) (*http.Response, error) {
+	req, err := client.Get411CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (client *HTTPClientFailureClient) Get411(ctx context.Context) (*http.Respon
 }
 
 // Get411CreateRequest creates the Get411 request.
-func (client *HTTPClientFailureClient) Get411CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get411CreateRequest(ctx context.Context, options *HTTPClientFailureGet411Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/411"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -336,8 +336,8 @@ func (client *HTTPClientFailureClient) Get411HandleError(resp *azcore.Response) 
 }
 
 // Get412 - Return 412 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get412(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get412CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get412(ctx context.Context, options *HTTPClientFailureGet412Options) (*http.Response, error) {
+	req, err := client.Get412CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (client *HTTPClientFailureClient) Get412(ctx context.Context) (*http.Respon
 }
 
 // Get412CreateRequest creates the Get412 request.
-func (client *HTTPClientFailureClient) Get412CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get412CreateRequest(ctx context.Context, options *HTTPClientFailureGet412Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/412"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -372,8 +372,8 @@ func (client *HTTPClientFailureClient) Get412HandleError(resp *azcore.Response) 
 }
 
 // Get416 - Return 416 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Get416(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get416CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Get416(ctx context.Context, options *HTTPClientFailureGet416Options) (*http.Response, error) {
+	req, err := client.Get416CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (client *HTTPClientFailureClient) Get416(ctx context.Context) (*http.Respon
 }
 
 // Get416CreateRequest creates the Get416 request.
-func (client *HTTPClientFailureClient) Get416CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Get416CreateRequest(ctx context.Context, options *HTTPClientFailureGet416Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/416"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -408,8 +408,8 @@ func (client *HTTPClientFailureClient) Get416HandleError(resp *azcore.Response) 
 }
 
 // Head400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Head400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Head400(ctx context.Context, options *HTTPClientFailureHead400Options) (*http.Response, error) {
+	req, err := client.Head400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context) (*http.Respo
 }
 
 // Head400CreateRequest creates the Head400 request.
-func (client *HTTPClientFailureClient) Head400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Head400CreateRequest(ctx context.Context, options *HTTPClientFailureHead400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -444,8 +444,8 @@ func (client *HTTPClientFailureClient) Head400HandleError(resp *azcore.Response)
 }
 
 // Head401 - Return 401 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Head401(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head401CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Head401(ctx context.Context, options *HTTPClientFailureHead401Options) (*http.Response, error) {
+	req, err := client.Head401CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +460,7 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context) (*http.Respo
 }
 
 // Head401CreateRequest creates the Head401 request.
-func (client *HTTPClientFailureClient) Head401CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Head401CreateRequest(ctx context.Context, options *HTTPClientFailureHead401Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/401"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -480,8 +480,8 @@ func (client *HTTPClientFailureClient) Head401HandleError(resp *azcore.Response)
 }
 
 // Head410 - Return 410 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Head410(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head410CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Head410(ctx context.Context, options *HTTPClientFailureHead410Options) (*http.Response, error) {
+	req, err := client.Head410CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context) (*http.Respo
 }
 
 // Head410CreateRequest creates the Head410 request.
-func (client *HTTPClientFailureClient) Head410CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Head410CreateRequest(ctx context.Context, options *HTTPClientFailureHead410Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/410"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -516,8 +516,8 @@ func (client *HTTPClientFailureClient) Head410HandleError(resp *azcore.Response)
 }
 
 // Head429 - Return 429 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Head429(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head429CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Head429(ctx context.Context, options *HTTPClientFailureHead429Options) (*http.Response, error) {
+	req, err := client.Head429CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +532,7 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context) (*http.Respo
 }
 
 // Head429CreateRequest creates the Head429 request.
-func (client *HTTPClientFailureClient) Head429CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Head429CreateRequest(ctx context.Context, options *HTTPClientFailureHead429Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/429"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -552,8 +552,8 @@ func (client *HTTPClientFailureClient) Head429HandleError(resp *azcore.Response)
 }
 
 // Options400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Options400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Options400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Options400(ctx context.Context, options *HTTPClientFailureOptions400Options) (*http.Response, error) {
+	req, err := client.Options400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func (client *HTTPClientFailureClient) Options400(ctx context.Context) (*http.Re
 }
 
 // Options400CreateRequest creates the Options400 request.
-func (client *HTTPClientFailureClient) Options400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Options400CreateRequest(ctx context.Context, options *HTTPClientFailureOptions400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -588,8 +588,8 @@ func (client *HTTPClientFailureClient) Options400HandleError(resp *azcore.Respon
 }
 
 // Options403 - Return 403 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Options403(ctx context.Context) (*http.Response, error) {
-	req, err := client.Options403CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Options403(ctx context.Context, options *HTTPClientFailureOptions403Options) (*http.Response, error) {
+	req, err := client.Options403CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +604,7 @@ func (client *HTTPClientFailureClient) Options403(ctx context.Context) (*http.Re
 }
 
 // Options403CreateRequest creates the Options403 request.
-func (client *HTTPClientFailureClient) Options403CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Options403CreateRequest(ctx context.Context, options *HTTPClientFailureOptions403Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/403"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -624,8 +624,8 @@ func (client *HTTPClientFailureClient) Options403HandleError(resp *azcore.Respon
 }
 
 // Options412 - Return 412 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Options412(ctx context.Context) (*http.Response, error) {
-	req, err := client.Options412CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Options412(ctx context.Context, options *HTTPClientFailureOptions412Options) (*http.Response, error) {
+	req, err := client.Options412CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -640,7 +640,7 @@ func (client *HTTPClientFailureClient) Options412(ctx context.Context) (*http.Re
 }
 
 // Options412CreateRequest creates the Options412 request.
-func (client *HTTPClientFailureClient) Options412CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Options412CreateRequest(ctx context.Context, options *HTTPClientFailureOptions412Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/412"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -660,8 +660,8 @@ func (client *HTTPClientFailureClient) Options412HandleError(resp *azcore.Respon
 }
 
 // Patch400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Patch400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Patch400(ctx context.Context, options *HTTPClientFailurePatch400Options) (*http.Response, error) {
+	req, err := client.Patch400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +676,7 @@ func (client *HTTPClientFailureClient) Patch400(ctx context.Context) (*http.Resp
 }
 
 // Patch400CreateRequest creates the Patch400 request.
-func (client *HTTPClientFailureClient) Patch400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Patch400CreateRequest(ctx context.Context, options *HTTPClientFailurePatch400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -696,8 +696,8 @@ func (client *HTTPClientFailureClient) Patch400HandleError(resp *azcore.Response
 }
 
 // Patch405 - Return 405 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Patch405(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch405CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Patch405(ctx context.Context, options *HTTPClientFailurePatch405Options) (*http.Response, error) {
+	req, err := client.Patch405CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -712,7 +712,7 @@ func (client *HTTPClientFailureClient) Patch405(ctx context.Context) (*http.Resp
 }
 
 // Patch405CreateRequest creates the Patch405 request.
-func (client *HTTPClientFailureClient) Patch405CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Patch405CreateRequest(ctx context.Context, options *HTTPClientFailurePatch405Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/405"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -732,8 +732,8 @@ func (client *HTTPClientFailureClient) Patch405HandleError(resp *azcore.Response
 }
 
 // Patch414 - Return 414 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Patch414(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch414CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Patch414(ctx context.Context, options *HTTPClientFailurePatch414Options) (*http.Response, error) {
+	req, err := client.Patch414CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +748,7 @@ func (client *HTTPClientFailureClient) Patch414(ctx context.Context) (*http.Resp
 }
 
 // Patch414CreateRequest creates the Patch414 request.
-func (client *HTTPClientFailureClient) Patch414CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Patch414CreateRequest(ctx context.Context, options *HTTPClientFailurePatch414Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/414"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -768,8 +768,8 @@ func (client *HTTPClientFailureClient) Patch414HandleError(resp *azcore.Response
 }
 
 // Post400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Post400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Post400(ctx context.Context, options *HTTPClientFailurePost400Options) (*http.Response, error) {
+	req, err := client.Post400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +784,7 @@ func (client *HTTPClientFailureClient) Post400(ctx context.Context) (*http.Respo
 }
 
 // Post400CreateRequest creates the Post400 request.
-func (client *HTTPClientFailureClient) Post400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Post400CreateRequest(ctx context.Context, options *HTTPClientFailurePost400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -804,8 +804,8 @@ func (client *HTTPClientFailureClient) Post400HandleError(resp *azcore.Response)
 }
 
 // Post406 - Return 406 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Post406(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post406CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Post406(ctx context.Context, options *HTTPClientFailurePost406Options) (*http.Response, error) {
+	req, err := client.Post406CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +820,7 @@ func (client *HTTPClientFailureClient) Post406(ctx context.Context) (*http.Respo
 }
 
 // Post406CreateRequest creates the Post406 request.
-func (client *HTTPClientFailureClient) Post406CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Post406CreateRequest(ctx context.Context, options *HTTPClientFailurePost406Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/406"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -840,8 +840,8 @@ func (client *HTTPClientFailureClient) Post406HandleError(resp *azcore.Response)
 }
 
 // Post415 - Return 415 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Post415(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post415CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Post415(ctx context.Context, options *HTTPClientFailurePost415Options) (*http.Response, error) {
+	req, err := client.Post415CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -856,7 +856,7 @@ func (client *HTTPClientFailureClient) Post415(ctx context.Context) (*http.Respo
 }
 
 // Post415CreateRequest creates the Post415 request.
-func (client *HTTPClientFailureClient) Post415CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Post415CreateRequest(ctx context.Context, options *HTTPClientFailurePost415Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/415"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -876,8 +876,8 @@ func (client *HTTPClientFailureClient) Post415HandleError(resp *azcore.Response)
 }
 
 // Put400 - Return 400 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Put400(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put400CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Put400(ctx context.Context, options *HTTPClientFailurePut400Options) (*http.Response, error) {
+	req, err := client.Put400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +892,7 @@ func (client *HTTPClientFailureClient) Put400(ctx context.Context) (*http.Respon
 }
 
 // Put400CreateRequest creates the Put400 request.
-func (client *HTTPClientFailureClient) Put400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Put400CreateRequest(ctx context.Context, options *HTTPClientFailurePut400Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -912,8 +912,8 @@ func (client *HTTPClientFailureClient) Put400HandleError(resp *azcore.Response) 
 }
 
 // Put404 - Return 404 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Put404(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put404CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Put404(ctx context.Context, options *HTTPClientFailurePut404Options) (*http.Response, error) {
+	req, err := client.Put404CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -928,7 +928,7 @@ func (client *HTTPClientFailureClient) Put404(ctx context.Context) (*http.Respon
 }
 
 // Put404CreateRequest creates the Put404 request.
-func (client *HTTPClientFailureClient) Put404CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Put404CreateRequest(ctx context.Context, options *HTTPClientFailurePut404Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/404"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -948,8 +948,8 @@ func (client *HTTPClientFailureClient) Put404HandleError(resp *azcore.Response) 
 }
 
 // Put409 - Return 409 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Put409(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put409CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Put409(ctx context.Context, options *HTTPClientFailurePut409Options) (*http.Response, error) {
+	req, err := client.Put409CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -964,7 +964,7 @@ func (client *HTTPClientFailureClient) Put409(ctx context.Context) (*http.Respon
 }
 
 // Put409CreateRequest creates the Put409 request.
-func (client *HTTPClientFailureClient) Put409CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Put409CreateRequest(ctx context.Context, options *HTTPClientFailurePut409Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/409"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -984,8 +984,8 @@ func (client *HTTPClientFailureClient) Put409HandleError(resp *azcore.Response) 
 }
 
 // Put413 - Return 413 status code - should be represented in the client as an error
-func (client *HTTPClientFailureClient) Put413(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put413CreateRequest(ctx)
+func (client *HTTPClientFailureClient) Put413(ctx context.Context, options *HTTPClientFailurePut413Options) (*http.Response, error) {
+	req, err := client.Put413CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1000,7 +1000,7 @@ func (client *HTTPClientFailureClient) Put413(ctx context.Context) (*http.Respon
 }
 
 // Put413CreateRequest creates the Put413 request.
-func (client *HTTPClientFailureClient) Put413CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPClientFailureClient) Put413CreateRequest(ctx context.Context, options *HTTPClientFailurePut413Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/client/413"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -17,11 +17,11 @@ import (
 // HTTPFailureOperations contains the methods for the HTTPFailure group.
 type HTTPFailureOperations interface {
 	// GetEmptyError - Get empty error form server
-	GetEmptyError(ctx context.Context) (*BoolResponse, error)
+	GetEmptyError(ctx context.Context, options *HTTPFailureGetEmptyErrorOptions) (*BoolResponse, error)
 	// GetNoModelEmpty - Get empty response from server
-	GetNoModelEmpty(ctx context.Context) (*BoolResponse, error)
+	GetNoModelEmpty(ctx context.Context, options *HTTPFailureGetNoModelEmptyOptions) (*BoolResponse, error)
 	// GetNoModelError - Get empty error form server
-	GetNoModelError(ctx context.Context) (*BoolResponse, error)
+	GetNoModelError(ctx context.Context, options *HTTPFailureGetNoModelErrorOptions) (*BoolResponse, error)
 }
 
 // HTTPFailureClient implements the HTTPFailureOperations interface.
@@ -41,8 +41,8 @@ func (client *HTTPFailureClient) Do(req *azcore.Request) (*azcore.Response, erro
 }
 
 // GetEmptyError - Get empty error form server
-func (client *HTTPFailureClient) GetEmptyError(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetEmptyErrorCreateRequest(ctx)
+func (client *HTTPFailureClient) GetEmptyError(ctx context.Context, options *HTTPFailureGetEmptyErrorOptions) (*BoolResponse, error) {
+	req, err := client.GetEmptyErrorCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func (client *HTTPFailureClient) GetEmptyError(ctx context.Context) (*BoolRespon
 }
 
 // GetEmptyErrorCreateRequest creates the GetEmptyError request.
-func (client *HTTPFailureClient) GetEmptyErrorCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPFailureClient) GetEmptyErrorCreateRequest(ctx context.Context, options *HTTPFailureGetEmptyErrorOptions) (*azcore.Request, error) {
 	urlPath := "/http/failure/emptybody/error"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -87,8 +87,8 @@ func (client *HTTPFailureClient) GetEmptyErrorHandleError(resp *azcore.Response)
 }
 
 // GetNoModelEmpty - Get empty response from server
-func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetNoModelEmptyCreateRequest(ctx)
+func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context, options *HTTPFailureGetNoModelEmptyOptions) (*BoolResponse, error) {
+	req, err := client.GetNoModelEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context) (*BoolResp
 }
 
 // GetNoModelEmptyCreateRequest creates the GetNoModelEmpty request.
-func (client *HTTPFailureClient) GetNoModelEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPFailureClient) GetNoModelEmptyCreateRequest(ctx context.Context, options *HTTPFailureGetNoModelEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/http/failure/nomodel/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *HTTPFailureClient) GetNoModelEmptyHandleError(resp *azcore.Respons
 }
 
 // GetNoModelError - Get empty error form server
-func (client *HTTPFailureClient) GetNoModelError(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.GetNoModelErrorCreateRequest(ctx)
+func (client *HTTPFailureClient) GetNoModelError(ctx context.Context, options *HTTPFailureGetNoModelErrorOptions) (*BoolResponse, error) {
+	req, err := client.GetNoModelErrorCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *HTTPFailureClient) GetNoModelError(ctx context.Context) (*BoolResp
 }
 
 // GetNoModelErrorCreateRequest creates the GetNoModelError request.
-func (client *HTTPFailureClient) GetNoModelErrorCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPFailureClient) GetNoModelErrorCreateRequest(ctx context.Context, options *HTTPFailureGetNoModelErrorOptions) (*azcore.Request, error) {
 	urlPath := "/http/failure/nomodel/error"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -15,38 +15,38 @@ import (
 // HTTPRedirectsOperations contains the methods for the HTTPRedirects group.
 type HTTPRedirectsOperations interface {
 	// Delete307 - Delete redirected with 307, resulting in a 200 after redirect
-	Delete307(ctx context.Context) (*http.Response, error)
+	Delete307(ctx context.Context, options *HTTPRedirectsDelete307Options) (*http.Response, error)
 	// Get300 - Return 300 status code and redirect to /http/success/200
 	// Possible return types are *HTTPRedirectsGet300Response, *StringArrayResponse
-	Get300(ctx context.Context) (interface{}, error)
+	Get300(ctx context.Context, options *HTTPRedirectsGet300Options) (interface{}, error)
 	// Get301 - Return 301 status code and redirect to /http/success/200
-	Get301(ctx context.Context) (*http.Response, error)
+	Get301(ctx context.Context, options *HTTPRedirectsGet301Options) (*http.Response, error)
 	// Get302 - Return 302 status code and redirect to /http/success/200
-	Get302(ctx context.Context) (*http.Response, error)
+	Get302(ctx context.Context, options *HTTPRedirectsGet302Options) (*http.Response, error)
 	// Get307 - Redirect get with 307, resulting in a 200 success
-	Get307(ctx context.Context) (*http.Response, error)
+	Get307(ctx context.Context, options *HTTPRedirectsGet307Options) (*http.Response, error)
 	// Head300 - Return 300 status code and redirect to /http/success/200
-	Head300(ctx context.Context) (*HTTPRedirectsHead300Response, error)
+	Head300(ctx context.Context, options *HTTPRedirectsHead300Options) (*HTTPRedirectsHead300Response, error)
 	// Head301 - Return 301 status code and redirect to /http/success/200
-	Head301(ctx context.Context) (*http.Response, error)
+	Head301(ctx context.Context, options *HTTPRedirectsHead301Options) (*http.Response, error)
 	// Head302 - Return 302 status code and redirect to /http/success/200
-	Head302(ctx context.Context) (*http.Response, error)
+	Head302(ctx context.Context, options *HTTPRedirectsHead302Options) (*http.Response, error)
 	// Head307 - Redirect with 307, resulting in a 200 success
-	Head307(ctx context.Context) (*http.Response, error)
+	Head307(ctx context.Context, options *HTTPRedirectsHead307Options) (*http.Response, error)
 	// Options307 - options redirected with 307, resulting in a 200 after redirect
-	Options307(ctx context.Context) (*http.Response, error)
+	Options307(ctx context.Context, options *HTTPRedirectsOptions307Options) (*http.Response, error)
 	// Patch302 - Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation
-	Patch302(ctx context.Context) (*HTTPRedirectsPatch302Response, error)
+	Patch302(ctx context.Context, options *HTTPRedirectsPatch302Options) (*HTTPRedirectsPatch302Response, error)
 	// Patch307 - Patch redirected with 307, resulting in a 200 after redirect
-	Patch307(ctx context.Context) (*http.Response, error)
+	Patch307(ctx context.Context, options *HTTPRedirectsPatch307Options) (*http.Response, error)
 	// Post303 - Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code
-	Post303(ctx context.Context) (*HTTPRedirectsPost303Response, error)
+	Post303(ctx context.Context, options *HTTPRedirectsPost303Options) (*HTTPRedirectsPost303Response, error)
 	// Post307 - Post redirected with 307, resulting in a 200 after redirect
-	Post307(ctx context.Context) (*http.Response, error)
+	Post307(ctx context.Context, options *HTTPRedirectsPost307Options) (*http.Response, error)
 	// Put301 - Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation
-	Put301(ctx context.Context) (*HTTPRedirectsPut301Response, error)
+	Put301(ctx context.Context, options *HTTPRedirectsPut301Options) (*HTTPRedirectsPut301Response, error)
 	// Put307 - Put redirected with 307, resulting in a 200 after redirect
-	Put307(ctx context.Context) (*http.Response, error)
+	Put307(ctx context.Context, options *HTTPRedirectsPut307Options) (*http.Response, error)
 }
 
 // HTTPRedirectsClient implements the HTTPRedirectsOperations interface.
@@ -66,8 +66,8 @@ func (client *HTTPRedirectsClient) Do(req *azcore.Request) (*azcore.Response, er
 }
 
 // Delete307 - Delete redirected with 307, resulting in a 200 after redirect
-func (client *HTTPRedirectsClient) Delete307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Delete307(ctx context.Context, options *HTTPRedirectsDelete307Options) (*http.Response, error) {
+	req, err := client.Delete307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (client *HTTPRedirectsClient) Delete307(ctx context.Context) (*http.Respons
 }
 
 // Delete307CreateRequest creates the Delete307 request.
-func (client *HTTPRedirectsClient) Delete307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Delete307CreateRequest(ctx context.Context, options *HTTPRedirectsDelete307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -103,8 +103,8 @@ func (client *HTTPRedirectsClient) Delete307HandleError(resp *azcore.Response) e
 
 // Get300 - Return 300 status code and redirect to /http/success/200
 // Possible return types are *HTTPRedirectsGet300Response, *StringArrayResponse
-func (client *HTTPRedirectsClient) Get300(ctx context.Context) (interface{}, error) {
-	req, err := client.Get300CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Get300(ctx context.Context, options *HTTPRedirectsGet300Options) (interface{}, error) {
+	req, err := client.Get300CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (client *HTTPRedirectsClient) Get300(ctx context.Context) (interface{}, err
 }
 
 // Get300CreateRequest creates the Get300 request.
-func (client *HTTPRedirectsClient) Get300CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Get300CreateRequest(ctx context.Context, options *HTTPRedirectsGet300Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/300"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -163,8 +163,8 @@ func (client *HTTPRedirectsClient) Get300HandleError(resp *azcore.Response) erro
 }
 
 // Get301 - Return 301 status code and redirect to /http/success/200
-func (client *HTTPRedirectsClient) Get301(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get301CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Get301(ctx context.Context, options *HTTPRedirectsGet301Options) (*http.Response, error) {
+	req, err := client.Get301CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (client *HTTPRedirectsClient) Get301(ctx context.Context) (*http.Response, 
 }
 
 // Get301CreateRequest creates the Get301 request.
-func (client *HTTPRedirectsClient) Get301CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Get301CreateRequest(ctx context.Context, options *HTTPRedirectsGet301Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -199,8 +199,8 @@ func (client *HTTPRedirectsClient) Get301HandleError(resp *azcore.Response) erro
 }
 
 // Get302 - Return 302 status code and redirect to /http/success/200
-func (client *HTTPRedirectsClient) Get302(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get302CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Get302(ctx context.Context, options *HTTPRedirectsGet302Options) (*http.Response, error) {
+	req, err := client.Get302CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func (client *HTTPRedirectsClient) Get302(ctx context.Context) (*http.Response, 
 }
 
 // Get302CreateRequest creates the Get302 request.
-func (client *HTTPRedirectsClient) Get302CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Get302CreateRequest(ctx context.Context, options *HTTPRedirectsGet302Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -235,8 +235,8 @@ func (client *HTTPRedirectsClient) Get302HandleError(resp *azcore.Response) erro
 }
 
 // Get307 - Redirect get with 307, resulting in a 200 success
-func (client *HTTPRedirectsClient) Get307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Get307(ctx context.Context, options *HTTPRedirectsGet307Options) (*http.Response, error) {
+	req, err := client.Get307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (client *HTTPRedirectsClient) Get307(ctx context.Context) (*http.Response, 
 }
 
 // Get307CreateRequest creates the Get307 request.
-func (client *HTTPRedirectsClient) Get307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Get307CreateRequest(ctx context.Context, options *HTTPRedirectsGet307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -271,8 +271,8 @@ func (client *HTTPRedirectsClient) Get307HandleError(resp *azcore.Response) erro
 }
 
 // Head300 - Return 300 status code and redirect to /http/success/200
-func (client *HTTPRedirectsClient) Head300(ctx context.Context) (*HTTPRedirectsHead300Response, error) {
-	req, err := client.Head300CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Head300(ctx context.Context, options *HTTPRedirectsHead300Options) (*HTTPRedirectsHead300Response, error) {
+	req, err := client.Head300CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (client *HTTPRedirectsClient) Head300(ctx context.Context) (*HTTPRedirectsH
 }
 
 // Head300CreateRequest creates the Head300 request.
-func (client *HTTPRedirectsClient) Head300CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Head300CreateRequest(ctx context.Context, options *HTTPRedirectsHead300Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/300"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -320,8 +320,8 @@ func (client *HTTPRedirectsClient) Head300HandleError(resp *azcore.Response) err
 }
 
 // Head301 - Return 301 status code and redirect to /http/success/200
-func (client *HTTPRedirectsClient) Head301(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head301CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Head301(ctx context.Context, options *HTTPRedirectsHead301Options) (*http.Response, error) {
+	req, err := client.Head301CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context) (*http.Response,
 }
 
 // Head301CreateRequest creates the Head301 request.
-func (client *HTTPRedirectsClient) Head301CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Head301CreateRequest(ctx context.Context, options *HTTPRedirectsHead301Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -356,8 +356,8 @@ func (client *HTTPRedirectsClient) Head301HandleError(resp *azcore.Response) err
 }
 
 // Head302 - Return 302 status code and redirect to /http/success/200
-func (client *HTTPRedirectsClient) Head302(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head302CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Head302(ctx context.Context, options *HTTPRedirectsHead302Options) (*http.Response, error) {
+	req, err := client.Head302CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context) (*http.Response,
 }
 
 // Head302CreateRequest creates the Head302 request.
-func (client *HTTPRedirectsClient) Head302CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Head302CreateRequest(ctx context.Context, options *HTTPRedirectsHead302Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -392,8 +392,8 @@ func (client *HTTPRedirectsClient) Head302HandleError(resp *azcore.Response) err
 }
 
 // Head307 - Redirect with 307, resulting in a 200 success
-func (client *HTTPRedirectsClient) Head307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Head307(ctx context.Context, options *HTTPRedirectsHead307Options) (*http.Response, error) {
+	req, err := client.Head307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context) (*http.Response,
 }
 
 // Head307CreateRequest creates the Head307 request.
-func (client *HTTPRedirectsClient) Head307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Head307CreateRequest(ctx context.Context, options *HTTPRedirectsHead307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -428,8 +428,8 @@ func (client *HTTPRedirectsClient) Head307HandleError(resp *azcore.Response) err
 }
 
 // Options307 - options redirected with 307, resulting in a 200 after redirect
-func (client *HTTPRedirectsClient) Options307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Options307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Options307(ctx context.Context, options *HTTPRedirectsOptions307Options) (*http.Response, error) {
+	req, err := client.Options307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (client *HTTPRedirectsClient) Options307(ctx context.Context) (*http.Respon
 }
 
 // Options307CreateRequest creates the Options307 request.
-func (client *HTTPRedirectsClient) Options307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Options307CreateRequest(ctx context.Context, options *HTTPRedirectsOptions307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -464,8 +464,8 @@ func (client *HTTPRedirectsClient) Options307HandleError(resp *azcore.Response) 
 }
 
 // Patch302 - Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation
-func (client *HTTPRedirectsClient) Patch302(ctx context.Context) (*HTTPRedirectsPatch302Response, error) {
-	req, err := client.Patch302CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Patch302(ctx context.Context, options *HTTPRedirectsPatch302Options) (*HTTPRedirectsPatch302Response, error) {
+	req, err := client.Patch302CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +484,7 @@ func (client *HTTPRedirectsClient) Patch302(ctx context.Context) (*HTTPRedirects
 }
 
 // Patch302CreateRequest creates the Patch302 request.
-func (client *HTTPRedirectsClient) Patch302CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Patch302CreateRequest(ctx context.Context, options *HTTPRedirectsPatch302Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/302"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -513,8 +513,8 @@ func (client *HTTPRedirectsClient) Patch302HandleError(resp *azcore.Response) er
 }
 
 // Patch307 - Patch redirected with 307, resulting in a 200 after redirect
-func (client *HTTPRedirectsClient) Patch307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Patch307(ctx context.Context, options *HTTPRedirectsPatch307Options) (*http.Response, error) {
+	req, err := client.Patch307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +529,7 @@ func (client *HTTPRedirectsClient) Patch307(ctx context.Context) (*http.Response
 }
 
 // Patch307CreateRequest creates the Patch307 request.
-func (client *HTTPRedirectsClient) Patch307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Patch307CreateRequest(ctx context.Context, options *HTTPRedirectsPatch307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -549,8 +549,8 @@ func (client *HTTPRedirectsClient) Patch307HandleError(resp *azcore.Response) er
 }
 
 // Post303 - Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code
-func (client *HTTPRedirectsClient) Post303(ctx context.Context) (*HTTPRedirectsPost303Response, error) {
-	req, err := client.Post303CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Post303(ctx context.Context, options *HTTPRedirectsPost303Options) (*HTTPRedirectsPost303Response, error) {
+	req, err := client.Post303CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (client *HTTPRedirectsClient) Post303(ctx context.Context) (*HTTPRedirectsP
 }
 
 // Post303CreateRequest creates the Post303 request.
-func (client *HTTPRedirectsClient) Post303CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Post303CreateRequest(ctx context.Context, options *HTTPRedirectsPost303Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/303"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -598,8 +598,8 @@ func (client *HTTPRedirectsClient) Post303HandleError(resp *azcore.Response) err
 }
 
 // Post307 - Post redirected with 307, resulting in a 200 after redirect
-func (client *HTTPRedirectsClient) Post307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Post307(ctx context.Context, options *HTTPRedirectsPost307Options) (*http.Response, error) {
+	req, err := client.Post307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +614,7 @@ func (client *HTTPRedirectsClient) Post307(ctx context.Context) (*http.Response,
 }
 
 // Post307CreateRequest creates the Post307 request.
-func (client *HTTPRedirectsClient) Post307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Post307CreateRequest(ctx context.Context, options *HTTPRedirectsPost307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -634,8 +634,8 @@ func (client *HTTPRedirectsClient) Post307HandleError(resp *azcore.Response) err
 }
 
 // Put301 - Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation
-func (client *HTTPRedirectsClient) Put301(ctx context.Context) (*HTTPRedirectsPut301Response, error) {
-	req, err := client.Put301CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Put301(ctx context.Context, options *HTTPRedirectsPut301Options) (*HTTPRedirectsPut301Response, error) {
+	req, err := client.Put301CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +654,7 @@ func (client *HTTPRedirectsClient) Put301(ctx context.Context) (*HTTPRedirectsPu
 }
 
 // Put301CreateRequest creates the Put301 request.
-func (client *HTTPRedirectsClient) Put301CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Put301CreateRequest(ctx context.Context, options *HTTPRedirectsPut301Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/301"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -683,8 +683,8 @@ func (client *HTTPRedirectsClient) Put301HandleError(resp *azcore.Response) erro
 }
 
 // Put307 - Put redirected with 307, resulting in a 200 after redirect
-func (client *HTTPRedirectsClient) Put307(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put307CreateRequest(ctx)
+func (client *HTTPRedirectsClient) Put307(ctx context.Context, options *HTTPRedirectsPut307Options) (*http.Response, error) {
+	req, err := client.Put307CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -699,7 +699,7 @@ func (client *HTTPRedirectsClient) Put307(ctx context.Context) (*http.Response, 
 }
 
 // Put307CreateRequest creates the Put307 request.
-func (client *HTTPRedirectsClient) Put307CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRedirectsClient) Put307CreateRequest(ctx context.Context, options *HTTPRedirectsPut307Options) (*azcore.Request, error) {
 	urlPath := "/http/redirect/307"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -14,23 +14,23 @@ import (
 // HTTPRetryOperations contains the methods for the HTTPRetry group.
 type HTTPRetryOperations interface {
 	// Delete503 - Return 503 status code, then 200 after retry
-	Delete503(ctx context.Context) (*http.Response, error)
+	Delete503(ctx context.Context, options *HTTPRetryDelete503Options) (*http.Response, error)
 	// Get502 - Return 502 status code, then 200 after retry
-	Get502(ctx context.Context) (*http.Response, error)
+	Get502(ctx context.Context, options *HTTPRetryGet502Options) (*http.Response, error)
 	// Head408 - Return 408 status code, then 200 after retry
-	Head408(ctx context.Context) (*http.Response, error)
+	Head408(ctx context.Context, options *HTTPRetryHead408Options) (*http.Response, error)
 	// Options502 - Return 502 status code, then 200 after retry
-	Options502(ctx context.Context) (*BoolResponse, error)
+	Options502(ctx context.Context, options *HTTPRetryOptions502Options) (*BoolResponse, error)
 	// Patch500 - Return 500 status code, then 200 after retry
-	Patch500(ctx context.Context) (*http.Response, error)
+	Patch500(ctx context.Context, options *HTTPRetryPatch500Options) (*http.Response, error)
 	// Patch504 - Return 504 status code, then 200 after retry
-	Patch504(ctx context.Context) (*http.Response, error)
+	Patch504(ctx context.Context, options *HTTPRetryPatch504Options) (*http.Response, error)
 	// Post503 - Return 503 status code, then 200 after retry
-	Post503(ctx context.Context) (*http.Response, error)
+	Post503(ctx context.Context, options *HTTPRetryPost503Options) (*http.Response, error)
 	// Put500 - Return 500 status code, then 200 after retry
-	Put500(ctx context.Context) (*http.Response, error)
+	Put500(ctx context.Context, options *HTTPRetryPut500Options) (*http.Response, error)
 	// Put504 - Return 504 status code, then 200 after retry
-	Put504(ctx context.Context) (*http.Response, error)
+	Put504(ctx context.Context, options *HTTPRetryPut504Options) (*http.Response, error)
 }
 
 // HTTPRetryClient implements the HTTPRetryOperations interface.
@@ -50,8 +50,8 @@ func (client *HTTPRetryClient) Do(req *azcore.Request) (*azcore.Response, error)
 }
 
 // Delete503 - Return 503 status code, then 200 after retry
-func (client *HTTPRetryClient) Delete503(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete503CreateRequest(ctx)
+func (client *HTTPRetryClient) Delete503(ctx context.Context, options *HTTPRetryDelete503Options) (*http.Response, error) {
+	req, err := client.Delete503CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (client *HTTPRetryClient) Delete503(ctx context.Context) (*http.Response, e
 }
 
 // Delete503CreateRequest creates the Delete503 request.
-func (client *HTTPRetryClient) Delete503CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Delete503CreateRequest(ctx context.Context, options *HTTPRetryDelete503Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/503"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -86,8 +86,8 @@ func (client *HTTPRetryClient) Delete503HandleError(resp *azcore.Response) error
 }
 
 // Get502 - Return 502 status code, then 200 after retry
-func (client *HTTPRetryClient) Get502(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get502CreateRequest(ctx)
+func (client *HTTPRetryClient) Get502(ctx context.Context, options *HTTPRetryGet502Options) (*http.Response, error) {
+	req, err := client.Get502CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (client *HTTPRetryClient) Get502(ctx context.Context) (*http.Response, erro
 }
 
 // Get502CreateRequest creates the Get502 request.
-func (client *HTTPRetryClient) Get502CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Get502CreateRequest(ctx context.Context, options *HTTPRetryGet502Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/502"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -122,8 +122,8 @@ func (client *HTTPRetryClient) Get502HandleError(resp *azcore.Response) error {
 }
 
 // Head408 - Return 408 status code, then 200 after retry
-func (client *HTTPRetryClient) Head408(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head408CreateRequest(ctx)
+func (client *HTTPRetryClient) Head408(ctx context.Context, options *HTTPRetryHead408Options) (*http.Response, error) {
+	req, err := client.Head408CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (client *HTTPRetryClient) Head408(ctx context.Context) (*http.Response, err
 }
 
 // Head408CreateRequest creates the Head408 request.
-func (client *HTTPRetryClient) Head408CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Head408CreateRequest(ctx context.Context, options *HTTPRetryHead408Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/408"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -158,8 +158,8 @@ func (client *HTTPRetryClient) Head408HandleError(resp *azcore.Response) error {
 }
 
 // Options502 - Return 502 status code, then 200 after retry
-func (client *HTTPRetryClient) Options502(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.Options502CreateRequest(ctx)
+func (client *HTTPRetryClient) Options502(ctx context.Context, options *HTTPRetryOptions502Options) (*BoolResponse, error) {
+	req, err := client.Options502CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (client *HTTPRetryClient) Options502(ctx context.Context) (*BoolResponse, e
 }
 
 // Options502CreateRequest creates the Options502 request.
-func (client *HTTPRetryClient) Options502CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Options502CreateRequest(ctx context.Context, options *HTTPRetryOptions502Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/502"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -204,8 +204,8 @@ func (client *HTTPRetryClient) Options502HandleError(resp *azcore.Response) erro
 }
 
 // Patch500 - Return 500 status code, then 200 after retry
-func (client *HTTPRetryClient) Patch500(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch500CreateRequest(ctx)
+func (client *HTTPRetryClient) Patch500(ctx context.Context, options *HTTPRetryPatch500Options) (*http.Response, error) {
+	req, err := client.Patch500CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (client *HTTPRetryClient) Patch500(ctx context.Context) (*http.Response, er
 }
 
 // Patch500CreateRequest creates the Patch500 request.
-func (client *HTTPRetryClient) Patch500CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Patch500CreateRequest(ctx context.Context, options *HTTPRetryPatch500Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/500"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -240,8 +240,8 @@ func (client *HTTPRetryClient) Patch500HandleError(resp *azcore.Response) error 
 }
 
 // Patch504 - Return 504 status code, then 200 after retry
-func (client *HTTPRetryClient) Patch504(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch504CreateRequest(ctx)
+func (client *HTTPRetryClient) Patch504(ctx context.Context, options *HTTPRetryPatch504Options) (*http.Response, error) {
+	req, err := client.Patch504CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (client *HTTPRetryClient) Patch504(ctx context.Context) (*http.Response, er
 }
 
 // Patch504CreateRequest creates the Patch504 request.
-func (client *HTTPRetryClient) Patch504CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Patch504CreateRequest(ctx context.Context, options *HTTPRetryPatch504Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/504"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -276,8 +276,8 @@ func (client *HTTPRetryClient) Patch504HandleError(resp *azcore.Response) error 
 }
 
 // Post503 - Return 503 status code, then 200 after retry
-func (client *HTTPRetryClient) Post503(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post503CreateRequest(ctx)
+func (client *HTTPRetryClient) Post503(ctx context.Context, options *HTTPRetryPost503Options) (*http.Response, error) {
+	req, err := client.Post503CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (client *HTTPRetryClient) Post503(ctx context.Context) (*http.Response, err
 }
 
 // Post503CreateRequest creates the Post503 request.
-func (client *HTTPRetryClient) Post503CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Post503CreateRequest(ctx context.Context, options *HTTPRetryPost503Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/503"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -312,8 +312,8 @@ func (client *HTTPRetryClient) Post503HandleError(resp *azcore.Response) error {
 }
 
 // Put500 - Return 500 status code, then 200 after retry
-func (client *HTTPRetryClient) Put500(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put500CreateRequest(ctx)
+func (client *HTTPRetryClient) Put500(ctx context.Context, options *HTTPRetryPut500Options) (*http.Response, error) {
+	req, err := client.Put500CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (client *HTTPRetryClient) Put500(ctx context.Context) (*http.Response, erro
 }
 
 // Put500CreateRequest creates the Put500 request.
-func (client *HTTPRetryClient) Put500CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Put500CreateRequest(ctx context.Context, options *HTTPRetryPut500Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/500"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -348,8 +348,8 @@ func (client *HTTPRetryClient) Put500HandleError(resp *azcore.Response) error {
 }
 
 // Put504 - Return 504 status code, then 200 after retry
-func (client *HTTPRetryClient) Put504(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put504CreateRequest(ctx)
+func (client *HTTPRetryClient) Put504(ctx context.Context, options *HTTPRetryPut504Options) (*http.Response, error) {
+	req, err := client.Put504CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +364,7 @@ func (client *HTTPRetryClient) Put504(ctx context.Context) (*http.Response, erro
 }
 
 // Put504CreateRequest creates the Put504 request.
-func (client *HTTPRetryClient) Put504CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPRetryClient) Put504CreateRequest(ctx context.Context, options *HTTPRetryPut504Options) (*azcore.Request, error) {
 	urlPath := "/http/retry/504"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure.go
@@ -14,13 +14,13 @@ import (
 // HTTPServerFailureOperations contains the methods for the HTTPServerFailure group.
 type HTTPServerFailureOperations interface {
 	// Delete505 - Return 505 status code - should be represented in the client as an error
-	Delete505(ctx context.Context) (*http.Response, error)
+	Delete505(ctx context.Context, options *HTTPServerFailureDelete505Options) (*http.Response, error)
 	// Get501 - Return 501 status code - should be represented in the client as an error
-	Get501(ctx context.Context) (*http.Response, error)
+	Get501(ctx context.Context, options *HTTPServerFailureGet501Options) (*http.Response, error)
 	// Head501 - Return 501 status code - should be represented in the client as an error
-	Head501(ctx context.Context) (*http.Response, error)
+	Head501(ctx context.Context, options *HTTPServerFailureHead501Options) (*http.Response, error)
 	// Post505 - Return 505 status code - should be represented in the client as an error
-	Post505(ctx context.Context) (*http.Response, error)
+	Post505(ctx context.Context, options *HTTPServerFailurePost505Options) (*http.Response, error)
 }
 
 // HTTPServerFailureClient implements the HTTPServerFailureOperations interface.
@@ -40,8 +40,8 @@ func (client *HTTPServerFailureClient) Do(req *azcore.Request) (*azcore.Response
 }
 
 // Delete505 - Return 505 status code - should be represented in the client as an error
-func (client *HTTPServerFailureClient) Delete505(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete505CreateRequest(ctx)
+func (client *HTTPServerFailureClient) Delete505(ctx context.Context, options *HTTPServerFailureDelete505Options) (*http.Response, error) {
+	req, err := client.Delete505CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (client *HTTPServerFailureClient) Delete505(ctx context.Context) (*http.Res
 }
 
 // Delete505CreateRequest creates the Delete505 request.
-func (client *HTTPServerFailureClient) Delete505CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPServerFailureClient) Delete505CreateRequest(ctx context.Context, options *HTTPServerFailureDelete505Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/server/505"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -76,8 +76,8 @@ func (client *HTTPServerFailureClient) Delete505HandleError(resp *azcore.Respons
 }
 
 // Get501 - Return 501 status code - should be represented in the client as an error
-func (client *HTTPServerFailureClient) Get501(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get501CreateRequest(ctx)
+func (client *HTTPServerFailureClient) Get501(ctx context.Context, options *HTTPServerFailureGet501Options) (*http.Response, error) {
+	req, err := client.Get501CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (client *HTTPServerFailureClient) Get501(ctx context.Context) (*http.Respon
 }
 
 // Get501CreateRequest creates the Get501 request.
-func (client *HTTPServerFailureClient) Get501CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPServerFailureClient) Get501CreateRequest(ctx context.Context, options *HTTPServerFailureGet501Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/server/501"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -112,8 +112,8 @@ func (client *HTTPServerFailureClient) Get501HandleError(resp *azcore.Response) 
 }
 
 // Head501 - Return 501 status code - should be represented in the client as an error
-func (client *HTTPServerFailureClient) Head501(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head501CreateRequest(ctx)
+func (client *HTTPServerFailureClient) Head501(ctx context.Context, options *HTTPServerFailureHead501Options) (*http.Response, error) {
+	req, err := client.Head501CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context) (*http.Respo
 }
 
 // Head501CreateRequest creates the Head501 request.
-func (client *HTTPServerFailureClient) Head501CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPServerFailureClient) Head501CreateRequest(ctx context.Context, options *HTTPServerFailureHead501Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/server/501"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -148,8 +148,8 @@ func (client *HTTPServerFailureClient) Head501HandleError(resp *azcore.Response)
 }
 
 // Post505 - Return 505 status code - should be represented in the client as an error
-func (client *HTTPServerFailureClient) Post505(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post505CreateRequest(ctx)
+func (client *HTTPServerFailureClient) Post505(ctx context.Context, options *HTTPServerFailurePost505Options) (*http.Response, error) {
+	req, err := client.Post505CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (client *HTTPServerFailureClient) Post505(ctx context.Context) (*http.Respo
 }
 
 // Post505CreateRequest creates the Post505 request.
-func (client *HTTPServerFailureClient) Post505CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPServerFailureClient) Post505CreateRequest(ctx context.Context, options *HTTPServerFailurePost505Options) (*azcore.Request, error) {
 	urlPath := "/http/failure/server/505"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -14,43 +14,43 @@ import (
 // HTTPSuccessOperations contains the methods for the HTTPSuccess group.
 type HTTPSuccessOperations interface {
 	// Delete200 - Delete simple boolean value true returns 200
-	Delete200(ctx context.Context) (*http.Response, error)
+	Delete200(ctx context.Context, options *HTTPSuccessDelete200Options) (*http.Response, error)
 	// Delete202 - Delete true Boolean value in request returns 202 (accepted)
-	Delete202(ctx context.Context) (*http.Response, error)
+	Delete202(ctx context.Context, options *HTTPSuccessDelete202Options) (*http.Response, error)
 	// Delete204 - Delete true Boolean value in request returns 204 (no content)
-	Delete204(ctx context.Context) (*http.Response, error)
+	Delete204(ctx context.Context, options *HTTPSuccessDelete204Options) (*http.Response, error)
 	// Get200 - Get 200 success
-	Get200(ctx context.Context) (*BoolResponse, error)
+	Get200(ctx context.Context, options *HTTPSuccessGet200Options) (*BoolResponse, error)
 	// Head200 - Return 200 status code if successful
-	Head200(ctx context.Context) (*http.Response, error)
+	Head200(ctx context.Context, options *HTTPSuccessHead200Options) (*http.Response, error)
 	// Head204 - Return 204 status code if successful
-	Head204(ctx context.Context) (*http.Response, error)
+	Head204(ctx context.Context, options *HTTPSuccessHead204Options) (*http.Response, error)
 	// Head404 - Return 404 status code
-	Head404(ctx context.Context) (*http.Response, error)
+	Head404(ctx context.Context, options *HTTPSuccessHead404Options) (*http.Response, error)
 	// Options200 - Options 200 success
-	Options200(ctx context.Context) (*BoolResponse, error)
+	Options200(ctx context.Context, options *HTTPSuccessOptions200Options) (*BoolResponse, error)
 	// Patch200 - Patch true Boolean value in request returning 200
-	Patch200(ctx context.Context) (*http.Response, error)
+	Patch200(ctx context.Context, options *HTTPSuccessPatch200Options) (*http.Response, error)
 	// Patch202 - Patch true Boolean value in request returns 202
-	Patch202(ctx context.Context) (*http.Response, error)
+	Patch202(ctx context.Context, options *HTTPSuccessPatch202Options) (*http.Response, error)
 	// Patch204 - Patch true Boolean value in request returns 204 (no content)
-	Patch204(ctx context.Context) (*http.Response, error)
+	Patch204(ctx context.Context, options *HTTPSuccessPatch204Options) (*http.Response, error)
 	// Post200 - Post bollean value true in request that returns a 200
-	Post200(ctx context.Context) (*http.Response, error)
+	Post200(ctx context.Context, options *HTTPSuccessPost200Options) (*http.Response, error)
 	// Post201 - Post true Boolean value in request returns 201 (Created)
-	Post201(ctx context.Context) (*http.Response, error)
+	Post201(ctx context.Context, options *HTTPSuccessPost201Options) (*http.Response, error)
 	// Post202 - Post true Boolean value in request returns 202 (Accepted)
-	Post202(ctx context.Context) (*http.Response, error)
+	Post202(ctx context.Context, options *HTTPSuccessPost202Options) (*http.Response, error)
 	// Post204 - Post true Boolean value in request returns 204 (no content)
-	Post204(ctx context.Context) (*http.Response, error)
+	Post204(ctx context.Context, options *HTTPSuccessPost204Options) (*http.Response, error)
 	// Put200 - Put boolean value true returning 200 success
-	Put200(ctx context.Context) (*http.Response, error)
+	Put200(ctx context.Context, options *HTTPSuccessPut200Options) (*http.Response, error)
 	// Put201 - Put true Boolean value in request returns 201
-	Put201(ctx context.Context) (*http.Response, error)
+	Put201(ctx context.Context, options *HTTPSuccessPut201Options) (*http.Response, error)
 	// Put202 - Put true Boolean value in request returns 202 (Accepted)
-	Put202(ctx context.Context) (*http.Response, error)
+	Put202(ctx context.Context, options *HTTPSuccessPut202Options) (*http.Response, error)
 	// Put204 - Put true Boolean value in request returns 204 (no content)
-	Put204(ctx context.Context) (*http.Response, error)
+	Put204(ctx context.Context, options *HTTPSuccessPut204Options) (*http.Response, error)
 }
 
 // HTTPSuccessClient implements the HTTPSuccessOperations interface.
@@ -70,8 +70,8 @@ func (client *HTTPSuccessClient) Do(req *azcore.Request) (*azcore.Response, erro
 }
 
 // Delete200 - Delete simple boolean value true returns 200
-func (client *HTTPSuccessClient) Delete200(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Delete200(ctx context.Context, options *HTTPSuccessDelete200Options) (*http.Response, error) {
+	req, err := client.Delete200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (client *HTTPSuccessClient) Delete200(ctx context.Context) (*http.Response,
 }
 
 // Delete200CreateRequest creates the Delete200 request.
-func (client *HTTPSuccessClient) Delete200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Delete200CreateRequest(ctx context.Context, options *HTTPSuccessDelete200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -106,8 +106,8 @@ func (client *HTTPSuccessClient) Delete200HandleError(resp *azcore.Response) err
 }
 
 // Delete202 - Delete true Boolean value in request returns 202 (accepted)
-func (client *HTTPSuccessClient) Delete202(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete202CreateRequest(ctx)
+func (client *HTTPSuccessClient) Delete202(ctx context.Context, options *HTTPSuccessDelete202Options) (*http.Response, error) {
+	req, err := client.Delete202CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (client *HTTPSuccessClient) Delete202(ctx context.Context) (*http.Response,
 }
 
 // Delete202CreateRequest creates the Delete202 request.
-func (client *HTTPSuccessClient) Delete202CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Delete202CreateRequest(ctx context.Context, options *HTTPSuccessDelete202Options) (*azcore.Request, error) {
 	urlPath := "/http/success/202"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -142,8 +142,8 @@ func (client *HTTPSuccessClient) Delete202HandleError(resp *azcore.Response) err
 }
 
 // Delete204 - Delete true Boolean value in request returns 204 (no content)
-func (client *HTTPSuccessClient) Delete204(ctx context.Context) (*http.Response, error) {
-	req, err := client.Delete204CreateRequest(ctx)
+func (client *HTTPSuccessClient) Delete204(ctx context.Context, options *HTTPSuccessDelete204Options) (*http.Response, error) {
+	req, err := client.Delete204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func (client *HTTPSuccessClient) Delete204(ctx context.Context) (*http.Response,
 }
 
 // Delete204CreateRequest creates the Delete204 request.
-func (client *HTTPSuccessClient) Delete204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Delete204CreateRequest(ctx context.Context, options *HTTPSuccessDelete204Options) (*azcore.Request, error) {
 	urlPath := "/http/success/204"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -178,8 +178,8 @@ func (client *HTTPSuccessClient) Delete204HandleError(resp *azcore.Response) err
 }
 
 // Get200 - Get 200 success
-func (client *HTTPSuccessClient) Get200(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.Get200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Get200(ctx context.Context, options *HTTPSuccessGet200Options) (*BoolResponse, error) {
+	req, err := client.Get200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (client *HTTPSuccessClient) Get200(ctx context.Context) (*BoolResponse, err
 }
 
 // Get200CreateRequest creates the Get200 request.
-func (client *HTTPSuccessClient) Get200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Get200CreateRequest(ctx context.Context, options *HTTPSuccessGet200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -224,8 +224,8 @@ func (client *HTTPSuccessClient) Get200HandleError(resp *azcore.Response) error 
 }
 
 // Head200 - Return 200 status code if successful
-func (client *HTTPSuccessClient) Head200(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSuccessHead200Options) (*http.Response, error) {
+	req, err := client.Head200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context) (*http.Response, e
 }
 
 // Head200CreateRequest creates the Head200 request.
-func (client *HTTPSuccessClient) Head200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Head200CreateRequest(ctx context.Context, options *HTTPSuccessHead200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -260,8 +260,8 @@ func (client *HTTPSuccessClient) Head200HandleError(resp *azcore.Response) error
 }
 
 // Head204 - Return 204 status code if successful
-func (client *HTTPSuccessClient) Head204(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head204CreateRequest(ctx)
+func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSuccessHead204Options) (*http.Response, error) {
+	req, err := client.Head204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context) (*http.Response, e
 }
 
 // Head204CreateRequest creates the Head204 request.
-func (client *HTTPSuccessClient) Head204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Head204CreateRequest(ctx context.Context, options *HTTPSuccessHead204Options) (*azcore.Request, error) {
 	urlPath := "/http/success/204"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -296,8 +296,8 @@ func (client *HTTPSuccessClient) Head204HandleError(resp *azcore.Response) error
 }
 
 // Head404 - Return 404 status code
-func (client *HTTPSuccessClient) Head404(ctx context.Context) (*http.Response, error) {
-	req, err := client.Head404CreateRequest(ctx)
+func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSuccessHead404Options) (*http.Response, error) {
+	req, err := client.Head404CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context) (*http.Response, e
 }
 
 // Head404CreateRequest creates the Head404 request.
-func (client *HTTPSuccessClient) Head404CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Head404CreateRequest(ctx context.Context, options *HTTPSuccessHead404Options) (*azcore.Request, error) {
 	urlPath := "/http/success/404"
 	req, err := azcore.NewRequest(ctx, http.MethodHead, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -332,8 +332,8 @@ func (client *HTTPSuccessClient) Head404HandleError(resp *azcore.Response) error
 }
 
 // Options200 - Options 200 success
-func (client *HTTPSuccessClient) Options200(ctx context.Context) (*BoolResponse, error) {
-	req, err := client.Options200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Options200(ctx context.Context, options *HTTPSuccessOptions200Options) (*BoolResponse, error) {
+	req, err := client.Options200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (client *HTTPSuccessClient) Options200(ctx context.Context) (*BoolResponse,
 }
 
 // Options200CreateRequest creates the Options200 request.
-func (client *HTTPSuccessClient) Options200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Options200CreateRequest(ctx context.Context, options *HTTPSuccessOptions200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodOptions, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -378,8 +378,8 @@ func (client *HTTPSuccessClient) Options200HandleError(resp *azcore.Response) er
 }
 
 // Patch200 - Patch true Boolean value in request returning 200
-func (client *HTTPSuccessClient) Patch200(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Patch200(ctx context.Context, options *HTTPSuccessPatch200Options) (*http.Response, error) {
+	req, err := client.Patch200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func (client *HTTPSuccessClient) Patch200(ctx context.Context) (*http.Response, 
 }
 
 // Patch200CreateRequest creates the Patch200 request.
-func (client *HTTPSuccessClient) Patch200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Patch200CreateRequest(ctx context.Context, options *HTTPSuccessPatch200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -414,8 +414,8 @@ func (client *HTTPSuccessClient) Patch200HandleError(resp *azcore.Response) erro
 }
 
 // Patch202 - Patch true Boolean value in request returns 202
-func (client *HTTPSuccessClient) Patch202(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch202CreateRequest(ctx)
+func (client *HTTPSuccessClient) Patch202(ctx context.Context, options *HTTPSuccessPatch202Options) (*http.Response, error) {
+	req, err := client.Patch202CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func (client *HTTPSuccessClient) Patch202(ctx context.Context) (*http.Response, 
 }
 
 // Patch202CreateRequest creates the Patch202 request.
-func (client *HTTPSuccessClient) Patch202CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Patch202CreateRequest(ctx context.Context, options *HTTPSuccessPatch202Options) (*azcore.Request, error) {
 	urlPath := "/http/success/202"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -450,8 +450,8 @@ func (client *HTTPSuccessClient) Patch202HandleError(resp *azcore.Response) erro
 }
 
 // Patch204 - Patch true Boolean value in request returns 204 (no content)
-func (client *HTTPSuccessClient) Patch204(ctx context.Context) (*http.Response, error) {
-	req, err := client.Patch204CreateRequest(ctx)
+func (client *HTTPSuccessClient) Patch204(ctx context.Context, options *HTTPSuccessPatch204Options) (*http.Response, error) {
+	req, err := client.Patch204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +466,7 @@ func (client *HTTPSuccessClient) Patch204(ctx context.Context) (*http.Response, 
 }
 
 // Patch204CreateRequest creates the Patch204 request.
-func (client *HTTPSuccessClient) Patch204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Patch204CreateRequest(ctx context.Context, options *HTTPSuccessPatch204Options) (*azcore.Request, error) {
 	urlPath := "/http/success/204"
 	req, err := azcore.NewRequest(ctx, http.MethodPatch, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -486,8 +486,8 @@ func (client *HTTPSuccessClient) Patch204HandleError(resp *azcore.Response) erro
 }
 
 // Post200 - Post bollean value true in request that returns a 200
-func (client *HTTPSuccessClient) Post200(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Post200(ctx context.Context, options *HTTPSuccessPost200Options) (*http.Response, error) {
+	req, err := client.Post200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +502,7 @@ func (client *HTTPSuccessClient) Post200(ctx context.Context) (*http.Response, e
 }
 
 // Post200CreateRequest creates the Post200 request.
-func (client *HTTPSuccessClient) Post200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Post200CreateRequest(ctx context.Context, options *HTTPSuccessPost200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -522,8 +522,8 @@ func (client *HTTPSuccessClient) Post200HandleError(resp *azcore.Response) error
 }
 
 // Post201 - Post true Boolean value in request returns 201 (Created)
-func (client *HTTPSuccessClient) Post201(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post201CreateRequest(ctx)
+func (client *HTTPSuccessClient) Post201(ctx context.Context, options *HTTPSuccessPost201Options) (*http.Response, error) {
+	req, err := client.Post201CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (client *HTTPSuccessClient) Post201(ctx context.Context) (*http.Response, e
 }
 
 // Post201CreateRequest creates the Post201 request.
-func (client *HTTPSuccessClient) Post201CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Post201CreateRequest(ctx context.Context, options *HTTPSuccessPost201Options) (*azcore.Request, error) {
 	urlPath := "/http/success/201"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -558,8 +558,8 @@ func (client *HTTPSuccessClient) Post201HandleError(resp *azcore.Response) error
 }
 
 // Post202 - Post true Boolean value in request returns 202 (Accepted)
-func (client *HTTPSuccessClient) Post202(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post202CreateRequest(ctx)
+func (client *HTTPSuccessClient) Post202(ctx context.Context, options *HTTPSuccessPost202Options) (*http.Response, error) {
+	req, err := client.Post202CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +574,7 @@ func (client *HTTPSuccessClient) Post202(ctx context.Context) (*http.Response, e
 }
 
 // Post202CreateRequest creates the Post202 request.
-func (client *HTTPSuccessClient) Post202CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Post202CreateRequest(ctx context.Context, options *HTTPSuccessPost202Options) (*azcore.Request, error) {
 	urlPath := "/http/success/202"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -594,8 +594,8 @@ func (client *HTTPSuccessClient) Post202HandleError(resp *azcore.Response) error
 }
 
 // Post204 - Post true Boolean value in request returns 204 (no content)
-func (client *HTTPSuccessClient) Post204(ctx context.Context) (*http.Response, error) {
-	req, err := client.Post204CreateRequest(ctx)
+func (client *HTTPSuccessClient) Post204(ctx context.Context, options *HTTPSuccessPost204Options) (*http.Response, error) {
+	req, err := client.Post204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (client *HTTPSuccessClient) Post204(ctx context.Context) (*http.Response, e
 }
 
 // Post204CreateRequest creates the Post204 request.
-func (client *HTTPSuccessClient) Post204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Post204CreateRequest(ctx context.Context, options *HTTPSuccessPost204Options) (*azcore.Request, error) {
 	urlPath := "/http/success/204"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -630,8 +630,8 @@ func (client *HTTPSuccessClient) Post204HandleError(resp *azcore.Response) error
 }
 
 // Put200 - Put boolean value true returning 200 success
-func (client *HTTPSuccessClient) Put200(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put200CreateRequest(ctx)
+func (client *HTTPSuccessClient) Put200(ctx context.Context, options *HTTPSuccessPut200Options) (*http.Response, error) {
+	req, err := client.Put200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -646,7 +646,7 @@ func (client *HTTPSuccessClient) Put200(ctx context.Context) (*http.Response, er
 }
 
 // Put200CreateRequest creates the Put200 request.
-func (client *HTTPSuccessClient) Put200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Put200CreateRequest(ctx context.Context, options *HTTPSuccessPut200Options) (*azcore.Request, error) {
 	urlPath := "/http/success/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -666,8 +666,8 @@ func (client *HTTPSuccessClient) Put200HandleError(resp *azcore.Response) error 
 }
 
 // Put201 - Put true Boolean value in request returns 201
-func (client *HTTPSuccessClient) Put201(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put201CreateRequest(ctx)
+func (client *HTTPSuccessClient) Put201(ctx context.Context, options *HTTPSuccessPut201Options) (*http.Response, error) {
+	req, err := client.Put201CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -682,7 +682,7 @@ func (client *HTTPSuccessClient) Put201(ctx context.Context) (*http.Response, er
 }
 
 // Put201CreateRequest creates the Put201 request.
-func (client *HTTPSuccessClient) Put201CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Put201CreateRequest(ctx context.Context, options *HTTPSuccessPut201Options) (*azcore.Request, error) {
 	urlPath := "/http/success/201"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -702,8 +702,8 @@ func (client *HTTPSuccessClient) Put201HandleError(resp *azcore.Response) error 
 }
 
 // Put202 - Put true Boolean value in request returns 202 (Accepted)
-func (client *HTTPSuccessClient) Put202(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put202CreateRequest(ctx)
+func (client *HTTPSuccessClient) Put202(ctx context.Context, options *HTTPSuccessPut202Options) (*http.Response, error) {
+	req, err := client.Put202CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -718,7 +718,7 @@ func (client *HTTPSuccessClient) Put202(ctx context.Context) (*http.Response, er
 }
 
 // Put202CreateRequest creates the Put202 request.
-func (client *HTTPSuccessClient) Put202CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Put202CreateRequest(ctx context.Context, options *HTTPSuccessPut202Options) (*azcore.Request, error) {
 	urlPath := "/http/success/202"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -738,8 +738,8 @@ func (client *HTTPSuccessClient) Put202HandleError(resp *azcore.Response) error 
 }
 
 // Put204 - Put true Boolean value in request returns 204 (no content)
-func (client *HTTPSuccessClient) Put204(ctx context.Context) (*http.Response, error) {
-	req, err := client.Put204CreateRequest(ctx)
+func (client *HTTPSuccessClient) Put204(ctx context.Context, options *HTTPSuccessPut204Options) (*http.Response, error) {
+	req, err := client.Put204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -754,7 +754,7 @@ func (client *HTTPSuccessClient) Put204(ctx context.Context) (*http.Response, er
 }
 
 // Put204CreateRequest creates the Put204 request.
-func (client *HTTPSuccessClient) Put204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *HTTPSuccessClient) Put204CreateRequest(ctx context.Context, options *HTTPSuccessPut204Options) (*azcore.Request, error) {
 	urlPath := "/http/success/204"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_models.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_models.go
@@ -76,6 +76,161 @@ func (e Error) Error() string {
 	return msg
 }
 
+// HTTPClientFailureDelete400Options contains the optional parameters for the HTTPClientFailure.Delete400 method.
+type HTTPClientFailureDelete400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureDelete407Options contains the optional parameters for the HTTPClientFailure.Delete407 method.
+type HTTPClientFailureDelete407Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureDelete417Options contains the optional parameters for the HTTPClientFailure.Delete417 method.
+type HTTPClientFailureDelete417Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet400Options contains the optional parameters for the HTTPClientFailure.Get400 method.
+type HTTPClientFailureGet400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet402Options contains the optional parameters for the HTTPClientFailure.Get402 method.
+type HTTPClientFailureGet402Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet403Options contains the optional parameters for the HTTPClientFailure.Get403 method.
+type HTTPClientFailureGet403Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet411Options contains the optional parameters for the HTTPClientFailure.Get411 method.
+type HTTPClientFailureGet411Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet412Options contains the optional parameters for the HTTPClientFailure.Get412 method.
+type HTTPClientFailureGet412Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureGet416Options contains the optional parameters for the HTTPClientFailure.Get416 method.
+type HTTPClientFailureGet416Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureHead400Options contains the optional parameters for the HTTPClientFailure.Head400 method.
+type HTTPClientFailureHead400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureHead401Options contains the optional parameters for the HTTPClientFailure.Head401 method.
+type HTTPClientFailureHead401Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureHead410Options contains the optional parameters for the HTTPClientFailure.Head410 method.
+type HTTPClientFailureHead410Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureHead429Options contains the optional parameters for the HTTPClientFailure.Head429 method.
+type HTTPClientFailureHead429Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureOptions400Options contains the optional parameters for the HTTPClientFailure.Options400 method.
+type HTTPClientFailureOptions400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureOptions403Options contains the optional parameters for the HTTPClientFailure.Options403 method.
+type HTTPClientFailureOptions403Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailureOptions412Options contains the optional parameters for the HTTPClientFailure.Options412 method.
+type HTTPClientFailureOptions412Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePatch400Options contains the optional parameters for the HTTPClientFailure.Patch400 method.
+type HTTPClientFailurePatch400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePatch405Options contains the optional parameters for the HTTPClientFailure.Patch405 method.
+type HTTPClientFailurePatch405Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePatch414Options contains the optional parameters for the HTTPClientFailure.Patch414 method.
+type HTTPClientFailurePatch414Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePost400Options contains the optional parameters for the HTTPClientFailure.Post400 method.
+type HTTPClientFailurePost400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePost406Options contains the optional parameters for the HTTPClientFailure.Post406 method.
+type HTTPClientFailurePost406Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePost415Options contains the optional parameters for the HTTPClientFailure.Post415 method.
+type HTTPClientFailurePost415Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePut400Options contains the optional parameters for the HTTPClientFailure.Put400 method.
+type HTTPClientFailurePut400Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePut404Options contains the optional parameters for the HTTPClientFailure.Put404 method.
+type HTTPClientFailurePut404Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePut409Options contains the optional parameters for the HTTPClientFailure.Put409 method.
+type HTTPClientFailurePut409Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPClientFailurePut413Options contains the optional parameters for the HTTPClientFailure.Put413 method.
+type HTTPClientFailurePut413Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPFailureGetEmptyErrorOptions contains the optional parameters for the HTTPFailure.GetEmptyError method.
+type HTTPFailureGetEmptyErrorOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPFailureGetNoModelEmptyOptions contains the optional parameters for the HTTPFailure.GetNoModelEmpty method.
+type HTTPFailureGetNoModelEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPFailureGetNoModelErrorOptions contains the optional parameters for the HTTPFailure.GetNoModelError method.
+type HTTPFailureGetNoModelErrorOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsDelete307Options contains the optional parameters for the HTTPRedirects.Delete307 method.
+type HTTPRedirectsDelete307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsGet300Options contains the optional parameters for the HTTPRedirects.Get300 method.
+type HTTPRedirectsGet300Options struct {
+	// placeholder for future optional parameters
+}
+
 // HTTPRedirectsGet300Response contains the response from method HTTPRedirects.Get300.
 type HTTPRedirectsGet300Response struct {
 	// Location contains the information returned from the Location header response.
@@ -83,6 +238,26 @@ type HTTPRedirectsGet300Response struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// HTTPRedirectsGet301Options contains the optional parameters for the HTTPRedirects.Get301 method.
+type HTTPRedirectsGet301Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsGet302Options contains the optional parameters for the HTTPRedirects.Get302 method.
+type HTTPRedirectsGet302Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsGet307Options contains the optional parameters for the HTTPRedirects.Get307 method.
+type HTTPRedirectsGet307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsHead300Options contains the optional parameters for the HTTPRedirects.Head300 method.
+type HTTPRedirectsHead300Options struct {
+	// placeholder for future optional parameters
 }
 
 // HTTPRedirectsHead300Response contains the response from method HTTPRedirects.Head300.
@@ -94,6 +269,31 @@ type HTTPRedirectsHead300Response struct {
 	RawResponse *http.Response
 }
 
+// HTTPRedirectsHead301Options contains the optional parameters for the HTTPRedirects.Head301 method.
+type HTTPRedirectsHead301Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsHead302Options contains the optional parameters for the HTTPRedirects.Head302 method.
+type HTTPRedirectsHead302Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsHead307Options contains the optional parameters for the HTTPRedirects.Head307 method.
+type HTTPRedirectsHead307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsOptions307Options contains the optional parameters for the HTTPRedirects.Options307 method.
+type HTTPRedirectsOptions307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsPatch302Options contains the optional parameters for the HTTPRedirects.Patch302 method.
+type HTTPRedirectsPatch302Options struct {
+	// placeholder for future optional parameters
+}
+
 // HTTPRedirectsPatch302Response contains the response from method HTTPRedirects.Patch302.
 type HTTPRedirectsPatch302Response struct {
 	// Location contains the information returned from the Location header response.
@@ -101,6 +301,16 @@ type HTTPRedirectsPatch302Response struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// HTTPRedirectsPatch307Options contains the optional parameters for the HTTPRedirects.Patch307 method.
+type HTTPRedirectsPatch307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsPost303Options contains the optional parameters for the HTTPRedirects.Post303 method.
+type HTTPRedirectsPost303Options struct {
+	// placeholder for future optional parameters
 }
 
 // HTTPRedirectsPost303Response contains the response from method HTTPRedirects.Post303.
@@ -112,6 +322,16 @@ type HTTPRedirectsPost303Response struct {
 	RawResponse *http.Response
 }
 
+// HTTPRedirectsPost307Options contains the optional parameters for the HTTPRedirects.Post307 method.
+type HTTPRedirectsPost307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRedirectsPut301Options contains the optional parameters for the HTTPRedirects.Put301 method.
+type HTTPRedirectsPut301Options struct {
+	// placeholder for future optional parameters
+}
+
 // HTTPRedirectsPut301Response contains the response from method HTTPRedirects.Put301.
 type HTTPRedirectsPut301Response struct {
 	// Location contains the information returned from the Location header response.
@@ -119,6 +339,375 @@ type HTTPRedirectsPut301Response struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// HTTPRedirectsPut307Options contains the optional parameters for the HTTPRedirects.Put307 method.
+type HTTPRedirectsPut307Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryDelete503Options contains the optional parameters for the HTTPRetry.Delete503 method.
+type HTTPRetryDelete503Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryGet502Options contains the optional parameters for the HTTPRetry.Get502 method.
+type HTTPRetryGet502Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryHead408Options contains the optional parameters for the HTTPRetry.Head408 method.
+type HTTPRetryHead408Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryOptions502Options contains the optional parameters for the HTTPRetry.Options502 method.
+type HTTPRetryOptions502Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryPatch500Options contains the optional parameters for the HTTPRetry.Patch500 method.
+type HTTPRetryPatch500Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryPatch504Options contains the optional parameters for the HTTPRetry.Patch504 method.
+type HTTPRetryPatch504Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryPost503Options contains the optional parameters for the HTTPRetry.Post503 method.
+type HTTPRetryPost503Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryPut500Options contains the optional parameters for the HTTPRetry.Put500 method.
+type HTTPRetryPut500Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPRetryPut504Options contains the optional parameters for the HTTPRetry.Put504 method.
+type HTTPRetryPut504Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPServerFailureDelete505Options contains the optional parameters for the HTTPServerFailure.Delete505 method.
+type HTTPServerFailureDelete505Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPServerFailureGet501Options contains the optional parameters for the HTTPServerFailure.Get501 method.
+type HTTPServerFailureGet501Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPServerFailureHead501Options contains the optional parameters for the HTTPServerFailure.Head501 method.
+type HTTPServerFailureHead501Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPServerFailurePost505Options contains the optional parameters for the HTTPServerFailure.Post505 method.
+type HTTPServerFailurePost505Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessDelete200Options contains the optional parameters for the HTTPSuccess.Delete200 method.
+type HTTPSuccessDelete200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessDelete202Options contains the optional parameters for the HTTPSuccess.Delete202 method.
+type HTTPSuccessDelete202Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessDelete204Options contains the optional parameters for the HTTPSuccess.Delete204 method.
+type HTTPSuccessDelete204Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessGet200Options contains the optional parameters for the HTTPSuccess.Get200 method.
+type HTTPSuccessGet200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessHead200Options contains the optional parameters for the HTTPSuccess.Head200 method.
+type HTTPSuccessHead200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessHead204Options contains the optional parameters for the HTTPSuccess.Head204 method.
+type HTTPSuccessHead204Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessHead404Options contains the optional parameters for the HTTPSuccess.Head404 method.
+type HTTPSuccessHead404Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessOptions200Options contains the optional parameters for the HTTPSuccess.Options200 method.
+type HTTPSuccessOptions200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPatch200Options contains the optional parameters for the HTTPSuccess.Patch200 method.
+type HTTPSuccessPatch200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPatch202Options contains the optional parameters for the HTTPSuccess.Patch202 method.
+type HTTPSuccessPatch202Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPatch204Options contains the optional parameters for the HTTPSuccess.Patch204 method.
+type HTTPSuccessPatch204Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPost200Options contains the optional parameters for the HTTPSuccess.Post200 method.
+type HTTPSuccessPost200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPost201Options contains the optional parameters for the HTTPSuccess.Post201 method.
+type HTTPSuccessPost201Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPost202Options contains the optional parameters for the HTTPSuccess.Post202 method.
+type HTTPSuccessPost202Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPost204Options contains the optional parameters for the HTTPSuccess.Post204 method.
+type HTTPSuccessPost204Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPut200Options contains the optional parameters for the HTTPSuccess.Put200 method.
+type HTTPSuccessPut200Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPut201Options contains the optional parameters for the HTTPSuccess.Put201 method.
+type HTTPSuccessPut201Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPut202Options contains the optional parameters for the HTTPSuccess.Put202 method.
+type HTTPSuccessPut202Options struct {
+	// placeholder for future optional parameters
+}
+
+// HTTPSuccessPut204Options contains the optional parameters for the HTTPSuccess.Put204 method.
+type HTTPSuccessPut204Options struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model201ModelDefaultError200ValidOptions contains the optional parameters for the MultipleResponses.Get200Model201ModelDefaultError200Valid
+// method.
+type MultipleResponsesGet200Model201ModelDefaultError200ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model201ModelDefaultError201ValidOptions contains the optional parameters for the MultipleResponses.Get200Model201ModelDefaultError201Valid
+// method.
+type MultipleResponsesGet200Model201ModelDefaultError201ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model201ModelDefaultError400ValidOptions contains the optional parameters for the MultipleResponses.Get200Model201ModelDefaultError400Valid
+// method.
+type MultipleResponsesGet200Model201ModelDefaultError400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model204NoModelDefaultError200ValidOptions contains the optional parameters for the MultipleResponses.Get200Model204NoModelDefaultError200Valid
+// method.
+type MultipleResponsesGet200Model204NoModelDefaultError200ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model204NoModelDefaultError201InvalidOptions contains the optional parameters for the MultipleResponses.Get200Model204NoModelDefaultError201Invalid
+// method.
+type MultipleResponsesGet200Model204NoModelDefaultError201InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model204NoModelDefaultError202NoneOptions contains the optional parameters for the MultipleResponses.Get200Model204NoModelDefaultError202None
+// method.
+type MultipleResponsesGet200Model204NoModelDefaultError202NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model204NoModelDefaultError204ValidOptions contains the optional parameters for the MultipleResponses.Get200Model204NoModelDefaultError204Valid
+// method.
+type MultipleResponsesGet200Model204NoModelDefaultError204ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200Model204NoModelDefaultError400ValidOptions contains the optional parameters for the MultipleResponses.Get200Model204NoModelDefaultError400Valid
+// method.
+type MultipleResponsesGet200Model204NoModelDefaultError400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA200InvalidOptions contains the optional parameters for the MultipleResponses.Get200ModelA200Invalid
+// method.
+type MultipleResponsesGet200ModelA200InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA200NoneOptions contains the optional parameters for the MultipleResponses.Get200ModelA200None
+// method.
+type MultipleResponsesGet200ModelA200NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA200ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA200Valid
+// method.
+type MultipleResponsesGet200ModelA200ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA201ModelC404ModelDDefaultError200Valid
+// method.
+type MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA201ModelC404ModelDDefaultError201Valid
+// method.
+type MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA201ModelC404ModelDDefaultError400Valid
+// method.
+type MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA201ModelC404ModelDDefaultError404Valid
+// method.
+type MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA202ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA202Valid
+// method.
+type MultipleResponsesGet200ModelA202ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA400InvalidOptions contains the optional parameters for the MultipleResponses.Get200ModelA400Invalid
+// method.
+type MultipleResponsesGet200ModelA400InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA400NoneOptions contains the optional parameters for the MultipleResponses.Get200ModelA400None
+// method.
+type MultipleResponsesGet200ModelA400NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet200ModelA400ValidOptions contains the optional parameters for the MultipleResponses.Get200ModelA400Valid
+// method.
+type MultipleResponsesGet200ModelA400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultError202NoneOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultError202None
+// method.
+type MultipleResponsesGet202None204NoneDefaultError202NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultError204NoneOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultError204None
+// method.
+type MultipleResponsesGet202None204NoneDefaultError204NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultError400ValidOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultError400Valid
+// method.
+type MultipleResponsesGet202None204NoneDefaultError400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultNone202InvalidOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultNone202Invalid
+// method.
+type MultipleResponsesGet202None204NoneDefaultNone202InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultNone204NoneOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultNone204None
+// method.
+type MultipleResponsesGet202None204NoneDefaultNone204NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultNone400InvalidOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultNone400Invalid
+// method.
+type MultipleResponsesGet202None204NoneDefaultNone400InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGet202None204NoneDefaultNone400NoneOptions contains the optional parameters for the MultipleResponses.Get202None204NoneDefaultNone400None
+// method.
+type MultipleResponsesGet202None204NoneDefaultNone400NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultModelA200NoneOptions contains the optional parameters for the MultipleResponses.GetDefaultModelA200None
+// method.
+type MultipleResponsesGetDefaultModelA200NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultModelA200ValidOptions contains the optional parameters for the MultipleResponses.GetDefaultModelA200Valid
+// method.
+type MultipleResponsesGetDefaultModelA200ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultModelA400NoneOptions contains the optional parameters for the MultipleResponses.GetDefaultModelA400None
+// method.
+type MultipleResponsesGetDefaultModelA400NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultModelA400ValidOptions contains the optional parameters for the MultipleResponses.GetDefaultModelA400Valid
+// method.
+type MultipleResponsesGetDefaultModelA400ValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultNone200InvalidOptions contains the optional parameters for the MultipleResponses.GetDefaultNone200Invalid
+// method.
+type MultipleResponsesGetDefaultNone200InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultNone200NoneOptions contains the optional parameters for the MultipleResponses.GetDefaultNone200None
+// method.
+type MultipleResponsesGetDefaultNone200NoneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultNone400InvalidOptions contains the optional parameters for the MultipleResponses.GetDefaultNone400Invalid
+// method.
+type MultipleResponsesGetDefaultNone400InvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleResponsesGetDefaultNone400NoneOptions contains the optional parameters for the MultipleResponses.GetDefaultNone400None
+// method.
+type MultipleResponsesGetDefaultNone400NoneOptions struct {
+	// placeholder for future optional parameters
 }
 
 type MyException struct {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -18,79 +18,79 @@ import (
 type MultipleResponsesOperations interface {
 	// Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 	// Possible return types are *MyExceptionResponse, *BResponse
-	Get200Model201ModelDefaultError200Valid(ctx context.Context) (interface{}, error)
+	Get200Model201ModelDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError200ValidOptions) (interface{}, error)
 	// Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 	// Possible return types are *MyExceptionResponse, *BResponse
-	Get200Model201ModelDefaultError201Valid(ctx context.Context) (interface{}, error)
+	Get200Model201ModelDefaultError201Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError201ValidOptions) (interface{}, error)
 	// Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 	// Possible return types are *MyExceptionResponse, *BResponse
-	Get200Model201ModelDefaultError400Valid(ctx context.Context) (interface{}, error)
+	Get200Model201ModelDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError400ValidOptions) (interface{}, error)
 	// Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-	Get200Model204NoModelDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200Model204NoModelDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError200ValidOptions) (*MyExceptionResponse, error)
 	// Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
-	Get200Model204NoModelDefaultError201Invalid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200Model204NoModelDefaultError201Invalid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError201InvalidOptions) (*MyExceptionResponse, error)
 	// Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
-	Get200Model204NoModelDefaultError202None(ctx context.Context) (*MyExceptionResponse, error)
+	Get200Model204NoModelDefaultError202None(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError202NoneOptions) (*MyExceptionResponse, error)
 	// Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
-	Get200Model204NoModelDefaultError204Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200Model204NoModelDefaultError204Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError204ValidOptions) (*MyExceptionResponse, error)
 	// Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
-	Get200Model204NoModelDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200Model204NoModelDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError400ValidOptions) (*MyExceptionResponse, error)
 	// Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
-	Get200ModelA200Invalid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA200Invalid(ctx context.Context, options *MultipleResponsesGet200ModelA200InvalidOptions) (*MyExceptionResponse, error)
 	// Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
-	Get200ModelA200None(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA200None(ctx context.Context, options *MultipleResponsesGet200ModelA200NoneOptions) (*MyExceptionResponse, error)
 	// Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
-	Get200ModelA200Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA200Valid(ctx context.Context, options *MultipleResponsesGet200ModelA200ValidOptions) (*MyExceptionResponse, error)
 	// Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-	Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (interface{}, error)
+	Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidOptions) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-	Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (interface{}, error)
+	Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidOptions) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-	Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (interface{}, error)
+	Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidOptions) (interface{}, error)
 	// Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 	// Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-	Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (interface{}, error)
+	Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidOptions) (interface{}, error)
 	// Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
-	Get200ModelA202Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA202Valid(ctx context.Context, options *MultipleResponsesGet200ModelA202ValidOptions) (*MyExceptionResponse, error)
 	// Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
-	Get200ModelA400Invalid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA400Invalid(ctx context.Context, options *MultipleResponsesGet200ModelA400InvalidOptions) (*MyExceptionResponse, error)
 	// Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
-	Get200ModelA400None(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA400None(ctx context.Context, options *MultipleResponsesGet200ModelA400NoneOptions) (*MyExceptionResponse, error)
 	// Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
-	Get200ModelA400Valid(ctx context.Context) (*MyExceptionResponse, error)
+	Get200ModelA400Valid(ctx context.Context, options *MultipleResponsesGet200ModelA400ValidOptions) (*MyExceptionResponse, error)
 	// Get202None204NoneDefaultError202None - Send a 202 response with no payload
-	Get202None204NoneDefaultError202None(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultError202None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError202NoneOptions) (*http.Response, error)
 	// Get202None204NoneDefaultError204None - Send a 204 response with no payload
-	Get202None204NoneDefaultError204None(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultError204None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError204NoneOptions) (*http.Response, error)
 	// Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-	Get202None204NoneDefaultError400Valid(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError400ValidOptions) (*http.Response, error)
 	// Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
-	Get202None204NoneDefaultNone202Invalid(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultNone202Invalid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone202InvalidOptions) (*http.Response, error)
 	// Get202None204NoneDefaultNone204None - Send a 204 response with no payload
-	Get202None204NoneDefaultNone204None(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultNone204None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone204NoneOptions) (*http.Response, error)
 	// Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
-	Get202None204NoneDefaultNone400Invalid(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultNone400Invalid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400InvalidOptions) (*http.Response, error)
 	// Get202None204NoneDefaultNone400None - Send a 400 response with no payload
-	Get202None204NoneDefaultNone400None(ctx context.Context) (*http.Response, error)
+	Get202None204NoneDefaultNone400None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400NoneOptions) (*http.Response, error)
 	// GetDefaultModelA200None - Send a 200 response with no payload
-	GetDefaultModelA200None(ctx context.Context) (*MyExceptionResponse, error)
+	GetDefaultModelA200None(ctx context.Context, options *MultipleResponsesGetDefaultModelA200NoneOptions) (*MyExceptionResponse, error)
 	// GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-	GetDefaultModelA200Valid(ctx context.Context) (*MyExceptionResponse, error)
+	GetDefaultModelA200Valid(ctx context.Context, options *MultipleResponsesGetDefaultModelA200ValidOptions) (*MyExceptionResponse, error)
 	// GetDefaultModelA400None - Send a 400 response with no payload
-	GetDefaultModelA400None(ctx context.Context) (*http.Response, error)
+	GetDefaultModelA400None(ctx context.Context, options *MultipleResponsesGetDefaultModelA400NoneOptions) (*http.Response, error)
 	// GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
-	GetDefaultModelA400Valid(ctx context.Context) (*http.Response, error)
+	GetDefaultModelA400Valid(ctx context.Context, options *MultipleResponsesGetDefaultModelA400ValidOptions) (*http.Response, error)
 	// GetDefaultNone200Invalid - Send a 200 response with invalid payload: {'statusCode': '200'}
-	GetDefaultNone200Invalid(ctx context.Context) (*http.Response, error)
+	GetDefaultNone200Invalid(ctx context.Context, options *MultipleResponsesGetDefaultNone200InvalidOptions) (*http.Response, error)
 	// GetDefaultNone200None - Send a 200 response with no payload
-	GetDefaultNone200None(ctx context.Context) (*http.Response, error)
+	GetDefaultNone200None(ctx context.Context, options *MultipleResponsesGetDefaultNone200NoneOptions) (*http.Response, error)
 	// GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
-	GetDefaultNone400Invalid(ctx context.Context) (*http.Response, error)
+	GetDefaultNone400Invalid(ctx context.Context, options *MultipleResponsesGetDefaultNone400InvalidOptions) (*http.Response, error)
 	// GetDefaultNone400None - Send a 400 response with no payload
-	GetDefaultNone400None(ctx context.Context) (*http.Response, error)
+	GetDefaultNone400None(ctx context.Context, options *MultipleResponsesGetDefaultNone400NoneOptions) (*http.Response, error)
 }
 
 // MultipleResponsesClient implements the MultipleResponsesOperations interface.
@@ -111,8 +111,8 @@ func (client *MultipleResponsesClient) Do(req *azcore.Request) (*azcore.Response
 
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 // Possible return types are *MyExceptionResponse, *BResponse
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200Model201ModelDefaultError200ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError200ValidOptions) (interface{}, error) {
+	req, err := client.Get200Model201ModelDefaultError200ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(c
 }
 
 // Get200Model201ModelDefaultError200ValidCreateRequest creates the Get200Model201ModelDefaultError200Valid request.
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError200ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/200/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -166,8 +166,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200ValidHa
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 // Possible return types are *MyExceptionResponse, *BResponse
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200Model201ModelDefaultError201ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError201ValidOptions) (interface{}, error) {
+	req, err := client.Get200Model201ModelDefaultError201ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(c
 }
 
 // Get200Model201ModelDefaultError201ValidCreateRequest creates the Get200Model201ModelDefaultError201Valid request.
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError201ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/201/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -221,8 +221,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201ValidHa
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 // Possible return types are *MyExceptionResponse, *BResponse
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200Model201ModelDefaultError400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError400ValidOptions) (interface{}, error) {
+	req, err := client.Get200Model201ModelDefaultError400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(c
 }
 
 // Get200Model201ModelDefaultError400ValidCreateRequest creates the Get200Model201ModelDefaultError400Valid request.
-func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model201ModelDefaultError400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/B/default/Error/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -275,8 +275,8 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400ValidHa
 }
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200Model204NoModelDefaultError200ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError200ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200Model204NoModelDefaultError200ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 }
 
 // Get200Model204NoModelDefaultError200ValidCreateRequest creates the Get200Model204NoModelDefaultError200Valid request.
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError200ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/200/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -321,8 +321,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 }
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Invalid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200Model204NoModelDefaultError201InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Invalid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError201InvalidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200Model204NoModelDefaultError201InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 }
 
 // Get200Model204NoModelDefaultError201InvalidCreateRequest creates the Get200Model204NoModelDefaultError201Invalid request.
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError201InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/201/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -367,8 +367,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 }
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200Model204NoModelDefaultError202NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError202NoneOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200Model204NoModelDefaultError202NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +387,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(
 }
 
 // Get200Model204NoModelDefaultError202NoneCreateRequest creates the Get200Model204NoModelDefaultError202None request.
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError202NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/202/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -413,8 +413,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202NoneH
 }
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200Model204NoModelDefaultError204ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError204ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200Model204NoModelDefaultError204ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 }
 
 // Get200Model204NoModelDefaultError204ValidCreateRequest creates the Get200Model204NoModelDefaultError204Valid request.
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError204ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/204/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -459,8 +459,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 }
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200Model204NoModelDefaultError400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError400ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200Model204NoModelDefaultError400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +479,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 }
 
 // Get200Model204NoModelDefaultError400ValidCreateRequest creates the Get200Model204NoModelDefaultError400Valid request.
-func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200Model204NoModelDefaultError400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/204/none/default/Error/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -505,8 +505,8 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 }
 
 // Get200ModelA200Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
-func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA200InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Context, options *MultipleResponsesGet200ModelA200InvalidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA200InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Contex
 }
 
 // Get200ModelA200InvalidCreateRequest creates the Get200ModelA200Invalid request.
-func (client *MultipleResponsesClient) Get200ModelA200InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA200InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA200InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -554,8 +554,8 @@ func (client *MultipleResponsesClient) Get200ModelA200InvalidHandleError(resp *a
 }
 
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
-func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA200NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context, options *MultipleResponsesGet200ModelA200NoneOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA200NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +574,7 @@ func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context) 
 }
 
 // Get200ModelA200NoneCreateRequest creates the Get200ModelA200None request.
-func (client *MultipleResponsesClient) Get200ModelA200NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA200NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA200NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -603,8 +603,8 @@ func (client *MultipleResponsesClient) Get200ModelA200NoneHandleError(resp *azco
 }
 
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
-func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA200ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context, options *MultipleResponsesGet200ModelA200ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA200ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -623,7 +623,7 @@ func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context)
 }
 
 // Get200ModelA200ValidCreateRequest creates the Get200ModelA200Valid request.
-func (client *MultipleResponsesClient) Get200ModelA200ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA200ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA200ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/200/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -653,8 +653,8 @@ func (client *MultipleResponsesClient) Get200ModelA200ValidHandleError(resp *azc
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 // Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidOptions) (interface{}, error) {
+	req, err := client.Get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -673,7 +673,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError200Valid request.
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -711,8 +711,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 // Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidOptions) (interface{}, error) {
+	req, err := client.Get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +731,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError201Valid request.
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -769,8 +769,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 // Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidOptions) (interface{}, error) {
+	req, err := client.Get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +789,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError400Valid request.
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -827,8 +827,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 // Possible return types are *MyExceptionResponse, *CResponse, *DResponse
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context) (interface{}, error) {
-	req, err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404Valid(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidOptions) (interface{}, error) {
+	req, err := client.Get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +847,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 }
 
 // Get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError404Valid request.
-func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -884,8 +884,8 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 }
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
-func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA202ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context, options *MultipleResponsesGet200ModelA202ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA202ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -904,7 +904,7 @@ func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context)
 }
 
 // Get200ModelA202ValidCreateRequest creates the Get200ModelA202Valid request.
-func (client *MultipleResponsesClient) Get200ModelA202ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA202ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA202ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/202/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -933,8 +933,8 @@ func (client *MultipleResponsesClient) Get200ModelA202ValidHandleError(resp *azc
 }
 
 // Get200ModelA400Invalid - Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
-func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA400InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Context, options *MultipleResponsesGet200ModelA400InvalidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA400InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +953,7 @@ func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Contex
 }
 
 // Get200ModelA400InvalidCreateRequest creates the Get200ModelA400Invalid request.
-func (client *MultipleResponsesClient) Get200ModelA400InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA400InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA400InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -982,8 +982,8 @@ func (client *MultipleResponsesClient) Get200ModelA400InvalidHandleError(resp *a
 }
 
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
-func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA400NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context, options *MultipleResponsesGet200ModelA400NoneOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA400NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1002,7 @@ func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context) 
 }
 
 // Get200ModelA400NoneCreateRequest creates the Get200ModelA400None request.
-func (client *MultipleResponsesClient) Get200ModelA400NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA400NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA400NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1031,8 +1031,8 @@ func (client *MultipleResponsesClient) Get200ModelA400NoneHandleError(resp *azco
 }
 
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
-func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.Get200ModelA400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context, options *MultipleResponsesGet200ModelA400ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.Get200ModelA400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +1051,7 @@ func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context)
 }
 
 // Get200ModelA400ValidCreateRequest creates the Get200ModelA400Valid request.
-func (client *MultipleResponsesClient) Get200ModelA400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get200ModelA400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet200ModelA400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/200/A/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1080,8 +1080,8 @@ func (client *MultipleResponsesClient) Get200ModelA400ValidHandleError(resp *azc
 }
 
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultError202NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError202NoneOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultError202NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1096,7 +1096,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx 
 }
 
 // Get202None204NoneDefaultError202NoneCreateRequest creates the Get202None204NoneDefaultError202None request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError202NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/202/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1116,8 +1116,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202NoneHandl
 }
 
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultError204NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError204NoneOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultError204NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1132,7 +1132,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx 
 }
 
 // Get202None204NoneDefaultError204NoneCreateRequest creates the Get202None204NoneDefaultError204None request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError204NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/204/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1152,8 +1152,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204NoneHandl
 }
 
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultError400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError400ValidOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultError400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1168,7 +1168,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx
 }
 
 // Get202None204NoneDefaultError400ValidCreateRequest creates the Get202None204NoneDefaultError400Valid request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultError400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/Error/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1188,8 +1188,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400ValidHand
 }
 
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultNone202InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone202InvalidOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultNone202InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1204,7 +1204,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ct
 }
 
 // Get202None204NoneDefaultNone202InvalidCreateRequest creates the Get202None204NoneDefaultNone202Invalid request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone202InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/202/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1226,8 +1226,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202InvalidHan
 }
 
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultNone204NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone204NoneOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultNone204NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1242,7 +1242,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx c
 }
 
 // Get202None204NoneDefaultNone204NoneCreateRequest creates the Get202None204NoneDefaultNone204None request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone204NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/204/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1264,8 +1264,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204NoneHandle
 }
 
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultNone400InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400InvalidOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultNone400InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1280,7 +1280,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ct
 }
 
 // Get202None204NoneDefaultNone400InvalidCreateRequest creates the Get202None204NoneDefaultNone400Invalid request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1302,8 +1302,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400InvalidHan
 }
 
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx context.Context) (*http.Response, error) {
-	req, err := client.Get202None204NoneDefaultNone400NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400NoneOptions) (*http.Response, error) {
+	req, err := client.Get202None204NoneDefaultNone400NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1318,7 +1318,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx c
 }
 
 // Get202None204NoneDefaultNone400NoneCreateRequest creates the Get202None204NoneDefaultNone400None request.
-func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneCreateRequest(ctx context.Context, options *MultipleResponsesGet202None204NoneDefaultNone400NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/202/none/204/none/default/none/response/400/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1340,8 +1340,8 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400NoneHandle
 }
 
 // GetDefaultModelA200None - Send a 200 response with no payload
-func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.GetDefaultModelA200NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Context, options *MultipleResponsesGetDefaultModelA200NoneOptions) (*MyExceptionResponse, error) {
+	req, err := client.GetDefaultModelA200NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1360,7 +1360,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Conte
 }
 
 // GetDefaultModelA200NoneCreateRequest creates the GetDefaultModelA200None request.
-func (client *MultipleResponsesClient) GetDefaultModelA200NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultModelA200NoneCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultModelA200NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/200/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1389,8 +1389,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA200NoneHandleError(resp *
 }
 
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
-func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Context) (*MyExceptionResponse, error) {
-	req, err := client.GetDefaultModelA200ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Context, options *MultipleResponsesGetDefaultModelA200ValidOptions) (*MyExceptionResponse, error) {
+	req, err := client.GetDefaultModelA200ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1409,7 +1409,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Cont
 }
 
 // GetDefaultModelA200ValidCreateRequest creates the GetDefaultModelA200Valid request.
-func (client *MultipleResponsesClient) GetDefaultModelA200ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultModelA200ValidCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultModelA200ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/200/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1438,8 +1438,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA200ValidHandleError(resp 
 }
 
 // GetDefaultModelA400None - Send a 400 response with no payload
-func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultModelA400NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Context, options *MultipleResponsesGetDefaultModelA400NoneOptions) (*http.Response, error) {
+	req, err := client.GetDefaultModelA400NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1454,7 +1454,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Conte
 }
 
 // GetDefaultModelA400NoneCreateRequest creates the GetDefaultModelA400None request.
-func (client *MultipleResponsesClient) GetDefaultModelA400NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultModelA400NoneCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultModelA400NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/400/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1474,8 +1474,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA400NoneHandleError(resp *
 }
 
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
-func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultModelA400ValidCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Context, options *MultipleResponsesGetDefaultModelA400ValidOptions) (*http.Response, error) {
+	req, err := client.GetDefaultModelA400ValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1490,7 +1490,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Cont
 }
 
 // GetDefaultModelA400ValidCreateRequest creates the GetDefaultModelA400Valid request.
-func (client *MultipleResponsesClient) GetDefaultModelA400ValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultModelA400ValidCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultModelA400ValidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/A/response/400/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1510,8 +1510,8 @@ func (client *MultipleResponsesClient) GetDefaultModelA400ValidHandleError(resp 
 }
 
 // GetDefaultNone200Invalid - Send a 200 response with invalid payload: {'statusCode': '200'}
-func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultNone200InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Context, options *MultipleResponsesGetDefaultNone200InvalidOptions) (*http.Response, error) {
+	req, err := client.GetDefaultNone200InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1526,7 +1526,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Cont
 }
 
 // GetDefaultNone200InvalidCreateRequest creates the GetDefaultNone200Invalid request.
-func (client *MultipleResponsesClient) GetDefaultNone200InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultNone200InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultNone200InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/200/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1548,8 +1548,8 @@ func (client *MultipleResponsesClient) GetDefaultNone200InvalidHandleError(resp 
 }
 
 // GetDefaultNone200None - Send a 200 response with no payload
-func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultNone200NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context, options *MultipleResponsesGetDefaultNone200NoneOptions) (*http.Response, error) {
+	req, err := client.GetDefaultNone200NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1564,7 +1564,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context
 }
 
 // GetDefaultNone200NoneCreateRequest creates the GetDefaultNone200None request.
-func (client *MultipleResponsesClient) GetDefaultNone200NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultNone200NoneCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultNone200NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/200/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1586,8 +1586,8 @@ func (client *MultipleResponsesClient) GetDefaultNone200NoneHandleError(resp *az
 }
 
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
-func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultNone400InvalidCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Context, options *MultipleResponsesGetDefaultNone400InvalidOptions) (*http.Response, error) {
+	req, err := client.GetDefaultNone400InvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1602,7 +1602,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Cont
 }
 
 // GetDefaultNone400InvalidCreateRequest creates the GetDefaultNone400Invalid request.
-func (client *MultipleResponsesClient) GetDefaultNone400InvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultNone400InvalidCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultNone400InvalidOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/400/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1624,8 +1624,8 @@ func (client *MultipleResponsesClient) GetDefaultNone400InvalidHandleError(resp 
 }
 
 // GetDefaultNone400None - Send a 400 response with no payload
-func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetDefaultNone400NoneCreateRequest(ctx)
+func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context, options *MultipleResponsesGetDefaultNone400NoneOptions) (*http.Response, error) {
+	req, err := client.GetDefaultNone400NoneCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1640,7 +1640,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context
 }
 
 // GetDefaultNone400NoneCreateRequest creates the GetDefaultNone400None request.
-func (client *MultipleResponsesClient) GetDefaultNone400NoneCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleResponsesClient) GetDefaultNone400NoneCreateRequest(ctx context.Context, options *MultipleResponsesGetDefaultNone400NoneOptions) (*azcore.Request, error) {
 	urlPath := "/http/payloads/default/none/response/400/none"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -18,7 +18,7 @@ func newIntClient() IntOperations {
 
 func TestIntGetInvalid(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetInvalid(context.Background())
+	result, err := client.GetInvalid(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -29,7 +29,7 @@ func TestIntGetInvalid(t *testing.T) {
 
 func TestIntGetInvalidUnixTime(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetInvalidUnixTime(context.Background())
+	result, err := client.GetInvalidUnixTime(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -40,7 +40,7 @@ func TestIntGetInvalidUnixTime(t *testing.T) {
 
 func TestIntGetNull(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -50,7 +50,7 @@ func TestIntGetNull(t *testing.T) {
 
 func TestIntGetNullUnixTime(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetNullUnixTime(context.Background())
+	result, err := client.GetNullUnixTime(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNullUnixTime: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestIntGetNullUnixTime(t *testing.T) {
 
 func TestIntGetOverflowInt32(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetOverflowInt32(context.Background())
+	result, err := client.GetOverflowInt32(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -71,7 +71,7 @@ func TestIntGetOverflowInt32(t *testing.T) {
 
 func TestIntGetOverflowInt64(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetOverflowInt64(context.Background())
+	result, err := client.GetOverflowInt64(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -82,7 +82,7 @@ func TestIntGetOverflowInt64(t *testing.T) {
 
 func TestIntGetUnderflowInt32(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetUnderflowInt32(context.Background())
+	result, err := client.GetUnderflowInt32(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -93,7 +93,7 @@ func TestIntGetUnderflowInt32(t *testing.T) {
 
 func TestIntGetUnderflowInt64(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetUnderflowInt64(context.Background())
+	result, err := client.GetUnderflowInt64(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -104,7 +104,7 @@ func TestIntGetUnderflowInt64(t *testing.T) {
 
 func TestIntGetUnixTime(t *testing.T) {
 	client := newIntClient()
-	result, err := client.GetUnixTime(context.Background())
+	result, err := client.GetUnixTime(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetUnixTime: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestIntGetUnixTime(t *testing.T) {
 
 func TestIntPutMax32(t *testing.T) {
 	client := newIntClient()
-	result, err := client.PutMax32(context.Background(), math.MaxInt32)
+	result, err := client.PutMax32(context.Background(), math.MaxInt32, nil)
 	if err != nil {
 		t.Fatalf("PutMax32: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestIntPutMax32(t *testing.T) {
 
 func TestIntPutMax64(t *testing.T) {
 	client := newIntClient()
-	result, err := client.PutMax64(context.Background(), math.MaxInt64)
+	result, err := client.PutMax64(context.Background(), math.MaxInt64, nil)
 	if err != nil {
 		t.Fatalf("PutMax64: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestIntPutMax64(t *testing.T) {
 
 func TestIntPutMin32(t *testing.T) {
 	client := newIntClient()
-	result, err := client.PutMin32(context.Background(), math.MinInt32)
+	result, err := client.PutMin32(context.Background(), math.MinInt32, nil)
 	if err != nil {
 		t.Fatalf("PutMin32: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestIntPutMin32(t *testing.T) {
 
 func TestIntPutMin64(t *testing.T) {
 	client := newIntClient()
-	result, err := client.PutMin64(context.Background(), math.MinInt64)
+	result, err := client.PutMin64(context.Background(), math.MinInt64, nil)
 	if err != nil {
 		t.Fatalf("PutMin64: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestIntPutMin64(t *testing.T) {
 func TestIntPutUnixTimeDate(t *testing.T) {
 	client := newIntClient()
 	t1 := time.Unix(1460505600, 0)
-	result, err := client.PutUnixTimeDate(context.Background(), t1)
+	result, err := client.PutUnixTimeDate(context.Background(), t1, nil)
 	if err != nil {
 		t.Fatalf("PutUnixTimeDate: %v", err)
 	}

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -15,33 +15,33 @@ import (
 // IntOperations contains the methods for the Int group.
 type IntOperations interface {
 	// GetInvalid - Get invalid Int value
-	GetInvalid(ctx context.Context) (*Int32Response, error)
+	GetInvalid(ctx context.Context, options *IntGetInvalidOptions) (*Int32Response, error)
 	// GetInvalidUnixTime - Get invalid Unix time value
-	GetInvalidUnixTime(ctx context.Context) (*TimeResponse, error)
+	GetInvalidUnixTime(ctx context.Context, options *IntGetInvalidUnixTimeOptions) (*TimeResponse, error)
 	// GetNull - Get null Int value
-	GetNull(ctx context.Context) (*Int32Response, error)
+	GetNull(ctx context.Context, options *IntGetNullOptions) (*Int32Response, error)
 	// GetNullUnixTime - Get null Unix time value
-	GetNullUnixTime(ctx context.Context) (*TimeResponse, error)
+	GetNullUnixTime(ctx context.Context, options *IntGetNullUnixTimeOptions) (*TimeResponse, error)
 	// GetOverflowInt32 - Get overflow Int32 value
-	GetOverflowInt32(ctx context.Context) (*Int32Response, error)
+	GetOverflowInt32(ctx context.Context, options *IntGetOverflowInt32Options) (*Int32Response, error)
 	// GetOverflowInt64 - Get overflow Int64 value
-	GetOverflowInt64(ctx context.Context) (*Int64Response, error)
+	GetOverflowInt64(ctx context.Context, options *IntGetOverflowInt64Options) (*Int64Response, error)
 	// GetUnderflowInt32 - Get underflow Int32 value
-	GetUnderflowInt32(ctx context.Context) (*Int32Response, error)
+	GetUnderflowInt32(ctx context.Context, options *IntGetUnderflowInt32Options) (*Int32Response, error)
 	// GetUnderflowInt64 - Get underflow Int64 value
-	GetUnderflowInt64(ctx context.Context) (*Int64Response, error)
+	GetUnderflowInt64(ctx context.Context, options *IntGetUnderflowInt64Options) (*Int64Response, error)
 	// GetUnixTime - Get datetime encoded as Unix time value
-	GetUnixTime(ctx context.Context) (*TimeResponse, error)
+	GetUnixTime(ctx context.Context, options *IntGetUnixTimeOptions) (*TimeResponse, error)
 	// PutMax32 - Put max int32 value
-	PutMax32(ctx context.Context, intBody int32) (*http.Response, error)
+	PutMax32(ctx context.Context, intBody int32, options *IntPutMax32Options) (*http.Response, error)
 	// PutMax64 - Put max int64 value
-	PutMax64(ctx context.Context, intBody int64) (*http.Response, error)
+	PutMax64(ctx context.Context, intBody int64, options *IntPutMax64Options) (*http.Response, error)
 	// PutMin32 - Put min int32 value
-	PutMin32(ctx context.Context, intBody int32) (*http.Response, error)
+	PutMin32(ctx context.Context, intBody int32, options *IntPutMin32Options) (*http.Response, error)
 	// PutMin64 - Put min int64 value
-	PutMin64(ctx context.Context, intBody int64) (*http.Response, error)
+	PutMin64(ctx context.Context, intBody int64, options *IntPutMin64Options) (*http.Response, error)
 	// PutUnixTimeDate - Put datetime encoded as Unix time
-	PutUnixTimeDate(ctx context.Context, intBody time.Time) (*http.Response, error)
+	PutUnixTimeDate(ctx context.Context, intBody time.Time, options *IntPutUnixTimeDateOptions) (*http.Response, error)
 }
 
 // IntClient implements the IntOperations interface.
@@ -61,8 +61,8 @@ func (client *IntClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetInvalid - Get invalid Int value
-func (client *IntClient) GetInvalid(ctx context.Context) (*Int32Response, error) {
-	req, err := client.GetInvalidCreateRequest(ctx)
+func (client *IntClient) GetInvalid(ctx context.Context, options *IntGetInvalidOptions) (*Int32Response, error) {
+	req, err := client.GetInvalidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (client *IntClient) GetInvalid(ctx context.Context) (*Int32Response, error)
 }
 
 // GetInvalidCreateRequest creates the GetInvalid request.
-func (client *IntClient) GetInvalidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetInvalidCreateRequest(ctx context.Context, options *IntGetInvalidOptions) (*azcore.Request, error) {
 	urlPath := "/int/invalid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -107,8 +107,8 @@ func (client *IntClient) GetInvalidHandleError(resp *azcore.Response) error {
 }
 
 // GetInvalidUnixTime - Get invalid Unix time value
-func (client *IntClient) GetInvalidUnixTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetInvalidUnixTimeCreateRequest(ctx)
+func (client *IntClient) GetInvalidUnixTime(ctx context.Context, options *IntGetInvalidUnixTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetInvalidUnixTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (client *IntClient) GetInvalidUnixTime(ctx context.Context) (*TimeResponse,
 }
 
 // GetInvalidUnixTimeCreateRequest creates the GetInvalidUnixTime request.
-func (client *IntClient) GetInvalidUnixTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetInvalidUnixTimeCreateRequest(ctx context.Context, options *IntGetInvalidUnixTimeOptions) (*azcore.Request, error) {
 	urlPath := "/int/invalidunixtime"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -154,8 +154,8 @@ func (client *IntClient) GetInvalidUnixTimeHandleError(resp *azcore.Response) er
 }
 
 // GetNull - Get null Int value
-func (client *IntClient) GetNull(ctx context.Context) (*Int32Response, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *IntClient) GetNull(ctx context.Context, options *IntGetNullOptions) (*Int32Response, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (client *IntClient) GetNull(ctx context.Context) (*Int32Response, error) {
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *IntClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetNullCreateRequest(ctx context.Context, options *IntGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/int/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -200,8 +200,8 @@ func (client *IntClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetNullUnixTime - Get null Unix time value
-func (client *IntClient) GetNullUnixTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetNullUnixTimeCreateRequest(ctx)
+func (client *IntClient) GetNullUnixTime(ctx context.Context, options *IntGetNullUnixTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetNullUnixTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (client *IntClient) GetNullUnixTime(ctx context.Context) (*TimeResponse, er
 }
 
 // GetNullUnixTimeCreateRequest creates the GetNullUnixTime request.
-func (client *IntClient) GetNullUnixTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetNullUnixTimeCreateRequest(ctx context.Context, options *IntGetNullUnixTimeOptions) (*azcore.Request, error) {
 	urlPath := "/int/nullunixtime"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -247,8 +247,8 @@ func (client *IntClient) GetNullUnixTimeHandleError(resp *azcore.Response) error
 }
 
 // GetOverflowInt32 - Get overflow Int32 value
-func (client *IntClient) GetOverflowInt32(ctx context.Context) (*Int32Response, error) {
-	req, err := client.GetOverflowInt32CreateRequest(ctx)
+func (client *IntClient) GetOverflowInt32(ctx context.Context, options *IntGetOverflowInt32Options) (*Int32Response, error) {
+	req, err := client.GetOverflowInt32CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (client *IntClient) GetOverflowInt32(ctx context.Context) (*Int32Response, 
 }
 
 // GetOverflowInt32CreateRequest creates the GetOverflowInt32 request.
-func (client *IntClient) GetOverflowInt32CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetOverflowInt32CreateRequest(ctx context.Context, options *IntGetOverflowInt32Options) (*azcore.Request, error) {
 	urlPath := "/int/overflowint32"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -293,8 +293,8 @@ func (client *IntClient) GetOverflowInt32HandleError(resp *azcore.Response) erro
 }
 
 // GetOverflowInt64 - Get overflow Int64 value
-func (client *IntClient) GetOverflowInt64(ctx context.Context) (*Int64Response, error) {
-	req, err := client.GetOverflowInt64CreateRequest(ctx)
+func (client *IntClient) GetOverflowInt64(ctx context.Context, options *IntGetOverflowInt64Options) (*Int64Response, error) {
+	req, err := client.GetOverflowInt64CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func (client *IntClient) GetOverflowInt64(ctx context.Context) (*Int64Response, 
 }
 
 // GetOverflowInt64CreateRequest creates the GetOverflowInt64 request.
-func (client *IntClient) GetOverflowInt64CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetOverflowInt64CreateRequest(ctx context.Context, options *IntGetOverflowInt64Options) (*azcore.Request, error) {
 	urlPath := "/int/overflowint64"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -339,8 +339,8 @@ func (client *IntClient) GetOverflowInt64HandleError(resp *azcore.Response) erro
 }
 
 // GetUnderflowInt32 - Get underflow Int32 value
-func (client *IntClient) GetUnderflowInt32(ctx context.Context) (*Int32Response, error) {
-	req, err := client.GetUnderflowInt32CreateRequest(ctx)
+func (client *IntClient) GetUnderflowInt32(ctx context.Context, options *IntGetUnderflowInt32Options) (*Int32Response, error) {
+	req, err := client.GetUnderflowInt32CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +359,7 @@ func (client *IntClient) GetUnderflowInt32(ctx context.Context) (*Int32Response,
 }
 
 // GetUnderflowInt32CreateRequest creates the GetUnderflowInt32 request.
-func (client *IntClient) GetUnderflowInt32CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetUnderflowInt32CreateRequest(ctx context.Context, options *IntGetUnderflowInt32Options) (*azcore.Request, error) {
 	urlPath := "/int/underflowint32"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -385,8 +385,8 @@ func (client *IntClient) GetUnderflowInt32HandleError(resp *azcore.Response) err
 }
 
 // GetUnderflowInt64 - Get underflow Int64 value
-func (client *IntClient) GetUnderflowInt64(ctx context.Context) (*Int64Response, error) {
-	req, err := client.GetUnderflowInt64CreateRequest(ctx)
+func (client *IntClient) GetUnderflowInt64(ctx context.Context, options *IntGetUnderflowInt64Options) (*Int64Response, error) {
+	req, err := client.GetUnderflowInt64CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (client *IntClient) GetUnderflowInt64(ctx context.Context) (*Int64Response,
 }
 
 // GetUnderflowInt64CreateRequest creates the GetUnderflowInt64 request.
-func (client *IntClient) GetUnderflowInt64CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetUnderflowInt64CreateRequest(ctx context.Context, options *IntGetUnderflowInt64Options) (*azcore.Request, error) {
 	urlPath := "/int/underflowint64"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -431,8 +431,8 @@ func (client *IntClient) GetUnderflowInt64HandleError(resp *azcore.Response) err
 }
 
 // GetUnixTime - Get datetime encoded as Unix time value
-func (client *IntClient) GetUnixTime(ctx context.Context) (*TimeResponse, error) {
-	req, err := client.GetUnixTimeCreateRequest(ctx)
+func (client *IntClient) GetUnixTime(ctx context.Context, options *IntGetUnixTimeOptions) (*TimeResponse, error) {
+	req, err := client.GetUnixTimeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func (client *IntClient) GetUnixTime(ctx context.Context) (*TimeResponse, error)
 }
 
 // GetUnixTimeCreateRequest creates the GetUnixTime request.
-func (client *IntClient) GetUnixTimeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetUnixTimeCreateRequest(ctx context.Context, options *IntGetUnixTimeOptions) (*azcore.Request, error) {
 	urlPath := "/int/unixtime"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -478,8 +478,8 @@ func (client *IntClient) GetUnixTimeHandleError(resp *azcore.Response) error {
 }
 
 // PutMax32 - Put max int32 value
-func (client *IntClient) PutMax32(ctx context.Context, intBody int32) (*http.Response, error) {
-	req, err := client.PutMax32CreateRequest(ctx, intBody)
+func (client *IntClient) PutMax32(ctx context.Context, intBody int32, options *IntPutMax32Options) (*http.Response, error) {
+	req, err := client.PutMax32CreateRequest(ctx, intBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +494,7 @@ func (client *IntClient) PutMax32(ctx context.Context, intBody int32) (*http.Res
 }
 
 // PutMax32CreateRequest creates the PutMax32 request.
-func (client *IntClient) PutMax32CreateRequest(ctx context.Context, intBody int32) (*azcore.Request, error) {
+func (client *IntClient) PutMax32CreateRequest(ctx context.Context, intBody int32, options *IntPutMax32Options) (*azcore.Request, error) {
 	urlPath := "/int/max/32"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -514,8 +514,8 @@ func (client *IntClient) PutMax32HandleError(resp *azcore.Response) error {
 }
 
 // PutMax64 - Put max int64 value
-func (client *IntClient) PutMax64(ctx context.Context, intBody int64) (*http.Response, error) {
-	req, err := client.PutMax64CreateRequest(ctx, intBody)
+func (client *IntClient) PutMax64(ctx context.Context, intBody int64, options *IntPutMax64Options) (*http.Response, error) {
+	req, err := client.PutMax64CreateRequest(ctx, intBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func (client *IntClient) PutMax64(ctx context.Context, intBody int64) (*http.Res
 }
 
 // PutMax64CreateRequest creates the PutMax64 request.
-func (client *IntClient) PutMax64CreateRequest(ctx context.Context, intBody int64) (*azcore.Request, error) {
+func (client *IntClient) PutMax64CreateRequest(ctx context.Context, intBody int64, options *IntPutMax64Options) (*azcore.Request, error) {
 	urlPath := "/int/max/64"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -550,8 +550,8 @@ func (client *IntClient) PutMax64HandleError(resp *azcore.Response) error {
 }
 
 // PutMin32 - Put min int32 value
-func (client *IntClient) PutMin32(ctx context.Context, intBody int32) (*http.Response, error) {
-	req, err := client.PutMin32CreateRequest(ctx, intBody)
+func (client *IntClient) PutMin32(ctx context.Context, intBody int32, options *IntPutMin32Options) (*http.Response, error) {
+	req, err := client.PutMin32CreateRequest(ctx, intBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +566,7 @@ func (client *IntClient) PutMin32(ctx context.Context, intBody int32) (*http.Res
 }
 
 // PutMin32CreateRequest creates the PutMin32 request.
-func (client *IntClient) PutMin32CreateRequest(ctx context.Context, intBody int32) (*azcore.Request, error) {
+func (client *IntClient) PutMin32CreateRequest(ctx context.Context, intBody int32, options *IntPutMin32Options) (*azcore.Request, error) {
 	urlPath := "/int/min/32"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -586,8 +586,8 @@ func (client *IntClient) PutMin32HandleError(resp *azcore.Response) error {
 }
 
 // PutMin64 - Put min int64 value
-func (client *IntClient) PutMin64(ctx context.Context, intBody int64) (*http.Response, error) {
-	req, err := client.PutMin64CreateRequest(ctx, intBody)
+func (client *IntClient) PutMin64(ctx context.Context, intBody int64, options *IntPutMin64Options) (*http.Response, error) {
+	req, err := client.PutMin64CreateRequest(ctx, intBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func (client *IntClient) PutMin64(ctx context.Context, intBody int64) (*http.Res
 }
 
 // PutMin64CreateRequest creates the PutMin64 request.
-func (client *IntClient) PutMin64CreateRequest(ctx context.Context, intBody int64) (*azcore.Request, error) {
+func (client *IntClient) PutMin64CreateRequest(ctx context.Context, intBody int64, options *IntPutMin64Options) (*azcore.Request, error) {
 	urlPath := "/int/min/64"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -622,8 +622,8 @@ func (client *IntClient) PutMin64HandleError(resp *azcore.Response) error {
 }
 
 // PutUnixTimeDate - Put datetime encoded as Unix time
-func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time) (*http.Response, error) {
-	req, err := client.PutUnixTimeDateCreateRequest(ctx, intBody)
+func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time, options *IntPutUnixTimeDateOptions) (*http.Response, error) {
+	req, err := client.PutUnixTimeDateCreateRequest(ctx, intBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +638,7 @@ func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time)
 }
 
 // PutUnixTimeDateCreateRequest creates the PutUnixTimeDate request.
-func (client *IntClient) PutUnixTimeDateCreateRequest(ctx context.Context, intBody time.Time) (*azcore.Request, error) {
+func (client *IntClient) PutUnixTimeDateCreateRequest(ctx context.Context, intBody time.Time, options *IntPutUnixTimeDateOptions) (*azcore.Request, error) {
 	urlPath := "/int/unixtime"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/integergroup/zz_generated_models.go
+++ b/test/autorest/integergroup/zz_generated_models.go
@@ -45,6 +45,76 @@ type Int64Response struct {
 	Value       *int64
 }
 
+// IntGetInvalidOptions contains the optional parameters for the Int.GetInvalid method.
+type IntGetInvalidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetInvalidUnixTimeOptions contains the optional parameters for the Int.GetInvalidUnixTime method.
+type IntGetInvalidUnixTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetNullOptions contains the optional parameters for the Int.GetNull method.
+type IntGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetNullUnixTimeOptions contains the optional parameters for the Int.GetNullUnixTime method.
+type IntGetNullUnixTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetOverflowInt32Options contains the optional parameters for the Int.GetOverflowInt32 method.
+type IntGetOverflowInt32Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetOverflowInt64Options contains the optional parameters for the Int.GetOverflowInt64 method.
+type IntGetOverflowInt64Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetUnderflowInt32Options contains the optional parameters for the Int.GetUnderflowInt32 method.
+type IntGetUnderflowInt32Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetUnderflowInt64Options contains the optional parameters for the Int.GetUnderflowInt64 method.
+type IntGetUnderflowInt64Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntGetUnixTimeOptions contains the optional parameters for the Int.GetUnixTime method.
+type IntGetUnixTimeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntPutMax32Options contains the optional parameters for the Int.PutMax32 method.
+type IntPutMax32Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntPutMax64Options contains the optional parameters for the Int.PutMax64 method.
+type IntPutMax64Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntPutMin32Options contains the optional parameters for the Int.PutMin32 method.
+type IntPutMin32Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntPutMin64Options contains the optional parameters for the Int.PutMin64 method.
+type IntPutMin64Options struct {
+	// placeholder for future optional parameters
+}
+
+// IntPutUnixTimeDateOptions contains the optional parameters for the Int.PutUnixTimeDate method.
+type IntPutUnixTimeDateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // TimeResponse is the response envelope for operations that return a time.Time type.
 type TimeResponse struct {
 	// RawResponse contains the underlying HTTP response.

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -21,7 +21,7 @@ func newLRORetrysClient() LroRetrysOperations {
 
 func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDelete202Retry200(context.Background())
+	resp, err := op.BeginDelete202Retry200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 
 func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background())
+	resp, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 
 func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	op := newLRORetrysClient()
-	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
+	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -37,7 +37,7 @@ func httpClientWithCookieJar() azcore.Transport {
 
 func TestLROResumeWrongPoller(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202NoRetry204(context.Background())
+	resp, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestLROResumeWrongPoller(t *testing.T) {
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202NoRetry204(context.Background())
+	resp, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 
 func TestLROBeginDelete202Retry200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete202Retry200(context.Background())
+	resp, err := op.BeginDelete202Retry200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 
 func TestLROBeginDelete204Succeeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDelete204Succeeded(context.Background())
+	resp, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 
 func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background())
+	resp, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 
 func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background())
+	resp, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 
 func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetryFailed(context.Background())
+	resp, err := op.BeginDeleteAsyncRetryFailed(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 
 func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetrySucceeded(context.Background())
+	resp, err := op.BeginDeleteAsyncRetrySucceeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 
 func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteAsyncRetrycanceled(context.Background())
+	resp, err := op.BeginDeleteAsyncRetrycanceled(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 
 func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteNoHeaderInRetry(context.Background())
+	resp, err := op.BeginDeleteNoHeaderInRetry(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 
 func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background())
+	resp, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 
 func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background())
+	resp, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 
 func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background())
+	resp, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +339,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 
 func TestLROBeginPost200WithPayload(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost200WithPayload(context.Background())
+	resp, err := op.BeginPost200WithPayload(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 
 func TestLROBeginPost202List(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPost202List(context.Background())
+	resp, err := op.BeginPost202List(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +569,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background())
+	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -596,7 +596,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background())
+	resp, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -624,7 +624,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 
 func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	op := newLROSClient()
-	resp, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background())
+	resp, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -19,7 +19,7 @@ func newLrosaDsClient() LrosaDsOperations {
 
 func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDelete202NonRetry400(context.Background())
+	resp, err := op.BeginDelete202NonRetry400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 
 func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
 	op := newLrosaDsClient()
-	_, err := op.BeginDelete202RetryInvalidHeader(context.Background())
+	_, err := op.BeginDelete202RetryInvalidHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -51,7 +51,7 @@ func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDelete204Succeeded(context.Background())
+	resp, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 
 func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetry400(context.Background())
+	resp, err := op.BeginDeleteAsyncRelativeRetry400(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
 	op := newLrosaDsClient()
-	_, err := op.BeginDeleteAsyncRelativeRetryInvalidHeader(context.Background())
+	_, err := op.BeginDeleteAsyncRelativeRetryInvalidHeader(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -104,7 +104,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background())
+	resp, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 	op := newLrosaDsClient()
-	resp, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background())
+	resp, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 
 func TestLROSADSBeginDeleteNonRetry400(t *testing.T) {
 	op := newLrosaDsClient()
-	_, err := op.BeginDeleteNonRetry400(context.Background())
+	_, err := op.BeginDeleteNonRetry400(context.Background(), nil)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -16,31 +16,31 @@ import (
 // LroRetrysOperations contains the methods for the LroRetrys group.
 type LroRetrysOperations interface {
 	// BeginDelete202Retry200 - Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginDelete202Retry200(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDelete202Retry200(ctx context.Context, options *LroRetrysDelete202Retry200Options) (*HTTPPollerResponse, error)
 	// ResumeDelete202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete202Retry200(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRelativeRetrySucceeded - Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysDeleteAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRelativeRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error)
 	// BeginDeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LroRetrysDeleteProvisioning202Accepted200SucceededOptions) (*ProductPollerResponse, error)
 	// ResumeDeleteProvisioning202Accepted200Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error)
 	// BeginPost202Retry200 - Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-	BeginPost202Retry200(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*HTTPPollerResponse, error)
+	BeginPost202Retry200(ctx context.Context, options *LroRetrysPost202Retry200Options) (*HTTPPollerResponse, error)
 	// ResumePost202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202Retry200(token string) (HTTPPoller, error)
 	// BeginPostAsyncRelativeRetrySucceeded - Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRelativeRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error)
 	// BeginPut201CreatingSucceeded200 - Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginPut201CreatingSucceeded200(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
+	BeginPut201CreatingSucceeded200(ctx context.Context, options *LroRetrysPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
 	// ResumePut201CreatingSucceeded200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut201CreatingSucceeded200(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetrySucceeded - Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetrySucceeded(token string) (ProductPoller, error)
 }
@@ -61,8 +61,8 @@ func (client *LroRetrysClient) Do(req *azcore.Request) (*azcore.Response, error)
 	return client.p.Do(req)
 }
 
-func (client *LroRetrysClient) BeginDelete202Retry200(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete202Retry200(ctx)
+func (client *LroRetrysClient) BeginDelete202Retry200(ctx context.Context, options *LroRetrysDelete202Retry200Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +96,8 @@ func (client *LroRetrysClient) ResumeDelete202Retry200(token string) (HTTPPoller
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LroRetrysClient) Delete202Retry200(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete202Retry200CreateRequest(ctx)
+func (client *LroRetrysClient) Delete202Retry200(ctx context.Context, options *LroRetrysDelete202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Delete202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (client *LroRetrysClient) Delete202Retry200(ctx context.Context) (*azcore.R
 }
 
 // Delete202Retry200CreateRequest creates the Delete202Retry200 request.
-func (client *LroRetrysClient) Delete202Retry200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LroRetrysClient) Delete202Retry200CreateRequest(ctx context.Context, options *LroRetrysDelete202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/delete/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -131,8 +131,8 @@ func (client *LroRetrysClient) Delete202Retry200HandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRelativeRetrySucceeded(ctx)
+func (client *LroRetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysDeleteAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *LroRetrysClient) ResumeDeleteAsyncRelativeRetrySucceeded(token str
 }
 
 // DeleteAsyncRelativeRetrySucceeded - Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRelativeRetrySucceededCreateRequest(ctx)
+func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysDeleteAsyncRelativeRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRelativeRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceeded(ctx context.Con
 }
 
 // DeleteAsyncRelativeRetrySucceededCreateRequest creates the DeleteAsyncRelativeRetrySucceeded request.
-func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededCreateRequest(ctx context.Context, options *LroRetrysDeleteAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/deleteasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -201,8 +201,8 @@ func (client *LroRetrysClient) DeleteAsyncRelativeRetrySucceededHandleError(resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.DeleteProvisioning202Accepted200Succeeded(ctx)
+func (client *LroRetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LroRetrysDeleteProvisioning202Accepted200SucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.DeleteProvisioning202Accepted200Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -236,8 +236,8 @@ func (client *LroRetrysClient) ResumeDeleteProvisioning202Accepted200Succeeded(t
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 500, then a  202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LroRetrysClient) DeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteProvisioning202Accepted200SucceededCreateRequest(ctx)
+func (client *LroRetrysClient) DeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LroRetrysDeleteProvisioning202Accepted200SucceededOptions) (*azcore.Response, error) {
+	req, err := client.DeleteProvisioning202Accepted200SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200Succeeded(ctx con
 }
 
 // DeleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
-func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededCreateRequest(ctx context.Context, options *LroRetrysDeleteProvisioning202Accepted200SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/delete/provisioning/202/accepted/200/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -277,8 +277,8 @@ func (client *LroRetrysClient) DeleteProvisioning202Accepted200SucceededHandleEr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginPost202Retry200(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202Retry200(ctx, lroRetrysPost202Retry200Options)
+func (client *LroRetrysClient) BeginPost202Retry200(ctx context.Context, options *LroRetrysPost202Retry200Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -312,8 +312,8 @@ func (client *LroRetrysClient) ResumePost202Retry200(token string) (HTTPPoller, 
 }
 
 // Post202Retry200 - Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-func (client *LroRetrysClient) Post202Retry200(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*azcore.Response, error) {
-	req, err := client.Post202Retry200CreateRequest(ctx, lroRetrysPost202Retry200Options)
+func (client *LroRetrysClient) Post202Retry200(ctx context.Context, options *LroRetrysPost202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Post202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -328,15 +328,15 @@ func (client *LroRetrysClient) Post202Retry200(ctx context.Context, lroRetrysPos
 }
 
 // Post202Retry200CreateRequest creates the Post202Retry200 request.
-func (client *LroRetrysClient) Post202Retry200CreateRequest(ctx context.Context, lroRetrysPost202Retry200Options *LroRetrysPost202Retry200Options) (*azcore.Request, error) {
+func (client *LroRetrysClient) Post202Retry200CreateRequest(ctx context.Context, options *LroRetrysPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/post/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lroRetrysPost202Retry200Options != nil {
-		return req, req.MarshalAsJSON(lroRetrysPost202Retry200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -350,8 +350,8 @@ func (client *LroRetrysClient) Post202Retry200HandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRelativeRetrySucceeded(ctx, lroRetrysPostAsyncRelativeRetrySucceededOptions)
+func (client *LroRetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -385,8 +385,8 @@ func (client *LroRetrysClient) ResumePostAsyncRelativeRetrySucceeded(token strin
 }
 
 // PostAsyncRelativeRetrySucceeded - Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LroRetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRelativeRetrySucceededCreateRequest(ctx, lroRetrysPostAsyncRelativeRetrySucceededOptions)
+func (client *LroRetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRelativeRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -401,15 +401,15 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Conte
 }
 
 // PostAsyncRelativeRetrySucceededCreateRequest creates the PostAsyncRelativeRetrySucceeded request.
-func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededCreateRequest(ctx context.Context, lroRetrysPostAsyncRelativeRetrySucceededOptions *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededCreateRequest(ctx context.Context, options *LroRetrysPostAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/postasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lroRetrysPostAsyncRelativeRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lroRetrysPostAsyncRelativeRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -423,8 +423,8 @@ func (client *LroRetrysClient) PostAsyncRelativeRetrySucceededHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginPut201CreatingSucceeded200(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put201CreatingSucceeded200(ctx, lroRetrysPut201CreatingSucceeded200Options)
+func (client *LroRetrysClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LroRetrysPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put201CreatingSucceeded200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -458,8 +458,8 @@ func (client *LroRetrysClient) ResumePut201CreatingSucceeded200(token string) (P
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LroRetrysClient) Put201CreatingSucceeded200(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Response, error) {
-	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, lroRetrysPut201CreatingSucceeded200Options)
+func (client *LroRetrysClient) Put201CreatingSucceeded200(ctx context.Context, options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Response, error) {
+	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -474,15 +474,15 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200(ctx context.Context, l
 }
 
 // Put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
-func (client *LroRetrysClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, lroRetrysPut201CreatingSucceeded200Options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+func (client *LroRetrysClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, options *LroRetrysPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/put/201/creating/succeeded/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lroRetrysPut201CreatingSucceeded200Options != nil {
-		return req, req.MarshalAsJSON(lroRetrysPut201CreatingSucceeded200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -502,8 +502,8 @@ func (client *LroRetrysClient) Put201CreatingSucceeded200HandleError(resp *azcor
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LroRetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetrySucceeded(ctx, lroRetrysPutAsyncRelativeRetrySucceededOptions)
+func (client *LroRetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -537,8 +537,8 @@ func (client *LroRetrysClient) ResumePutAsyncRelativeRetrySucceeded(token string
 }
 
 // PutAsyncRelativeRetrySucceeded - Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LroRetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetrySucceededCreateRequest(ctx, lroRetrysPutAsyncRelativeRetrySucceededOptions)
+func (client *LroRetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Context, options *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -553,15 +553,15 @@ func (client *LroRetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Contex
 }
 
 // PutAsyncRelativeRetrySucceededCreateRequest creates the PutAsyncRelativeRetrySucceeded request.
-func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededCreateRequest(ctx context.Context, lroRetrysPutAsyncRelativeRetrySucceededOptions *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LroRetrysClient) PutAsyncRelativeRetrySucceededCreateRequest(ctx context.Context, options *LroRetrysPutAsyncRelativeRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/retryerror/putasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lroRetrysPutAsyncRelativeRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lroRetrysPutAsyncRelativeRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -16,167 +16,167 @@ import (
 // LrOSOperations contains the methods for the LrOS group.
 type LrOSOperations interface {
 	// BeginDelete202NoRetry204 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginDelete202NoRetry204(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDelete202NoRetry204(ctx context.Context, options *LrOSDelete202NoRetry204Options) (*ProductPollerResponse, error)
 	// ResumeDelete202NoRetry204 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete202NoRetry204(token string) (ProductPoller, error)
 	// BeginDelete202Retry200 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginDelete202Retry200(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDelete202Retry200(ctx context.Context, options *LrOSDelete202Retry200Options) (*ProductPollerResponse, error)
 	// ResumeDelete202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete202Retry200(token string) (ProductPoller, error)
 	// BeginDelete204Succeeded - Long running delete succeeds and returns right away
-	BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDelete204Succeeded(ctx context.Context, options *LrOSDelete204SucceededOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete204Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete204Succeeded(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncNoHeaderInRetry - Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
-	BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, options *LrOSDeleteAsyncNoHeaderInRetryOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncNoHeaderInRetry - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncNoHeaderInRetry(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncNoRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncNoRetrySucceededOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncNoRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncNoRetrySucceeded(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRetryFailed - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRetryFailed(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRetryFailed(ctx context.Context, options *LrOSDeleteAsyncRetryFailedOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRetryFailed - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRetryFailed(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncRetrySucceededOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRetrySucceeded(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRetrycanceled - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRetrycanceled(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRetrycanceled(ctx context.Context, options *LrOSDeleteAsyncRetrycanceledOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRetrycanceled - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRetrycanceled(token string) (HTTPPoller, error)
 	// BeginDeleteNoHeaderInRetry - Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
-	BeginDeleteNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteNoHeaderInRetry(ctx context.Context, options *LrOSDeleteNoHeaderInRetryOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteNoHeaderInRetry - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteNoHeaderInRetry(token string) (HTTPPoller, error)
 	// BeginDeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LrOSDeleteProvisioning202Accepted200SucceededOptions) (*ProductPollerResponse, error)
 	// ResumeDeleteProvisioning202Accepted200Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error)
 	// BeginDeleteProvisioning202DeletingFailed200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
-	BeginDeleteProvisioning202DeletingFailed200(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDeleteProvisioning202DeletingFailed200(ctx context.Context, options *LrOSDeleteProvisioning202DeletingFailed200Options) (*ProductPollerResponse, error)
 	// ResumeDeleteProvisioning202DeletingFailed200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteProvisioning202DeletingFailed200(token string) (ProductPoller, error)
 	// BeginDeleteProvisioning202Deletingcanceled200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
-	BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context) (*ProductPollerResponse, error)
+	BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context, options *LrOSDeleteProvisioning202Deletingcanceled200Options) (*ProductPollerResponse, error)
 	// ResumeDeleteProvisioning202Deletingcanceled200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteProvisioning202Deletingcanceled200(token string) (ProductPoller, error)
 	// BeginPost200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
-	BeginPost200WithPayload(ctx context.Context) (*SKUPollerResponse, error)
+	BeginPost200WithPayload(ctx context.Context, options *LrOSPost200WithPayloadOptions) (*SKUPollerResponse, error)
 	// ResumePost200WithPayload - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost200WithPayload(token string) (SKUPoller, error)
 	// BeginPost202List - Long running put request, service returns a 202 with empty body to first request, returns a 200 with body [{ 'id': '100', 'name': 'foo' }].
-	BeginPost202List(ctx context.Context) (*ProductArrayPollerResponse, error)
+	BeginPost202List(ctx context.Context, options *LrOSPost202ListOptions) (*ProductArrayPollerResponse, error)
 	// ResumePost202List - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202List(token string) (ProductArrayPoller, error)
 	// BeginPost202NoRetry204 - Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success
-	BeginPost202NoRetry204(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*ProductPollerResponse, error)
+	BeginPost202NoRetry204(ctx context.Context, options *LrOSPost202NoRetry204Options) (*ProductPollerResponse, error)
 	// ResumePost202NoRetry204 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202NoRetry204(token string) (ProductPoller, error)
 	// BeginPost202Retry200 - Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-	BeginPost202Retry200(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*HTTPPollerResponse, error)
+	BeginPost202Retry200(ctx context.Context, options *LrOSPost202Retry200Options) (*HTTPPollerResponse, error)
 	// ResumePost202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202Retry200(token string) (HTTPPoller, error)
 	// BeginPostAsyncNoRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncNoRetrySucceeded(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPostAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPostAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePostAsyncNoRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncNoRetrySucceeded(token string) (ProductPoller, error)
 	// BeginPostAsyncRetryFailed - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRetryFailed(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRetryFailed(ctx context.Context, options *LrOSPostAsyncRetryFailedOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRetryFailed - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRetryFailed(token string) (HTTPPoller, error)
 	// BeginPostAsyncRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPostAsyncRetrySucceeded(ctx context.Context, options *LrOSPostAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePostAsyncRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRetrySucceeded(token string) (ProductPoller, error)
 	// BeginPostAsyncRetrycanceled - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRetrycanceled(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRetrycanceled(ctx context.Context, options *LrOSPostAsyncRetrycanceledOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRetrycanceled - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRetrycanceled(token string) (HTTPPoller, error)
 	// BeginPostDoubleHeadersFinalAzureHeaderGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object
-	BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context) (*ProductPollerResponse, error)
+	BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetOptions) (*ProductPollerResponse, error)
 	// ResumePostDoubleHeadersFinalAzureHeaderGet - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostDoubleHeadersFinalAzureHeaderGet(token string) (ProductPoller, error)
 	// BeginPostDoubleHeadersFinalAzureHeaderGetDefault - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object if you support initial Autorest behavior.
-	BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context) (*ProductPollerResponse, error)
+	BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (*ProductPollerResponse, error)
 	// ResumePostDoubleHeadersFinalAzureHeaderGetDefault - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostDoubleHeadersFinalAzureHeaderGetDefault(token string) (ProductPoller, error)
 	// BeginPostDoubleHeadersFinalLocationGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final object
-	BeginPostDoubleHeadersFinalLocationGet(ctx context.Context) (*ProductPollerResponse, error)
+	BeginPostDoubleHeadersFinalLocationGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalLocationGetOptions) (*ProductPollerResponse, error)
 	// ResumePostDoubleHeadersFinalLocationGet - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostDoubleHeadersFinalLocationGet(token string) (ProductPoller, error)
 	// BeginPut200Acceptedcanceled200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
-	BeginPut200Acceptedcanceled200(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*ProductPollerResponse, error)
+	BeginPut200Acceptedcanceled200(ctx context.Context, options *LrOSPut200Acceptedcanceled200Options) (*ProductPollerResponse, error)
 	// ResumePut200Acceptedcanceled200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut200Acceptedcanceled200(token string) (ProductPoller, error)
 	// BeginPut200Succeeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
-	BeginPut200Succeeded(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*ProductPollerResponse, error)
+	BeginPut200Succeeded(ctx context.Context, options *LrOSPut200SucceededOptions) (*ProductPollerResponse, error)
 	// ResumePut200Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut200Succeeded(token string) (ProductPoller, error)
 	// BeginPut200SucceededNoState - Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
-	BeginPut200SucceededNoState(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*ProductPollerResponse, error)
+	BeginPut200SucceededNoState(ctx context.Context, options *LrOSPut200SucceededNoStateOptions) (*ProductPollerResponse, error)
 	// ResumePut200SucceededNoState - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut200SucceededNoState(token string) (ProductPoller, error)
 	// BeginPut200UpdatingSucceeded204 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginPut200UpdatingSucceeded204(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*ProductPollerResponse, error)
+	BeginPut200UpdatingSucceeded204(ctx context.Context, options *LrOSPut200UpdatingSucceeded204Options) (*ProductPollerResponse, error)
 	// ResumePut200UpdatingSucceeded204 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut200UpdatingSucceeded204(token string) (ProductPoller, error)
 	// BeginPut201CreatingFailed200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
-	BeginPut201CreatingFailed200(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*ProductPollerResponse, error)
+	BeginPut201CreatingFailed200(ctx context.Context, options *LrOSPut201CreatingFailed200Options) (*ProductPollerResponse, error)
 	// ResumePut201CreatingFailed200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut201CreatingFailed200(token string) (ProductPoller, error)
 	// BeginPut201CreatingSucceeded200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginPut201CreatingSucceeded200(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
+	BeginPut201CreatingSucceeded200(ctx context.Context, options *LrOSPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
 	// ResumePut201CreatingSucceeded200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut201CreatingSucceeded200(token string) (ProductPoller, error)
 	// BeginPut201Succeeded - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
-	BeginPut201Succeeded(ctx context.Context, lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*ProductPollerResponse, error)
+	BeginPut201Succeeded(ctx context.Context, options *LrOSPut201SucceededOptions) (*ProductPollerResponse, error)
 	// ResumePut201Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut201Succeeded(token string) (ProductPoller, error)
 	// BeginPut202Retry200 - Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState
-	BeginPut202Retry200(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*ProductPollerResponse, error)
+	BeginPut202Retry200(ctx context.Context, options *LrOSPut202Retry200Options) (*ProductPollerResponse, error)
 	// ResumePut202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut202Retry200(token string) (ProductPoller, error)
 	// BeginPutAsyncNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
-	BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncNoHeaderInRetry(ctx context.Context, options *LrOSPutAsyncNoHeaderInRetryOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncNoHeaderInRetry - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncNoHeaderInRetry(token string) (ProductPoller, error)
 	// BeginPutAsyncNoRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPutAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncNoRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncNoRetrySucceeded(token string) (ProductPoller, error)
 	// BeginPutAsyncNoRetrycanceled - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncNoRetrycanceled(ctx context.Context, options *LrOSPutAsyncNoRetrycanceledOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncNoRetrycanceled - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncNoRetrycanceled(token string) (ProductPoller, error)
 	// BeginPutAsyncNonResource - Long running put request with non resource.
-	BeginPutAsyncNonResource(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*SKUPollerResponse, error)
+	BeginPutAsyncNonResource(ctx context.Context, options *LrOSPutAsyncNonResourceOptions) (*SKUPollerResponse, error)
 	// ResumePutAsyncNonResource - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncNonResource(token string) (SKUPoller, error)
 	// BeginPutAsyncRetryFailed - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRetryFailed(ctx context.Context, options *LrOSPutAsyncRetryFailedOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRetryFailed - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRetryFailed(token string) (ProductPoller, error)
 	// BeginPutAsyncRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRetrySucceeded(ctx context.Context, options *LrOSPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error)
 	// BeginPutAsyncSubResource - Long running put request with sub resource.
-	BeginPutAsyncSubResource(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*SubProductPollerResponse, error)
+	BeginPutAsyncSubResource(ctx context.Context, options *LrOSPutAsyncSubResourceOptions) (*SubProductPollerResponse, error)
 	// ResumePutAsyncSubResource - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncSubResource(token string) (SubProductPoller, error)
 	// BeginPutNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
-	BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*ProductPollerResponse, error)
+	BeginPutNoHeaderInRetry(ctx context.Context, options *LrOSPutNoHeaderInRetryOptions) (*ProductPollerResponse, error)
 	// ResumePutNoHeaderInRetry - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutNoHeaderInRetry(token string) (ProductPoller, error)
 	// BeginPutNonResource - Long running put request with non resource.
-	BeginPutNonResource(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*SKUPollerResponse, error)
+	BeginPutNonResource(ctx context.Context, options *LrOSPutNonResourceOptions) (*SKUPollerResponse, error)
 	// ResumePutNonResource - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutNonResource(token string) (SKUPoller, error)
 	// BeginPutSubResource - Long running put request with sub resource.
-	BeginPutSubResource(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*SubProductPollerResponse, error)
+	BeginPutSubResource(ctx context.Context, options *LrOSPutSubResourceOptions) (*SubProductPollerResponse, error)
 	// ResumePutSubResource - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutSubResource(token string) (SubProductPoller, error)
 }
@@ -197,8 +197,8 @@ func (client *LrOSClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *LrOSClient) BeginDelete202NoRetry204(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.Delete202NoRetry204(ctx)
+func (client *LrOSClient) BeginDelete202NoRetry204(ctx context.Context, options *LrOSDelete202NoRetry204Options) (*ProductPollerResponse, error) {
+	resp, err := client.Delete202NoRetry204(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +232,8 @@ func (client *LrOSClient) ResumeDelete202NoRetry204(token string) (ProductPoller
 }
 
 // Delete202NoRetry204 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSClient) Delete202NoRetry204(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete202NoRetry204CreateRequest(ctx)
+func (client *LrOSClient) Delete202NoRetry204(ctx context.Context, options *LrOSDelete202NoRetry204Options) (*azcore.Response, error) {
+	req, err := client.Delete202NoRetry204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (client *LrOSClient) Delete202NoRetry204(ctx context.Context) (*azcore.Resp
 }
 
 // Delete202NoRetry204CreateRequest creates the Delete202NoRetry204 request.
-func (client *LrOSClient) Delete202NoRetry204CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) Delete202NoRetry204CreateRequest(ctx context.Context, options *LrOSDelete202NoRetry204Options) (*azcore.Request, error) {
 	urlPath := "/lro/delete/202/noretry/204"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -273,8 +273,8 @@ func (client *LrOSClient) Delete202NoRetry204HandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDelete202Retry200(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.Delete202Retry200(ctx)
+func (client *LrOSClient) BeginDelete202Retry200(ctx context.Context, options *LrOSDelete202Retry200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Delete202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -308,8 +308,8 @@ func (client *LrOSClient) ResumeDelete202Retry200(token string) (ProductPoller, 
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSClient) Delete202Retry200(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete202Retry200CreateRequest(ctx)
+func (client *LrOSClient) Delete202Retry200(ctx context.Context, options *LrOSDelete202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Delete202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (client *LrOSClient) Delete202Retry200(ctx context.Context) (*azcore.Respon
 }
 
 // Delete202Retry200CreateRequest creates the Delete202Retry200 request.
-func (client *LrOSClient) Delete202Retry200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) Delete202Retry200CreateRequest(ctx context.Context, options *LrOSDelete202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/delete/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -349,8 +349,8 @@ func (client *LrOSClient) Delete202Retry200HandleError(resp *azcore.Response) er
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete204Succeeded(ctx)
+func (client *LrOSClient) BeginDelete204Succeeded(ctx context.Context, options *LrOSDelete204SucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete204Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -384,8 +384,8 @@ func (client *LrOSClient) ResumeDelete204Succeeded(token string) (HTTPPoller, er
 }
 
 // Delete204Succeeded - Long running delete succeeds and returns right away
-func (client *LrOSClient) Delete204Succeeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete204SucceededCreateRequest(ctx)
+func (client *LrOSClient) Delete204Succeeded(ctx context.Context, options *LrOSDelete204SucceededOptions) (*azcore.Response, error) {
+	req, err := client.Delete204SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func (client *LrOSClient) Delete204Succeeded(ctx context.Context) (*azcore.Respo
 }
 
 // Delete204SucceededCreateRequest creates the Delete204Succeeded request.
-func (client *LrOSClient) Delete204SucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) Delete204SucceededCreateRequest(ctx context.Context, options *LrOSDelete204SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/delete/204/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -419,8 +419,8 @@ func (client *LrOSClient) Delete204SucceededHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncNoHeaderInRetry(ctx)
+func (client *LrOSClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, options *LrOSDeleteAsyncNoHeaderInRetryOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncNoHeaderInRetry(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -454,8 +454,8 @@ func (client *LrOSClient) ResumeDeleteAsyncNoHeaderInRetry(token string) (HTTPPo
 }
 
 // DeleteAsyncNoHeaderInRetry - Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
-func (client *LrOSClient) DeleteAsyncNoHeaderInRetry(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncNoHeaderInRetryCreateRequest(ctx)
+func (client *LrOSClient) DeleteAsyncNoHeaderInRetry(ctx context.Context, options *LrOSDeleteAsyncNoHeaderInRetryOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncNoHeaderInRetryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +470,7 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetry(ctx context.Context) (*azco
 }
 
 // DeleteAsyncNoHeaderInRetryCreateRequest creates the DeleteAsyncNoHeaderInRetry request.
-func (client *LrOSClient) DeleteAsyncNoHeaderInRetryCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteAsyncNoHeaderInRetryCreateRequest(ctx context.Context, options *LrOSDeleteAsyncNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/noheader/202/204"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -489,8 +489,8 @@ func (client *LrOSClient) DeleteAsyncNoHeaderInRetryHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncNoRetrySucceeded(ctx)
+func (client *LrOSClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncNoRetrySucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -524,8 +524,8 @@ func (client *LrOSClient) ResumeDeleteAsyncNoRetrySucceeded(token string) (HTTPP
 }
 
 // DeleteAsyncNoRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) DeleteAsyncNoRetrySucceeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncNoRetrySucceededCreateRequest(ctx)
+func (client *LrOSClient) DeleteAsyncNoRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncNoRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncNoRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceeded(ctx context.Context) (*azc
 }
 
 // DeleteAsyncNoRetrySucceededCreateRequest creates the DeleteAsyncNoRetrySucceeded request.
-func (client *LrOSClient) DeleteAsyncNoRetrySucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteAsyncNoRetrySucceededCreateRequest(ctx context.Context, options *LrOSDeleteAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/noretry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -559,8 +559,8 @@ func (client *LrOSClient) DeleteAsyncNoRetrySucceededHandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteAsyncRetryFailed(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRetryFailed(ctx)
+func (client *LrOSClient) BeginDeleteAsyncRetryFailed(ctx context.Context, options *LrOSDeleteAsyncRetryFailedOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRetryFailed(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -594,8 +594,8 @@ func (client *LrOSClient) ResumeDeleteAsyncRetryFailed(token string) (HTTPPoller
 }
 
 // DeleteAsyncRetryFailed - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) DeleteAsyncRetryFailed(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRetryFailedCreateRequest(ctx)
+func (client *LrOSClient) DeleteAsyncRetryFailed(ctx context.Context, options *LrOSDeleteAsyncRetryFailedOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRetryFailedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (client *LrOSClient) DeleteAsyncRetryFailed(ctx context.Context) (*azcore.R
 }
 
 // DeleteAsyncRetryFailedCreateRequest creates the DeleteAsyncRetryFailed request.
-func (client *LrOSClient) DeleteAsyncRetryFailedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteAsyncRetryFailedCreateRequest(ctx context.Context, options *LrOSDeleteAsyncRetryFailedOptions) (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/failed"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -629,8 +629,8 @@ func (client *LrOSClient) DeleteAsyncRetryFailedHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRetrySucceeded(ctx)
+func (client *LrOSClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncRetrySucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -664,8 +664,8 @@ func (client *LrOSClient) ResumeDeleteAsyncRetrySucceeded(token string) (HTTPPol
 }
 
 // DeleteAsyncRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) DeleteAsyncRetrySucceeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRetrySucceededCreateRequest(ctx)
+func (client *LrOSClient) DeleteAsyncRetrySucceeded(ctx context.Context, options *LrOSDeleteAsyncRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +680,7 @@ func (client *LrOSClient) DeleteAsyncRetrySucceeded(ctx context.Context) (*azcor
 }
 
 // DeleteAsyncRetrySucceededCreateRequest creates the DeleteAsyncRetrySucceeded request.
-func (client *LrOSClient) DeleteAsyncRetrySucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteAsyncRetrySucceededCreateRequest(ctx context.Context, options *LrOSDeleteAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -699,8 +699,8 @@ func (client *LrOSClient) DeleteAsyncRetrySucceededHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteAsyncRetrycanceled(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRetrycanceled(ctx)
+func (client *LrOSClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, options *LrOSDeleteAsyncRetrycanceledOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRetrycanceled(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -734,8 +734,8 @@ func (client *LrOSClient) ResumeDeleteAsyncRetrycanceled(token string) (HTTPPoll
 }
 
 // DeleteAsyncRetrycanceled - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) DeleteAsyncRetrycanceled(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRetrycanceledCreateRequest(ctx)
+func (client *LrOSClient) DeleteAsyncRetrycanceled(ctx context.Context, options *LrOSDeleteAsyncRetrycanceledOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRetrycanceledCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -750,7 +750,7 @@ func (client *LrOSClient) DeleteAsyncRetrycanceled(ctx context.Context) (*azcore
 }
 
 // DeleteAsyncRetrycanceledCreateRequest creates the DeleteAsyncRetrycanceled request.
-func (client *LrOSClient) DeleteAsyncRetrycanceledCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteAsyncRetrycanceledCreateRequest(ctx context.Context, options *LrOSDeleteAsyncRetrycanceledOptions) (*azcore.Request, error) {
 	urlPath := "/lro/deleteasync/retry/canceled"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -769,8 +769,8 @@ func (client *LrOSClient) DeleteAsyncRetrycanceledHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteNoHeaderInRetry(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteNoHeaderInRetry(ctx)
+func (client *LrOSClient) BeginDeleteNoHeaderInRetry(ctx context.Context, options *LrOSDeleteNoHeaderInRetryOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteNoHeaderInRetry(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -804,8 +804,8 @@ func (client *LrOSClient) ResumeDeleteNoHeaderInRetry(token string) (HTTPPoller,
 }
 
 // DeleteNoHeaderInRetry - Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do not contain location header.
-func (client *LrOSClient) DeleteNoHeaderInRetry(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteNoHeaderInRetryCreateRequest(ctx)
+func (client *LrOSClient) DeleteNoHeaderInRetry(ctx context.Context, options *LrOSDeleteNoHeaderInRetryOptions) (*azcore.Response, error) {
+	req, err := client.DeleteNoHeaderInRetryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -820,7 +820,7 @@ func (client *LrOSClient) DeleteNoHeaderInRetry(ctx context.Context) (*azcore.Re
 }
 
 // DeleteNoHeaderInRetryCreateRequest creates the DeleteNoHeaderInRetry request.
-func (client *LrOSClient) DeleteNoHeaderInRetryCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteNoHeaderInRetryCreateRequest(ctx context.Context, options *LrOSDeleteNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/delete/noheader"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -839,8 +839,8 @@ func (client *LrOSClient) DeleteNoHeaderInRetryHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.DeleteProvisioning202Accepted200Succeeded(ctx)
+func (client *LrOSClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LrOSDeleteProvisioning202Accepted200SucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.DeleteProvisioning202Accepted200Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -874,8 +874,8 @@ func (client *LrOSClient) ResumeDeleteProvisioning202Accepted200Succeeded(token 
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSClient) DeleteProvisioning202Accepted200Succeeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteProvisioning202Accepted200SucceededCreateRequest(ctx)
+func (client *LrOSClient) DeleteProvisioning202Accepted200Succeeded(ctx context.Context, options *LrOSDeleteProvisioning202Accepted200SucceededOptions) (*azcore.Response, error) {
+	req, err := client.DeleteProvisioning202Accepted200SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -890,7 +890,7 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200Succeeded(ctx context.
 }
 
 // DeleteProvisioning202Accepted200SucceededCreateRequest creates the DeleteProvisioning202Accepted200Succeeded request.
-func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededCreateRequest(ctx context.Context, options *LrOSDeleteProvisioning202Accepted200SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/accepted/200/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -915,8 +915,8 @@ func (client *LrOSClient) DeleteProvisioning202Accepted200SucceededHandleError(r
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.DeleteProvisioning202DeletingFailed200(ctx)
+func (client *LrOSClient) BeginDeleteProvisioning202DeletingFailed200(ctx context.Context, options *LrOSDeleteProvisioning202DeletingFailed200Options) (*ProductPollerResponse, error) {
+	resp, err := client.DeleteProvisioning202DeletingFailed200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -950,8 +950,8 @@ func (client *LrOSClient) ResumeDeleteProvisioning202DeletingFailed200(token str
 }
 
 // DeleteProvisioning202DeletingFailed200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
-func (client *LrOSClient) DeleteProvisioning202DeletingFailed200(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteProvisioning202DeletingFailed200CreateRequest(ctx)
+func (client *LrOSClient) DeleteProvisioning202DeletingFailed200(ctx context.Context, options *LrOSDeleteProvisioning202DeletingFailed200Options) (*azcore.Response, error) {
+	req, err := client.DeleteProvisioning202DeletingFailed200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -966,7 +966,7 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200(ctx context.Con
 }
 
 // DeleteProvisioning202DeletingFailed200CreateRequest creates the DeleteProvisioning202DeletingFailed200 request.
-func (client *LrOSClient) DeleteProvisioning202DeletingFailed200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteProvisioning202DeletingFailed200CreateRequest(ctx context.Context, options *LrOSDeleteProvisioning202DeletingFailed200Options) (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/deleting/200/failed"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -991,8 +991,8 @@ func (client *LrOSClient) DeleteProvisioning202DeletingFailed200HandleError(resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.DeleteProvisioning202Deletingcanceled200(ctx)
+func (client *LrOSClient) BeginDeleteProvisioning202Deletingcanceled200(ctx context.Context, options *LrOSDeleteProvisioning202Deletingcanceled200Options) (*ProductPollerResponse, error) {
+	resp, err := client.DeleteProvisioning202Deletingcanceled200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,8 +1026,8 @@ func (client *LrOSClient) ResumeDeleteProvisioning202Deletingcanceled200(token s
 }
 
 // DeleteProvisioning202Deletingcanceled200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
-func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteProvisioning202Deletingcanceled200CreateRequest(ctx)
+func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200(ctx context.Context, options *LrOSDeleteProvisioning202Deletingcanceled200Options) (*azcore.Response, error) {
+	req, err := client.DeleteProvisioning202Deletingcanceled200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1042,7 +1042,7 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200(ctx context.C
 }
 
 // DeleteProvisioning202Deletingcanceled200CreateRequest creates the DeleteProvisioning202Deletingcanceled200 request.
-func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200CreateRequest(ctx context.Context, options *LrOSDeleteProvisioning202Deletingcanceled200Options) (*azcore.Request, error) {
 	urlPath := "/lro/delete/provisioning/202/deleting/200/canceled"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1067,8 +1067,8 @@ func (client *LrOSClient) DeleteProvisioning202Deletingcanceled200HandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPost200WithPayload(ctx context.Context) (*SKUPollerResponse, error) {
-	resp, err := client.Post200WithPayload(ctx)
+func (client *LrOSClient) BeginPost200WithPayload(ctx context.Context, options *LrOSPost200WithPayloadOptions) (*SKUPollerResponse, error) {
+	resp, err := client.Post200WithPayload(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1102,8 +1102,8 @@ func (client *LrOSClient) ResumePost200WithPayload(token string) (SKUPoller, err
 }
 
 // Post200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response body after success.
-func (client *LrOSClient) Post200WithPayload(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Post200WithPayloadCreateRequest(ctx)
+func (client *LrOSClient) Post200WithPayload(ctx context.Context, options *LrOSPost200WithPayloadOptions) (*azcore.Response, error) {
+	req, err := client.Post200WithPayloadCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1118,7 @@ func (client *LrOSClient) Post200WithPayload(ctx context.Context) (*azcore.Respo
 }
 
 // Post200WithPayloadCreateRequest creates the Post200WithPayload request.
-func (client *LrOSClient) Post200WithPayloadCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) Post200WithPayloadCreateRequest(ctx context.Context, options *LrOSPost200WithPayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/post/payload/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1143,8 +1143,8 @@ func (client *LrOSClient) Post200WithPayloadHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPost202List(ctx context.Context) (*ProductArrayPollerResponse, error) {
-	resp, err := client.Post202List(ctx)
+func (client *LrOSClient) BeginPost202List(ctx context.Context, options *LrOSPost202ListOptions) (*ProductArrayPollerResponse, error) {
+	resp, err := client.Post202List(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1178,8 +1178,8 @@ func (client *LrOSClient) ResumePost202List(token string) (ProductArrayPoller, e
 }
 
 // Post202List - Long running put request, service returns a 202 with empty body to first request, returns a 200 with body [{ 'id': '100', 'name': 'foo' }].
-func (client *LrOSClient) Post202List(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Post202ListCreateRequest(ctx)
+func (client *LrOSClient) Post202List(ctx context.Context, options *LrOSPost202ListOptions) (*azcore.Response, error) {
+	req, err := client.Post202ListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1194,7 +1194,7 @@ func (client *LrOSClient) Post202List(ctx context.Context) (*azcore.Response, er
 }
 
 // Post202ListCreateRequest creates the Post202List request.
-func (client *LrOSClient) Post202ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) Post202ListCreateRequest(ctx context.Context, options *LrOSPost202ListOptions) (*azcore.Request, error) {
 	urlPath := "/lro/list"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1219,8 +1219,8 @@ func (client *LrOSClient) Post202ListHandleError(resp *azcore.Response) error {
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPost202NoRetry204(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*ProductPollerResponse, error) {
-	resp, err := client.Post202NoRetry204(ctx, lrOSPost202NoRetry204Options)
+func (client *LrOSClient) BeginPost202NoRetry204(ctx context.Context, options *LrOSPost202NoRetry204Options) (*ProductPollerResponse, error) {
+	resp, err := client.Post202NoRetry204(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1254,8 +1254,8 @@ func (client *LrOSClient) ResumePost202NoRetry204(token string) (ProductPoller, 
 }
 
 // Post202NoRetry204 - Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success
-func (client *LrOSClient) Post202NoRetry204(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*azcore.Response, error) {
-	req, err := client.Post202NoRetry204CreateRequest(ctx, lrOSPost202NoRetry204Options)
+func (client *LrOSClient) Post202NoRetry204(ctx context.Context, options *LrOSPost202NoRetry204Options) (*azcore.Response, error) {
+	req, err := client.Post202NoRetry204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1270,15 +1270,15 @@ func (client *LrOSClient) Post202NoRetry204(ctx context.Context, lrOSPost202NoRe
 }
 
 // Post202NoRetry204CreateRequest creates the Post202NoRetry204 request.
-func (client *LrOSClient) Post202NoRetry204CreateRequest(ctx context.Context, lrOSPost202NoRetry204Options *LrOSPost202NoRetry204Options) (*azcore.Request, error) {
+func (client *LrOSClient) Post202NoRetry204CreateRequest(ctx context.Context, options *LrOSPost202NoRetry204Options) (*azcore.Request, error) {
 	urlPath := "/lro/post/202/noretry/204"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPost202NoRetry204Options != nil {
-		return req, req.MarshalAsJSON(lrOSPost202NoRetry204Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1298,8 +1298,8 @@ func (client *LrOSClient) Post202NoRetry204HandleError(resp *azcore.Response) er
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPost202Retry200(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202Retry200(ctx, lrOSPost202Retry200Options)
+func (client *LrOSClient) BeginPost202Retry200(ctx context.Context, options *LrOSPost202Retry200Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1333,8 +1333,8 @@ func (client *LrOSClient) ResumePost202Retry200(token string) (HTTPPoller, error
 }
 
 // Post202Retry200 - Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-func (client *LrOSClient) Post202Retry200(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*azcore.Response, error) {
-	req, err := client.Post202Retry200CreateRequest(ctx, lrOSPost202Retry200Options)
+func (client *LrOSClient) Post202Retry200(ctx context.Context, options *LrOSPost202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Post202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,15 +1349,15 @@ func (client *LrOSClient) Post202Retry200(ctx context.Context, lrOSPost202Retry2
 }
 
 // Post202Retry200CreateRequest creates the Post202Retry200 request.
-func (client *LrOSClient) Post202Retry200CreateRequest(ctx context.Context, lrOSPost202Retry200Options *LrOSPost202Retry200Options) (*azcore.Request, error) {
+func (client *LrOSClient) Post202Retry200CreateRequest(ctx context.Context, options *LrOSPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/post/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPost202Retry200Options != nil {
-		return req, req.MarshalAsJSON(lrOSPost202Retry200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1371,8 +1371,8 @@ func (client *LrOSClient) Post202Retry200HandleError(resp *azcore.Response) erro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PostAsyncNoRetrySucceeded(ctx, lrOSPostAsyncNoRetrySucceededOptions)
+func (client *LrOSClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPostAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PostAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1406,8 +1406,8 @@ func (client *LrOSClient) ResumePostAsyncNoRetrySucceeded(token string) (Product
 }
 
 // PostAsyncNoRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PostAsyncNoRetrySucceeded(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncNoRetrySucceededCreateRequest(ctx, lrOSPostAsyncNoRetrySucceededOptions)
+func (client *LrOSClient) PostAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncNoRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1422,15 +1422,15 @@ func (client *LrOSClient) PostAsyncNoRetrySucceeded(ctx context.Context, lrOSPos
 }
 
 // PostAsyncNoRetrySucceededCreateRequest creates the PostAsyncNoRetrySucceeded request.
-func (client *LrOSClient) PostAsyncNoRetrySucceededCreateRequest(ctx context.Context, lrOSPostAsyncNoRetrySucceededOptions *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PostAsyncNoRetrySucceededCreateRequest(ctx context.Context, options *LrOSPostAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/noretry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPostAsyncNoRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPostAsyncNoRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1450,8 +1450,8 @@ func (client *LrOSClient) PostAsyncNoRetrySucceededHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostAsyncRetryFailed(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRetryFailed(ctx, lrOSPostAsyncRetryFailedOptions)
+func (client *LrOSClient) BeginPostAsyncRetryFailed(ctx context.Context, options *LrOSPostAsyncRetryFailedOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRetryFailed(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1485,8 +1485,8 @@ func (client *LrOSClient) ResumePostAsyncRetryFailed(token string) (HTTPPoller, 
 }
 
 // PostAsyncRetryFailed - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PostAsyncRetryFailed(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRetryFailedCreateRequest(ctx, lrOSPostAsyncRetryFailedOptions)
+func (client *LrOSClient) PostAsyncRetryFailed(ctx context.Context, options *LrOSPostAsyncRetryFailedOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRetryFailedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1501,15 +1501,15 @@ func (client *LrOSClient) PostAsyncRetryFailed(ctx context.Context, lrOSPostAsyn
 }
 
 // PostAsyncRetryFailedCreateRequest creates the PostAsyncRetryFailed request.
-func (client *LrOSClient) PostAsyncRetryFailedCreateRequest(ctx context.Context, lrOSPostAsyncRetryFailedOptions *LrOSPostAsyncRetryFailedOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PostAsyncRetryFailedCreateRequest(ctx context.Context, options *LrOSPostAsyncRetryFailedOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/failed"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPostAsyncRetryFailedOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPostAsyncRetryFailedOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1523,8 +1523,8 @@ func (client *LrOSClient) PostAsyncRetryFailedHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PostAsyncRetrySucceeded(ctx, lrOSPostAsyncRetrySucceededOptions)
+func (client *LrOSClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LrOSPostAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PostAsyncRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1558,8 +1558,8 @@ func (client *LrOSClient) ResumePostAsyncRetrySucceeded(token string) (ProductPo
 }
 
 // PostAsyncRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PostAsyncRetrySucceeded(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRetrySucceededCreateRequest(ctx, lrOSPostAsyncRetrySucceededOptions)
+func (client *LrOSClient) PostAsyncRetrySucceeded(ctx context.Context, options *LrOSPostAsyncRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1574,15 +1574,15 @@ func (client *LrOSClient) PostAsyncRetrySucceeded(ctx context.Context, lrOSPostA
 }
 
 // PostAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
-func (client *LrOSClient) PostAsyncRetrySucceededCreateRequest(ctx context.Context, lrOSPostAsyncRetrySucceededOptions *LrOSPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PostAsyncRetrySucceededCreateRequest(ctx context.Context, options *LrOSPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPostAsyncRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPostAsyncRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1602,8 +1602,8 @@ func (client *LrOSClient) PostAsyncRetrySucceededHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostAsyncRetrycanceled(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRetrycanceled(ctx, lrOSPostAsyncRetrycanceledOptions)
+func (client *LrOSClient) BeginPostAsyncRetrycanceled(ctx context.Context, options *LrOSPostAsyncRetrycanceledOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRetrycanceled(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1637,8 +1637,8 @@ func (client *LrOSClient) ResumePostAsyncRetrycanceled(token string) (HTTPPoller
 }
 
 // PostAsyncRetrycanceled - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PostAsyncRetrycanceled(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRetrycanceledCreateRequest(ctx, lrOSPostAsyncRetrycanceledOptions)
+func (client *LrOSClient) PostAsyncRetrycanceled(ctx context.Context, options *LrOSPostAsyncRetrycanceledOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRetrycanceledCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1653,15 +1653,15 @@ func (client *LrOSClient) PostAsyncRetrycanceled(ctx context.Context, lrOSPostAs
 }
 
 // PostAsyncRetrycanceledCreateRequest creates the PostAsyncRetrycanceled request.
-func (client *LrOSClient) PostAsyncRetrycanceledCreateRequest(ctx context.Context, lrOSPostAsyncRetrycanceledOptions *LrOSPostAsyncRetrycanceledOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PostAsyncRetrycanceledCreateRequest(ctx context.Context, options *LrOSPostAsyncRetrycanceledOptions) (*azcore.Request, error) {
 	urlPath := "/lro/postasync/retry/canceled"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPostAsyncRetrycanceledOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPostAsyncRetrycanceledOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1675,8 +1675,8 @@ func (client *LrOSClient) PostAsyncRetrycanceledHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.PostDoubleHeadersFinalAzureHeaderGet(ctx)
+func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PostDoubleHeadersFinalAzureHeaderGet(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1710,8 +1710,8 @@ func (client *LrOSClient) ResumePostDoubleHeadersFinalAzureHeaderGet(token strin
 }
 
 // PostDoubleHeadersFinalAzureHeaderGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object
-func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGet(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx)
+func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetOptions) (*azcore.Response, error) {
+	req, err := client.PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1726,7 +1726,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGet(ctx context.Conte
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGet request.
-func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetOptions) (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGet"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1751,8 +1751,8 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.PostDoubleHeadersFinalAzureHeaderGetDefault(ctx)
+func (client *LrOSClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PostDoubleHeadersFinalAzureHeaderGetDefault(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1786,8 +1786,8 @@ func (client *LrOSClient) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(toke
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetDefault - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final object if you support initial Autorest behavior.
-func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest(ctx)
+func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (*azcore.Response, error) {
+	req, err := client.PostDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1802,7 +1802,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefault(ctx contex
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest creates the PostDoubleHeadersFinalAzureHeaderGetDefault request.
-func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultCreateRequest(ctx context.Context, options *LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions) (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1827,8 +1827,8 @@ func (client *LrOSClient) PostDoubleHeadersFinalAzureHeaderGetDefaultHandleError
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context) (*ProductPollerResponse, error) {
-	resp, err := client.PostDoubleHeadersFinalLocationGet(ctx)
+func (client *LrOSClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalLocationGetOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PostDoubleHeadersFinalLocationGet(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1862,8 +1862,8 @@ func (client *LrOSClient) ResumePostDoubleHeadersFinalLocationGet(token string) 
 }
 
 // PostDoubleHeadersFinalLocationGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final object
-func (client *LrOSClient) PostDoubleHeadersFinalLocationGet(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.PostDoubleHeadersFinalLocationGetCreateRequest(ctx)
+func (client *LrOSClient) PostDoubleHeadersFinalLocationGet(ctx context.Context, options *LrOSPostDoubleHeadersFinalLocationGetOptions) (*azcore.Response, error) {
+	req, err := client.PostDoubleHeadersFinalLocationGetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1878,7 +1878,7 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGet(ctx context.Context)
 }
 
 // PostDoubleHeadersFinalLocationGetCreateRequest creates the PostDoubleHeadersFinalLocationGet request.
-func (client *LrOSClient) PostDoubleHeadersFinalLocationGetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrOSClient) PostDoubleHeadersFinalLocationGetCreateRequest(ctx context.Context, options *LrOSPostDoubleHeadersFinalLocationGetOptions) (*azcore.Request, error) {
 	urlPath := "/lro/LROPostDoubleHeadersFinalLocationGet"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1903,8 +1903,8 @@ func (client *LrOSClient) PostDoubleHeadersFinalLocationGetHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut200Acceptedcanceled200(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put200Acceptedcanceled200(ctx, lrOSPut200Acceptedcanceled200Options)
+func (client *LrOSClient) BeginPut200Acceptedcanceled200(ctx context.Context, options *LrOSPut200Acceptedcanceled200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put200Acceptedcanceled200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1938,8 +1938,8 @@ func (client *LrOSClient) ResumePut200Acceptedcanceled200(token string) (Product
 }
 
 // Put200Acceptedcanceled200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Canceled’
-func (client *LrOSClient) Put200Acceptedcanceled200(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*azcore.Response, error) {
-	req, err := client.Put200Acceptedcanceled200CreateRequest(ctx, lrOSPut200Acceptedcanceled200Options)
+func (client *LrOSClient) Put200Acceptedcanceled200(ctx context.Context, options *LrOSPut200Acceptedcanceled200Options) (*azcore.Response, error) {
+	req, err := client.Put200Acceptedcanceled200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1954,15 +1954,15 @@ func (client *LrOSClient) Put200Acceptedcanceled200(ctx context.Context, lrOSPut
 }
 
 // Put200Acceptedcanceled200CreateRequest creates the Put200Acceptedcanceled200 request.
-func (client *LrOSClient) Put200Acceptedcanceled200CreateRequest(ctx context.Context, lrOSPut200Acceptedcanceled200Options *LrOSPut200Acceptedcanceled200Options) (*azcore.Request, error) {
+func (client *LrOSClient) Put200Acceptedcanceled200CreateRequest(ctx context.Context, options *LrOSPut200Acceptedcanceled200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/accepted/canceled/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut200Acceptedcanceled200Options != nil {
-		return req, req.MarshalAsJSON(lrOSPut200Acceptedcanceled200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1982,8 +1982,8 @@ func (client *LrOSClient) Put200Acceptedcanceled200HandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut200Succeeded(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.Put200Succeeded(ctx, lrOSPut200SucceededOptions)
+func (client *LrOSClient) BeginPut200Succeeded(ctx context.Context, options *LrOSPut200SucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.Put200Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2017,8 +2017,8 @@ func (client *LrOSClient) ResumePut200Succeeded(token string) (ProductPoller, er
 }
 
 // Put200Succeeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
-func (client *LrOSClient) Put200Succeeded(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*azcore.Response, error) {
-	req, err := client.Put200SucceededCreateRequest(ctx, lrOSPut200SucceededOptions)
+func (client *LrOSClient) Put200Succeeded(ctx context.Context, options *LrOSPut200SucceededOptions) (*azcore.Response, error) {
+	req, err := client.Put200SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2033,15 +2033,15 @@ func (client *LrOSClient) Put200Succeeded(ctx context.Context, lrOSPut200Succeed
 }
 
 // Put200SucceededCreateRequest creates the Put200Succeeded request.
-func (client *LrOSClient) Put200SucceededCreateRequest(ctx context.Context, lrOSPut200SucceededOptions *LrOSPut200SucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) Put200SucceededCreateRequest(ctx context.Context, options *LrOSPut200SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut200SucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPut200SucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2061,8 +2061,8 @@ func (client *LrOSClient) Put200SucceededHandleError(resp *azcore.Response) erro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut200SucceededNoState(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*ProductPollerResponse, error) {
-	resp, err := client.Put200SucceededNoState(ctx, lrOSPut200SucceededNoStateOptions)
+func (client *LrOSClient) BeginPut200SucceededNoState(ctx context.Context, options *LrOSPut200SucceededNoStateOptions) (*ProductPollerResponse, error) {
+	resp, err := client.Put200SucceededNoState(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2096,8 +2096,8 @@ func (client *LrOSClient) ResumePut200SucceededNoState(token string) (ProductPol
 }
 
 // Put200SucceededNoState - Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
-func (client *LrOSClient) Put200SucceededNoState(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*azcore.Response, error) {
-	req, err := client.Put200SucceededNoStateCreateRequest(ctx, lrOSPut200SucceededNoStateOptions)
+func (client *LrOSClient) Put200SucceededNoState(ctx context.Context, options *LrOSPut200SucceededNoStateOptions) (*azcore.Response, error) {
+	req, err := client.Put200SucceededNoStateCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2112,15 +2112,15 @@ func (client *LrOSClient) Put200SucceededNoState(ctx context.Context, lrOSPut200
 }
 
 // Put200SucceededNoStateCreateRequest creates the Put200SucceededNoState request.
-func (client *LrOSClient) Put200SucceededNoStateCreateRequest(ctx context.Context, lrOSPut200SucceededNoStateOptions *LrOSPut200SucceededNoStateOptions) (*azcore.Request, error) {
+func (client *LrOSClient) Put200SucceededNoStateCreateRequest(ctx context.Context, options *LrOSPut200SucceededNoStateOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/succeeded/nostate"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut200SucceededNoStateOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPut200SucceededNoStateOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2140,8 +2140,8 @@ func (client *LrOSClient) Put200SucceededNoStateHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut200UpdatingSucceeded204(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put200UpdatingSucceeded204(ctx, lrOSPut200UpdatingSucceeded204Options)
+func (client *LrOSClient) BeginPut200UpdatingSucceeded204(ctx context.Context, options *LrOSPut200UpdatingSucceeded204Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put200UpdatingSucceeded204(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2175,8 +2175,8 @@ func (client *LrOSClient) ResumePut200UpdatingSucceeded204(token string) (Produc
 }
 
 // Put200UpdatingSucceeded204 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSClient) Put200UpdatingSucceeded204(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Response, error) {
-	req, err := client.Put200UpdatingSucceeded204CreateRequest(ctx, lrOSPut200UpdatingSucceeded204Options)
+func (client *LrOSClient) Put200UpdatingSucceeded204(ctx context.Context, options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Response, error) {
+	req, err := client.Put200UpdatingSucceeded204CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2191,15 +2191,15 @@ func (client *LrOSClient) Put200UpdatingSucceeded204(ctx context.Context, lrOSPu
 }
 
 // Put200UpdatingSucceeded204CreateRequest creates the Put200UpdatingSucceeded204 request.
-func (client *LrOSClient) Put200UpdatingSucceeded204CreateRequest(ctx context.Context, lrOSPut200UpdatingSucceeded204Options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Request, error) {
+func (client *LrOSClient) Put200UpdatingSucceeded204CreateRequest(ctx context.Context, options *LrOSPut200UpdatingSucceeded204Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/200/updating/succeeded/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut200UpdatingSucceeded204Options != nil {
-		return req, req.MarshalAsJSON(lrOSPut200UpdatingSucceeded204Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2219,8 +2219,8 @@ func (client *LrOSClient) Put200UpdatingSucceeded204HandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut201CreatingFailed200(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put201CreatingFailed200(ctx, lrOSPut201CreatingFailed200Options)
+func (client *LrOSClient) BeginPut201CreatingFailed200(ctx context.Context, options *LrOSPut201CreatingFailed200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put201CreatingFailed200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2254,8 +2254,8 @@ func (client *LrOSClient) ResumePut201CreatingFailed200(token string) (ProductPo
 }
 
 // Put201CreatingFailed200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Failed’
-func (client *LrOSClient) Put201CreatingFailed200(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*azcore.Response, error) {
-	req, err := client.Put201CreatingFailed200CreateRequest(ctx, lrOSPut201CreatingFailed200Options)
+func (client *LrOSClient) Put201CreatingFailed200(ctx context.Context, options *LrOSPut201CreatingFailed200Options) (*azcore.Response, error) {
+	req, err := client.Put201CreatingFailed200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2270,15 +2270,15 @@ func (client *LrOSClient) Put201CreatingFailed200(ctx context.Context, lrOSPut20
 }
 
 // Put201CreatingFailed200CreateRequest creates the Put201CreatingFailed200 request.
-func (client *LrOSClient) Put201CreatingFailed200CreateRequest(ctx context.Context, lrOSPut201CreatingFailed200Options *LrOSPut201CreatingFailed200Options) (*azcore.Request, error) {
+func (client *LrOSClient) Put201CreatingFailed200CreateRequest(ctx context.Context, options *LrOSPut201CreatingFailed200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/created/failed/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut201CreatingFailed200Options != nil {
-		return req, req.MarshalAsJSON(lrOSPut201CreatingFailed200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2298,8 +2298,8 @@ func (client *LrOSClient) Put201CreatingFailed200HandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put201CreatingSucceeded200(ctx, lrOSPut201CreatingSucceeded200Options)
+func (client *LrOSClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LrOSPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put201CreatingSucceeded200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2333,8 +2333,8 @@ func (client *LrOSClient) ResumePut201CreatingSucceeded200(token string) (Produc
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSClient) Put201CreatingSucceeded200(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*azcore.Response, error) {
-	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, lrOSPut201CreatingSucceeded200Options)
+func (client *LrOSClient) Put201CreatingSucceeded200(ctx context.Context, options *LrOSPut201CreatingSucceeded200Options) (*azcore.Response, error) {
+	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2349,15 +2349,15 @@ func (client *LrOSClient) Put201CreatingSucceeded200(ctx context.Context, lrOSPu
 }
 
 // Put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
-func (client *LrOSClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, lrOSPut201CreatingSucceeded200Options *LrOSPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+func (client *LrOSClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, options *LrOSPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/creating/succeeded/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut201CreatingSucceeded200Options != nil {
-		return req, req.MarshalAsJSON(lrOSPut201CreatingSucceeded200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2377,8 +2377,8 @@ func (client *LrOSClient) Put201CreatingSucceeded200HandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut201Succeeded(ctx context.Context, lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.Put201Succeeded(ctx, lrOSPut201SucceededOptions)
+func (client *LrOSClient) BeginPut201Succeeded(ctx context.Context, options *LrOSPut201SucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.Put201Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2412,8 +2412,8 @@ func (client *LrOSClient) ResumePut201Succeeded(token string) (ProductPoller, er
 }
 
 // Put201Succeeded - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
-func (client *LrOSClient) Put201Succeeded(ctx context.Context, lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*azcore.Response, error) {
-	req, err := client.Put201SucceededCreateRequest(ctx, lrOSPut201SucceededOptions)
+func (client *LrOSClient) Put201Succeeded(ctx context.Context, options *LrOSPut201SucceededOptions) (*azcore.Response, error) {
+	req, err := client.Put201SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2428,15 +2428,15 @@ func (client *LrOSClient) Put201Succeeded(ctx context.Context, lrOSPut201Succeed
 }
 
 // Put201SucceededCreateRequest creates the Put201Succeeded request.
-func (client *LrOSClient) Put201SucceededCreateRequest(ctx context.Context, lrOSPut201SucceededOptions *LrOSPut201SucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) Put201SucceededCreateRequest(ctx context.Context, options *LrOSPut201SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/201/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut201SucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPut201SucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2456,8 +2456,8 @@ func (client *LrOSClient) Put201SucceededHandleError(resp *azcore.Response) erro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPut202Retry200(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put202Retry200(ctx, lrOSPut202Retry200Options)
+func (client *LrOSClient) BeginPut202Retry200(ctx context.Context, options *LrOSPut202Retry200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2491,8 +2491,8 @@ func (client *LrOSClient) ResumePut202Retry200(token string) (ProductPoller, err
 }
 
 // Put202Retry200 - Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns a 200 and an entity that doesn't contains ProvisioningState
-func (client *LrOSClient) Put202Retry200(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*azcore.Response, error) {
-	req, err := client.Put202Retry200CreateRequest(ctx, lrOSPut202Retry200Options)
+func (client *LrOSClient) Put202Retry200(ctx context.Context, options *LrOSPut202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Put202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2507,15 +2507,15 @@ func (client *LrOSClient) Put202Retry200(ctx context.Context, lrOSPut202Retry200
 }
 
 // Put202Retry200CreateRequest creates the Put202Retry200 request.
-func (client *LrOSClient) Put202Retry200CreateRequest(ctx context.Context, lrOSPut202Retry200Options *LrOSPut202Retry200Options) (*azcore.Request, error) {
+func (client *LrOSClient) Put202Retry200CreateRequest(ctx context.Context, options *LrOSPut202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/put/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPut202Retry200Options != nil {
-		return req, req.MarshalAsJSON(lrOSPut202Retry200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2535,8 +2535,8 @@ func (client *LrOSClient) Put202Retry200HandleError(resp *azcore.Response) error
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncNoHeaderInRetry(ctx, lrOSPutAsyncNoHeaderInRetryOptions)
+func (client *LrOSClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, options *LrOSPutAsyncNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncNoHeaderInRetry(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2570,8 +2570,8 @@ func (client *LrOSClient) ResumePutAsyncNoHeaderInRetry(token string) (ProductPo
 }
 
 // PutAsyncNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
-func (client *LrOSClient) PutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncNoHeaderInRetryCreateRequest(ctx, lrOSPutAsyncNoHeaderInRetryOptions)
+func (client *LrOSClient) PutAsyncNoHeaderInRetry(ctx context.Context, options *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncNoHeaderInRetryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2586,15 +2586,15 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetry(ctx context.Context, lrOSPutAs
 }
 
 // PutAsyncNoHeaderInRetryCreateRequest creates the PutAsyncNoHeaderInRetry request.
-func (client *LrOSClient) PutAsyncNoHeaderInRetryCreateRequest(ctx context.Context, lrOSPutAsyncNoHeaderInRetryOptions *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncNoHeaderInRetryCreateRequest(ctx context.Context, options *LrOSPutAsyncNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noheader/201/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncNoHeaderInRetryOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncNoHeaderInRetryOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2614,8 +2614,8 @@ func (client *LrOSClient) PutAsyncNoHeaderInRetryHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncNoRetrySucceeded(ctx, lrOSPutAsyncNoRetrySucceededOptions)
+func (client *LrOSClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPutAsyncNoRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncNoRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2649,8 +2649,8 @@ func (client *LrOSClient) ResumePutAsyncNoRetrySucceeded(token string) (ProductP
 }
 
 // PutAsyncNoRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncNoRetrySucceededCreateRequest(ctx, lrOSPutAsyncNoRetrySucceededOptions)
+func (client *LrOSClient) PutAsyncNoRetrySucceeded(ctx context.Context, options *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncNoRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2665,15 +2665,15 @@ func (client *LrOSClient) PutAsyncNoRetrySucceeded(ctx context.Context, lrOSPutA
 }
 
 // PutAsyncNoRetrySucceededCreateRequest creates the PutAsyncNoRetrySucceeded request.
-func (client *LrOSClient) PutAsyncNoRetrySucceededCreateRequest(ctx context.Context, lrOSPutAsyncNoRetrySucceededOptions *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncNoRetrySucceededCreateRequest(ctx context.Context, options *LrOSPutAsyncNoRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noretry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncNoRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncNoRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2693,8 +2693,8 @@ func (client *LrOSClient) PutAsyncNoRetrySucceededHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncNoRetrycanceled(ctx, lrOSPutAsyncNoRetrycanceledOptions)
+func (client *LrOSClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, options *LrOSPutAsyncNoRetrycanceledOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncNoRetrycanceled(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2728,8 +2728,8 @@ func (client *LrOSClient) ResumePutAsyncNoRetrycanceled(token string) (ProductPo
 }
 
 // PutAsyncNoRetrycanceled - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncNoRetrycanceledCreateRequest(ctx, lrOSPutAsyncNoRetrycanceledOptions)
+func (client *LrOSClient) PutAsyncNoRetrycanceled(ctx context.Context, options *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncNoRetrycanceledCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2744,15 +2744,15 @@ func (client *LrOSClient) PutAsyncNoRetrycanceled(ctx context.Context, lrOSPutAs
 }
 
 // PutAsyncNoRetrycanceledCreateRequest creates the PutAsyncNoRetrycanceled request.
-func (client *LrOSClient) PutAsyncNoRetrycanceledCreateRequest(ctx context.Context, lrOSPutAsyncNoRetrycanceledOptions *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncNoRetrycanceledCreateRequest(ctx context.Context, options *LrOSPutAsyncNoRetrycanceledOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/noretry/canceled"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncNoRetrycanceledOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncNoRetrycanceledOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2772,8 +2772,8 @@ func (client *LrOSClient) PutAsyncNoRetrycanceledHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncNonResource(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*SKUPollerResponse, error) {
-	resp, err := client.PutAsyncNonResource(ctx, lrOSPutAsyncNonResourceOptions)
+func (client *LrOSClient) BeginPutAsyncNonResource(ctx context.Context, options *LrOSPutAsyncNonResourceOptions) (*SKUPollerResponse, error) {
+	resp, err := client.PutAsyncNonResource(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2807,8 +2807,8 @@ func (client *LrOSClient) ResumePutAsyncNonResource(token string) (SKUPoller, er
 }
 
 // PutAsyncNonResource - Long running put request with non resource.
-func (client *LrOSClient) PutAsyncNonResource(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncNonResourceCreateRequest(ctx, lrOSPutAsyncNonResourceOptions)
+func (client *LrOSClient) PutAsyncNonResource(ctx context.Context, options *LrOSPutAsyncNonResourceOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncNonResourceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2823,15 +2823,15 @@ func (client *LrOSClient) PutAsyncNonResource(ctx context.Context, lrOSPutAsyncN
 }
 
 // PutAsyncNonResourceCreateRequest creates the PutAsyncNonResource request.
-func (client *LrOSClient) PutAsyncNonResourceCreateRequest(ctx context.Context, lrOSPutAsyncNonResourceOptions *LrOSPutAsyncNonResourceOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncNonResourceCreateRequest(ctx context.Context, options *LrOSPutAsyncNonResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putnonresourceasync/202/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncNonResourceOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncNonResourceOptions.Sku)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Sku)
 	}
 	return req, nil
 }
@@ -2851,8 +2851,8 @@ func (client *LrOSClient) PutAsyncNonResourceHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRetryFailed(ctx, lrOSPutAsyncRetryFailedOptions)
+func (client *LrOSClient) BeginPutAsyncRetryFailed(ctx context.Context, options *LrOSPutAsyncRetryFailedOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRetryFailed(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2886,8 +2886,8 @@ func (client *LrOSClient) ResumePutAsyncRetryFailed(token string) (ProductPoller
 }
 
 // PutAsyncRetryFailed - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRetryFailedCreateRequest(ctx, lrOSPutAsyncRetryFailedOptions)
+func (client *LrOSClient) PutAsyncRetryFailed(ctx context.Context, options *LrOSPutAsyncRetryFailedOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRetryFailedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2902,15 +2902,15 @@ func (client *LrOSClient) PutAsyncRetryFailed(ctx context.Context, lrOSPutAsyncR
 }
 
 // PutAsyncRetryFailedCreateRequest creates the PutAsyncRetryFailed request.
-func (client *LrOSClient) PutAsyncRetryFailedCreateRequest(ctx context.Context, lrOSPutAsyncRetryFailedOptions *LrOSPutAsyncRetryFailedOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncRetryFailedCreateRequest(ctx context.Context, options *LrOSPutAsyncRetryFailedOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/retry/failed"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncRetryFailedOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncRetryFailedOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -2930,8 +2930,8 @@ func (client *LrOSClient) PutAsyncRetryFailedHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRetrySucceeded(ctx, lrOSPutAsyncRetrySucceededOptions)
+func (client *LrOSClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LrOSPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2965,8 +2965,8 @@ func (client *LrOSClient) ResumePutAsyncRetrySucceeded(token string) (ProductPol
 }
 
 // PutAsyncRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSClient) PutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRetrySucceededCreateRequest(ctx, lrOSPutAsyncRetrySucceededOptions)
+func (client *LrOSClient) PutAsyncRetrySucceeded(ctx context.Context, options *LrOSPutAsyncRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2981,15 +2981,15 @@ func (client *LrOSClient) PutAsyncRetrySucceeded(ctx context.Context, lrOSPutAsy
 }
 
 // PutAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
-func (client *LrOSClient) PutAsyncRetrySucceededCreateRequest(ctx context.Context, lrOSPutAsyncRetrySucceededOptions *LrOSPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncRetrySucceededCreateRequest(ctx context.Context, options *LrOSPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -3009,8 +3009,8 @@ func (client *LrOSClient) PutAsyncRetrySucceededHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutAsyncSubResource(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*SubProductPollerResponse, error) {
-	resp, err := client.PutAsyncSubResource(ctx, lrOSPutAsyncSubResourceOptions)
+func (client *LrOSClient) BeginPutAsyncSubResource(ctx context.Context, options *LrOSPutAsyncSubResourceOptions) (*SubProductPollerResponse, error) {
+	resp, err := client.PutAsyncSubResource(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3044,8 +3044,8 @@ func (client *LrOSClient) ResumePutAsyncSubResource(token string) (SubProductPol
 }
 
 // PutAsyncSubResource - Long running put request with sub resource.
-func (client *LrOSClient) PutAsyncSubResource(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncSubResourceCreateRequest(ctx, lrOSPutAsyncSubResourceOptions)
+func (client *LrOSClient) PutAsyncSubResource(ctx context.Context, options *LrOSPutAsyncSubResourceOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncSubResourceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3060,15 +3060,15 @@ func (client *LrOSClient) PutAsyncSubResource(ctx context.Context, lrOSPutAsyncS
 }
 
 // PutAsyncSubResourceCreateRequest creates the PutAsyncSubResource request.
-func (client *LrOSClient) PutAsyncSubResourceCreateRequest(ctx context.Context, lrOSPutAsyncSubResourceOptions *LrOSPutAsyncSubResourceOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutAsyncSubResourceCreateRequest(ctx context.Context, options *LrOSPutAsyncSubResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putsubresourceasync/202/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutAsyncSubResourceOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutAsyncSubResourceOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -3088,8 +3088,8 @@ func (client *LrOSClient) PutAsyncSubResourceHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutNoHeaderInRetry(ctx, lrOSPutNoHeaderInRetryOptions)
+func (client *LrOSClient) BeginPutNoHeaderInRetry(ctx context.Context, options *LrOSPutNoHeaderInRetryOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutNoHeaderInRetry(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3123,8 +3123,8 @@ func (client *LrOSClient) ResumePutNoHeaderInRetry(token string) (ProductPoller,
 }
 
 // PutNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status do not contain location header.
-func (client *LrOSClient) PutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*azcore.Response, error) {
-	req, err := client.PutNoHeaderInRetryCreateRequest(ctx, lrOSPutNoHeaderInRetryOptions)
+func (client *LrOSClient) PutNoHeaderInRetry(ctx context.Context, options *LrOSPutNoHeaderInRetryOptions) (*azcore.Response, error) {
+	req, err := client.PutNoHeaderInRetryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3139,15 +3139,15 @@ func (client *LrOSClient) PutNoHeaderInRetry(ctx context.Context, lrOSPutNoHeade
 }
 
 // PutNoHeaderInRetryCreateRequest creates the PutNoHeaderInRetry request.
-func (client *LrOSClient) PutNoHeaderInRetryCreateRequest(ctx context.Context, lrOSPutNoHeaderInRetryOptions *LrOSPutNoHeaderInRetryOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutNoHeaderInRetryCreateRequest(ctx context.Context, options *LrOSPutNoHeaderInRetryOptions) (*azcore.Request, error) {
 	urlPath := "/lro/put/noheader/202/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutNoHeaderInRetryOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutNoHeaderInRetryOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -3167,8 +3167,8 @@ func (client *LrOSClient) PutNoHeaderInRetryHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutNonResource(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*SKUPollerResponse, error) {
-	resp, err := client.PutNonResource(ctx, lrOSPutNonResourceOptions)
+func (client *LrOSClient) BeginPutNonResource(ctx context.Context, options *LrOSPutNonResourceOptions) (*SKUPollerResponse, error) {
+	resp, err := client.PutNonResource(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3202,8 +3202,8 @@ func (client *LrOSClient) ResumePutNonResource(token string) (SKUPoller, error) 
 }
 
 // PutNonResource - Long running put request with non resource.
-func (client *LrOSClient) PutNonResource(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*azcore.Response, error) {
-	req, err := client.PutNonResourceCreateRequest(ctx, lrOSPutNonResourceOptions)
+func (client *LrOSClient) PutNonResource(ctx context.Context, options *LrOSPutNonResourceOptions) (*azcore.Response, error) {
+	req, err := client.PutNonResourceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3218,15 +3218,15 @@ func (client *LrOSClient) PutNonResource(ctx context.Context, lrOSPutNonResource
 }
 
 // PutNonResourceCreateRequest creates the PutNonResource request.
-func (client *LrOSClient) PutNonResourceCreateRequest(ctx context.Context, lrOSPutNonResourceOptions *LrOSPutNonResourceOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutNonResourceCreateRequest(ctx context.Context, options *LrOSPutNonResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putnonresource/202/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutNonResourceOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutNonResourceOptions.Sku)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Sku)
 	}
 	return req, nil
 }
@@ -3246,8 +3246,8 @@ func (client *LrOSClient) PutNonResourceHandleError(resp *azcore.Response) error
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSClient) BeginPutSubResource(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*SubProductPollerResponse, error) {
-	resp, err := client.PutSubResource(ctx, lrOSPutSubResourceOptions)
+func (client *LrOSClient) BeginPutSubResource(ctx context.Context, options *LrOSPutSubResourceOptions) (*SubProductPollerResponse, error) {
+	resp, err := client.PutSubResource(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3281,8 +3281,8 @@ func (client *LrOSClient) ResumePutSubResource(token string) (SubProductPoller, 
 }
 
 // PutSubResource - Long running put request with sub resource.
-func (client *LrOSClient) PutSubResource(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*azcore.Response, error) {
-	req, err := client.PutSubResourceCreateRequest(ctx, lrOSPutSubResourceOptions)
+func (client *LrOSClient) PutSubResource(ctx context.Context, options *LrOSPutSubResourceOptions) (*azcore.Response, error) {
+	req, err := client.PutSubResourceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -3297,15 +3297,15 @@ func (client *LrOSClient) PutSubResource(ctx context.Context, lrOSPutSubResource
 }
 
 // PutSubResourceCreateRequest creates the PutSubResource request.
-func (client *LrOSClient) PutSubResourceCreateRequest(ctx context.Context, lrOSPutSubResourceOptions *LrOSPutSubResourceOptions) (*azcore.Request, error) {
+func (client *LrOSClient) PutSubResourceCreateRequest(ctx context.Context, options *LrOSPutSubResourceOptions) (*azcore.Request, error) {
 	urlPath := "/lro/putsubresource/202/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSPutSubResourceOptions != nil {
-		return req, req.MarshalAsJSON(lrOSPutSubResourceOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -16,107 +16,107 @@ import (
 // LrosaDsOperations contains the methods for the LrosaDs group.
 type LrosaDsOperations interface {
 	// BeginDelete202NonRetry400 - Long running delete request, service returns a 202 with a location header
-	BeginDelete202NonRetry400(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDelete202NonRetry400(ctx context.Context, options *LrosaDsDelete202NonRetry400Options) (*HTTPPollerResponse, error)
 	// ResumeDelete202NonRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete202NonRetry400(token string) (HTTPPoller, error)
 	// BeginDelete202RetryInvalidHeader - Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers
-	BeginDelete202RetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDelete202RetryInvalidHeader(ctx context.Context, options *LrosaDsDelete202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete202RetryInvalidHeader - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete202RetryInvalidHeader(token string) (HTTPPoller, error)
 	// BeginDelete204Succeeded - Long running delete request, service returns a 204 to the initial request, indicating success.
-	BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDelete204Succeeded(ctx context.Context, options *LrosaDsDelete204SucceededOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete204Succeeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete204Succeeded(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRelativeRetry400 - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRelativeRetry400(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRelativeRetry400(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetry400Options) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRelativeRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRelativeRetry400(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRelativeRetryInvalidHeader - Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid
-	BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRelativeRetryInvalidHeader - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRelativeRetryInvalidJSONPolling - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRelativeRetryInvalidJSONPolling - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error)
 	// BeginDeleteAsyncRelativeRetryNoStatus - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryNoStatusOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteAsyncRelativeRetryNoStatus - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteAsyncRelativeRetryNoStatus(token string) (HTTPPoller, error)
 	// BeginDeleteNonRetry400 - Long running delete request, service returns a 400 with an error body
-	BeginDeleteNonRetry400(ctx context.Context) (*HTTPPollerResponse, error)
+	BeginDeleteNonRetry400(ctx context.Context, options *LrosaDsDeleteNonRetry400Options) (*HTTPPollerResponse, error)
 	// ResumeDeleteNonRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteNonRetry400(token string) (HTTPPoller, error)
 	// BeginPost202NoLocation - Long running post request, service returns a 202 to the initial request, without a location header.
-	BeginPost202NoLocation(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*HTTPPollerResponse, error)
+	BeginPost202NoLocation(ctx context.Context, options *LrosaDsPost202NoLocationOptions) (*HTTPPollerResponse, error)
 	// ResumePost202NoLocation - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202NoLocation(token string) (HTTPPoller, error)
 	// BeginPost202NonRetry400 - Long running post request, service returns a 202 with a location header
-	BeginPost202NonRetry400(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*HTTPPollerResponse, error)
+	BeginPost202NonRetry400(ctx context.Context, options *LrosaDsPost202NonRetry400Options) (*HTTPPollerResponse, error)
 	// ResumePost202NonRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202NonRetry400(token string) (HTTPPoller, error)
 	// BeginPost202RetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
-	BeginPost202RetryInvalidHeader(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
+	BeginPost202RetryInvalidHeader(ctx context.Context, options *LrosaDsPost202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
 	// ResumePost202RetryInvalidHeader - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202RetryInvalidHeader(token string) (HTTPPoller, error)
 	// BeginPostAsyncRelativeRetry400 - Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRelativeRetry400(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*HTTPPollerResponse, error)
+	BeginPostAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPostAsyncRelativeRetry400Options) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRelativeRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRelativeRetry400(token string) (HTTPPoller, error)
 	// BeginPostAsyncRelativeRetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
-	BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRelativeRetryInvalidHeader - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error)
 	// BeginPostAsyncRelativeRetryInvalidJSONPolling - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRelativeRetryInvalidJSONPolling - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error)
 	// BeginPostAsyncRelativeRetryNoPayload - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRelativeRetryNoPayload - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRelativeRetryNoPayload(token string) (HTTPPoller, error)
 	// BeginPostNonRetry400 - Long running post request, service returns a 400 with no error body
-	BeginPostNonRetry400(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*HTTPPollerResponse, error)
+	BeginPostNonRetry400(ctx context.Context, options *LrosaDsPostNonRetry400Options) (*HTTPPollerResponse, error)
 	// ResumePostNonRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostNonRetry400(token string) (HTTPPoller, error)
 	// BeginPut200InvalidJSON - Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json
-	BeginPut200InvalidJSON(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*ProductPollerResponse, error)
+	BeginPut200InvalidJSON(ctx context.Context, options *LrosaDsPut200InvalidJSONOptions) (*ProductPollerResponse, error)
 	// ResumePut200InvalidJSON - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut200InvalidJSON(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetry400 - Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRelativeRetry400(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPutAsyncRelativeRetry400Options) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetry400(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetryInvalidHeader - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
-	BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetryInvalidHeader - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetryInvalidHeader(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetryInvalidJSONPolling - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetryInvalidJSONPolling - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetryInvalidJSONPolling(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetryNoStatus - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetryNoStatus - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetryNoStatus(token string) (ProductPoller, error)
 	// BeginPutAsyncRelativeRetryNoStatusPayload - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRelativeRetryNoStatusPayload - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRelativeRetryNoStatusPayload(token string) (ProductPoller, error)
 	// BeginPutError201NoProvisioningStatePayload - Long running put request, service returns a 201 to the initial request with no payload
-	BeginPutError201NoProvisioningStatePayload(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*ProductPollerResponse, error)
+	BeginPutError201NoProvisioningStatePayload(ctx context.Context, options *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*ProductPollerResponse, error)
 	// ResumePutError201NoProvisioningStatePayload - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutError201NoProvisioningStatePayload(token string) (ProductPoller, error)
 	// BeginPutNonRetry201Creating400 - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
-	BeginPutNonRetry201Creating400(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*ProductPollerResponse, error)
+	BeginPutNonRetry201Creating400(ctx context.Context, options *LrosaDsPutNonRetry201Creating400Options) (*ProductPollerResponse, error)
 	// ResumePutNonRetry201Creating400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutNonRetry201Creating400(token string) (ProductPoller, error)
 	// BeginPutNonRetry201Creating400InvalidJSON - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
-	BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*ProductPollerResponse, error)
+	BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, options *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*ProductPollerResponse, error)
 	// ResumePutNonRetry201Creating400InvalidJSON - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutNonRetry201Creating400InvalidJSON(token string) (ProductPoller, error)
 	// BeginPutNonRetry400 - Long running put request, service returns a 400 to the initial request
-	BeginPutNonRetry400(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*ProductPollerResponse, error)
+	BeginPutNonRetry400(ctx context.Context, options *LrosaDsPutNonRetry400Options) (*ProductPollerResponse, error)
 	// ResumePutNonRetry400 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutNonRetry400(token string) (ProductPoller, error)
 }
@@ -137,8 +137,8 @@ func (client *LrosaDsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *LrosaDsClient) BeginDelete202NonRetry400(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete202NonRetry400(ctx)
+func (client *LrosaDsClient) BeginDelete202NonRetry400(ctx context.Context, options *LrosaDsDelete202NonRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete202NonRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -172,8 +172,8 @@ func (client *LrosaDsClient) ResumeDelete202NonRetry400(token string) (HTTPPolle
 }
 
 // Delete202NonRetry400 - Long running delete request, service returns a 202 with a location header
-func (client *LrosaDsClient) Delete202NonRetry400(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete202NonRetry400CreateRequest(ctx)
+func (client *LrosaDsClient) Delete202NonRetry400(ctx context.Context, options *LrosaDsDelete202NonRetry400Options) (*azcore.Response, error) {
+	req, err := client.Delete202NonRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (client *LrosaDsClient) Delete202NonRetry400(ctx context.Context) (*azcore.
 }
 
 // Delete202NonRetry400CreateRequest creates the Delete202NonRetry400 request.
-func (client *LrosaDsClient) Delete202NonRetry400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) Delete202NonRetry400CreateRequest(ctx context.Context, options *LrosaDsDelete202NonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/delete/202/retry/400"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -207,8 +207,8 @@ func (client *LrosaDsClient) Delete202NonRetry400HandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDelete202RetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete202RetryInvalidHeader(ctx)
+func (client *LrosaDsClient) BeginDelete202RetryInvalidHeader(ctx context.Context, options *LrosaDsDelete202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete202RetryInvalidHeader(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +242,8 @@ func (client *LrosaDsClient) ResumeDelete202RetryInvalidHeader(token string) (HT
 }
 
 // Delete202RetryInvalidHeader - Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location' and 'Retry-After' headers
-func (client *LrosaDsClient) Delete202RetryInvalidHeader(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete202RetryInvalidHeaderCreateRequest(ctx)
+func (client *LrosaDsClient) Delete202RetryInvalidHeader(ctx context.Context, options *LrosaDsDelete202RetryInvalidHeaderOptions) (*azcore.Response, error) {
+	req, err := client.Delete202RetryInvalidHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeader(ctx context.Context) (*
 }
 
 // Delete202RetryInvalidHeaderCreateRequest creates the Delete202RetryInvalidHeader request.
-func (client *LrosaDsClient) Delete202RetryInvalidHeaderCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) Delete202RetryInvalidHeaderCreateRequest(ctx context.Context, options *LrosaDsDelete202RetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/delete/202/retry/invalidheader"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -277,8 +277,8 @@ func (client *LrosaDsClient) Delete202RetryInvalidHeaderHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDelete204Succeeded(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete204Succeeded(ctx)
+func (client *LrosaDsClient) BeginDelete204Succeeded(ctx context.Context, options *LrosaDsDelete204SucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete204Succeeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -312,8 +312,8 @@ func (client *LrosaDsClient) ResumeDelete204Succeeded(token string) (HTTPPoller,
 }
 
 // Delete204Succeeded - Long running delete request, service returns a 204 to the initial request, indicating success.
-func (client *LrosaDsClient) Delete204Succeeded(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.Delete204SucceededCreateRequest(ctx)
+func (client *LrosaDsClient) Delete204Succeeded(ctx context.Context, options *LrosaDsDelete204SucceededOptions) (*azcore.Response, error) {
+	req, err := client.Delete204SucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (client *LrosaDsClient) Delete204Succeeded(ctx context.Context) (*azcore.Re
 }
 
 // Delete204SucceededCreateRequest creates the Delete204Succeeded request.
-func (client *LrosaDsClient) Delete204SucceededCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) Delete204SucceededCreateRequest(ctx context.Context, options *LrosaDsDelete204SucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/delete/204/nolocation"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -347,8 +347,8 @@ func (client *LrosaDsClient) Delete204SucceededHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRelativeRetry400(ctx)
+func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRelativeRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -382,8 +382,8 @@ func (client *LrosaDsClient) ResumeDeleteAsyncRelativeRetry400(token string) (HT
 }
 
 // DeleteAsyncRelativeRetry400 - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) DeleteAsyncRelativeRetry400(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRelativeRetry400CreateRequest(ctx)
+func (client *LrosaDsClient) DeleteAsyncRelativeRetry400(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetry400Options) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRelativeRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400(ctx context.Context) (*
 }
 
 // DeleteAsyncRelativeRetry400CreateRequest creates the DeleteAsyncRelativeRetry400 request.
-func (client *LrosaDsClient) DeleteAsyncRelativeRetry400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) DeleteAsyncRelativeRetry400CreateRequest(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/deleteasync/retry/400"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -417,8 +417,8 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetry400HandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRelativeRetryInvalidHeader(ctx)
+func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -452,8 +452,8 @@ func (client *LrosaDsClient) ResumeDeleteAsyncRelativeRetryInvalidHeader(token s
 }
 
 // DeleteAsyncRelativeRetryInvalidHeader - Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation header is invalid
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeader(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(ctx)
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +468,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeader(ctx context.C
 }
 
 // DeleteAsyncRelativeRetryInvalidHeaderCreateRequest creates the DeleteAsyncRelativeRetryInvalidHeader request.
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/invalidheader"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -487,8 +487,8 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidHeaderHandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRelativeRetryInvalidJSONPolling(ctx)
+func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -522,8 +522,8 @@ func (client *LrosaDsClient) ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(to
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPolling - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx)
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPolling(ctx cont
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPollingCreateRequest creates the DeleteAsyncRelativeRetryInvalidJSONPolling request.
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/invalidjsonpolling"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -557,8 +557,8 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryInvalidJSONPollingHandleErr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteAsyncRelativeRetryNoStatus(ctx)
+func (client *LrosaDsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryNoStatusOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteAsyncRelativeRetryNoStatus(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -592,8 +592,8 @@ func (client *LrosaDsClient) ResumeDeleteAsyncRelativeRetryNoStatus(token string
 }
 
 // DeleteAsyncRelativeRetryNoStatus - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatus(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx)
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryNoStatusOptions) (*azcore.Response, error) {
+	req, err := client.DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -608,7 +608,7 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatus(ctx context.Contex
 }
 
 // DeleteAsyncRelativeRetryNoStatusCreateRequest creates the DeleteAsyncRelativeRetryNoStatus request.
-func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusCreateRequest(ctx context.Context, options *LrosaDsDeleteAsyncRelativeRetryNoStatusOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/deleteasync/retry/nostatus"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -627,8 +627,8 @@ func (client *LrosaDsClient) DeleteAsyncRelativeRetryNoStatusHandleError(resp *a
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginDeleteNonRetry400(ctx context.Context) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteNonRetry400(ctx)
+func (client *LrosaDsClient) BeginDeleteNonRetry400(ctx context.Context, options *LrosaDsDeleteNonRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteNonRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -662,8 +662,8 @@ func (client *LrosaDsClient) ResumeDeleteNonRetry400(token string) (HTTPPoller, 
 }
 
 // DeleteNonRetry400 - Long running delete request, service returns a 400 with an error body
-func (client *LrosaDsClient) DeleteNonRetry400(ctx context.Context) (*azcore.Response, error) {
-	req, err := client.DeleteNonRetry400CreateRequest(ctx)
+func (client *LrosaDsClient) DeleteNonRetry400(ctx context.Context, options *LrosaDsDeleteNonRetry400Options) (*azcore.Response, error) {
+	req, err := client.DeleteNonRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (client *LrosaDsClient) DeleteNonRetry400(ctx context.Context) (*azcore.Res
 }
 
 // DeleteNonRetry400CreateRequest creates the DeleteNonRetry400 request.
-func (client *LrosaDsClient) DeleteNonRetry400CreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LrosaDsClient) DeleteNonRetry400CreateRequest(ctx context.Context, options *LrosaDsDeleteNonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/delete/400"
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -697,8 +697,8 @@ func (client *LrosaDsClient) DeleteNonRetry400HandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPost202NoLocation(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202NoLocation(ctx, lrosaDsPost202NoLocationOptions)
+func (client *LrosaDsClient) BeginPost202NoLocation(ctx context.Context, options *LrosaDsPost202NoLocationOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202NoLocation(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -732,8 +732,8 @@ func (client *LrosaDsClient) ResumePost202NoLocation(token string) (HTTPPoller, 
 }
 
 // Post202NoLocation - Long running post request, service returns a 202 to the initial request, without a location header.
-func (client *LrosaDsClient) Post202NoLocation(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*azcore.Response, error) {
-	req, err := client.Post202NoLocationCreateRequest(ctx, lrosaDsPost202NoLocationOptions)
+func (client *LrosaDsClient) Post202NoLocation(ctx context.Context, options *LrosaDsPost202NoLocationOptions) (*azcore.Response, error) {
+	req, err := client.Post202NoLocationCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -748,15 +748,15 @@ func (client *LrosaDsClient) Post202NoLocation(ctx context.Context, lrosaDsPost2
 }
 
 // Post202NoLocationCreateRequest creates the Post202NoLocation request.
-func (client *LrosaDsClient) Post202NoLocationCreateRequest(ctx context.Context, lrosaDsPost202NoLocationOptions *LrosaDsPost202NoLocationOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) Post202NoLocationCreateRequest(ctx context.Context, options *LrosaDsPost202NoLocationOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/post/202/nolocation"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPost202NoLocationOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPost202NoLocationOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -770,8 +770,8 @@ func (client *LrosaDsClient) Post202NoLocationHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPost202NonRetry400(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202NonRetry400(ctx, lrosaDsPost202NonRetry400Options)
+func (client *LrosaDsClient) BeginPost202NonRetry400(ctx context.Context, options *LrosaDsPost202NonRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202NonRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -805,8 +805,8 @@ func (client *LrosaDsClient) ResumePost202NonRetry400(token string) (HTTPPoller,
 }
 
 // Post202NonRetry400 - Long running post request, service returns a 202 with a location header
-func (client *LrosaDsClient) Post202NonRetry400(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*azcore.Response, error) {
-	req, err := client.Post202NonRetry400CreateRequest(ctx, lrosaDsPost202NonRetry400Options)
+func (client *LrosaDsClient) Post202NonRetry400(ctx context.Context, options *LrosaDsPost202NonRetry400Options) (*azcore.Response, error) {
+	req, err := client.Post202NonRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -821,15 +821,15 @@ func (client *LrosaDsClient) Post202NonRetry400(ctx context.Context, lrosaDsPost
 }
 
 // Post202NonRetry400CreateRequest creates the Post202NonRetry400 request.
-func (client *LrosaDsClient) Post202NonRetry400CreateRequest(ctx context.Context, lrosaDsPost202NonRetry400Options *LrosaDsPost202NonRetry400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) Post202NonRetry400CreateRequest(ctx context.Context, options *LrosaDsPost202NonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/post/202/retry/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPost202NonRetry400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPost202NonRetry400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -843,8 +843,8 @@ func (client *LrosaDsClient) Post202NonRetry400HandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPost202RetryInvalidHeader(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202RetryInvalidHeader(ctx, lrosaDsPost202RetryInvalidHeaderOptions)
+func (client *LrosaDsClient) BeginPost202RetryInvalidHeader(ctx context.Context, options *LrosaDsPost202RetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202RetryInvalidHeader(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -878,8 +878,8 @@ func (client *LrosaDsClient) ResumePost202RetryInvalidHeader(token string) (HTTP
 }
 
 // Post202RetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
-func (client *LrosaDsClient) Post202RetryInvalidHeader(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Response, error) {
-	req, err := client.Post202RetryInvalidHeaderCreateRequest(ctx, lrosaDsPost202RetryInvalidHeaderOptions)
+func (client *LrosaDsClient) Post202RetryInvalidHeader(ctx context.Context, options *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Response, error) {
+	req, err := client.Post202RetryInvalidHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -894,15 +894,15 @@ func (client *LrosaDsClient) Post202RetryInvalidHeader(ctx context.Context, lros
 }
 
 // Post202RetryInvalidHeaderCreateRequest creates the Post202RetryInvalidHeader request.
-func (client *LrosaDsClient) Post202RetryInvalidHeaderCreateRequest(ctx context.Context, lrosaDsPost202RetryInvalidHeaderOptions *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) Post202RetryInvalidHeaderCreateRequest(ctx context.Context, options *LrosaDsPost202RetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/post/202/retry/invalidheader"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPost202RetryInvalidHeaderOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPost202RetryInvalidHeaderOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -916,8 +916,8 @@ func (client *LrosaDsClient) Post202RetryInvalidHeaderHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPostAsyncRelativeRetry400(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRelativeRetry400(ctx, lrosaDsPostAsyncRelativeRetry400Options)
+func (client *LrosaDsClient) BeginPostAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPostAsyncRelativeRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRelativeRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -951,8 +951,8 @@ func (client *LrosaDsClient) ResumePostAsyncRelativeRetry400(token string) (HTTP
 }
 
 // PostAsyncRelativeRetry400 - Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PostAsyncRelativeRetry400(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Response, error) {
-	req, err := client.PostAsyncRelativeRetry400CreateRequest(ctx, lrosaDsPostAsyncRelativeRetry400Options)
+func (client *LrosaDsClient) PostAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Response, error) {
+	req, err := client.PostAsyncRelativeRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -967,15 +967,15 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400(ctx context.Context, lros
 }
 
 // PostAsyncRelativeRetry400CreateRequest creates the PostAsyncRelativeRetry400 request.
-func (client *LrosaDsClient) PostAsyncRelativeRetry400CreateRequest(ctx context.Context, lrosaDsPostAsyncRelativeRetry400Options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) PostAsyncRelativeRetry400CreateRequest(ctx context.Context, options *LrosaDsPostAsyncRelativeRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/postasync/retry/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPostAsyncRelativeRetry400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetry400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -989,8 +989,8 @@ func (client *LrosaDsClient) PostAsyncRelativeRetry400HandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRelativeRetryInvalidHeader(ctx, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions)
+func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,8 +1024,8 @@ func (client *LrosaDsClient) ResumePostAsyncRelativeRetryInvalidHeader(token str
 }
 
 // PostAsyncRelativeRetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
-func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRelativeRetryInvalidHeaderCreateRequest(ctx, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions)
+func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRelativeRetryInvalidHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1040,15 +1040,15 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Con
 }
 
 // PostAsyncRelativeRetryInvalidHeaderCreateRequest creates the PostAsyncRelativeRetryInvalidHeader request.
-func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/invalidheader"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryInvalidHeaderOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1062,8 +1062,8 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidHeaderHandleError(resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRelativeRetryInvalidJSONPolling(ctx, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions)
+func (client *LrosaDsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,8 +1097,8 @@ func (client *LrosaDsClient) ResumePostAsyncRelativeRetryInvalidJSONPolling(toke
 }
 
 // PostAsyncRelativeRetryInvalidJSONPolling - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions)
+func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1113,15 +1113,15 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx contex
 }
 
 // PostAsyncRelativeRetryInvalidJSONPollingCreateRequest creates the PostAsyncRelativeRetryInvalidJSONPolling request.
-func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context, lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/invalidjsonpolling"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryInvalidJsonPollingOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1135,8 +1135,8 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryInvalidJSONPollingHandleError
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRelativeRetryNoPayload(ctx, lrosaDsPostAsyncRelativeRetryNoPayloadOptions)
+func (client *LrosaDsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRelativeRetryNoPayload(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1170,8 +1170,8 @@ func (client *LrosaDsClient) ResumePostAsyncRelativeRetryNoPayload(token string)
 }
 
 // PostAsyncRelativeRetryNoPayload - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRelativeRetryNoPayloadCreateRequest(ctx, lrosaDsPostAsyncRelativeRetryNoPayloadOptions)
+func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRelativeRetryNoPayloadCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1186,15 +1186,15 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context
 }
 
 // PostAsyncRelativeRetryNoPayloadCreateRequest creates the PostAsyncRelativeRetryNoPayload request.
-func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadCreateRequest(ctx context.Context, lrosaDsPostAsyncRelativeRetryNoPayloadOptions *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadCreateRequest(ctx context.Context, options *LrosaDsPostAsyncRelativeRetryNoPayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/postasync/retry/nopayload"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPostAsyncRelativeRetryNoPayloadOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPostAsyncRelativeRetryNoPayloadOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1208,8 +1208,8 @@ func (client *LrosaDsClient) PostAsyncRelativeRetryNoPayloadHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPostNonRetry400(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*HTTPPollerResponse, error) {
-	resp, err := client.PostNonRetry400(ctx, lrosaDsPostNonRetry400Options)
+func (client *LrosaDsClient) BeginPostNonRetry400(ctx context.Context, options *LrosaDsPostNonRetry400Options) (*HTTPPollerResponse, error) {
+	resp, err := client.PostNonRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1243,8 +1243,8 @@ func (client *LrosaDsClient) ResumePostNonRetry400(token string) (HTTPPoller, er
 }
 
 // PostNonRetry400 - Long running post request, service returns a 400 with no error body
-func (client *LrosaDsClient) PostNonRetry400(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*azcore.Response, error) {
-	req, err := client.PostNonRetry400CreateRequest(ctx, lrosaDsPostNonRetry400Options)
+func (client *LrosaDsClient) PostNonRetry400(ctx context.Context, options *LrosaDsPostNonRetry400Options) (*azcore.Response, error) {
+	req, err := client.PostNonRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1259,15 +1259,15 @@ func (client *LrosaDsClient) PostNonRetry400(ctx context.Context, lrosaDsPostNon
 }
 
 // PostNonRetry400CreateRequest creates the PostNonRetry400 request.
-func (client *LrosaDsClient) PostNonRetry400CreateRequest(ctx context.Context, lrosaDsPostNonRetry400Options *LrosaDsPostNonRetry400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) PostNonRetry400CreateRequest(ctx context.Context, options *LrosaDsPostNonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/post/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPostNonRetry400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPostNonRetry400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1281,8 +1281,8 @@ func (client *LrosaDsClient) PostNonRetry400HandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPut200InvalidJSON(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*ProductPollerResponse, error) {
-	resp, err := client.Put200InvalidJSON(ctx, lrosaDsPut200InvalidJsonOptions)
+func (client *LrosaDsClient) BeginPut200InvalidJSON(ctx context.Context, options *LrosaDsPut200InvalidJSONOptions) (*ProductPollerResponse, error) {
+	resp, err := client.Put200InvalidJSON(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1316,8 +1316,8 @@ func (client *LrosaDsClient) ResumePut200InvalidJSON(token string) (ProductPolle
 }
 
 // Put200InvalidJSON - Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json
-func (client *LrosaDsClient) Put200InvalidJSON(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*azcore.Response, error) {
-	req, err := client.Put200InvalidJSONCreateRequest(ctx, lrosaDsPut200InvalidJsonOptions)
+func (client *LrosaDsClient) Put200InvalidJSON(ctx context.Context, options *LrosaDsPut200InvalidJSONOptions) (*azcore.Response, error) {
+	req, err := client.Put200InvalidJSONCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1332,15 +1332,15 @@ func (client *LrosaDsClient) Put200InvalidJSON(ctx context.Context, lrosaDsPut20
 }
 
 // Put200InvalidJSONCreateRequest creates the Put200InvalidJSON request.
-func (client *LrosaDsClient) Put200InvalidJSONCreateRequest(ctx context.Context, lrosaDsPut200InvalidJsonOptions *LrosaDsPut200InvalidJSONOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) Put200InvalidJSONCreateRequest(ctx context.Context, options *LrosaDsPut200InvalidJSONOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/put/200/invalidjson"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPut200InvalidJsonOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPut200InvalidJsonOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1360,8 +1360,8 @@ func (client *LrosaDsClient) Put200InvalidJSONHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetry400(ctx, lrosaDsPutAsyncRelativeRetry400Options)
+func (client *LrosaDsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPutAsyncRelativeRetry400Options) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1395,8 +1395,8 @@ func (client *LrosaDsClient) ResumePutAsyncRelativeRetry400(token string) (Produ
 }
 
 // PutAsyncRelativeRetry400 - Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PutAsyncRelativeRetry400(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetry400CreateRequest(ctx, lrosaDsPutAsyncRelativeRetry400Options)
+func (client *LrosaDsClient) PutAsyncRelativeRetry400(ctx context.Context, options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1411,15 +1411,15 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400(ctx context.Context, lrosa
 }
 
 // PutAsyncRelativeRetry400CreateRequest creates the PutAsyncRelativeRetry400 request.
-func (client *LrosaDsClient) PutAsyncRelativeRetry400CreateRequest(ctx context.Context, lrosaDsPutAsyncRelativeRetry400Options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutAsyncRelativeRetry400CreateRequest(ctx context.Context, options *LrosaDsPutAsyncRelativeRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/putasync/retry/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutAsyncRelativeRetry400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetry400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1439,8 +1439,8 @@ func (client *LrosaDsClient) PutAsyncRelativeRetry400HandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetryInvalidHeader(ctx, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions)
+func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetryInvalidHeader(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1474,8 +1474,8 @@ func (client *LrosaDsClient) ResumePutAsyncRelativeRetryInvalidHeader(token stri
 }
 
 // PutAsyncRelativeRetryInvalidHeader - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header is invalid.
-func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions)
+func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1490,15 +1490,15 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Cont
 }
 
 // PutAsyncRelativeRetryInvalidHeaderCreateRequest creates the PutAsyncRelativeRetryInvalidHeader request.
-func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderCreateRequest(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/invalidheader"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryInvalidHeaderOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1518,8 +1518,8 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidHeaderHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetryInvalidJSONPolling(ctx, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions)
+func (client *LrosaDsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetryInvalidJSONPolling(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1553,8 +1553,8 @@ func (client *LrosaDsClient) ResumePutAsyncRelativeRetryInvalidJSONPolling(token
 }
 
 // PutAsyncRelativeRetryInvalidJSONPolling - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions)
+func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1569,15 +1569,15 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context
 }
 
 // PutAsyncRelativeRetryInvalidJSONPollingCreateRequest creates the PutAsyncRelativeRetryInvalidJSONPolling request.
-func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context, lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingCreateRequest(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryInvalidJSONPollingOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/invalidjsonpolling"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryInvalidJsonPollingOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1597,8 +1597,8 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryInvalidJSONPollingHandleError(
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetryNoStatus(ctx, lrosaDsPutAsyncRelativeRetryNoStatusOptions)
+func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetryNoStatus(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1632,8 +1632,8 @@ func (client *LrosaDsClient) ResumePutAsyncRelativeRetryNoStatus(token string) (
 }
 
 // PutAsyncRelativeRetryNoStatus - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetryNoStatusCreateRequest(ctx, lrosaDsPutAsyncRelativeRetryNoStatusOptions)
+func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetryNoStatusCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1648,15 +1648,15 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, 
 }
 
 // PutAsyncRelativeRetryNoStatusCreateRequest creates the PutAsyncRelativeRetryNoStatus request.
-func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusCreateRequest(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusOptions *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusCreateRequest(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/nostatus"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutAsyncRelativeRetryNoStatusOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryNoStatusOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1676,8 +1676,8 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusHandleError(resp *azco
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRelativeRetryNoStatusPayload(ctx, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions)
+func (client *LrosaDsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRelativeRetryNoStatusPayload(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1711,8 +1711,8 @@ func (client *LrosaDsClient) ResumePutAsyncRelativeRetryNoStatusPayload(token st
 }
 
 // PutAsyncRelativeRetryNoStatusPayload - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRelativeRetryNoStatusPayloadCreateRequest(ctx, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions)
+func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRelativeRetryNoStatusPayloadCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1727,15 +1727,15 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Co
 }
 
 // PutAsyncRelativeRetryNoStatusPayloadCreateRequest creates the PutAsyncRelativeRetryNoStatusPayload request.
-func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadCreateRequest(ctx context.Context, lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadCreateRequest(ctx context.Context, options *LrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/putasync/retry/nostatuspayload"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutAsyncRelativeRetryNoStatusPayloadOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1755,8 +1755,8 @@ func (client *LrosaDsClient) PutAsyncRelativeRetryNoStatusPayloadHandleError(res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutError201NoProvisioningStatePayload(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutError201NoProvisioningStatePayload(ctx, lrosaDsPutError201NoProvisioningStatePayloadOptions)
+func (client *LrosaDsClient) BeginPutError201NoProvisioningStatePayload(ctx context.Context, options *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutError201NoProvisioningStatePayload(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1790,8 +1790,8 @@ func (client *LrosaDsClient) ResumePutError201NoProvisioningStatePayload(token s
 }
 
 // PutError201NoProvisioningStatePayload - Long running put request, service returns a 201 to the initial request with no payload
-func (client *LrosaDsClient) PutError201NoProvisioningStatePayload(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Response, error) {
-	req, err := client.PutError201NoProvisioningStatePayloadCreateRequest(ctx, lrosaDsPutError201NoProvisioningStatePayloadOptions)
+func (client *LrosaDsClient) PutError201NoProvisioningStatePayload(ctx context.Context, options *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Response, error) {
+	req, err := client.PutError201NoProvisioningStatePayloadCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1806,15 +1806,15 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayload(ctx context.C
 }
 
 // PutError201NoProvisioningStatePayloadCreateRequest creates the PutError201NoProvisioningStatePayload request.
-func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadCreateRequest(ctx context.Context, lrosaDsPutError201NoProvisioningStatePayloadOptions *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadCreateRequest(ctx context.Context, options *LrosaDsPutError201NoProvisioningStatePayloadOptions) (*azcore.Request, error) {
 	urlPath := "/lro/error/put/201/noprovisioningstatepayload"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutError201NoProvisioningStatePayloadOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutError201NoProvisioningStatePayloadOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1834,8 +1834,8 @@ func (client *LrosaDsClient) PutError201NoProvisioningStatePayloadHandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutNonRetry201Creating400(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*ProductPollerResponse, error) {
-	resp, err := client.PutNonRetry201Creating400(ctx, lrosaDsPutNonRetry201Creating400Options)
+func (client *LrosaDsClient) BeginPutNonRetry201Creating400(ctx context.Context, options *LrosaDsPutNonRetry201Creating400Options) (*ProductPollerResponse, error) {
+	resp, err := client.PutNonRetry201Creating400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1869,8 +1869,8 @@ func (client *LrosaDsClient) ResumePutNonRetry201Creating400(token string) (Prod
 }
 
 // PutNonRetry201Creating400 - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
-func (client *LrosaDsClient) PutNonRetry201Creating400(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Response, error) {
-	req, err := client.PutNonRetry201Creating400CreateRequest(ctx, lrosaDsPutNonRetry201Creating400Options)
+func (client *LrosaDsClient) PutNonRetry201Creating400(ctx context.Context, options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Response, error) {
+	req, err := client.PutNonRetry201Creating400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1885,15 +1885,15 @@ func (client *LrosaDsClient) PutNonRetry201Creating400(ctx context.Context, lros
 }
 
 // PutNonRetry201Creating400CreateRequest creates the PutNonRetry201Creating400 request.
-func (client *LrosaDsClient) PutNonRetry201Creating400CreateRequest(ctx context.Context, lrosaDsPutNonRetry201Creating400Options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutNonRetry201Creating400CreateRequest(ctx context.Context, options *LrosaDsPutNonRetry201Creating400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/201/creating/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutNonRetry201Creating400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutNonRetry201Creating400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1913,8 +1913,8 @@ func (client *LrosaDsClient) PutNonRetry201Creating400HandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutNonRetry201Creating400InvalidJSON(ctx, lrosaDsPutNonRetry201Creating400InvalidJsonOptions)
+func (client *LrosaDsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx context.Context, options *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutNonRetry201Creating400InvalidJSON(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1948,8 +1948,8 @@ func (client *LrosaDsClient) ResumePutNonRetry201Creating400InvalidJSON(token st
 }
 
 // PutNonRetry201Creating400InvalidJSON - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
-func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Response, error) {
-	req, err := client.PutNonRetry201Creating400InvalidJSONCreateRequest(ctx, lrosaDsPutNonRetry201Creating400InvalidJsonOptions)
+func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Context, options *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Response, error) {
+	req, err := client.PutNonRetry201Creating400InvalidJSONCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1964,15 +1964,15 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Co
 }
 
 // PutNonRetry201Creating400InvalidJSONCreateRequest creates the PutNonRetry201Creating400InvalidJSON request.
-func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONCreateRequest(ctx context.Context, lrosaDsPutNonRetry201Creating400InvalidJsonOptions *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONCreateRequest(ctx context.Context, options *LrosaDsPutNonRetry201Creating400InvalidJSONOptions) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/201/creating/400/invalidjson"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutNonRetry201Creating400InvalidJsonOptions != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutNonRetry201Creating400InvalidJsonOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -1992,8 +1992,8 @@ func (client *LrosaDsClient) PutNonRetry201Creating400InvalidJSONHandleError(res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrosaDsClient) BeginPutNonRetry400(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*ProductPollerResponse, error) {
-	resp, err := client.PutNonRetry400(ctx, lrosaDsPutNonRetry400Options)
+func (client *LrosaDsClient) BeginPutNonRetry400(ctx context.Context, options *LrosaDsPutNonRetry400Options) (*ProductPollerResponse, error) {
+	resp, err := client.PutNonRetry400(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2027,8 +2027,8 @@ func (client *LrosaDsClient) ResumePutNonRetry400(token string) (ProductPoller, 
 }
 
 // PutNonRetry400 - Long running put request, service returns a 400 to the initial request
-func (client *LrosaDsClient) PutNonRetry400(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*azcore.Response, error) {
-	req, err := client.PutNonRetry400CreateRequest(ctx, lrosaDsPutNonRetry400Options)
+func (client *LrosaDsClient) PutNonRetry400(ctx context.Context, options *LrosaDsPutNonRetry400Options) (*azcore.Response, error) {
+	req, err := client.PutNonRetry400CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2043,15 +2043,15 @@ func (client *LrosaDsClient) PutNonRetry400(ctx context.Context, lrosaDsPutNonRe
 }
 
 // PutNonRetry400CreateRequest creates the PutNonRetry400 request.
-func (client *LrosaDsClient) PutNonRetry400CreateRequest(ctx context.Context, lrosaDsPutNonRetry400Options *LrosaDsPutNonRetry400Options) (*azcore.Request, error) {
+func (client *LrosaDsClient) PutNonRetry400CreateRequest(ctx context.Context, options *LrosaDsPutNonRetry400Options) (*azcore.Request, error) {
 	urlPath := "/lro/nonretryerror/put/400"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrosaDsPutNonRetry400Options != nil {
-		return req, req.MarshalAsJSON(lrosaDsPutNonRetry400Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -16,19 +16,19 @@ import (
 // LrOSCustomHeaderOperations contains the methods for the LrOSCustomHeader group.
 type LrOSCustomHeaderOperations interface {
 	// BeginPost202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-	BeginPost202Retry200(ctx context.Context, lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*HTTPPollerResponse, error)
+	BeginPost202Retry200(ctx context.Context, options *LrOSCustomHeaderPost202Retry200Options) (*HTTPPollerResponse, error)
 	// ResumePost202Retry200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePost202Retry200(token string) (HTTPPoller, error)
 	// BeginPostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*HTTPPollerResponse, error)
+	BeginPostAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*HTTPPollerResponse, error)
 	// ResumePostAsyncRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePostAsyncRetrySucceeded(token string) (HTTPPoller, error)
 	// BeginPut201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-	BeginPut201CreatingSucceeded200(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
+	BeginPut201CreatingSucceeded200(ctx context.Context, options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*ProductPollerResponse, error)
 	// ResumePut201CreatingSucceeded200 - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePut201CreatingSucceeded200(token string) (ProductPoller, error)
 	// BeginPutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-	BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
+	BeginPutAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error)
 	// ResumePutAsyncRetrySucceeded - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error)
 }
@@ -49,8 +49,8 @@ func (client *LrOSCustomHeaderClient) Do(req *azcore.Request) (*azcore.Response,
 	return client.p.Do(req)
 }
 
-func (client *LrOSCustomHeaderClient) BeginPost202Retry200(ctx context.Context, lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*HTTPPollerResponse, error) {
-	resp, err := client.Post202Retry200(ctx, lrOSCustomHeaderPost202Retry200Options)
+func (client *LrOSCustomHeaderClient) BeginPost202Retry200(ctx context.Context, options *LrOSCustomHeaderPost202Retry200Options) (*HTTPPollerResponse, error) {
+	resp, err := client.Post202Retry200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +84,8 @@ func (client *LrOSCustomHeaderClient) ResumePost202Retry200(token string) (HTTPP
 }
 
 // Post202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
-func (client *LrOSCustomHeaderClient) Post202Retry200(ctx context.Context, lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Response, error) {
-	req, err := client.Post202Retry200CreateRequest(ctx, lrOSCustomHeaderPost202Retry200Options)
+func (client *LrOSCustomHeaderClient) Post202Retry200(ctx context.Context, options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Response, error) {
+	req, err := client.Post202Retry200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,15 +100,15 @@ func (client *LrOSCustomHeaderClient) Post202Retry200(ctx context.Context, lrOSC
 }
 
 // Post202Retry200CreateRequest creates the Post202Retry200 request.
-func (client *LrOSCustomHeaderClient) Post202Retry200CreateRequest(ctx context.Context, lrOSCustomHeaderPost202Retry200Options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Request, error) {
+func (client *LrOSCustomHeaderClient) Post202Retry200CreateRequest(ctx context.Context, options *LrOSCustomHeaderPost202Retry200Options) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/post/202/retry/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSCustomHeaderPost202Retry200Options != nil {
-		return req, req.MarshalAsJSON(lrOSCustomHeaderPost202Retry200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -122,8 +122,8 @@ func (client *LrOSCustomHeaderClient) Post202Retry200HandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PostAsyncRetrySucceeded(ctx, lrOSCustomHeaderPostAsyncRetrySucceededOptions)
+func (client *LrOSCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PostAsyncRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -157,8 +157,8 @@ func (client *LrOSCustomHeaderClient) ResumePostAsyncRetrySucceeded(token string
 }
 
 // PostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PostAsyncRetrySucceededCreateRequest(ctx, lrOSCustomHeaderPostAsyncRetrySucceededOptions)
+func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PostAsyncRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -173,15 +173,15 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Contex
 }
 
 // PostAsyncRetrySucceededCreateRequest creates the PostAsyncRetrySucceeded request.
-func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededCreateRequest(ctx context.Context, lrOSCustomHeaderPostAsyncRetrySucceededOptions *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededCreateRequest(ctx context.Context, options *LrOSCustomHeaderPostAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/postasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSCustomHeaderPostAsyncRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSCustomHeaderPostAsyncRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -195,8 +195,8 @@ func (client *LrOSCustomHeaderClient) PostAsyncRetrySucceededHandleError(resp *a
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
-	resp, err := client.Put201CreatingSucceeded200(ctx, lrOSCustomHeaderPut201CreatingSucceeded200Options)
+func (client *LrOSCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx context.Context, options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*ProductPollerResponse, error) {
+	resp, err := client.Put201CreatingSucceeded200(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -230,8 +230,8 @@ func (client *LrOSCustomHeaderClient) ResumePut201CreatingSucceeded200(token str
 }
 
 // Put201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
-func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Response, error) {
-	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, lrOSCustomHeaderPut201CreatingSucceeded200Options)
+func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Context, options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Response, error) {
+	req, err := client.Put201CreatingSucceeded200CreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -246,15 +246,15 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Con
 }
 
 // Put201CreatingSucceeded200CreateRequest creates the Put201CreatingSucceeded200 request.
-func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, lrOSCustomHeaderPut201CreatingSucceeded200Options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Request, error) {
+func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200CreateRequest(ctx context.Context, options *LrOSCustomHeaderPut201CreatingSucceeded200Options) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/put/201/creating/succeeded/200"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSCustomHeaderPut201CreatingSucceeded200Options != nil {
-		return req, req.MarshalAsJSON(lrOSCustomHeaderPut201CreatingSucceeded200Options.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }
@@ -274,8 +274,8 @@ func (client *LrOSCustomHeaderClient) Put201CreatingSucceeded200HandleError(resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LrOSCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
-	resp, err := client.PutAsyncRetrySucceeded(ctx, lrOSCustomHeaderPutAsyncRetrySucceededOptions)
+func (client *LrOSCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*ProductPollerResponse, error) {
+	resp, err := client.PutAsyncRetrySucceeded(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -309,8 +309,8 @@ func (client *LrOSCustomHeaderClient) ResumePutAsyncRetrySucceeded(token string)
 }
 
 // PutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
-func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Response, error) {
-	req, err := client.PutAsyncRetrySucceededCreateRequest(ctx, lrOSCustomHeaderPutAsyncRetrySucceededOptions)
+func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context, options *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Response, error) {
+	req, err := client.PutAsyncRetrySucceededCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -325,15 +325,15 @@ func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context
 }
 
 // PutAsyncRetrySucceededCreateRequest creates the PutAsyncRetrySucceeded request.
-func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededCreateRequest(ctx context.Context, lrOSCustomHeaderPutAsyncRetrySucceededOptions *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
+func (client *LrOSCustomHeaderClient) PutAsyncRetrySucceededCreateRequest(ctx context.Context, options *LrOSCustomHeaderPutAsyncRetrySucceededOptions) (*azcore.Request, error) {
 	urlPath := "/lro/customheader/putasync/retry/succeeded"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if lrOSCustomHeaderPutAsyncRetrySucceededOptions != nil {
-		return req, req.MarshalAsJSON(lrOSCustomHeaderPutAsyncRetrySucceededOptions.Product)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
 }

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -71,6 +71,79 @@ type LrOSCustomHeaderPutAsyncRetrySucceededOptions struct {
 	Product *Product
 }
 
+// LrOSDelete202NoRetry204Options contains the optional parameters for the LrOS.Delete202NoRetry204 method.
+type LrOSDelete202NoRetry204Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDelete202Retry200Options contains the optional parameters for the LrOS.Delete202Retry200 method.
+type LrOSDelete202Retry200Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDelete204SucceededOptions contains the optional parameters for the LrOS.Delete204Succeeded method.
+type LrOSDelete204SucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteAsyncNoHeaderInRetryOptions contains the optional parameters for the LrOS.DeleteAsyncNoHeaderInRetry method.
+type LrOSDeleteAsyncNoHeaderInRetryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteAsyncNoRetrySucceededOptions contains the optional parameters for the LrOS.DeleteAsyncNoRetrySucceeded method.
+type LrOSDeleteAsyncNoRetrySucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteAsyncRetryFailedOptions contains the optional parameters for the LrOS.DeleteAsyncRetryFailed method.
+type LrOSDeleteAsyncRetryFailedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteAsyncRetrySucceededOptions contains the optional parameters for the LrOS.DeleteAsyncRetrySucceeded method.
+type LrOSDeleteAsyncRetrySucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteAsyncRetrycanceledOptions contains the optional parameters for the LrOS.DeleteAsyncRetrycanceled method.
+type LrOSDeleteAsyncRetrycanceledOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteNoHeaderInRetryOptions contains the optional parameters for the LrOS.DeleteNoHeaderInRetry method.
+type LrOSDeleteNoHeaderInRetryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteProvisioning202Accepted200SucceededOptions contains the optional parameters for the LrOS.DeleteProvisioning202Accepted200Succeeded
+// method.
+type LrOSDeleteProvisioning202Accepted200SucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteProvisioning202DeletingFailed200Options contains the optional parameters for the LrOS.DeleteProvisioning202DeletingFailed200
+// method.
+type LrOSDeleteProvisioning202DeletingFailed200Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSDeleteProvisioning202Deletingcanceled200Options contains the optional parameters for the LrOS.DeleteProvisioning202Deletingcanceled200
+// method.
+type LrOSDeleteProvisioning202Deletingcanceled200Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSPost200WithPayloadOptions contains the optional parameters for the LrOS.Post200WithPayload method.
+type LrOSPost200WithPayloadOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSPost202ListOptions contains the optional parameters for the LrOS.Post202List method.
+type LrOSPost202ListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // LrOSPost202NoRetry204Options contains the optional parameters for the LrOS.Post202NoRetry204 method.
 type LrOSPost202NoRetry204Options struct {
 	// Product to put
@@ -105,6 +178,24 @@ type LrOSPostAsyncRetrySucceededOptions struct {
 type LrOSPostAsyncRetrycanceledOptions struct {
 	// Product to put
 	Product *Product
+}
+
+// LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions contains the optional parameters for the LrOS.PostDoubleHeadersFinalAzureHeaderGetDefault
+// method.
+type LrOSPostDoubleHeadersFinalAzureHeaderGetDefaultOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSPostDoubleHeadersFinalAzureHeaderGetOptions contains the optional parameters for the LrOS.PostDoubleHeadersFinalAzureHeaderGet
+// method.
+type LrOSPostDoubleHeadersFinalAzureHeaderGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrOSPostDoubleHeadersFinalLocationGetOptions contains the optional parameters for the LrOS.PostDoubleHeadersFinalLocationGet
+// method.
+type LrOSPostDoubleHeadersFinalLocationGetOptions struct {
+	// placeholder for future optional parameters
 }
 
 // LrOSPut200Acceptedcanceled200Options contains the optional parameters for the LrOS.Put200Acceptedcanceled200 method.
@@ -215,6 +306,23 @@ type LrOSPutSubResourceOptions struct {
 	Product *SubProduct
 }
 
+// LroRetrysDelete202Retry200Options contains the optional parameters for the LroRetrys.Delete202Retry200 method.
+type LroRetrysDelete202Retry200Options struct {
+	// placeholder for future optional parameters
+}
+
+// LroRetrysDeleteAsyncRelativeRetrySucceededOptions contains the optional parameters for the LroRetrys.DeleteAsyncRelativeRetrySucceeded
+// method.
+type LroRetrysDeleteAsyncRelativeRetrySucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LroRetrysDeleteProvisioning202Accepted200SucceededOptions contains the optional parameters for the LroRetrys.DeleteProvisioning202Accepted200Succeeded
+// method.
+type LroRetrysDeleteProvisioning202Accepted200SucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
 // LroRetrysPost202Retry200Options contains the optional parameters for the LroRetrys.Post202Retry200 method.
 type LroRetrysPost202Retry200Options struct {
 	// Product to put
@@ -240,6 +348,51 @@ type LroRetrysPut201CreatingSucceeded200Options struct {
 type LroRetrysPutAsyncRelativeRetrySucceededOptions struct {
 	// Product to put
 	Product *Product
+}
+
+// LrosaDsDelete202NonRetry400Options contains the optional parameters for the LrosaDs.Delete202NonRetry400 method.
+type LrosaDsDelete202NonRetry400Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDelete202RetryInvalidHeaderOptions contains the optional parameters for the LrosaDs.Delete202RetryInvalidHeader
+// method.
+type LrosaDsDelete202RetryInvalidHeaderOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDelete204SucceededOptions contains the optional parameters for the LrosaDs.Delete204Succeeded method.
+type LrosaDsDelete204SucceededOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDeleteAsyncRelativeRetry400Options contains the optional parameters for the LrosaDs.DeleteAsyncRelativeRetry400
+// method.
+type LrosaDsDeleteAsyncRelativeRetry400Options struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions contains the optional parameters for the LrosaDs.DeleteAsyncRelativeRetryInvalidHeader
+// method.
+type LrosaDsDeleteAsyncRelativeRetryInvalidHeaderOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions contains the optional parameters for the LrosaDs.DeleteAsyncRelativeRetryInvalidJSONPolling
+// method.
+type LrosaDsDeleteAsyncRelativeRetryInvalidJSONPollingOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDeleteAsyncRelativeRetryNoStatusOptions contains the optional parameters for the LrosaDs.DeleteAsyncRelativeRetryNoStatus
+// method.
+type LrosaDsDeleteAsyncRelativeRetryNoStatusOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LrosaDsDeleteNonRetry400Options contains the optional parameters for the LrosaDs.DeleteNonRetry400 method.
+type LrosaDsDeleteNonRetry400Options struct {
+	// placeholder for future optional parameters
 }
 
 // LrosaDsPost202NoLocationOptions contains the optional parameters for the LrosaDs.Post202NoLocation method.

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -21,7 +21,7 @@ func newMediaTypesClient() MediaTypesClientOperations {
 func TestAnalyzeBody(t *testing.T) {
 	client := newMediaTypesClient()
 	body := azcore.NopCloser(bytes.NewReader([]byte("PDF")))
-	result, err := client.AnalyzeBody(context.Background(), ContentTypeApplicationPDF, body)
+	result, err := client.AnalyzeBody(context.Background(), ContentTypeApplicationPDF, body, nil)
 	if err != nil {
 		t.Fatalf("AnalyzeBody: %v", err)
 	}

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -18,9 +18,9 @@ import (
 // MediaTypesClientOperations contains the methods for the MediaTypesClient group.
 type MediaTypesClientOperations interface {
 	// AnalyzeBody - Analyze body, that could be different media types.
-	AnalyzeBody(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser) (*StringResponse, error)
+	AnalyzeBody(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser, options *MediaTypesClientAnalyzeBodyOptions) (*StringResponse, error)
 	// AnalyzeBodyWithSourcePath - Analyze body, that could be different media types.
-	AnalyzeBodyWithSourcePath(ctx context.Context, mediaTypesClientAnalyzeBodyWithSourcePathOptions *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*StringResponse, error)
+	AnalyzeBodyWithSourcePath(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*StringResponse, error)
 	// ContentTypeWithEncoding - Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter
 	ContentTypeWithEncoding(ctx context.Context, input string) (*StringResponse, error)
 }
@@ -42,8 +42,8 @@ func (client *MediaTypesClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // AnalyzeBody - Analyze body, that could be different media types.
-func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser) (*StringResponse, error) {
-	req, err := client.AnalyzeBodyCreateRequest(ctx, contentType, input)
+func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser, options *MediaTypesClientAnalyzeBodyOptions) (*StringResponse, error) {
+	req, err := client.AnalyzeBodyCreateRequest(ctx, contentType, input, options)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType Con
 }
 
 // AnalyzeBodyCreateRequest creates the AnalyzeBody request.
-func (client *MediaTypesClient) AnalyzeBodyCreateRequest(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser) (*azcore.Request, error) {
+func (client *MediaTypesClient) AnalyzeBodyCreateRequest(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser, options *MediaTypesClientAnalyzeBodyOptions) (*azcore.Request, error) {
 	urlPath := "/mediatypes/analyze"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -92,8 +92,8 @@ func (client *MediaTypesClient) AnalyzeBodyHandleError(resp *azcore.Response) er
 }
 
 // AnalyzeBodyWithSourcePath - Analyze body, that could be different media types.
-func (client *MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, mediaTypesClientAnalyzeBodyWithSourcePathOptions *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*StringResponse, error) {
-	req, err := client.AnalyzeBodyWithSourcePathCreateRequest(ctx, mediaTypesClientAnalyzeBodyWithSourcePathOptions)
+func (client *MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*StringResponse, error) {
+	req, err := client.AnalyzeBodyWithSourcePathCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,15 +112,15 @@ func (client *MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, m
 }
 
 // AnalyzeBodyWithSourcePathCreateRequest creates the AnalyzeBodyWithSourcePath request.
-func (client *MediaTypesClient) AnalyzeBodyWithSourcePathCreateRequest(ctx context.Context, mediaTypesClientAnalyzeBodyWithSourcePathOptions *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*azcore.Request, error) {
+func (client *MediaTypesClient) AnalyzeBodyWithSourcePathCreateRequest(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*azcore.Request, error) {
 	urlPath := "/mediatypes/analyze"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if mediaTypesClientAnalyzeBodyWithSourcePathOptions != nil {
-		return req, req.MarshalAsJSON(mediaTypesClientAnalyzeBodyWithSourcePathOptions.Input)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil
 }

--- a/test/autorest/mediatypesgroup/zz_generated_models.go
+++ b/test/autorest/mediatypesgroup/zz_generated_models.go
@@ -7,6 +7,11 @@ package mediatypesgroup
 
 import "net/http"
 
+// MediaTypesClientAnalyzeBodyOptions contains the optional parameters for the MediaTypesClient.AnalyzeBody method.
+type MediaTypesClientAnalyzeBodyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // MediaTypesClientAnalyzeBodyWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithSourcePath
 // method.
 type MediaTypesClientAnalyzeBodyWithSourcePathOptions struct {

--- a/test/autorest/migroup/migroup_test.go
+++ b/test/autorest/migroup/migroup_test.go
@@ -18,7 +18,7 @@ func newMultipleInheritanceServiceClient() MultipleInheritanceServiceClientOpera
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
 func TestGetCat(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
-	result, err := client.GetCat(context.Background())
+	result, err := client.GetCat(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestGetCat(t *testing.T) {
 // GetFeline - Get a feline where meows and hisses are true
 func TestGetFeline(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
-	result, err := client.GetFeline(context.Background())
+	result, err := client.GetFeline(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestGetFeline(t *testing.T) {
 // GetHorse - Get a horse with name 'Fred' and isAShowHorse true
 func TestGetHorse(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
-	result, err := client.GetHorse(context.Background())
+	result, err := client.GetHorse(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestGetHorse(t *testing.T) {
 // GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
 func TestGetKitten(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
-	result, err := client.GetKitten(context.Background())
+	result, err := client.GetKitten(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestGetKitten(t *testing.T) {
 // GetPet - Get a pet with name 'Peanut'
 func TestGetPet(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
-	result, err := client.GetPet(context.Background())
+	result, err := client.GetPet(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestPutCat(t *testing.T) {
 			Name: to.StringPtr("Boots"),
 		},
 		LikesMilk: to.BoolPtr(false),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestPutFeline(t *testing.T) {
 	result, err := client.PutFeline(context.Background(), Feline{
 		Hisses: to.BoolPtr(true),
 		Meows:  to.BoolPtr(false),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestPutHorse(t *testing.T) {
 			Name: to.StringPtr("General"),
 		},
 		IsAShowHorse: to.BoolPtr(false),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestPutKitten(t *testing.T) {
 			LikesMilk: to.BoolPtr(false),
 		},
 		EatsMiceYet: to.BoolPtr(true),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func TestPutPet(t *testing.T) {
 	client := newMultipleInheritanceServiceClient()
 	result, err := client.PutPet(context.Background(), Pet{
 		Name: to.StringPtr("Butter"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/migroup/zz_generated_models.go
+++ b/test/autorest/migroup/zz_generated_models.go
@@ -83,6 +83,66 @@ type KittenResponse struct {
 	RawResponse *http.Response
 }
 
+// MultipleInheritanceServiceClientGetCatOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetCat
+// method.
+type MultipleInheritanceServiceClientGetCatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientGetFelineOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetFeline
+// method.
+type MultipleInheritanceServiceClientGetFelineOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientGetHorseOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetHorse
+// method.
+type MultipleInheritanceServiceClientGetHorseOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientGetKittenOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetKitten
+// method.
+type MultipleInheritanceServiceClientGetKittenOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientGetPetOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetPet
+// method.
+type MultipleInheritanceServiceClientGetPetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientPutCatOptions contains the optional parameters for the MultipleInheritanceServiceClient.PutCat
+// method.
+type MultipleInheritanceServiceClientPutCatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientPutFelineOptions contains the optional parameters for the MultipleInheritanceServiceClient.PutFeline
+// method.
+type MultipleInheritanceServiceClientPutFelineOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientPutHorseOptions contains the optional parameters for the MultipleInheritanceServiceClient.PutHorse
+// method.
+type MultipleInheritanceServiceClientPutHorseOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientPutKittenOptions contains the optional parameters for the MultipleInheritanceServiceClient.PutKitten
+// method.
+type MultipleInheritanceServiceClientPutKittenOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MultipleInheritanceServiceClientPutPetOptions contains the optional parameters for the MultipleInheritanceServiceClient.PutPet
+// method.
+type MultipleInheritanceServiceClientPutPetOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Pet struct {
 	Name *string `json:"name,omitempty"`
 }

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -17,25 +17,25 @@ import (
 // MultipleInheritanceServiceClientOperations contains the methods for the MultipleInheritanceServiceClient group.
 type MultipleInheritanceServiceClientOperations interface {
 	// GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
-	GetCat(ctx context.Context) (*CatResponse, error)
+	GetCat(ctx context.Context, options *MultipleInheritanceServiceClientGetCatOptions) (*CatResponse, error)
 	// GetFeline - Get a feline where meows and hisses are true
-	GetFeline(ctx context.Context) (*FelineResponse, error)
+	GetFeline(ctx context.Context, options *MultipleInheritanceServiceClientGetFelineOptions) (*FelineResponse, error)
 	// GetHorse - Get a horse with name 'Fred' and isAShowHorse true
-	GetHorse(ctx context.Context) (*HorseResponse, error)
+	GetHorse(ctx context.Context, options *MultipleInheritanceServiceClientGetHorseOptions) (*HorseResponse, error)
 	// GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
-	GetKitten(ctx context.Context) (*KittenResponse, error)
+	GetKitten(ctx context.Context, options *MultipleInheritanceServiceClientGetKittenOptions) (*KittenResponse, error)
 	// GetPet - Get a pet with name 'Peanut'
-	GetPet(ctx context.Context) (*PetResponse, error)
+	GetPet(ctx context.Context, options *MultipleInheritanceServiceClientGetPetOptions) (*PetResponse, error)
 	// PutCat - Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true
-	PutCat(ctx context.Context, cat Cat) (*StringResponse, error)
+	PutCat(ctx context.Context, cat Cat, options *MultipleInheritanceServiceClientPutCatOptions) (*StringResponse, error)
 	// PutFeline - Put a feline who hisses and doesn't meow
-	PutFeline(ctx context.Context, feline Feline) (*StringResponse, error)
+	PutFeline(ctx context.Context, feline Feline, options *MultipleInheritanceServiceClientPutFelineOptions) (*StringResponse, error)
 	// PutHorse - Put a horse with name 'General' and isAShowHorse false
-	PutHorse(ctx context.Context, horse Horse) (*StringResponse, error)
+	PutHorse(ctx context.Context, horse Horse, options *MultipleInheritanceServiceClientPutHorseOptions) (*StringResponse, error)
 	// PutKitten - Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true
-	PutKitten(ctx context.Context, kitten Kitten) (*StringResponse, error)
+	PutKitten(ctx context.Context, kitten Kitten, options *MultipleInheritanceServiceClientPutKittenOptions) (*StringResponse, error)
 	// PutPet - Put a pet with name 'Butter'
-	PutPet(ctx context.Context, pet Pet) (*StringResponse, error)
+	PutPet(ctx context.Context, pet Pet, options *MultipleInheritanceServiceClientPutPetOptions) (*StringResponse, error)
 }
 
 // MultipleInheritanceServiceClient implements the MultipleInheritanceServiceClientOperations interface.
@@ -55,8 +55,8 @@ func (client *MultipleInheritanceServiceClient) Do(req *azcore.Request) (*azcore
 }
 
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
-func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context) (*CatResponse, error) {
-	req, err := client.GetCatCreateRequest(ctx)
+func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context, options *MultipleInheritanceServiceClientGetCatOptions) (*CatResponse, error) {
+	req, err := client.GetCatCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context) (*Ca
 }
 
 // GetCatCreateRequest creates the GetCat request.
-func (client *MultipleInheritanceServiceClient) GetCatCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) GetCatCreateRequest(ctx context.Context, options *MultipleInheritanceServiceClientGetCatOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/cat"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -101,8 +101,8 @@ func (client *MultipleInheritanceServiceClient) GetCatHandleError(resp *azcore.R
 }
 
 // GetFeline - Get a feline where meows and hisses are true
-func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context) (*FelineResponse, error) {
-	req, err := client.GetFelineCreateRequest(ctx)
+func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context, options *MultipleInheritanceServiceClientGetFelineOptions) (*FelineResponse, error) {
+	req, err := client.GetFelineCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context) (
 }
 
 // GetFelineCreateRequest creates the GetFeline request.
-func (client *MultipleInheritanceServiceClient) GetFelineCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) GetFelineCreateRequest(ctx context.Context, options *MultipleInheritanceServiceClientGetFelineOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/feline"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -147,8 +147,8 @@ func (client *MultipleInheritanceServiceClient) GetFelineHandleError(resp *azcor
 }
 
 // GetHorse - Get a horse with name 'Fred' and isAShowHorse true
-func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context) (*HorseResponse, error) {
-	req, err := client.GetHorseCreateRequest(ctx)
+func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context, options *MultipleInheritanceServiceClientGetHorseOptions) (*HorseResponse, error) {
+	req, err := client.GetHorseCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context) (*
 }
 
 // GetHorseCreateRequest creates the GetHorse request.
-func (client *MultipleInheritanceServiceClient) GetHorseCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) GetHorseCreateRequest(ctx context.Context, options *MultipleInheritanceServiceClientGetHorseOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/horse"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -193,8 +193,8 @@ func (client *MultipleInheritanceServiceClient) GetHorseHandleError(resp *azcore
 }
 
 // GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
-func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context) (*KittenResponse, error) {
-	req, err := client.GetKittenCreateRequest(ctx)
+func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context, options *MultipleInheritanceServiceClientGetKittenOptions) (*KittenResponse, error) {
+	req, err := client.GetKittenCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context) (
 }
 
 // GetKittenCreateRequest creates the GetKitten request.
-func (client *MultipleInheritanceServiceClient) GetKittenCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) GetKittenCreateRequest(ctx context.Context, options *MultipleInheritanceServiceClientGetKittenOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/kitten"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -239,8 +239,8 @@ func (client *MultipleInheritanceServiceClient) GetKittenHandleError(resp *azcor
 }
 
 // GetPet - Get a pet with name 'Peanut'
-func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context) (*PetResponse, error) {
-	req, err := client.GetPetCreateRequest(ctx)
+func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context, options *MultipleInheritanceServiceClientGetPetOptions) (*PetResponse, error) {
+	req, err := client.GetPetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context) (*Pe
 }
 
 // GetPetCreateRequest creates the GetPet request.
-func (client *MultipleInheritanceServiceClient) GetPetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) GetPetCreateRequest(ctx context.Context, options *MultipleInheritanceServiceClientGetPetOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/pet"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -285,8 +285,8 @@ func (client *MultipleInheritanceServiceClient) GetPetHandleError(resp *azcore.R
 }
 
 // PutCat - Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true
-func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat Cat) (*StringResponse, error) {
-	req, err := client.PutCatCreateRequest(ctx, cat)
+func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat Cat, options *MultipleInheritanceServiceClientPutCatOptions) (*StringResponse, error) {
+	req, err := client.PutCatCreateRequest(ctx, cat, options)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat 
 }
 
 // PutCatCreateRequest creates the PutCat request.
-func (client *MultipleInheritanceServiceClient) PutCatCreateRequest(ctx context.Context, cat Cat) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) PutCatCreateRequest(ctx context.Context, cat Cat, options *MultipleInheritanceServiceClientPutCatOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/cat"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -334,8 +334,8 @@ func (client *MultipleInheritanceServiceClient) PutCatHandleError(resp *azcore.R
 }
 
 // PutFeline - Put a feline who hisses and doesn't meow
-func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, feline Feline) (*StringResponse, error) {
-	req, err := client.PutFelineCreateRequest(ctx, feline)
+func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, feline Feline, options *MultipleInheritanceServiceClientPutFelineOptions) (*StringResponse, error) {
+	req, err := client.PutFelineCreateRequest(ctx, feline, options)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, f
 }
 
 // PutFelineCreateRequest creates the PutFeline request.
-func (client *MultipleInheritanceServiceClient) PutFelineCreateRequest(ctx context.Context, feline Feline) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) PutFelineCreateRequest(ctx context.Context, feline Feline, options *MultipleInheritanceServiceClientPutFelineOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/feline"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -383,8 +383,8 @@ func (client *MultipleInheritanceServiceClient) PutFelineHandleError(resp *azcor
 }
 
 // PutHorse - Put a horse with name 'General' and isAShowHorse false
-func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, horse Horse) (*StringResponse, error) {
-	req, err := client.PutHorseCreateRequest(ctx, horse)
+func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, horse Horse, options *MultipleInheritanceServiceClientPutHorseOptions) (*StringResponse, error) {
+	req, err := client.PutHorseCreateRequest(ctx, horse, options)
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +403,7 @@ func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, ho
 }
 
 // PutHorseCreateRequest creates the PutHorse request.
-func (client *MultipleInheritanceServiceClient) PutHorseCreateRequest(ctx context.Context, horse Horse) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) PutHorseCreateRequest(ctx context.Context, horse Horse, options *MultipleInheritanceServiceClientPutHorseOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/horse"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -432,8 +432,8 @@ func (client *MultipleInheritanceServiceClient) PutHorseHandleError(resp *azcore
 }
 
 // PutKitten - Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true
-func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, kitten Kitten) (*StringResponse, error) {
-	req, err := client.PutKittenCreateRequest(ctx, kitten)
+func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, kitten Kitten, options *MultipleInheritanceServiceClientPutKittenOptions) (*StringResponse, error) {
+	req, err := client.PutKittenCreateRequest(ctx, kitten, options)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +452,7 @@ func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, k
 }
 
 // PutKittenCreateRequest creates the PutKitten request.
-func (client *MultipleInheritanceServiceClient) PutKittenCreateRequest(ctx context.Context, kitten Kitten) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) PutKittenCreateRequest(ctx context.Context, kitten Kitten, options *MultipleInheritanceServiceClientPutKittenOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/kitten"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -481,8 +481,8 @@ func (client *MultipleInheritanceServiceClient) PutKittenHandleError(resp *azcor
 }
 
 // PutPet - Put a pet with name 'Butter'
-func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet Pet) (*StringResponse, error) {
-	req, err := client.PutPetCreateRequest(ctx, pet)
+func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet Pet, options *MultipleInheritanceServiceClientPutPetOptions) (*StringResponse, error) {
+	req, err := client.PutPetCreateRequest(ctx, pet, options)
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +501,7 @@ func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet 
 }
 
 // PutPetCreateRequest creates the PutPet request.
-func (client *MultipleInheritanceServiceClient) PutPetCreateRequest(ctx context.Context, pet Pet) (*azcore.Request, error) {
+func (client *MultipleInheritanceServiceClient) PutPetCreateRequest(ctx context.Context, pet Pet, options *MultipleInheritanceServiceClientPutPetOptions) (*azcore.Request, error) {
 	urlPath := "/multipleInheritance/pet"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths.go
@@ -16,7 +16,7 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// GetEmpty - Get a 200 to test a valid base uri
-	GetEmpty(ctx context.Context, vault string, secret string, keyName string, pathsGetEmptyOptions *PathsGetEmptyOptions) (*http.Response, error)
+	GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*http.Response, error)
 }
 
 // PathsClient implements the PathsOperations interface.
@@ -37,8 +37,8 @@ func (client *PathsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
-func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret string, keyName string, pathsGetEmptyOptions *PathsGetEmptyOptions) (*http.Response, error) {
-	req, err := client.GetEmptyCreateRequest(ctx, vault, secret, keyName, pathsGetEmptyOptions)
+func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*http.Response, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, vault, secret, keyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret st
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault string, secret string, keyName string, pathsGetEmptyOptions *PathsGetEmptyOptions) (*azcore.Request, error) {
+func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault string, secret string, keyName string, options *PathsGetEmptyOptions) (*azcore.Request, error) {
 	host := "{vault}{secret}{dnsSuffix}"
 	host = strings.ReplaceAll(host, "{dnsSuffix}", client.dnsSuffix)
 	host = strings.ReplaceAll(host, "{vault}", vault)
@@ -66,8 +66,8 @@ func (client *PathsClient) GetEmptyCreateRequest(ctx context.Context, vault stri
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pathsGetEmptyOptions != nil && pathsGetEmptyOptions.KeyVersion != nil {
-		query.Set("keyVersion", *pathsGetEmptyOptions.KeyVersion)
+	if options != nil && options.KeyVersion != nil {
+		query.Set("keyVersion", *options.KeyVersion)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -17,7 +17,7 @@ func newFloatClient() FloatOperations {
 // Get - Get a float enum
 func TestFloatGet(t *testing.T) {
 	client := newFloatClient()
-	result, err := client.Get(context.Background())
+	result, err := client.Get(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -17,7 +17,7 @@ func newIntClient() IntOperations {
 // Get - Get an int enum
 func TestIntGet(t *testing.T) {
 	client := newIntClient()
-	result, err := client.Get(context.Background())
+	result, err := client.Get(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -17,9 +17,9 @@ import (
 // FloatOperations contains the methods for the Float group.
 type FloatOperations interface {
 	// Get - Get a float enum
-	Get(ctx context.Context) (*FloatEnumResponse, error)
+	Get(ctx context.Context, options *FloatGetOptions) (*FloatEnumResponse, error)
 	// Put - Put a float enum
-	Put(ctx context.Context, floatPutOptions *FloatPutOptions) (*StringResponse, error)
+	Put(ctx context.Context, options *FloatPutOptions) (*StringResponse, error)
 }
 
 // FloatClient implements the FloatOperations interface.
@@ -39,8 +39,8 @@ func (client *FloatClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // Get - Get a float enum
-func (client *FloatClient) Get(ctx context.Context) (*FloatEnumResponse, error) {
-	req, err := client.GetCreateRequest(ctx)
+func (client *FloatClient) Get(ctx context.Context, options *FloatGetOptions) (*FloatEnumResponse, error) {
+	req, err := client.GetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *FloatClient) Get(ctx context.Context) (*FloatEnumResponse, error) 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *FloatClient) GetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FloatClient) GetCreateRequest(ctx context.Context, options *FloatGetOptions) (*azcore.Request, error) {
 	urlPath := "/nonStringEnums/float/get"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -88,8 +88,8 @@ func (client *FloatClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // Put - Put a float enum
-func (client *FloatClient) Put(ctx context.Context, floatPutOptions *FloatPutOptions) (*StringResponse, error) {
-	req, err := client.PutCreateRequest(ctx, floatPutOptions)
+func (client *FloatClient) Put(ctx context.Context, options *FloatPutOptions) (*StringResponse, error) {
+	req, err := client.PutCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,15 +108,15 @@ func (client *FloatClient) Put(ctx context.Context, floatPutOptions *FloatPutOpt
 }
 
 // PutCreateRequest creates the Put request.
-func (client *FloatClient) PutCreateRequest(ctx context.Context, floatPutOptions *FloatPutOptions) (*azcore.Request, error) {
+func (client *FloatClient) PutCreateRequest(ctx context.Context, options *FloatPutOptions) (*azcore.Request, error) {
 	urlPath := "/nonStringEnums/float/put"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if floatPutOptions != nil {
-		return req, req.MarshalAsJSON(floatPutOptions.Input)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -17,9 +17,9 @@ import (
 // IntOperations contains the methods for the Int group.
 type IntOperations interface {
 	// Get - Get an int enum
-	Get(ctx context.Context) (*IntEnumResponse, error)
+	Get(ctx context.Context, options *IntGetOptions) (*IntEnumResponse, error)
 	// Put - Put an int enum
-	Put(ctx context.Context, intPutOptions *IntPutOptions) (*StringResponse, error)
+	Put(ctx context.Context, options *IntPutOptions) (*StringResponse, error)
 }
 
 // IntClient implements the IntOperations interface.
@@ -39,8 +39,8 @@ func (client *IntClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // Get - Get an int enum
-func (client *IntClient) Get(ctx context.Context) (*IntEnumResponse, error) {
-	req, err := client.GetCreateRequest(ctx)
+func (client *IntClient) Get(ctx context.Context, options *IntGetOptions) (*IntEnumResponse, error) {
+	req, err := client.GetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *IntClient) Get(ctx context.Context) (*IntEnumResponse, error) {
 }
 
 // GetCreateRequest creates the Get request.
-func (client *IntClient) GetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IntClient) GetCreateRequest(ctx context.Context, options *IntGetOptions) (*azcore.Request, error) {
 	urlPath := "/nonStringEnums/int/get"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -88,8 +88,8 @@ func (client *IntClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // Put - Put an int enum
-func (client *IntClient) Put(ctx context.Context, intPutOptions *IntPutOptions) (*StringResponse, error) {
-	req, err := client.PutCreateRequest(ctx, intPutOptions)
+func (client *IntClient) Put(ctx context.Context, options *IntPutOptions) (*StringResponse, error) {
+	req, err := client.PutCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,15 +108,15 @@ func (client *IntClient) Put(ctx context.Context, intPutOptions *IntPutOptions) 
 }
 
 // PutCreateRequest creates the Put request.
-func (client *IntClient) PutCreateRequest(ctx context.Context, intPutOptions *IntPutOptions) (*azcore.Request, error) {
+func (client *IntClient) PutCreateRequest(ctx context.Context, options *IntPutOptions) (*azcore.Request, error) {
 	urlPath := "/nonStringEnums/int/put"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if intPutOptions != nil {
-		return req, req.MarshalAsJSON(intPutOptions.Input)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_models.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_models.go
@@ -16,6 +16,11 @@ type FloatEnumResponse struct {
 	Value *FloatEnum
 }
 
+// FloatGetOptions contains the optional parameters for the Float.Get method.
+type FloatGetOptions struct {
+	// placeholder for future optional parameters
+}
+
 // FloatPutOptions contains the optional parameters for the Float.Put method.
 type FloatPutOptions struct {
 	// Input float enum.
@@ -29,6 +34,11 @@ type IntEnumResponse struct {
 
 	// List of integer enums
 	Value *IntEnum
+}
+
+// IntGetOptions contains the optional parameters for the Int.Get method.
+type IntGetOptions struct {
+	// placeholder for future optional parameters
 }
 
 // IntPutOptions contains the optional parameters for the Int.Put method.

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -16,7 +16,7 @@ func newNumberClient() NumberOperations {
 
 func TestNumberGetBigDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDecimal(context.Background())
+	result, err := client.GetBigDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDecimal: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestNumberGetBigDecimal(t *testing.T) {
 
 func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDecimalNegativeDecimal(context.Background())
+	result, err := client.GetBigDecimalNegativeDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDecimalNegativeDecimal: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
 
 func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDecimalPositiveDecimal(context.Background())
+	result, err := client.GetBigDecimalPositiveDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDecimalPositiveDecimal: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
 
 func TestNumberGetBigDouble(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDouble(context.Background())
+	result, err := client.GetBigDouble(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDouble: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestNumberGetBigDouble(t *testing.T) {
 
 func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDoubleNegativeDecimal(context.Background())
+	result, err := client.GetBigDoubleNegativeDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDoubleNegativeDecimal: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
 
 func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigDoublePositiveDecimal(context.Background())
+	result, err := client.GetBigDoublePositiveDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigDoublePositiveDecimal: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
 
 func TestNumberGetBigFloat(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetBigFloat(context.Background())
+	result, err := client.GetBigFloat(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBigFloat: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestNumberGetBigFloat(t *testing.T) {
 
 func TestNumberGetInvalidDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetInvalidDecimal(context.Background())
+	result, err := client.GetInvalidDecimal(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("unexpected nil error")
 	}
@@ -104,7 +104,7 @@ func TestNumberGetInvalidDecimal(t *testing.T) {
 
 func TestNumberGetInvalidDouble(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetInvalidDouble(context.Background())
+	result, err := client.GetInvalidDouble(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("unexpected nil error")
 	}
@@ -115,7 +115,7 @@ func TestNumberGetInvalidDouble(t *testing.T) {
 
 func TestNumberGetInvalidFloat(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetInvalidFloat(context.Background())
+	result, err := client.GetInvalidFloat(context.Background(), nil)
 	if err == nil {
 		t.Fatalf("unexpected nil error")
 	}
@@ -126,7 +126,7 @@ func TestNumberGetInvalidFloat(t *testing.T) {
 
 func TestNumberGetNull(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestNumberGetNull(t *testing.T) {
 
 func TestNumberGetSmallDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetSmallDecimal(context.Background())
+	result, err := client.GetSmallDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetSmallDecimal: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestNumberGetSmallDecimal(t *testing.T) {
 
 func TestNumberGetSmallDouble(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetSmallDouble(context.Background())
+	result, err := client.GetSmallDouble(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetSmallDouble: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestNumberGetSmallDouble(t *testing.T) {
 
 func TestNumberGetSmallFloat(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.GetSmallFloat(context.Background())
+	result, err := client.GetSmallFloat(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetSmallFloat: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestNumberGetSmallFloat(t *testing.T) {
 
 func TestNumberPutBigDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDecimal(context.Background(), 2.5976931e+101)
+	result, err := client.PutBigDecimal(context.Background(), 2.5976931e+101, nil)
 	if err != nil {
 		t.Fatalf("PutBigDecimal: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestNumberPutBigDecimal(t *testing.T) {
 
 func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDecimalNegativeDecimal(context.Background())
+	result, err := client.PutBigDecimalNegativeDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutBigDecimalNegativeDecimal: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
 
 func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDecimalPositiveDecimal(context.Background())
+	result, err := client.PutBigDecimalPositiveDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutBigDecimalPositiveDecimal: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
 
 func TestNumberPutBigDouble(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDouble(context.Background(), 2.5976931e+101)
+	result, err := client.PutBigDouble(context.Background(), 2.5976931e+101, nil)
 	if err != nil {
 		t.Fatalf("PutBigDouble: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestNumberPutBigDouble(t *testing.T) {
 
 func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDoubleNegativeDecimal(context.Background())
+	result, err := client.PutBigDoubleNegativeDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutBigDoubleNegativeDecimal: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
 
 func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigDoublePositiveDecimal(context.Background())
+	result, err := client.PutBigDoublePositiveDecimal(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutBigDeoublePositiveDecimal: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
 
 func TestNumberPutBigFloat(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutBigFloat(context.Background(), 3.402823e+20)
+	result, err := client.PutBigFloat(context.Background(), 3.402823e+20, nil)
 	if err != nil {
 		t.Fatalf("PutBigFloat: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestNumberPutBigFloat(t *testing.T) {
 
 func TestNumberPutSmallDecimal(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutSmallDecimal(context.Background(), 2.5976931e-101)
+	result, err := client.PutSmallDecimal(context.Background(), 2.5976931e-101, nil)
 	if err != nil {
 		t.Fatalf("PutSmallDecimal: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestNumberPutSmallDecimal(t *testing.T) {
 
 func TestNumberPutSmallDouble(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutSmallDouble(context.Background(), 2.5976931e-101)
+	result, err := client.PutSmallDouble(context.Background(), 2.5976931e-101, nil)
 	if err != nil {
 		t.Fatalf("PutSmallDouble: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestNumberPutSmallDouble(t *testing.T) {
 
 func TestNumberPutSmallFloat(t *testing.T) {
 	client := newNumberClient()
-	result, err := client.PutSmallFloat(context.Background(), 3.402823e-20)
+	result, err := client.PutSmallFloat(context.Background(), 3.402823e-20, nil)
 	if err != nil {
 		t.Fatalf("PutSmallFloat: %v", err)
 	}

--- a/test/autorest/numbergroup/zz_generated_models.go
+++ b/test/autorest/numbergroup/zz_generated_models.go
@@ -43,3 +43,127 @@ type Float64Response struct {
 	RawResponse *http.Response
 	Value       *float64
 }
+
+// NumberGetBigDecimalNegativeDecimalOptions contains the optional parameters for the Number.GetBigDecimalNegativeDecimal
+// method.
+type NumberGetBigDecimalNegativeDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigDecimalOptions contains the optional parameters for the Number.GetBigDecimal method.
+type NumberGetBigDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigDecimalPositiveDecimalOptions contains the optional parameters for the Number.GetBigDecimalPositiveDecimal
+// method.
+type NumberGetBigDecimalPositiveDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigDoubleNegativeDecimalOptions contains the optional parameters for the Number.GetBigDoubleNegativeDecimal method.
+type NumberGetBigDoubleNegativeDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigDoubleOptions contains the optional parameters for the Number.GetBigDouble method.
+type NumberGetBigDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigDoublePositiveDecimalOptions contains the optional parameters for the Number.GetBigDoublePositiveDecimal method.
+type NumberGetBigDoublePositiveDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetBigFloatOptions contains the optional parameters for the Number.GetBigFloat method.
+type NumberGetBigFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetInvalidDecimalOptions contains the optional parameters for the Number.GetInvalidDecimal method.
+type NumberGetInvalidDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetInvalidDoubleOptions contains the optional parameters for the Number.GetInvalidDouble method.
+type NumberGetInvalidDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetInvalidFloatOptions contains the optional parameters for the Number.GetInvalidFloat method.
+type NumberGetInvalidFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetNullOptions contains the optional parameters for the Number.GetNull method.
+type NumberGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetSmallDecimalOptions contains the optional parameters for the Number.GetSmallDecimal method.
+type NumberGetSmallDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetSmallDoubleOptions contains the optional parameters for the Number.GetSmallDouble method.
+type NumberGetSmallDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberGetSmallFloatOptions contains the optional parameters for the Number.GetSmallFloat method.
+type NumberGetSmallFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDecimalNegativeDecimalOptions contains the optional parameters for the Number.PutBigDecimalNegativeDecimal
+// method.
+type NumberPutBigDecimalNegativeDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDecimalOptions contains the optional parameters for the Number.PutBigDecimal method.
+type NumberPutBigDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDecimalPositiveDecimalOptions contains the optional parameters for the Number.PutBigDecimalPositiveDecimal
+// method.
+type NumberPutBigDecimalPositiveDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDoubleNegativeDecimalOptions contains the optional parameters for the Number.PutBigDoubleNegativeDecimal method.
+type NumberPutBigDoubleNegativeDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDoubleOptions contains the optional parameters for the Number.PutBigDouble method.
+type NumberPutBigDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigDoublePositiveDecimalOptions contains the optional parameters for the Number.PutBigDoublePositiveDecimal method.
+type NumberPutBigDoublePositiveDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutBigFloatOptions contains the optional parameters for the Number.PutBigFloat method.
+type NumberPutBigFloatOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutSmallDecimalOptions contains the optional parameters for the Number.PutSmallDecimal method.
+type NumberPutSmallDecimalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutSmallDoubleOptions contains the optional parameters for the Number.PutSmallDouble method.
+type NumberPutSmallDoubleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NumberPutSmallFloatOptions contains the optional parameters for the Number.PutSmallFloat method.
+type NumberPutSmallFloatOptions struct {
+	// placeholder for future optional parameters
+}

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -14,53 +14,53 @@ import (
 // NumberOperations contains the methods for the Number group.
 type NumberOperations interface {
 	// GetBigDecimal - Get big decimal value 2.5976931e+101
-	GetBigDecimal(ctx context.Context) (*Float64Response, error)
+	GetBigDecimal(ctx context.Context, options *NumberGetBigDecimalOptions) (*Float64Response, error)
 	// GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
-	GetBigDecimalNegativeDecimal(ctx context.Context) (*Float64Response, error)
+	GetBigDecimalNegativeDecimal(ctx context.Context, options *NumberGetBigDecimalNegativeDecimalOptions) (*Float64Response, error)
 	// GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
-	GetBigDecimalPositiveDecimal(ctx context.Context) (*Float64Response, error)
+	GetBigDecimalPositiveDecimal(ctx context.Context, options *NumberGetBigDecimalPositiveDecimalOptions) (*Float64Response, error)
 	// GetBigDouble - Get big double value 2.5976931e+101
-	GetBigDouble(ctx context.Context) (*Float64Response, error)
+	GetBigDouble(ctx context.Context, options *NumberGetBigDoubleOptions) (*Float64Response, error)
 	// GetBigDoubleNegativeDecimal - Get big double value -99999999.99
-	GetBigDoubleNegativeDecimal(ctx context.Context) (*Float64Response, error)
+	GetBigDoubleNegativeDecimal(ctx context.Context, options *NumberGetBigDoubleNegativeDecimalOptions) (*Float64Response, error)
 	// GetBigDoublePositiveDecimal - Get big double value 99999999.99
-	GetBigDoublePositiveDecimal(ctx context.Context) (*Float64Response, error)
+	GetBigDoublePositiveDecimal(ctx context.Context, options *NumberGetBigDoublePositiveDecimalOptions) (*Float64Response, error)
 	// GetBigFloat - Get big float value 3.402823e+20
-	GetBigFloat(ctx context.Context) (*Float32Response, error)
+	GetBigFloat(ctx context.Context, options *NumberGetBigFloatOptions) (*Float32Response, error)
 	// GetInvalidDecimal - Get invalid decimal Number value
-	GetInvalidDecimal(ctx context.Context) (*Float64Response, error)
+	GetInvalidDecimal(ctx context.Context, options *NumberGetInvalidDecimalOptions) (*Float64Response, error)
 	// GetInvalidDouble - Get invalid double Number value
-	GetInvalidDouble(ctx context.Context) (*Float64Response, error)
+	GetInvalidDouble(ctx context.Context, options *NumberGetInvalidDoubleOptions) (*Float64Response, error)
 	// GetInvalidFloat - Get invalid float Number value
-	GetInvalidFloat(ctx context.Context) (*Float32Response, error)
+	GetInvalidFloat(ctx context.Context, options *NumberGetInvalidFloatOptions) (*Float32Response, error)
 	// GetNull - Get null Number value
-	GetNull(ctx context.Context) (*Float32Response, error)
+	GetNull(ctx context.Context, options *NumberGetNullOptions) (*Float32Response, error)
 	// GetSmallDecimal - Get small decimal value 2.5976931e-101
-	GetSmallDecimal(ctx context.Context) (*Float64Response, error)
+	GetSmallDecimal(ctx context.Context, options *NumberGetSmallDecimalOptions) (*Float64Response, error)
 	// GetSmallDouble - Get big double value 2.5976931e-101
-	GetSmallDouble(ctx context.Context) (*Float64Response, error)
+	GetSmallDouble(ctx context.Context, options *NumberGetSmallDoubleOptions) (*Float64Response, error)
 	// GetSmallFloat - Get big double value 3.402823e-20
-	GetSmallFloat(ctx context.Context) (*Float64Response, error)
+	GetSmallFloat(ctx context.Context, options *NumberGetSmallFloatOptions) (*Float64Response, error)
 	// PutBigDecimal - Put big decimal value 2.5976931e+101
-	PutBigDecimal(ctx context.Context, numberBody float64) (*http.Response, error)
+	PutBigDecimal(ctx context.Context, numberBody float64, options *NumberPutBigDecimalOptions) (*http.Response, error)
 	// PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
-	PutBigDecimalNegativeDecimal(ctx context.Context) (*http.Response, error)
+	PutBigDecimalNegativeDecimal(ctx context.Context, options *NumberPutBigDecimalNegativeDecimalOptions) (*http.Response, error)
 	// PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
-	PutBigDecimalPositiveDecimal(ctx context.Context) (*http.Response, error)
+	PutBigDecimalPositiveDecimal(ctx context.Context, options *NumberPutBigDecimalPositiveDecimalOptions) (*http.Response, error)
 	// PutBigDouble - Put big double value 2.5976931e+101
-	PutBigDouble(ctx context.Context, numberBody float64) (*http.Response, error)
+	PutBigDouble(ctx context.Context, numberBody float64, options *NumberPutBigDoubleOptions) (*http.Response, error)
 	// PutBigDoubleNegativeDecimal - Put big double value -99999999.99
-	PutBigDoubleNegativeDecimal(ctx context.Context) (*http.Response, error)
+	PutBigDoubleNegativeDecimal(ctx context.Context, options *NumberPutBigDoubleNegativeDecimalOptions) (*http.Response, error)
 	// PutBigDoublePositiveDecimal - Put big double value 99999999.99
-	PutBigDoublePositiveDecimal(ctx context.Context) (*http.Response, error)
+	PutBigDoublePositiveDecimal(ctx context.Context, options *NumberPutBigDoublePositiveDecimalOptions) (*http.Response, error)
 	// PutBigFloat - Put big float value 3.402823e+20
-	PutBigFloat(ctx context.Context, numberBody float32) (*http.Response, error)
+	PutBigFloat(ctx context.Context, numberBody float32, options *NumberPutBigFloatOptions) (*http.Response, error)
 	// PutSmallDecimal - Put small decimal value 2.5976931e-101
-	PutSmallDecimal(ctx context.Context, numberBody float64) (*http.Response, error)
+	PutSmallDecimal(ctx context.Context, numberBody float64, options *NumberPutSmallDecimalOptions) (*http.Response, error)
 	// PutSmallDouble - Put small double value 2.5976931e-101
-	PutSmallDouble(ctx context.Context, numberBody float64) (*http.Response, error)
+	PutSmallDouble(ctx context.Context, numberBody float64, options *NumberPutSmallDoubleOptions) (*http.Response, error)
 	// PutSmallFloat - Put small float value 3.402823e-20
-	PutSmallFloat(ctx context.Context, numberBody float32) (*http.Response, error)
+	PutSmallFloat(ctx context.Context, numberBody float32, options *NumberPutSmallFloatOptions) (*http.Response, error)
 }
 
 // NumberClient implements the NumberOperations interface.
@@ -80,8 +80,8 @@ func (client *NumberClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetBigDecimal - Get big decimal value 2.5976931e+101
-func (client *NumberClient) GetBigDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDecimalCreateRequest(ctx)
+func (client *NumberClient) GetBigDecimal(ctx context.Context, options *NumberGetBigDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetBigDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (client *NumberClient) GetBigDecimal(ctx context.Context) (*Float64Response
 }
 
 // GetBigDecimalCreateRequest creates the GetBigDecimal request.
-func (client *NumberClient) GetBigDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDecimalCreateRequest(ctx context.Context, options *NumberGetBigDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -126,8 +126,8 @@ func (client *NumberClient) GetBigDecimalHandleError(resp *azcore.Response) erro
 }
 
 // GetBigDecimalNegativeDecimal - Get big decimal value -99999999.99
-func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDecimalNegativeDecimalCreateRequest(ctx)
+func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context, options *NumberGetBigDecimalNegativeDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetBigDecimalNegativeDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context) (*
 }
 
 // GetBigDecimalNegativeDecimalCreateRequest creates the GetBigDecimalNegativeDecimal request.
-func (client *NumberClient) GetBigDecimalNegativeDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDecimalNegativeDecimalCreateRequest(ctx context.Context, options *NumberGetBigDecimalNegativeDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -172,8 +172,8 @@ func (client *NumberClient) GetBigDecimalNegativeDecimalHandleError(resp *azcore
 }
 
 // GetBigDecimalPositiveDecimal - Get big decimal value 99999999.99
-func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDecimalPositiveDecimalCreateRequest(ctx)
+func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context, options *NumberGetBigDecimalPositiveDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetBigDecimalPositiveDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context) (*
 }
 
 // GetBigDecimalPositiveDecimalCreateRequest creates the GetBigDecimalPositiveDecimal request.
-func (client *NumberClient) GetBigDecimalPositiveDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDecimalPositiveDecimalCreateRequest(ctx context.Context, options *NumberGetBigDecimalPositiveDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -218,8 +218,8 @@ func (client *NumberClient) GetBigDecimalPositiveDecimalHandleError(resp *azcore
 }
 
 // GetBigDouble - Get big double value 2.5976931e+101
-func (client *NumberClient) GetBigDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDoubleCreateRequest(ctx)
+func (client *NumberClient) GetBigDouble(ctx context.Context, options *NumberGetBigDoubleOptions) (*Float64Response, error) {
+	req, err := client.GetBigDoubleCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func (client *NumberClient) GetBigDouble(ctx context.Context) (*Float64Response,
 }
 
 // GetBigDoubleCreateRequest creates the GetBigDouble request.
-func (client *NumberClient) GetBigDoubleCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDoubleCreateRequest(ctx context.Context, options *NumberGetBigDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -264,8 +264,8 @@ func (client *NumberClient) GetBigDoubleHandleError(resp *azcore.Response) error
 }
 
 // GetBigDoubleNegativeDecimal - Get big double value -99999999.99
-func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDoubleNegativeDecimalCreateRequest(ctx)
+func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context, options *NumberGetBigDoubleNegativeDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetBigDoubleNegativeDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context) (*F
 }
 
 // GetBigDoubleNegativeDecimalCreateRequest creates the GetBigDoubleNegativeDecimal request.
-func (client *NumberClient) GetBigDoubleNegativeDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDoubleNegativeDecimalCreateRequest(ctx context.Context, options *NumberGetBigDoubleNegativeDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -310,8 +310,8 @@ func (client *NumberClient) GetBigDoubleNegativeDecimalHandleError(resp *azcore.
 }
 
 // GetBigDoublePositiveDecimal - Get big double value 99999999.99
-func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetBigDoublePositiveDecimalCreateRequest(ctx)
+func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context, options *NumberGetBigDoublePositiveDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetBigDoublePositiveDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context) (*F
 }
 
 // GetBigDoublePositiveDecimalCreateRequest creates the GetBigDoublePositiveDecimal request.
-func (client *NumberClient) GetBigDoublePositiveDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigDoublePositiveDecimalCreateRequest(ctx context.Context, options *NumberGetBigDoublePositiveDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -356,8 +356,8 @@ func (client *NumberClient) GetBigDoublePositiveDecimalHandleError(resp *azcore.
 }
 
 // GetBigFloat - Get big float value 3.402823e+20
-func (client *NumberClient) GetBigFloat(ctx context.Context) (*Float32Response, error) {
-	req, err := client.GetBigFloatCreateRequest(ctx)
+func (client *NumberClient) GetBigFloat(ctx context.Context, options *NumberGetBigFloatOptions) (*Float32Response, error) {
+	req, err := client.GetBigFloatCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (client *NumberClient) GetBigFloat(ctx context.Context) (*Float32Response, 
 }
 
 // GetBigFloatCreateRequest creates the GetBigFloat request.
-func (client *NumberClient) GetBigFloatCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetBigFloatCreateRequest(ctx context.Context, options *NumberGetBigFloatOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -402,8 +402,8 @@ func (client *NumberClient) GetBigFloatHandleError(resp *azcore.Response) error 
 }
 
 // GetInvalidDecimal - Get invalid decimal Number value
-func (client *NumberClient) GetInvalidDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetInvalidDecimalCreateRequest(ctx)
+func (client *NumberClient) GetInvalidDecimal(ctx context.Context, options *NumberGetInvalidDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetInvalidDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func (client *NumberClient) GetInvalidDecimal(ctx context.Context) (*Float64Resp
 }
 
 // GetInvalidDecimalCreateRequest creates the GetInvalidDecimal request.
-func (client *NumberClient) GetInvalidDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetInvalidDecimalCreateRequest(ctx context.Context, options *NumberGetInvalidDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/invaliddecimal"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -448,8 +448,8 @@ func (client *NumberClient) GetInvalidDecimalHandleError(resp *azcore.Response) 
 }
 
 // GetInvalidDouble - Get invalid double Number value
-func (client *NumberClient) GetInvalidDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetInvalidDoubleCreateRequest(ctx)
+func (client *NumberClient) GetInvalidDouble(ctx context.Context, options *NumberGetInvalidDoubleOptions) (*Float64Response, error) {
+	req, err := client.GetInvalidDoubleCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +468,7 @@ func (client *NumberClient) GetInvalidDouble(ctx context.Context) (*Float64Respo
 }
 
 // GetInvalidDoubleCreateRequest creates the GetInvalidDouble request.
-func (client *NumberClient) GetInvalidDoubleCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetInvalidDoubleCreateRequest(ctx context.Context, options *NumberGetInvalidDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/number/invaliddouble"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -494,8 +494,8 @@ func (client *NumberClient) GetInvalidDoubleHandleError(resp *azcore.Response) e
 }
 
 // GetInvalidFloat - Get invalid float Number value
-func (client *NumberClient) GetInvalidFloat(ctx context.Context) (*Float32Response, error) {
-	req, err := client.GetInvalidFloatCreateRequest(ctx)
+func (client *NumberClient) GetInvalidFloat(ctx context.Context, options *NumberGetInvalidFloatOptions) (*Float32Response, error) {
+	req, err := client.GetInvalidFloatCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (client *NumberClient) GetInvalidFloat(ctx context.Context) (*Float32Respon
 }
 
 // GetInvalidFloatCreateRequest creates the GetInvalidFloat request.
-func (client *NumberClient) GetInvalidFloatCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetInvalidFloatCreateRequest(ctx context.Context, options *NumberGetInvalidFloatOptions) (*azcore.Request, error) {
 	urlPath := "/number/invalidfloat"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -540,8 +540,8 @@ func (client *NumberClient) GetInvalidFloatHandleError(resp *azcore.Response) er
 }
 
 // GetNull - Get null Number value
-func (client *NumberClient) GetNull(ctx context.Context) (*Float32Response, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *NumberClient) GetNull(ctx context.Context, options *NumberGetNullOptions) (*Float32Response, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (client *NumberClient) GetNull(ctx context.Context) (*Float32Response, erro
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *NumberClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetNullCreateRequest(ctx context.Context, options *NumberGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/number/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -586,8 +586,8 @@ func (client *NumberClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetSmallDecimal - Get small decimal value 2.5976931e-101
-func (client *NumberClient) GetSmallDecimal(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetSmallDecimalCreateRequest(ctx)
+func (client *NumberClient) GetSmallDecimal(ctx context.Context, options *NumberGetSmallDecimalOptions) (*Float64Response, error) {
+	req, err := client.GetSmallDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +606,7 @@ func (client *NumberClient) GetSmallDecimal(ctx context.Context) (*Float64Respon
 }
 
 // GetSmallDecimalCreateRequest creates the GetSmallDecimal request.
-func (client *NumberClient) GetSmallDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetSmallDecimalCreateRequest(ctx context.Context, options *NumberGetSmallDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -632,8 +632,8 @@ func (client *NumberClient) GetSmallDecimalHandleError(resp *azcore.Response) er
 }
 
 // GetSmallDouble - Get big double value 2.5976931e-101
-func (client *NumberClient) GetSmallDouble(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetSmallDoubleCreateRequest(ctx)
+func (client *NumberClient) GetSmallDouble(ctx context.Context, options *NumberGetSmallDoubleOptions) (*Float64Response, error) {
+	req, err := client.GetSmallDoubleCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +652,7 @@ func (client *NumberClient) GetSmallDouble(ctx context.Context) (*Float64Respons
 }
 
 // GetSmallDoubleCreateRequest creates the GetSmallDouble request.
-func (client *NumberClient) GetSmallDoubleCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetSmallDoubleCreateRequest(ctx context.Context, options *NumberGetSmallDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -678,8 +678,8 @@ func (client *NumberClient) GetSmallDoubleHandleError(resp *azcore.Response) err
 }
 
 // GetSmallFloat - Get big double value 3.402823e-20
-func (client *NumberClient) GetSmallFloat(ctx context.Context) (*Float64Response, error) {
-	req, err := client.GetSmallFloatCreateRequest(ctx)
+func (client *NumberClient) GetSmallFloat(ctx context.Context, options *NumberGetSmallFloatOptions) (*Float64Response, error) {
+	req, err := client.GetSmallFloatCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (client *NumberClient) GetSmallFloat(ctx context.Context) (*Float64Response
 }
 
 // GetSmallFloatCreateRequest creates the GetSmallFloat request.
-func (client *NumberClient) GetSmallFloatCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) GetSmallFloatCreateRequest(ctx context.Context, options *NumberGetSmallFloatOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -724,8 +724,8 @@ func (client *NumberClient) GetSmallFloatHandleError(resp *azcore.Response) erro
 }
 
 // PutBigDecimal - Put big decimal value 2.5976931e+101
-func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.PutBigDecimalCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float64, options *NumberPutBigDecimalOptions) (*http.Response, error) {
+	req, err := client.PutBigDecimalCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -740,7 +740,7 @@ func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float6
 }
 
 // PutBigDecimalCreateRequest creates the PutBigDecimal request.
-func (client *NumberClient) PutBigDecimalCreateRequest(ctx context.Context, numberBody float64) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDecimalCreateRequest(ctx context.Context, numberBody float64, options *NumberPutBigDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/2.5976931e+101"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -760,8 +760,8 @@ func (client *NumberClient) PutBigDecimalHandleError(resp *azcore.Response) erro
 }
 
 // PutBigDecimalNegativeDecimal - Put big decimal value -99999999.99
-func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutBigDecimalNegativeDecimalCreateRequest(ctx)
+func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context, options *NumberPutBigDecimalNegativeDecimalOptions) (*http.Response, error) {
+	req, err := client.PutBigDecimalNegativeDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -776,7 +776,7 @@ func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context) (*
 }
 
 // PutBigDecimalNegativeDecimalCreateRequest creates the PutBigDecimalNegativeDecimal request.
-func (client *NumberClient) PutBigDecimalNegativeDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDecimalNegativeDecimalCreateRequest(ctx context.Context, options *NumberPutBigDecimalNegativeDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/-99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -796,8 +796,8 @@ func (client *NumberClient) PutBigDecimalNegativeDecimalHandleError(resp *azcore
 }
 
 // PutBigDecimalPositiveDecimal - Put big decimal value 99999999.99
-func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutBigDecimalPositiveDecimalCreateRequest(ctx)
+func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context, options *NumberPutBigDecimalPositiveDecimalOptions) (*http.Response, error) {
+	req, err := client.PutBigDecimalPositiveDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -812,7 +812,7 @@ func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context) (*
 }
 
 // PutBigDecimalPositiveDecimalCreateRequest creates the PutBigDecimalPositiveDecimal request.
-func (client *NumberClient) PutBigDecimalPositiveDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDecimalPositiveDecimalCreateRequest(ctx context.Context, options *NumberPutBigDecimalPositiveDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/decimal/99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -832,8 +832,8 @@ func (client *NumberClient) PutBigDecimalPositiveDecimalHandleError(resp *azcore
 }
 
 // PutBigDouble - Put big double value 2.5976931e+101
-func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.PutBigDoubleCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64, options *NumberPutBigDoubleOptions) (*http.Response, error) {
+	req, err := client.PutBigDoubleCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -848,7 +848,7 @@ func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64
 }
 
 // PutBigDoubleCreateRequest creates the PutBigDouble request.
-func (client *NumberClient) PutBigDoubleCreateRequest(ctx context.Context, numberBody float64) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDoubleCreateRequest(ctx context.Context, numberBody float64, options *NumberPutBigDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/2.5976931e+101"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -868,8 +868,8 @@ func (client *NumberClient) PutBigDoubleHandleError(resp *azcore.Response) error
 }
 
 // PutBigDoubleNegativeDecimal - Put big double value -99999999.99
-func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutBigDoubleNegativeDecimalCreateRequest(ctx)
+func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context, options *NumberPutBigDoubleNegativeDecimalOptions) (*http.Response, error) {
+	req, err := client.PutBigDoubleNegativeDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -884,7 +884,7 @@ func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context) (*h
 }
 
 // PutBigDoubleNegativeDecimalCreateRequest creates the PutBigDoubleNegativeDecimal request.
-func (client *NumberClient) PutBigDoubleNegativeDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDoubleNegativeDecimalCreateRequest(ctx context.Context, options *NumberPutBigDoubleNegativeDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/-99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -904,8 +904,8 @@ func (client *NumberClient) PutBigDoubleNegativeDecimalHandleError(resp *azcore.
 }
 
 // PutBigDoublePositiveDecimal - Put big double value 99999999.99
-func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutBigDoublePositiveDecimalCreateRequest(ctx)
+func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context, options *NumberPutBigDoublePositiveDecimalOptions) (*http.Response, error) {
+	req, err := client.PutBigDoublePositiveDecimalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +920,7 @@ func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context) (*h
 }
 
 // PutBigDoublePositiveDecimalCreateRequest creates the PutBigDoublePositiveDecimal request.
-func (client *NumberClient) PutBigDoublePositiveDecimalCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NumberClient) PutBigDoublePositiveDecimalCreateRequest(ctx context.Context, options *NumberPutBigDoublePositiveDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/double/99999999.99"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -940,8 +940,8 @@ func (client *NumberClient) PutBigDoublePositiveDecimalHandleError(resp *azcore.
 }
 
 // PutBigFloat - Put big float value 3.402823e+20
-func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
-	req, err := client.PutBigFloatCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32, options *NumberPutBigFloatOptions) (*http.Response, error) {
+	req, err := client.PutBigFloatCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -956,7 +956,7 @@ func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32)
 }
 
 // PutBigFloatCreateRequest creates the PutBigFloat request.
-func (client *NumberClient) PutBigFloatCreateRequest(ctx context.Context, numberBody float32) (*azcore.Request, error) {
+func (client *NumberClient) PutBigFloatCreateRequest(ctx context.Context, numberBody float32, options *NumberPutBigFloatOptions) (*azcore.Request, error) {
 	urlPath := "/number/big/float/3.402823e+20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -976,8 +976,8 @@ func (client *NumberClient) PutBigFloatHandleError(resp *azcore.Response) error 
 }
 
 // PutSmallDecimal - Put small decimal value 2.5976931e-101
-func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.PutSmallDecimalCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody float64, options *NumberPutSmallDecimalOptions) (*http.Response, error) {
+	req, err := client.PutSmallDecimalCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -992,7 +992,7 @@ func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody floa
 }
 
 // PutSmallDecimalCreateRequest creates the PutSmallDecimal request.
-func (client *NumberClient) PutSmallDecimalCreateRequest(ctx context.Context, numberBody float64) (*azcore.Request, error) {
+func (client *NumberClient) PutSmallDecimalCreateRequest(ctx context.Context, numberBody float64, options *NumberPutSmallDecimalOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/decimal/2.5976931e-101"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1012,8 +1012,8 @@ func (client *NumberClient) PutSmallDecimalHandleError(resp *azcore.Response) er
 }
 
 // PutSmallDouble - Put small double value 2.5976931e-101
-func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float64) (*http.Response, error) {
-	req, err := client.PutSmallDoubleCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float64, options *NumberPutSmallDoubleOptions) (*http.Response, error) {
+	req, err := client.PutSmallDoubleCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1028,7 +1028,7 @@ func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float
 }
 
 // PutSmallDoubleCreateRequest creates the PutSmallDouble request.
-func (client *NumberClient) PutSmallDoubleCreateRequest(ctx context.Context, numberBody float64) (*azcore.Request, error) {
+func (client *NumberClient) PutSmallDoubleCreateRequest(ctx context.Context, numberBody float64, options *NumberPutSmallDoubleOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/double/2.5976931e-101"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1048,8 +1048,8 @@ func (client *NumberClient) PutSmallDoubleHandleError(resp *azcore.Response) err
 }
 
 // PutSmallFloat - Put small float value 3.402823e-20
-func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float32) (*http.Response, error) {
-	req, err := client.PutSmallFloatCreateRequest(ctx, numberBody)
+func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float32, options *NumberPutSmallFloatOptions) (*http.Response, error) {
+	req, err := client.PutSmallFloatCreateRequest(ctx, numberBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1064,7 +1064,7 @@ func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float3
 }
 
 // PutSmallFloatCreateRequest creates the PutSmallFloat request.
-func (client *NumberClient) PutSmallFloatCreateRequest(ctx context.Context, numberBody float32) (*azcore.Request, error) {
+func (client *NumberClient) PutSmallFloatCreateRequest(ctx context.Context, numberBody float32, options *NumberPutSmallFloatOptions) (*azcore.Request, error) {
 	urlPath := "/number/small/float/3.402823e-20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -117,7 +117,7 @@ func TestExplicitPostOptionalStringProperty(t *testing.T) {
 func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredArrayHeader(context.Background(), nil)
+	result, err := client.PostRequiredArrayHeader(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -130,7 +130,7 @@ func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredArrayParameter(context.Background(), nil)
+	result, err := client.PostRequiredArrayParameter(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -142,7 +142,7 @@ func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredArrayProperty(context.Background(), ArrayWrapper{Value: nil})
+	result, err := client.PostRequiredArrayProperty(context.Background(), ArrayWrapper{Value: nil}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -155,7 +155,7 @@ func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 func TestExplicitPostRequiredClassParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredClassParameter(context.Background(), Product{})
+	result, err := client.PostRequiredClassParameter(context.Background(), Product{}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -167,7 +167,7 @@ func TestExplicitPostRequiredClassParameter(t *testing.T) {
 func TestExplicitPostRequiredClassProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredClassProperty(context.Background(), ClassWrapper{})
+	result, err := client.PostRequiredClassProperty(context.Background(), ClassWrapper{}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -180,7 +180,7 @@ func TestExplicitPostRequiredClassProperty(t *testing.T) {
 func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
 	client := newExplicitClient()
-	result, err := client.PostRequiredIntegerHeader(context.Background(), 0)
+	result, err := client.PostRequiredIntegerHeader(context.Background(), 0, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -193,7 +193,7 @@ func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
 	client := newExplicitClient()
-	result, err := client.PostRequiredIntegerParameter(context.Background(), 0)
+	result, err := client.PostRequiredIntegerParameter(context.Background(), 0, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -206,7 +206,7 @@ func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredIntegerProperty(context.Background(), IntWrapper{})
+	result, err := client.PostRequiredIntegerProperty(context.Background(), IntWrapper{}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -219,7 +219,7 @@ func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 func TestExplicitPostRequiredStringHeader(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
 	client := newExplicitClient()
-	result, err := client.PostRequiredStringHeader(context.Background(), "")
+	result, err := client.PostRequiredStringHeader(context.Background(), "", nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -232,7 +232,7 @@ func TestExplicitPostRequiredStringHeader(t *testing.T) {
 func TestExplicitPostRequiredStringParameter(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
 	client := newExplicitClient()
-	result, err := client.PostRequiredStringParameter(context.Background(), "")
+	result, err := client.PostRequiredStringParameter(context.Background(), "", nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -245,7 +245,7 @@ func TestExplicitPostRequiredStringParameter(t *testing.T) {
 func TestExplicitPostRequiredStringProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
 	client := newExplicitClient()
-	result, err := client.PostRequiredStringProperty(context.Background(), StringWrapper{})
+	result, err := client.PostRequiredStringProperty(context.Background(), StringWrapper{}, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -16,7 +16,7 @@ func newImplicitClient() ImplicitOperations {
 
 func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
 	client := newImplicitClient()
-	result, err := client.GetOptionalGlobalQuery(context.Background())
+	result, err := client.GetOptionalGlobalQuery(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetOptionalGlobalQuery: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
 func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
 	client := newImplicitClient()
-	result, err := client.GetRequiredGlobalPath(context.Background())
+	result, err := client.GetRequiredGlobalPath(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalPath: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
 	client := newImplicitClient()
-	result, err := client.GetRequiredGlobalQuery(context.Background())
+	result, err := client.GetRequiredGlobalQuery(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetRequiredGlobalQuery: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 func TestImplicitGetRequiredPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
 	client := newImplicitClient()
-	result, err := client.GetRequiredPath(context.Background(), "")
+	result, err := client.GetRequiredPath(context.Background(), "", nil)
 	if err != nil {
 		t.Fatalf("GetRequiredPath: %v", err)
 	}

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -16,49 +16,49 @@ import (
 // ExplicitOperations contains the methods for the Explicit group.
 type ExplicitOperations interface {
 	// PostOptionalArrayHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
-	PostOptionalArrayHeader(ctx context.Context, explicitPostOptionalArrayHeaderOptions *ExplicitPostOptionalArrayHeaderOptions) (*http.Response, error)
+	PostOptionalArrayHeader(ctx context.Context, options *ExplicitPostOptionalArrayHeaderOptions) (*http.Response, error)
 	// PostOptionalArrayParameter - Test explicitly optional array. Please put null.
-	PostOptionalArrayParameter(ctx context.Context, explicitPostOptionalArrayParameterOptions *ExplicitPostOptionalArrayParameterOptions) (*http.Response, error)
+	PostOptionalArrayParameter(ctx context.Context, options *ExplicitPostOptionalArrayParameterOptions) (*http.Response, error)
 	// PostOptionalArrayProperty - Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
-	PostOptionalArrayProperty(ctx context.Context, explicitPostOptionalArrayPropertyOptions *ExplicitPostOptionalArrayPropertyOptions) (*http.Response, error)
+	PostOptionalArrayProperty(ctx context.Context, options *ExplicitPostOptionalArrayPropertyOptions) (*http.Response, error)
 	// PostOptionalClassParameter - Test explicitly optional complex object. Please put null.
-	PostOptionalClassParameter(ctx context.Context, explicitPostOptionalClassParameterOptions *ExplicitPostOptionalClassParameterOptions) (*http.Response, error)
+	PostOptionalClassParameter(ctx context.Context, options *ExplicitPostOptionalClassParameterOptions) (*http.Response, error)
 	// PostOptionalClassProperty - Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
-	PostOptionalClassProperty(ctx context.Context, explicitPostOptionalClassPropertyOptions *ExplicitPostOptionalClassPropertyOptions) (*http.Response, error)
+	PostOptionalClassProperty(ctx context.Context, options *ExplicitPostOptionalClassPropertyOptions) (*http.Response, error)
 	// PostOptionalIntegerHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
-	PostOptionalIntegerHeader(ctx context.Context, explicitPostOptionalIntegerHeaderOptions *ExplicitPostOptionalIntegerHeaderOptions) (*http.Response, error)
+	PostOptionalIntegerHeader(ctx context.Context, options *ExplicitPostOptionalIntegerHeaderOptions) (*http.Response, error)
 	// PostOptionalIntegerParameter - Test explicitly optional integer. Please put null.
-	PostOptionalIntegerParameter(ctx context.Context, explicitPostOptionalIntegerParameterOptions *ExplicitPostOptionalIntegerParameterOptions) (*http.Response, error)
+	PostOptionalIntegerParameter(ctx context.Context, options *ExplicitPostOptionalIntegerParameterOptions) (*http.Response, error)
 	// PostOptionalIntegerProperty - Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
-	PostOptionalIntegerProperty(ctx context.Context, explicitPostOptionalIntegerPropertyOptions *ExplicitPostOptionalIntegerPropertyOptions) (*http.Response, error)
+	PostOptionalIntegerProperty(ctx context.Context, options *ExplicitPostOptionalIntegerPropertyOptions) (*http.Response, error)
 	// PostOptionalStringHeader - Test explicitly optional string. Please put a header 'headerParameter' => null.
-	PostOptionalStringHeader(ctx context.Context, explicitPostOptionalStringHeaderOptions *ExplicitPostOptionalStringHeaderOptions) (*http.Response, error)
+	PostOptionalStringHeader(ctx context.Context, options *ExplicitPostOptionalStringHeaderOptions) (*http.Response, error)
 	// PostOptionalStringParameter - Test explicitly optional string. Please put null.
-	PostOptionalStringParameter(ctx context.Context, explicitPostOptionalStringParameterOptions *ExplicitPostOptionalStringParameterOptions) (*http.Response, error)
+	PostOptionalStringParameter(ctx context.Context, options *ExplicitPostOptionalStringParameterOptions) (*http.Response, error)
 	// PostOptionalStringProperty - Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
-	PostOptionalStringProperty(ctx context.Context, explicitPostOptionalStringPropertyOptions *ExplicitPostOptionalStringPropertyOptions) (*http.Response, error)
+	PostOptionalStringProperty(ctx context.Context, options *ExplicitPostOptionalStringPropertyOptions) (*http.Response, error)
 	// PostRequiredArrayHeader - Test explicitly required array. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-	PostRequiredArrayHeader(ctx context.Context, headerParameter []string) (*http.Response, error)
+	PostRequiredArrayHeader(ctx context.Context, headerParameter []string, options *ExplicitPostRequiredArrayHeaderOptions) (*http.Response, error)
 	// PostRequiredArrayParameter - Test explicitly required array. Please put null and the client library should throw before the request is sent.
-	PostRequiredArrayParameter(ctx context.Context, bodyParameter []string) (*http.Response, error)
+	PostRequiredArrayParameter(ctx context.Context, bodyParameter []string, options *ExplicitPostRequiredArrayParameterOptions) (*http.Response, error)
 	// PostRequiredArrayProperty - Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
-	PostRequiredArrayProperty(ctx context.Context, bodyParameter ArrayWrapper) (*http.Response, error)
+	PostRequiredArrayProperty(ctx context.Context, bodyParameter ArrayWrapper, options *ExplicitPostRequiredArrayPropertyOptions) (*http.Response, error)
 	// PostRequiredClassParameter - Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
-	PostRequiredClassParameter(ctx context.Context, bodyParameter Product) (*http.Response, error)
+	PostRequiredClassParameter(ctx context.Context, bodyParameter Product, options *ExplicitPostRequiredClassParameterOptions) (*http.Response, error)
 	// PostRequiredClassProperty - Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
-	PostRequiredClassProperty(ctx context.Context, bodyParameter ClassWrapper) (*http.Response, error)
+	PostRequiredClassProperty(ctx context.Context, bodyParameter ClassWrapper, options *ExplicitPostRequiredClassPropertyOptions) (*http.Response, error)
 	// PostRequiredIntegerHeader - Test explicitly required integer. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-	PostRequiredIntegerHeader(ctx context.Context, headerParameter int32) (*http.Response, error)
+	PostRequiredIntegerHeader(ctx context.Context, headerParameter int32, options *ExplicitPostRequiredIntegerHeaderOptions) (*http.Response, error)
 	// PostRequiredIntegerParameter - Test explicitly required integer. Please put null and the client library should throw before the request is sent.
-	PostRequiredIntegerParameter(ctx context.Context, bodyParameter int32) (*http.Response, error)
+	PostRequiredIntegerParameter(ctx context.Context, bodyParameter int32, options *ExplicitPostRequiredIntegerParameterOptions) (*http.Response, error)
 	// PostRequiredIntegerProperty - Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
-	PostRequiredIntegerProperty(ctx context.Context, bodyParameter IntWrapper) (*http.Response, error)
+	PostRequiredIntegerProperty(ctx context.Context, bodyParameter IntWrapper, options *ExplicitPostRequiredIntegerPropertyOptions) (*http.Response, error)
 	// PostRequiredStringHeader - Test explicitly required string. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-	PostRequiredStringHeader(ctx context.Context, headerParameter string) (*http.Response, error)
+	PostRequiredStringHeader(ctx context.Context, headerParameter string, options *ExplicitPostRequiredStringHeaderOptions) (*http.Response, error)
 	// PostRequiredStringParameter - Test explicitly required string. Please put null and the client library should throw before the request is sent.
-	PostRequiredStringParameter(ctx context.Context, bodyParameter string) (*http.Response, error)
+	PostRequiredStringParameter(ctx context.Context, bodyParameter string, options *ExplicitPostRequiredStringParameterOptions) (*http.Response, error)
 	// PostRequiredStringProperty - Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
-	PostRequiredStringProperty(ctx context.Context, bodyParameter StringWrapper) (*http.Response, error)
+	PostRequiredStringProperty(ctx context.Context, bodyParameter StringWrapper, options *ExplicitPostRequiredStringPropertyOptions) (*http.Response, error)
 }
 
 // ExplicitClient implements the ExplicitOperations interface.
@@ -78,8 +78,8 @@ func (client *ExplicitClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // PostOptionalArrayHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
-func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, explicitPostOptionalArrayHeaderOptions *ExplicitPostOptionalArrayHeaderOptions) (*http.Response, error) {
-	req, err := client.PostOptionalArrayHeaderCreateRequest(ctx, explicitPostOptionalArrayHeaderOptions)
+func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, options *ExplicitPostOptionalArrayHeaderOptions) (*http.Response, error) {
+	req, err := client.PostOptionalArrayHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -94,14 +94,14 @@ func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, expli
 }
 
 // PostOptionalArrayHeaderCreateRequest creates the PostOptionalArrayHeader request.
-func (client *ExplicitClient) PostOptionalArrayHeaderCreateRequest(ctx context.Context, explicitPostOptionalArrayHeaderOptions *ExplicitPostOptionalArrayHeaderOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalArrayHeaderCreateRequest(ctx context.Context, options *ExplicitPostOptionalArrayHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if explicitPostOptionalArrayHeaderOptions != nil && explicitPostOptionalArrayHeaderOptions.HeaderParameter != nil {
-		req.Header.Set("headerParameter", strings.Join(*explicitPostOptionalArrayHeaderOptions.HeaderParameter, ","))
+	if options != nil && options.HeaderParameter != nil {
+		req.Header.Set("headerParameter", strings.Join(*options.HeaderParameter, ","))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -117,8 +117,8 @@ func (client *ExplicitClient) PostOptionalArrayHeaderHandleError(resp *azcore.Re
 }
 
 // PostOptionalArrayParameter - Test explicitly optional array. Please put null.
-func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, explicitPostOptionalArrayParameterOptions *ExplicitPostOptionalArrayParameterOptions) (*http.Response, error) {
-	req, err := client.PostOptionalArrayParameterCreateRequest(ctx, explicitPostOptionalArrayParameterOptions)
+func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, options *ExplicitPostOptionalArrayParameterOptions) (*http.Response, error) {
+	req, err := client.PostOptionalArrayParameterCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -133,15 +133,15 @@ func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, ex
 }
 
 // PostOptionalArrayParameterCreateRequest creates the PostOptionalArrayParameter request.
-func (client *ExplicitClient) PostOptionalArrayParameterCreateRequest(ctx context.Context, explicitPostOptionalArrayParameterOptions *ExplicitPostOptionalArrayParameterOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalArrayParameterCreateRequest(ctx context.Context, options *ExplicitPostOptionalArrayParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalArrayParameterOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalArrayParameterOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -156,8 +156,8 @@ func (client *ExplicitClient) PostOptionalArrayParameterHandleError(resp *azcore
 }
 
 // PostOptionalArrayProperty - Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
-func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, explicitPostOptionalArrayPropertyOptions *ExplicitPostOptionalArrayPropertyOptions) (*http.Response, error) {
-	req, err := client.PostOptionalArrayPropertyCreateRequest(ctx, explicitPostOptionalArrayPropertyOptions)
+func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, options *ExplicitPostOptionalArrayPropertyOptions) (*http.Response, error) {
+	req, err := client.PostOptionalArrayPropertyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -172,15 +172,15 @@ func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, exp
 }
 
 // PostOptionalArrayPropertyCreateRequest creates the PostOptionalArrayProperty request.
-func (client *ExplicitClient) PostOptionalArrayPropertyCreateRequest(ctx context.Context, explicitPostOptionalArrayPropertyOptions *ExplicitPostOptionalArrayPropertyOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalArrayPropertyCreateRequest(ctx context.Context, options *ExplicitPostOptionalArrayPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/array/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalArrayPropertyOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalArrayPropertyOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -195,8 +195,8 @@ func (client *ExplicitClient) PostOptionalArrayPropertyHandleError(resp *azcore.
 }
 
 // PostOptionalClassParameter - Test explicitly optional complex object. Please put null.
-func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, explicitPostOptionalClassParameterOptions *ExplicitPostOptionalClassParameterOptions) (*http.Response, error) {
-	req, err := client.PostOptionalClassParameterCreateRequest(ctx, explicitPostOptionalClassParameterOptions)
+func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, options *ExplicitPostOptionalClassParameterOptions) (*http.Response, error) {
+	req, err := client.PostOptionalClassParameterCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -211,15 +211,15 @@ func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, ex
 }
 
 // PostOptionalClassParameterCreateRequest creates the PostOptionalClassParameter request.
-func (client *ExplicitClient) PostOptionalClassParameterCreateRequest(ctx context.Context, explicitPostOptionalClassParameterOptions *ExplicitPostOptionalClassParameterOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalClassParameterCreateRequest(ctx context.Context, options *ExplicitPostOptionalClassParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/class/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalClassParameterOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalClassParameterOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -234,8 +234,8 @@ func (client *ExplicitClient) PostOptionalClassParameterHandleError(resp *azcore
 }
 
 // PostOptionalClassProperty - Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
-func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, explicitPostOptionalClassPropertyOptions *ExplicitPostOptionalClassPropertyOptions) (*http.Response, error) {
-	req, err := client.PostOptionalClassPropertyCreateRequest(ctx, explicitPostOptionalClassPropertyOptions)
+func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, options *ExplicitPostOptionalClassPropertyOptions) (*http.Response, error) {
+	req, err := client.PostOptionalClassPropertyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -250,15 +250,15 @@ func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, exp
 }
 
 // PostOptionalClassPropertyCreateRequest creates the PostOptionalClassProperty request.
-func (client *ExplicitClient) PostOptionalClassPropertyCreateRequest(ctx context.Context, explicitPostOptionalClassPropertyOptions *ExplicitPostOptionalClassPropertyOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalClassPropertyCreateRequest(ctx context.Context, options *ExplicitPostOptionalClassPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/class/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalClassPropertyOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalClassPropertyOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -273,8 +273,8 @@ func (client *ExplicitClient) PostOptionalClassPropertyHandleError(resp *azcore.
 }
 
 // PostOptionalIntegerHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
-func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, explicitPostOptionalIntegerHeaderOptions *ExplicitPostOptionalIntegerHeaderOptions) (*http.Response, error) {
-	req, err := client.PostOptionalIntegerHeaderCreateRequest(ctx, explicitPostOptionalIntegerHeaderOptions)
+func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, options *ExplicitPostOptionalIntegerHeaderOptions) (*http.Response, error) {
+	req, err := client.PostOptionalIntegerHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -289,14 +289,14 @@ func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, exp
 }
 
 // PostOptionalIntegerHeaderCreateRequest creates the PostOptionalIntegerHeader request.
-func (client *ExplicitClient) PostOptionalIntegerHeaderCreateRequest(ctx context.Context, explicitPostOptionalIntegerHeaderOptions *ExplicitPostOptionalIntegerHeaderOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalIntegerHeaderCreateRequest(ctx context.Context, options *ExplicitPostOptionalIntegerHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if explicitPostOptionalIntegerHeaderOptions != nil && explicitPostOptionalIntegerHeaderOptions.HeaderParameter != nil {
-		req.Header.Set("headerParameter", strconv.FormatInt(int64(*explicitPostOptionalIntegerHeaderOptions.HeaderParameter), 10))
+	if options != nil && options.HeaderParameter != nil {
+		req.Header.Set("headerParameter", strconv.FormatInt(int64(*options.HeaderParameter), 10))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -312,8 +312,8 @@ func (client *ExplicitClient) PostOptionalIntegerHeaderHandleError(resp *azcore.
 }
 
 // PostOptionalIntegerParameter - Test explicitly optional integer. Please put null.
-func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, explicitPostOptionalIntegerParameterOptions *ExplicitPostOptionalIntegerParameterOptions) (*http.Response, error) {
-	req, err := client.PostOptionalIntegerParameterCreateRequest(ctx, explicitPostOptionalIntegerParameterOptions)
+func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, options *ExplicitPostOptionalIntegerParameterOptions) (*http.Response, error) {
+	req, err := client.PostOptionalIntegerParameterCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -328,15 +328,15 @@ func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, 
 }
 
 // PostOptionalIntegerParameterCreateRequest creates the PostOptionalIntegerParameter request.
-func (client *ExplicitClient) PostOptionalIntegerParameterCreateRequest(ctx context.Context, explicitPostOptionalIntegerParameterOptions *ExplicitPostOptionalIntegerParameterOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalIntegerParameterCreateRequest(ctx context.Context, options *ExplicitPostOptionalIntegerParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalIntegerParameterOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalIntegerParameterOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -351,8 +351,8 @@ func (client *ExplicitClient) PostOptionalIntegerParameterHandleError(resp *azco
 }
 
 // PostOptionalIntegerProperty - Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
-func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, explicitPostOptionalIntegerPropertyOptions *ExplicitPostOptionalIntegerPropertyOptions) (*http.Response, error) {
-	req, err := client.PostOptionalIntegerPropertyCreateRequest(ctx, explicitPostOptionalIntegerPropertyOptions)
+func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, options *ExplicitPostOptionalIntegerPropertyOptions) (*http.Response, error) {
+	req, err := client.PostOptionalIntegerPropertyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -367,15 +367,15 @@ func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, e
 }
 
 // PostOptionalIntegerPropertyCreateRequest creates the PostOptionalIntegerProperty request.
-func (client *ExplicitClient) PostOptionalIntegerPropertyCreateRequest(ctx context.Context, explicitPostOptionalIntegerPropertyOptions *ExplicitPostOptionalIntegerPropertyOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalIntegerPropertyCreateRequest(ctx context.Context, options *ExplicitPostOptionalIntegerPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/integer/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalIntegerPropertyOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalIntegerPropertyOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -390,8 +390,8 @@ func (client *ExplicitClient) PostOptionalIntegerPropertyHandleError(resp *azcor
 }
 
 // PostOptionalStringHeader - Test explicitly optional string. Please put a header 'headerParameter' => null.
-func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, explicitPostOptionalStringHeaderOptions *ExplicitPostOptionalStringHeaderOptions) (*http.Response, error) {
-	req, err := client.PostOptionalStringHeaderCreateRequest(ctx, explicitPostOptionalStringHeaderOptions)
+func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, options *ExplicitPostOptionalStringHeaderOptions) (*http.Response, error) {
+	req, err := client.PostOptionalStringHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -406,14 +406,14 @@ func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, expl
 }
 
 // PostOptionalStringHeaderCreateRequest creates the PostOptionalStringHeader request.
-func (client *ExplicitClient) PostOptionalStringHeaderCreateRequest(ctx context.Context, explicitPostOptionalStringHeaderOptions *ExplicitPostOptionalStringHeaderOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalStringHeaderCreateRequest(ctx context.Context, options *ExplicitPostOptionalStringHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if explicitPostOptionalStringHeaderOptions != nil && explicitPostOptionalStringHeaderOptions.BodyParameter != nil {
-		req.Header.Set("bodyParameter", *explicitPostOptionalStringHeaderOptions.BodyParameter)
+	if options != nil && options.BodyParameter != nil {
+		req.Header.Set("bodyParameter", *options.BodyParameter)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -429,8 +429,8 @@ func (client *ExplicitClient) PostOptionalStringHeaderHandleError(resp *azcore.R
 }
 
 // PostOptionalStringParameter - Test explicitly optional string. Please put null.
-func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, explicitPostOptionalStringParameterOptions *ExplicitPostOptionalStringParameterOptions) (*http.Response, error) {
-	req, err := client.PostOptionalStringParameterCreateRequest(ctx, explicitPostOptionalStringParameterOptions)
+func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, options *ExplicitPostOptionalStringParameterOptions) (*http.Response, error) {
+	req, err := client.PostOptionalStringParameterCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -445,15 +445,15 @@ func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, e
 }
 
 // PostOptionalStringParameterCreateRequest creates the PostOptionalStringParameter request.
-func (client *ExplicitClient) PostOptionalStringParameterCreateRequest(ctx context.Context, explicitPostOptionalStringParameterOptions *ExplicitPostOptionalStringParameterOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalStringParameterCreateRequest(ctx context.Context, options *ExplicitPostOptionalStringParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalStringParameterOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalStringParameterOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -468,8 +468,8 @@ func (client *ExplicitClient) PostOptionalStringParameterHandleError(resp *azcor
 }
 
 // PostOptionalStringProperty - Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
-func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, explicitPostOptionalStringPropertyOptions *ExplicitPostOptionalStringPropertyOptions) (*http.Response, error) {
-	req, err := client.PostOptionalStringPropertyCreateRequest(ctx, explicitPostOptionalStringPropertyOptions)
+func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, options *ExplicitPostOptionalStringPropertyOptions) (*http.Response, error) {
+	req, err := client.PostOptionalStringPropertyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -484,15 +484,15 @@ func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, ex
 }
 
 // PostOptionalStringPropertyCreateRequest creates the PostOptionalStringProperty request.
-func (client *ExplicitClient) PostOptionalStringPropertyCreateRequest(ctx context.Context, explicitPostOptionalStringPropertyOptions *ExplicitPostOptionalStringPropertyOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) PostOptionalStringPropertyCreateRequest(ctx context.Context, options *ExplicitPostOptionalStringPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/optional/string/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if explicitPostOptionalStringPropertyOptions != nil {
-		return req, req.MarshalAsJSON(explicitPostOptionalStringPropertyOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -507,8 +507,8 @@ func (client *ExplicitClient) PostOptionalStringPropertyHandleError(resp *azcore
 }
 
 // PostRequiredArrayHeader - Test explicitly required array. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, headerParameter []string) (*http.Response, error) {
-	req, err := client.PostRequiredArrayHeaderCreateRequest(ctx, headerParameter)
+func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, headerParameter []string, options *ExplicitPostRequiredArrayHeaderOptions) (*http.Response, error) {
+	req, err := client.PostRequiredArrayHeaderCreateRequest(ctx, headerParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +523,7 @@ func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, heade
 }
 
 // PostRequiredArrayHeaderCreateRequest creates the PostRequiredArrayHeader request.
-func (client *ExplicitClient) PostRequiredArrayHeaderCreateRequest(ctx context.Context, headerParameter []string) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredArrayHeaderCreateRequest(ctx context.Context, headerParameter []string, options *ExplicitPostRequiredArrayHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -544,8 +544,8 @@ func (client *ExplicitClient) PostRequiredArrayHeaderHandleError(resp *azcore.Re
 }
 
 // PostRequiredArrayParameter - Test explicitly required array. Please put null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bodyParameter []string) (*http.Response, error) {
-	req, err := client.PostRequiredArrayParameterCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bodyParameter []string, options *ExplicitPostRequiredArrayParameterOptions) (*http.Response, error) {
+	req, err := client.PostRequiredArrayParameterCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -560,7 +560,7 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 }
 
 // PostRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
-func (client *ExplicitClient) PostRequiredArrayParameterCreateRequest(ctx context.Context, bodyParameter []string) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredArrayParameterCreateRequest(ctx context.Context, bodyParameter []string, options *ExplicitPostRequiredArrayParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -580,8 +580,8 @@ func (client *ExplicitClient) PostRequiredArrayParameterHandleError(resp *azcore
 }
 
 // PostRequiredArrayProperty - Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bodyParameter ArrayWrapper) (*http.Response, error) {
-	req, err := client.PostRequiredArrayPropertyCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bodyParameter ArrayWrapper, options *ExplicitPostRequiredArrayPropertyOptions) (*http.Response, error) {
+	req, err := client.PostRequiredArrayPropertyCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +596,7 @@ func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bod
 }
 
 // PostRequiredArrayPropertyCreateRequest creates the PostRequiredArrayProperty request.
-func (client *ExplicitClient) PostRequiredArrayPropertyCreateRequest(ctx context.Context, bodyParameter ArrayWrapper) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredArrayPropertyCreateRequest(ctx context.Context, bodyParameter ArrayWrapper, options *ExplicitPostRequiredArrayPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -616,8 +616,8 @@ func (client *ExplicitClient) PostRequiredArrayPropertyHandleError(resp *azcore.
 }
 
 // PostRequiredClassParameter - Test explicitly required complex object. Please put null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bodyParameter Product) (*http.Response, error) {
-	req, err := client.PostRequiredClassParameterCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bodyParameter Product, options *ExplicitPostRequiredClassParameterOptions) (*http.Response, error) {
+	req, err := client.PostRequiredClassParameterCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +632,7 @@ func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bo
 }
 
 // PostRequiredClassParameterCreateRequest creates the PostRequiredClassParameter request.
-func (client *ExplicitClient) PostRequiredClassParameterCreateRequest(ctx context.Context, bodyParameter Product) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredClassParameterCreateRequest(ctx context.Context, bodyParameter Product, options *ExplicitPostRequiredClassParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/class/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -652,8 +652,8 @@ func (client *ExplicitClient) PostRequiredClassParameterHandleError(resp *azcore
 }
 
 // PostRequiredClassProperty - Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bodyParameter ClassWrapper) (*http.Response, error) {
-	req, err := client.PostRequiredClassPropertyCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bodyParameter ClassWrapper, options *ExplicitPostRequiredClassPropertyOptions) (*http.Response, error) {
+	req, err := client.PostRequiredClassPropertyCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -668,7 +668,7 @@ func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bod
 }
 
 // PostRequiredClassPropertyCreateRequest creates the PostRequiredClassProperty request.
-func (client *ExplicitClient) PostRequiredClassPropertyCreateRequest(ctx context.Context, bodyParameter ClassWrapper) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredClassPropertyCreateRequest(ctx context.Context, bodyParameter ClassWrapper, options *ExplicitPostRequiredClassPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/class/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -688,8 +688,8 @@ func (client *ExplicitClient) PostRequiredClassPropertyHandleError(resp *azcore.
 }
 
 // PostRequiredIntegerHeader - Test explicitly required integer. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, headerParameter int32) (*http.Response, error) {
-	req, err := client.PostRequiredIntegerHeaderCreateRequest(ctx, headerParameter)
+func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, headerParameter int32, options *ExplicitPostRequiredIntegerHeaderOptions) (*http.Response, error) {
+	req, err := client.PostRequiredIntegerHeaderCreateRequest(ctx, headerParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +704,7 @@ func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, hea
 }
 
 // PostRequiredIntegerHeaderCreateRequest creates the PostRequiredIntegerHeader request.
-func (client *ExplicitClient) PostRequiredIntegerHeaderCreateRequest(ctx context.Context, headerParameter int32) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredIntegerHeaderCreateRequest(ctx context.Context, headerParameter int32, options *ExplicitPostRequiredIntegerHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -725,8 +725,8 @@ func (client *ExplicitClient) PostRequiredIntegerHeaderHandleError(resp *azcore.
 }
 
 // PostRequiredIntegerParameter - Test explicitly required integer. Please put null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, bodyParameter int32) (*http.Response, error) {
-	req, err := client.PostRequiredIntegerParameterCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, bodyParameter int32, options *ExplicitPostRequiredIntegerParameterOptions) (*http.Response, error) {
+	req, err := client.PostRequiredIntegerParameterCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -741,7 +741,7 @@ func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, 
 }
 
 // PostRequiredIntegerParameterCreateRequest creates the PostRequiredIntegerParameter request.
-func (client *ExplicitClient) PostRequiredIntegerParameterCreateRequest(ctx context.Context, bodyParameter int32) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredIntegerParameterCreateRequest(ctx context.Context, bodyParameter int32, options *ExplicitPostRequiredIntegerParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -761,8 +761,8 @@ func (client *ExplicitClient) PostRequiredIntegerParameterHandleError(resp *azco
 }
 
 // PostRequiredIntegerProperty - Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, bodyParameter IntWrapper) (*http.Response, error) {
-	req, err := client.PostRequiredIntegerPropertyCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, bodyParameter IntWrapper, options *ExplicitPostRequiredIntegerPropertyOptions) (*http.Response, error) {
+	req, err := client.PostRequiredIntegerPropertyCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +777,7 @@ func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, b
 }
 
 // PostRequiredIntegerPropertyCreateRequest creates the PostRequiredIntegerProperty request.
-func (client *ExplicitClient) PostRequiredIntegerPropertyCreateRequest(ctx context.Context, bodyParameter IntWrapper) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredIntegerPropertyCreateRequest(ctx context.Context, bodyParameter IntWrapper, options *ExplicitPostRequiredIntegerPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/integer/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -797,8 +797,8 @@ func (client *ExplicitClient) PostRequiredIntegerPropertyHandleError(resp *azcor
 }
 
 // PostRequiredStringHeader - Test explicitly required string. Please put a header 'headerParameter' => null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, headerParameter string) (*http.Response, error) {
-	req, err := client.PostRequiredStringHeaderCreateRequest(ctx, headerParameter)
+func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, headerParameter string, options *ExplicitPostRequiredStringHeaderOptions) (*http.Response, error) {
+	req, err := client.PostRequiredStringHeaderCreateRequest(ctx, headerParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -813,7 +813,7 @@ func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, head
 }
 
 // PostRequiredStringHeaderCreateRequest creates the PostRequiredStringHeader request.
-func (client *ExplicitClient) PostRequiredStringHeaderCreateRequest(ctx context.Context, headerParameter string) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredStringHeaderCreateRequest(ctx context.Context, headerParameter string, options *ExplicitPostRequiredStringHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -834,8 +834,8 @@ func (client *ExplicitClient) PostRequiredStringHeaderHandleError(resp *azcore.R
 }
 
 // PostRequiredStringParameter - Test explicitly required string. Please put null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, bodyParameter string) (*http.Response, error) {
-	req, err := client.PostRequiredStringParameterCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, bodyParameter string, options *ExplicitPostRequiredStringParameterOptions) (*http.Response, error) {
+	req, err := client.PostRequiredStringParameterCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -850,7 +850,7 @@ func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, b
 }
 
 // PostRequiredStringParameterCreateRequest creates the PostRequiredStringParameter request.
-func (client *ExplicitClient) PostRequiredStringParameterCreateRequest(ctx context.Context, bodyParameter string) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredStringParameterCreateRequest(ctx context.Context, bodyParameter string, options *ExplicitPostRequiredStringParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -870,8 +870,8 @@ func (client *ExplicitClient) PostRequiredStringParameterHandleError(resp *azcor
 }
 
 // PostRequiredStringProperty - Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bodyParameter StringWrapper) (*http.Response, error) {
-	req, err := client.PostRequiredStringPropertyCreateRequest(ctx, bodyParameter)
+func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bodyParameter StringWrapper, options *ExplicitPostRequiredStringPropertyOptions) (*http.Response, error) {
+	req, err := client.PostRequiredStringPropertyCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -886,7 +886,7 @@ func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bo
 }
 
 // PostRequiredStringPropertyCreateRequest creates the PostRequiredStringProperty request.
-func (client *ExplicitClient) PostRequiredStringPropertyCreateRequest(ctx context.Context, bodyParameter StringWrapper) (*azcore.Request, error) {
+func (client *ExplicitClient) PostRequiredStringPropertyCreateRequest(ctx context.Context, bodyParameter StringWrapper, options *ExplicitPostRequiredStringPropertyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/string/property"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -17,19 +17,19 @@ import (
 // ImplicitOperations contains the methods for the Implicit group.
 type ImplicitOperations interface {
 	// GetOptionalGlobalQuery - Test implicitly optional query parameter
-	GetOptionalGlobalQuery(ctx context.Context) (*http.Response, error)
+	GetOptionalGlobalQuery(ctx context.Context, options *ImplicitGetOptionalGlobalQueryOptions) (*http.Response, error)
 	// GetRequiredGlobalPath - Test implicitly required path parameter
-	GetRequiredGlobalPath(ctx context.Context) (*http.Response, error)
+	GetRequiredGlobalPath(ctx context.Context, options *ImplicitGetRequiredGlobalPathOptions) (*http.Response, error)
 	// GetRequiredGlobalQuery - Test implicitly required query parameter
-	GetRequiredGlobalQuery(ctx context.Context) (*http.Response, error)
+	GetRequiredGlobalQuery(ctx context.Context, options *ImplicitGetRequiredGlobalQueryOptions) (*http.Response, error)
 	// GetRequiredPath - Test implicitly required path parameter
-	GetRequiredPath(ctx context.Context, pathParameter string) (*http.Response, error)
+	GetRequiredPath(ctx context.Context, pathParameter string, options *ImplicitGetRequiredPathOptions) (*http.Response, error)
 	// PutOptionalBody - Test implicitly optional body parameter
-	PutOptionalBody(ctx context.Context, implicitPutOptionalBodyOptions *ImplicitPutOptionalBodyOptions) (*http.Response, error)
+	PutOptionalBody(ctx context.Context, options *ImplicitPutOptionalBodyOptions) (*http.Response, error)
 	// PutOptionalHeader - Test implicitly optional header parameter
-	PutOptionalHeader(ctx context.Context, implicitPutOptionalHeaderOptions *ImplicitPutOptionalHeaderOptions) (*http.Response, error)
+	PutOptionalHeader(ctx context.Context, options *ImplicitPutOptionalHeaderOptions) (*http.Response, error)
 	// PutOptionalQuery - Test implicitly optional query parameter
-	PutOptionalQuery(ctx context.Context, implicitPutOptionalQueryOptions *ImplicitPutOptionalQueryOptions) (*http.Response, error)
+	PutOptionalQuery(ctx context.Context, options *ImplicitPutOptionalQueryOptions) (*http.Response, error)
 }
 
 // ImplicitClient implements the ImplicitOperations interface.
@@ -52,8 +52,8 @@ func (client *ImplicitClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // GetOptionalGlobalQuery - Test implicitly optional query parameter
-func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetOptionalGlobalQueryCreateRequest(ctx)
+func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context, options *ImplicitGetOptionalGlobalQueryOptions) (*http.Response, error) {
+	req, err := client.GetOptionalGlobalQueryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context) (*http
 }
 
 // GetOptionalGlobalQueryCreateRequest creates the GetOptionalGlobalQuery request.
-func (client *ImplicitClient) GetOptionalGlobalQueryCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ImplicitClient) GetOptionalGlobalQueryCreateRequest(ctx context.Context, options *ImplicitGetOptionalGlobalQueryOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/global/optional/query"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -93,8 +93,8 @@ func (client *ImplicitClient) GetOptionalGlobalQueryHandleError(resp *azcore.Res
 }
 
 // GetRequiredGlobalPath - Test implicitly required path parameter
-func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetRequiredGlobalPathCreateRequest(ctx)
+func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context, options *ImplicitGetRequiredGlobalPathOptions) (*http.Response, error) {
+	req, err := client.GetRequiredGlobalPathCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context) (*http.
 }
 
 // GetRequiredGlobalPathCreateRequest creates the GetRequiredGlobalPath request.
-func (client *ImplicitClient) GetRequiredGlobalPathCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ImplicitClient) GetRequiredGlobalPathCreateRequest(ctx context.Context, options *ImplicitGetRequiredGlobalPathOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/global/required/path/{required-global-path}"
 	urlPath = strings.ReplaceAll(urlPath, "{required-global-path}", url.PathEscape(client.requiredGlobalPath))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -130,8 +130,8 @@ func (client *ImplicitClient) GetRequiredGlobalPathHandleError(resp *azcore.Resp
 }
 
 // GetRequiredGlobalQuery - Test implicitly required query parameter
-func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetRequiredGlobalQueryCreateRequest(ctx)
+func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context, options *ImplicitGetRequiredGlobalQueryOptions) (*http.Response, error) {
+	req, err := client.GetRequiredGlobalQueryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context) (*http
 }
 
 // GetRequiredGlobalQueryCreateRequest creates the GetRequiredGlobalQuery request.
-func (client *ImplicitClient) GetRequiredGlobalQueryCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ImplicitClient) GetRequiredGlobalQueryCreateRequest(ctx context.Context, options *ImplicitGetRequiredGlobalQueryOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/global/required/query"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -169,8 +169,8 @@ func (client *ImplicitClient) GetRequiredGlobalQueryHandleError(resp *azcore.Res
 }
 
 // GetRequiredPath - Test implicitly required path parameter
-func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter string) (*http.Response, error) {
-	req, err := client.GetRequiredPathCreateRequest(ctx, pathParameter)
+func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter string, options *ImplicitGetRequiredPathOptions) (*http.Response, error) {
+	req, err := client.GetRequiredPathCreateRequest(ctx, pathParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter
 }
 
 // GetRequiredPathCreateRequest creates the GetRequiredPath request.
-func (client *ImplicitClient) GetRequiredPathCreateRequest(ctx context.Context, pathParameter string) (*azcore.Request, error) {
+func (client *ImplicitClient) GetRequiredPathCreateRequest(ctx context.Context, pathParameter string, options *ImplicitGetRequiredPathOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/required/path/{pathParameter}"
 	urlPath = strings.ReplaceAll(urlPath, "{pathParameter}", url.PathEscape(pathParameter))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -206,8 +206,8 @@ func (client *ImplicitClient) GetRequiredPathHandleError(resp *azcore.Response) 
 }
 
 // PutOptionalBody - Test implicitly optional body parameter
-func (client *ImplicitClient) PutOptionalBody(ctx context.Context, implicitPutOptionalBodyOptions *ImplicitPutOptionalBodyOptions) (*http.Response, error) {
-	req, err := client.PutOptionalBodyCreateRequest(ctx, implicitPutOptionalBodyOptions)
+func (client *ImplicitClient) PutOptionalBody(ctx context.Context, options *ImplicitPutOptionalBodyOptions) (*http.Response, error) {
+	req, err := client.PutOptionalBodyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -222,15 +222,15 @@ func (client *ImplicitClient) PutOptionalBody(ctx context.Context, implicitPutOp
 }
 
 // PutOptionalBodyCreateRequest creates the PutOptionalBody request.
-func (client *ImplicitClient) PutOptionalBodyCreateRequest(ctx context.Context, implicitPutOptionalBodyOptions *ImplicitPutOptionalBodyOptions) (*azcore.Request, error) {
+func (client *ImplicitClient) PutOptionalBodyCreateRequest(ctx context.Context, options *ImplicitPutOptionalBodyOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/body"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if implicitPutOptionalBodyOptions != nil {
-		return req, req.MarshalAsJSON(implicitPutOptionalBodyOptions.BodyParameter)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
 }
@@ -245,8 +245,8 @@ func (client *ImplicitClient) PutOptionalBodyHandleError(resp *azcore.Response) 
 }
 
 // PutOptionalHeader - Test implicitly optional header parameter
-func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, implicitPutOptionalHeaderOptions *ImplicitPutOptionalHeaderOptions) (*http.Response, error) {
-	req, err := client.PutOptionalHeaderCreateRequest(ctx, implicitPutOptionalHeaderOptions)
+func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, options *ImplicitPutOptionalHeaderOptions) (*http.Response, error) {
+	req, err := client.PutOptionalHeaderCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -261,14 +261,14 @@ func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, implicitPut
 }
 
 // PutOptionalHeaderCreateRequest creates the PutOptionalHeader request.
-func (client *ImplicitClient) PutOptionalHeaderCreateRequest(ctx context.Context, implicitPutOptionalHeaderOptions *ImplicitPutOptionalHeaderOptions) (*azcore.Request, error) {
+func (client *ImplicitClient) PutOptionalHeaderCreateRequest(ctx context.Context, options *ImplicitPutOptionalHeaderOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/header"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if implicitPutOptionalHeaderOptions != nil && implicitPutOptionalHeaderOptions.QueryParameter != nil {
-		req.Header.Set("queryParameter", *implicitPutOptionalHeaderOptions.QueryParameter)
+	if options != nil && options.QueryParameter != nil {
+		req.Header.Set("queryParameter", *options.QueryParameter)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -284,8 +284,8 @@ func (client *ImplicitClient) PutOptionalHeaderHandleError(resp *azcore.Response
 }
 
 // PutOptionalQuery - Test implicitly optional query parameter
-func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, implicitPutOptionalQueryOptions *ImplicitPutOptionalQueryOptions) (*http.Response, error) {
-	req, err := client.PutOptionalQueryCreateRequest(ctx, implicitPutOptionalQueryOptions)
+func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, options *ImplicitPutOptionalQueryOptions) (*http.Response, error) {
+	req, err := client.PutOptionalQueryCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -300,15 +300,15 @@ func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, implicitPutO
 }
 
 // PutOptionalQueryCreateRequest creates the PutOptionalQuery request.
-func (client *ImplicitClient) PutOptionalQueryCreateRequest(ctx context.Context, implicitPutOptionalQueryOptions *ImplicitPutOptionalQueryOptions) (*azcore.Request, error) {
+func (client *ImplicitClient) PutOptionalQueryCreateRequest(ctx context.Context, options *ImplicitPutOptionalQueryOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/implicit/optional/query"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if implicitPutOptionalQueryOptions != nil && implicitPutOptionalQueryOptions.QueryParameter != nil {
-		query.Set("queryParameter", *implicitPutOptionalQueryOptions.QueryParameter)
+	if options != nil && options.QueryParameter != nil {
+		query.Set("queryParameter", *options.QueryParameter)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/optionalgroup/zz_generated_models.go
+++ b/test/autorest/optionalgroup/zz_generated_models.go
@@ -104,8 +104,84 @@ type ExplicitPostOptionalStringPropertyOptions struct {
 	BodyParameter *StringOptionalWrapper
 }
 
+// ExplicitPostRequiredArrayHeaderOptions contains the optional parameters for the Explicit.PostRequiredArrayHeader method.
+type ExplicitPostRequiredArrayHeaderOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredArrayParameterOptions contains the optional parameters for the Explicit.PostRequiredArrayParameter
+// method.
+type ExplicitPostRequiredArrayParameterOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredArrayPropertyOptions contains the optional parameters for the Explicit.PostRequiredArrayProperty method.
+type ExplicitPostRequiredArrayPropertyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredClassParameterOptions contains the optional parameters for the Explicit.PostRequiredClassParameter
+// method.
+type ExplicitPostRequiredClassParameterOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredClassPropertyOptions contains the optional parameters for the Explicit.PostRequiredClassProperty method.
+type ExplicitPostRequiredClassPropertyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredIntegerHeaderOptions contains the optional parameters for the Explicit.PostRequiredIntegerHeader method.
+type ExplicitPostRequiredIntegerHeaderOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredIntegerParameterOptions contains the optional parameters for the Explicit.PostRequiredIntegerParameter
+// method.
+type ExplicitPostRequiredIntegerParameterOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredIntegerPropertyOptions contains the optional parameters for the Explicit.PostRequiredIntegerProperty
+// method.
+type ExplicitPostRequiredIntegerPropertyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredStringHeaderOptions contains the optional parameters for the Explicit.PostRequiredStringHeader method.
+type ExplicitPostRequiredStringHeaderOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredStringParameterOptions contains the optional parameters for the Explicit.PostRequiredStringParameter
+// method.
+type ExplicitPostRequiredStringParameterOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExplicitPostRequiredStringPropertyOptions contains the optional parameters for the Explicit.PostRequiredStringProperty
+// method.
+type ExplicitPostRequiredStringPropertyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ImplicitGetOptionalGlobalQueryOptions contains the optional parameters for the Implicit.GetOptionalGlobalQuery method.
 type ImplicitGetOptionalGlobalQueryOptions struct {
+}
+
+// ImplicitGetRequiredGlobalPathOptions contains the optional parameters for the Implicit.GetRequiredGlobalPath method.
+type ImplicitGetRequiredGlobalPathOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ImplicitGetRequiredGlobalQueryOptions contains the optional parameters for the Implicit.GetRequiredGlobalQuery method.
+type ImplicitGetRequiredGlobalQueryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ImplicitGetRequiredPathOptions contains the optional parameters for the Implicit.GetRequiredPath method.
+type ImplicitGetRequiredPathOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ImplicitPutOptionalBodyOptions contains the optional parameters for the Implicit.PutOptionalBody method.

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -58,7 +58,7 @@ func TestGetMultiplePages(t *testing.T) {
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
 func TestGetMultiplePagesFailure(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFailure()
+	page := client.GetMultiplePagesFailure(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -81,7 +81,7 @@ func TestGetMultiplePagesFailure(t *testing.T) {
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
 func TestGetMultiplePagesFailureURI(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFailureURI()
+	page := client.GetMultiplePagesFailureURI(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -104,7 +104,7 @@ func TestGetMultiplePagesFailureURI(t *testing.T) {
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
 func TestGetMultiplePagesFragmentNextLink(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesFragmentNextLink("1.6", "test_user")
+	page := client.GetMultiplePagesFragmentNextLink("1.6", "test_user", nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -190,7 +190,7 @@ func TestGetMultiplePagesLro(t *testing.T) {
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
 func TestGetMultiplePagesRetryFirst(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesRetryFirst()
+	page := client.GetMultiplePagesRetryFirst(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -213,7 +213,7 @@ func TestGetMultiplePagesRetryFirst(t *testing.T) {
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
 func TestGetMultiplePagesRetrySecond(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetMultiplePagesRetrySecond()
+	page := client.GetMultiplePagesRetrySecond(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -259,7 +259,7 @@ func TestGetMultiplePagesWithOffset(t *testing.T) {
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
 func TestGetNoItemNamePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetNoItemNamePages()
+	page := client.GetNoItemNamePages(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -282,7 +282,7 @@ func TestGetNoItemNamePages(t *testing.T) {
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
 func TestGetNullNextLinkNamePages(t *testing.T) {
 	client := newPagingClient()
-	resp, err := client.GetNullNextLinkNamePages(context.Background())
+	resp, err := client.GetNullNextLinkNamePages(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +317,7 @@ func TestGetOdataMultiplePages(t *testing.T) {
 // GetPagingModelWithItemNameWithXmsClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
 func TestGetPagingModelWithItemNameWithXmsClientName(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetPagingModelWithItemNameWithXmsClientName()
+	page := client.GetPagingModelWithItemNameWithXmsClientName(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -340,7 +340,7 @@ func TestGetPagingModelWithItemNameWithXmsClientName(t *testing.T) {
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
 func TestGetSinglePages(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetSinglePages()
+	page := client.GetSinglePages(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -363,7 +363,7 @@ func TestGetSinglePages(t *testing.T) {
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
 func TestGetSinglePagesFailure(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetSinglePagesFailure()
+	page := client.GetSinglePagesFailure(nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
@@ -386,7 +386,7 @@ func TestGetSinglePagesFailure(t *testing.T) {
 // GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
 func TestGetWithQueryParams(t *testing.T) {
 	client := newPagingClient()
-	page := client.GetWithQueryParams(100)
+	page := client.GetWithQueryParams(100, nil)
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -37,6 +37,28 @@ type OperationResult struct {
 	Status *OperationResultStatus `json:"status,omitempty"`
 }
 
+// PagingGetMultiplePagesFailureOptions contains the optional parameters for the Paging.GetMultiplePagesFailure method.
+type PagingGetMultiplePagesFailureOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetMultiplePagesFailureURIOptions contains the optional parameters for the Paging.GetMultiplePagesFailureURI method.
+type PagingGetMultiplePagesFailureURIOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetMultiplePagesFragmentNextLinkOptions contains the optional parameters for the Paging.GetMultiplePagesFragmentNextLink
+// method.
+type PagingGetMultiplePagesFragmentNextLinkOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetMultiplePagesFragmentWithGroupingNextLinkOptions contains the optional parameters for the Paging.GetMultiplePagesFragmentWithGroupingNextLink
+// method.
+type PagingGetMultiplePagesFragmentWithGroupingNextLinkOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PagingGetMultiplePagesLroOptions contains the optional parameters for the Paging.GetMultiplePagesLro method.
 type PagingGetMultiplePagesLroOptions struct {
 	ClientRequestId *string
@@ -55,6 +77,16 @@ type PagingGetMultiplePagesOptions struct {
 	Timeout *int32
 }
 
+// PagingGetMultiplePagesRetryFirstOptions contains the optional parameters for the Paging.GetMultiplePagesRetryFirst method.
+type PagingGetMultiplePagesRetryFirstOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetMultiplePagesRetrySecondOptions contains the optional parameters for the Paging.GetMultiplePagesRetrySecond method.
+type PagingGetMultiplePagesRetrySecondOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PagingGetMultiplePagesWithOffsetOptions contains the optional parameters for the Paging.GetMultiplePagesWithOffset method.
 type PagingGetMultiplePagesWithOffsetOptions struct {
 	ClientRequestId *string
@@ -66,6 +98,16 @@ type PagingGetMultiplePagesWithOffsetOptions struct {
 	Timeout *int32
 }
 
+// PagingGetNoItemNamePagesOptions contains the optional parameters for the Paging.GetNoItemNamePages method.
+type PagingGetNoItemNamePagesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetNullNextLinkNamePagesOptions contains the optional parameters for the Paging.GetNullNextLinkNamePages method.
+type PagingGetNullNextLinkNamePagesOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PagingGetOdataMultiplePagesOptions contains the optional parameters for the Paging.GetOdataMultiplePages method.
 type PagingGetOdataMultiplePagesOptions struct {
 	ClientRequestId *string
@@ -73,6 +115,43 @@ type PagingGetOdataMultiplePagesOptions struct {
 	Maxresults *int32
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
+}
+
+// PagingGetPagingModelWithItemNameWithXmsClientNameOptions contains the optional parameters for the Paging.GetPagingModelWithItemNameWithXmsClientName
+// method.
+type PagingGetPagingModelWithItemNameWithXmsClientNameOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetSinglePagesFailureOptions contains the optional parameters for the Paging.GetSinglePagesFailure method.
+type PagingGetSinglePagesFailureOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetSinglePagesOptions contains the optional parameters for the Paging.GetSinglePages method.
+type PagingGetSinglePagesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingGetWithQueryParamsOptions contains the optional parameters for the Paging.GetWithQueryParams method.
+type PagingGetWithQueryParamsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingNextFragmentOptions contains the optional parameters for the Paging.NextFragment method.
+type PagingNextFragmentOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingNextFragmentWithGroupingOptions contains the optional parameters for the Paging.NextFragmentWithGrouping method.
+type PagingNextFragmentWithGroupingOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PagingNextOperationWithQueryParamsOptions contains the optional parameters for the Paging.NextOperationWithQueryParams
+// method.
+type PagingNextOperationWithQueryParamsOptions struct {
+	// placeholder for future optional parameters
 }
 
 type Product struct {

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -138,22 +138,6 @@ type PagingGetWithQueryParamsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// PagingNextFragmentOptions contains the optional parameters for the Paging.NextFragment method.
-type PagingNextFragmentOptions struct {
-	// placeholder for future optional parameters
-}
-
-// PagingNextFragmentWithGroupingOptions contains the optional parameters for the Paging.NextFragmentWithGrouping method.
-type PagingNextFragmentWithGroupingOptions struct {
-	// placeholder for future optional parameters
-}
-
-// PagingNextOperationWithQueryParamsOptions contains the optional parameters for the Paging.NextOperationWithQueryParams
-// method.
-type PagingNextOperationWithQueryParamsOptions struct {
-	// placeholder for future optional parameters
-}
-
 type Product struct {
 	Properties *ProductProperties `json:"properties,omitempty"`
 }

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -22,39 +22,39 @@ import (
 // PagingOperations contains the methods for the Paging group.
 type PagingOperations interface {
 	// GetMultiplePages - A paging operation that includes a nextLink that has 10 pages
-	GetMultiplePages(pagingGetMultiplePagesOptions *PagingGetMultiplePagesOptions) ProductResultPager
+	GetMultiplePages(options *PagingGetMultiplePagesOptions) ProductResultPager
 	// GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
-	GetMultiplePagesFailure() ProductResultPager
+	GetMultiplePagesFailure(options *PagingGetMultiplePagesFailureOptions) ProductResultPager
 	// GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
-	GetMultiplePagesFailureURI() ProductResultPager
+	GetMultiplePagesFailureURI(options *PagingGetMultiplePagesFailureURIOptions) ProductResultPager
 	// GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
-	GetMultiplePagesFragmentNextLink(apiVersion string, tenant string) OdataProductResultPager
+	GetMultiplePagesFragmentNextLink(apiVersion string, tenant string, options *PagingGetMultiplePagesFragmentNextLinkOptions) OdataProductResultPager
 	// GetMultiplePagesFragmentWithGroupingNextLink - A paging operation that doesn't return a full URL, just a fragment with parameters grouped
 	GetMultiplePagesFragmentWithGroupingNextLink(customParameterGroup CustomParameterGroup) OdataProductResultPager
 	// BeginGetMultiplePagesLro - A long-running paging operation that includes a nextLink that has 10 pages
-	BeginGetMultiplePagesLro(ctx context.Context, pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*ProductResultPagerPollerResponse, error)
+	BeginGetMultiplePagesLro(ctx context.Context, options *PagingGetMultiplePagesLroOptions) (*ProductResultPagerPollerResponse, error)
 	// ResumeGetMultiplePagesLro - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetMultiplePagesLro(token string) (ProductResultPagerPoller, error)
 	// GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
-	GetMultiplePagesRetryFirst() ProductResultPager
+	GetMultiplePagesRetryFirst(options *PagingGetMultiplePagesRetryFirstOptions) ProductResultPager
 	// GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
-	GetMultiplePagesRetrySecond() ProductResultPager
+	GetMultiplePagesRetrySecond(options *PagingGetMultiplePagesRetrySecondOptions) ProductResultPager
 	// GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
 	GetMultiplePagesWithOffset(pagingGetMultiplePagesWithOffsetOptions PagingGetMultiplePagesWithOffsetOptions) ProductResultPager
 	// GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
-	GetNoItemNamePages() ProductResultValuePager
+	GetNoItemNamePages(options *PagingGetNoItemNamePagesOptions) ProductResultValuePager
 	// GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
-	GetNullNextLinkNamePages(ctx context.Context) (*ProductResultResponse, error)
+	GetNullNextLinkNamePages(ctx context.Context, options *PagingGetNullNextLinkNamePagesOptions) (*ProductResultResponse, error)
 	// GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
-	GetOdataMultiplePages(pagingGetOdataMultiplePagesOptions *PagingGetOdataMultiplePagesOptions) OdataProductResultPager
+	GetOdataMultiplePages(options *PagingGetOdataMultiplePagesOptions) OdataProductResultPager
 	// GetPagingModelWithItemNameWithXmsClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
-	GetPagingModelWithItemNameWithXmsClientName() ProductResultValueWithXmsClientNamePager
+	GetPagingModelWithItemNameWithXmsClientName(options *PagingGetPagingModelWithItemNameWithXmsClientNameOptions) ProductResultValueWithXmsClientNamePager
 	// GetSinglePages - A paging operation that finishes on the first call without a nextlink
-	GetSinglePages() ProductResultPager
+	GetSinglePages(options *PagingGetSinglePagesOptions) ProductResultPager
 	// GetSinglePagesFailure - A paging operation that receives a 400 on the first call
-	GetSinglePagesFailure() ProductResultPager
+	GetSinglePagesFailure(options *PagingGetSinglePagesFailureOptions) ProductResultPager
 	// GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
-	GetWithQueryParams(requiredQueryParameter int32) ProductResultPager
+	GetWithQueryParams(requiredQueryParameter int32, options *PagingGetWithQueryParamsOptions) ProductResultPager
 }
 
 // PagingClient implements the PagingOperations interface.
@@ -74,11 +74,11 @@ func (client *PagingClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetMultiplePages - A paging operation that includes a nextLink that has 10 pages
-func (client *PagingClient) GetMultiplePages(pagingGetMultiplePagesOptions *PagingGetMultiplePagesOptions) ProductResultPager {
+func (client *PagingClient) GetMultiplePages(options *PagingGetMultiplePagesOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesCreateRequest(ctx, pagingGetMultiplePagesOptions)
+			return client.GetMultiplePagesCreateRequest(ctx, options)
 		},
 		responder: client.GetMultiplePagesHandleResponse,
 		errorer:   client.GetMultiplePagesHandleError,
@@ -89,20 +89,20 @@ func (client *PagingClient) GetMultiplePages(pagingGetMultiplePagesOptions *Pagi
 }
 
 // GetMultiplePagesCreateRequest creates the GetMultiplePages request.
-func (client *PagingClient) GetMultiplePagesCreateRequest(ctx context.Context, pagingGetMultiplePagesOptions *PagingGetMultiplePagesOptions) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesCreateRequest(ctx context.Context, options *PagingGetMultiplePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if pagingGetMultiplePagesOptions != nil && pagingGetMultiplePagesOptions.ClientRequestId != nil {
-		req.Header.Set("client-request-id", *pagingGetMultiplePagesOptions.ClientRequestId)
+	if options != nil && options.ClientRequestId != nil {
+		req.Header.Set("client-request-id", *options.ClientRequestId)
 	}
-	if pagingGetMultiplePagesOptions != nil && pagingGetMultiplePagesOptions.Maxresults != nil {
-		req.Header.Set("maxresults", strconv.FormatInt(int64(*pagingGetMultiplePagesOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		req.Header.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if pagingGetMultiplePagesOptions != nil && pagingGetMultiplePagesOptions.Timeout != nil {
-		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetMultiplePagesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		req.Header.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -127,11 +127,11 @@ func (client *PagingClient) GetMultiplePagesHandleError(resp *azcore.Response) e
 }
 
 // GetMultiplePagesFailure - A paging operation that receives a 400 on the second call
-func (client *PagingClient) GetMultiplePagesFailure() ProductResultPager {
+func (client *PagingClient) GetMultiplePagesFailure(options *PagingGetMultiplePagesFailureOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesFailureCreateRequest(ctx)
+			return client.GetMultiplePagesFailureCreateRequest(ctx, options)
 		},
 		responder: client.GetMultiplePagesFailureHandleResponse,
 		errorer:   client.GetMultiplePagesFailureHandleError,
@@ -142,7 +142,7 @@ func (client *PagingClient) GetMultiplePagesFailure() ProductResultPager {
 }
 
 // GetMultiplePagesFailureCreateRequest creates the GetMultiplePagesFailure request.
-func (client *PagingClient) GetMultiplePagesFailureCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesFailureCreateRequest(ctx context.Context, options *PagingGetMultiplePagesFailureOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/failure"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -171,11 +171,11 @@ func (client *PagingClient) GetMultiplePagesFailureHandleError(resp *azcore.Resp
 }
 
 // GetMultiplePagesFailureURI - A paging operation that receives an invalid nextLink
-func (client *PagingClient) GetMultiplePagesFailureURI() ProductResultPager {
+func (client *PagingClient) GetMultiplePagesFailureURI(options *PagingGetMultiplePagesFailureURIOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesFailureURICreateRequest(ctx)
+			return client.GetMultiplePagesFailureURICreateRequest(ctx, options)
 		},
 		responder: client.GetMultiplePagesFailureURIHandleResponse,
 		errorer:   client.GetMultiplePagesFailureURIHandleError,
@@ -186,7 +186,7 @@ func (client *PagingClient) GetMultiplePagesFailureURI() ProductResultPager {
 }
 
 // GetMultiplePagesFailureURICreateRequest creates the GetMultiplePagesFailureURI request.
-func (client *PagingClient) GetMultiplePagesFailureURICreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesFailureURICreateRequest(ctx context.Context, options *PagingGetMultiplePagesFailureURIOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/failureuri"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -215,22 +215,22 @@ func (client *PagingClient) GetMultiplePagesFailureURIHandleError(resp *azcore.R
 }
 
 // GetMultiplePagesFragmentNextLink - A paging operation that doesn't return a full URL, just a fragment
-func (client *PagingClient) GetMultiplePagesFragmentNextLink(apiVersion string, tenant string) OdataProductResultPager {
+func (client *PagingClient) GetMultiplePagesFragmentNextLink(apiVersion string, tenant string, options *PagingGetMultiplePagesFragmentNextLinkOptions) OdataProductResultPager {
 	return &odataProductResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesFragmentNextLinkCreateRequest(ctx, apiVersion, tenant)
+			return client.GetMultiplePagesFragmentNextLinkCreateRequest(ctx, apiVersion, tenant, options)
 		},
 		responder: client.GetMultiplePagesFragmentNextLinkHandleResponse,
 		errorer:   client.GetMultiplePagesFragmentNextLinkHandleError,
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
-			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink)
+			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink, options)
 		},
 	}
 }
 
 // GetMultiplePagesFragmentNextLinkCreateRequest creates the GetMultiplePagesFragmentNextLink request.
-func (client *PagingClient) GetMultiplePagesFragmentNextLinkCreateRequest(ctx context.Context, apiVersion string, tenant string) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesFragmentNextLinkCreateRequest(ctx context.Context, apiVersion string, tenant string, options *PagingGetMultiplePagesFragmentNextLinkOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/fragment/{tenant}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -310,8 +310,8 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLinkHandleEr
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*ProductResultPagerPollerResponse, error) {
-	resp, err := client.GetMultiplePagesLro(ctx, pagingGetMultiplePagesLroOptions)
+func (client *PagingClient) BeginGetMultiplePagesLro(ctx context.Context, options *PagingGetMultiplePagesLroOptions) (*ProductResultPagerPollerResponse, error) {
+	resp, err := client.GetMultiplePagesLro(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -355,8 +355,8 @@ func (client *PagingClient) ResumeGetMultiplePagesLro(token string) (ProductResu
 }
 
 // GetMultiplePagesLro - A long-running paging operation that includes a nextLink that has 10 pages
-func (client *PagingClient) GetMultiplePagesLro(ctx context.Context, pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*azcore.Response, error) {
-	req, err := client.GetMultiplePagesLroCreateRequest(ctx, pagingGetMultiplePagesLroOptions)
+func (client *PagingClient) GetMultiplePagesLro(ctx context.Context, options *PagingGetMultiplePagesLroOptions) (*azcore.Response, error) {
+	req, err := client.GetMultiplePagesLroCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -371,20 +371,20 @@ func (client *PagingClient) GetMultiplePagesLro(ctx context.Context, pagingGetMu
 }
 
 // GetMultiplePagesLroCreateRequest creates the GetMultiplePagesLro request.
-func (client *PagingClient) GetMultiplePagesLroCreateRequest(ctx context.Context, pagingGetMultiplePagesLroOptions *PagingGetMultiplePagesLroOptions) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesLroCreateRequest(ctx context.Context, options *PagingGetMultiplePagesLroOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/lro"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if pagingGetMultiplePagesLroOptions != nil && pagingGetMultiplePagesLroOptions.ClientRequestId != nil {
-		req.Header.Set("client-request-id", *pagingGetMultiplePagesLroOptions.ClientRequestId)
+	if options != nil && options.ClientRequestId != nil {
+		req.Header.Set("client-request-id", *options.ClientRequestId)
 	}
-	if pagingGetMultiplePagesLroOptions != nil && pagingGetMultiplePagesLroOptions.Maxresults != nil {
-		req.Header.Set("maxresults", strconv.FormatInt(int64(*pagingGetMultiplePagesLroOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		req.Header.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if pagingGetMultiplePagesLroOptions != nil && pagingGetMultiplePagesLroOptions.Timeout != nil {
-		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetMultiplePagesLroOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		req.Header.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -409,11 +409,11 @@ func (client *PagingClient) GetMultiplePagesLroHandleError(resp *azcore.Response
 }
 
 // GetMultiplePagesRetryFirst - A paging operation that fails on the first call with 500 and then retries and then get a response including a nextLink that has 10 pages
-func (client *PagingClient) GetMultiplePagesRetryFirst() ProductResultPager {
+func (client *PagingClient) GetMultiplePagesRetryFirst(options *PagingGetMultiplePagesRetryFirstOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesRetryFirstCreateRequest(ctx)
+			return client.GetMultiplePagesRetryFirstCreateRequest(ctx, options)
 		},
 		responder: client.GetMultiplePagesRetryFirstHandleResponse,
 		errorer:   client.GetMultiplePagesRetryFirstHandleError,
@@ -424,7 +424,7 @@ func (client *PagingClient) GetMultiplePagesRetryFirst() ProductResultPager {
 }
 
 // GetMultiplePagesRetryFirstCreateRequest creates the GetMultiplePagesRetryFirst request.
-func (client *PagingClient) GetMultiplePagesRetryFirstCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesRetryFirstCreateRequest(ctx context.Context, options *PagingGetMultiplePagesRetryFirstOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/retryfirst"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -453,11 +453,11 @@ func (client *PagingClient) GetMultiplePagesRetryFirstHandleError(resp *azcore.R
 }
 
 // GetMultiplePagesRetrySecond - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first with 500. The client should retry and finish all 10 pages eventually.
-func (client *PagingClient) GetMultiplePagesRetrySecond() ProductResultPager {
+func (client *PagingClient) GetMultiplePagesRetrySecond(options *PagingGetMultiplePagesRetrySecondOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetMultiplePagesRetrySecondCreateRequest(ctx)
+			return client.GetMultiplePagesRetrySecondCreateRequest(ctx, options)
 		},
 		responder: client.GetMultiplePagesRetrySecondHandleResponse,
 		errorer:   client.GetMultiplePagesRetrySecondHandleError,
@@ -468,7 +468,7 @@ func (client *PagingClient) GetMultiplePagesRetrySecond() ProductResultPager {
 }
 
 // GetMultiplePagesRetrySecondCreateRequest creates the GetMultiplePagesRetrySecond request.
-func (client *PagingClient) GetMultiplePagesRetrySecondCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetMultiplePagesRetrySecondCreateRequest(ctx context.Context, options *PagingGetMultiplePagesRetrySecondOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/retrysecond"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -551,11 +551,11 @@ func (client *PagingClient) GetMultiplePagesWithOffsetHandleError(resp *azcore.R
 }
 
 // GetNoItemNamePages - A paging operation that must return result of the default 'value' node.
-func (client *PagingClient) GetNoItemNamePages() ProductResultValuePager {
+func (client *PagingClient) GetNoItemNamePages(options *PagingGetNoItemNamePagesOptions) ProductResultValuePager {
 	return &productResultValuePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetNoItemNamePagesCreateRequest(ctx)
+			return client.GetNoItemNamePagesCreateRequest(ctx, options)
 		},
 		responder: client.GetNoItemNamePagesHandleResponse,
 		errorer:   client.GetNoItemNamePagesHandleError,
@@ -566,7 +566,7 @@ func (client *PagingClient) GetNoItemNamePages() ProductResultValuePager {
 }
 
 // GetNoItemNamePagesCreateRequest creates the GetNoItemNamePages request.
-func (client *PagingClient) GetNoItemNamePagesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetNoItemNamePagesCreateRequest(ctx context.Context, options *PagingGetNoItemNamePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/noitemname"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -595,8 +595,8 @@ func (client *PagingClient) GetNoItemNamePagesHandleError(resp *azcore.Response)
 }
 
 // GetNullNextLinkNamePages - A paging operation that must ignore any kind of nextLink, and stop after page 1.
-func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context) (*ProductResultResponse, error) {
-	req, err := client.GetNullNextLinkNamePagesCreateRequest(ctx)
+func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context, options *PagingGetNullNextLinkNamePagesOptions) (*ProductResultResponse, error) {
+	req, err := client.GetNullNextLinkNamePagesCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +615,7 @@ func (client *PagingClient) GetNullNextLinkNamePages(ctx context.Context) (*Prod
 }
 
 // GetNullNextLinkNamePagesCreateRequest creates the GetNullNextLinkNamePages request.
-func (client *PagingClient) GetNullNextLinkNamePagesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetNullNextLinkNamePagesCreateRequest(ctx context.Context, options *PagingGetNullNextLinkNamePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/nullnextlink"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -644,11 +644,11 @@ func (client *PagingClient) GetNullNextLinkNamePagesHandleError(resp *azcore.Res
 }
 
 // GetOdataMultiplePages - A paging operation that includes a nextLink in odata format that has 10 pages
-func (client *PagingClient) GetOdataMultiplePages(pagingGetOdataMultiplePagesOptions *PagingGetOdataMultiplePagesOptions) OdataProductResultPager {
+func (client *PagingClient) GetOdataMultiplePages(options *PagingGetOdataMultiplePagesOptions) OdataProductResultPager {
 	return &odataProductResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetOdataMultiplePagesCreateRequest(ctx, pagingGetOdataMultiplePagesOptions)
+			return client.GetOdataMultiplePagesCreateRequest(ctx, options)
 		},
 		responder: client.GetOdataMultiplePagesHandleResponse,
 		errorer:   client.GetOdataMultiplePagesHandleError,
@@ -659,20 +659,20 @@ func (client *PagingClient) GetOdataMultiplePages(pagingGetOdataMultiplePagesOpt
 }
 
 // GetOdataMultiplePagesCreateRequest creates the GetOdataMultiplePages request.
-func (client *PagingClient) GetOdataMultiplePagesCreateRequest(ctx context.Context, pagingGetOdataMultiplePagesOptions *PagingGetOdataMultiplePagesOptions) (*azcore.Request, error) {
+func (client *PagingClient) GetOdataMultiplePagesCreateRequest(ctx context.Context, options *PagingGetOdataMultiplePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/odata"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if pagingGetOdataMultiplePagesOptions != nil && pagingGetOdataMultiplePagesOptions.ClientRequestId != nil {
-		req.Header.Set("client-request-id", *pagingGetOdataMultiplePagesOptions.ClientRequestId)
+	if options != nil && options.ClientRequestId != nil {
+		req.Header.Set("client-request-id", *options.ClientRequestId)
 	}
-	if pagingGetOdataMultiplePagesOptions != nil && pagingGetOdataMultiplePagesOptions.Maxresults != nil {
-		req.Header.Set("maxresults", strconv.FormatInt(int64(*pagingGetOdataMultiplePagesOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		req.Header.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if pagingGetOdataMultiplePagesOptions != nil && pagingGetOdataMultiplePagesOptions.Timeout != nil {
-		req.Header.Set("timeout", strconv.FormatInt(int64(*pagingGetOdataMultiplePagesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		req.Header.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -697,11 +697,11 @@ func (client *PagingClient) GetOdataMultiplePagesHandleError(resp *azcore.Respon
 }
 
 // GetPagingModelWithItemNameWithXmsClientName - A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.
-func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientName() ProductResultValueWithXmsClientNamePager {
+func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientName(options *PagingGetPagingModelWithItemNameWithXmsClientNameOptions) ProductResultValueWithXmsClientNamePager {
 	return &productResultValueWithXmsClientNamePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetPagingModelWithItemNameWithXmsClientNameCreateRequest(ctx)
+			return client.GetPagingModelWithItemNameWithXmsClientNameCreateRequest(ctx, options)
 		},
 		responder: client.GetPagingModelWithItemNameWithXmsClientNameHandleResponse,
 		errorer:   client.GetPagingModelWithItemNameWithXmsClientNameHandleError,
@@ -712,7 +712,7 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientName() Produc
 }
 
 // GetPagingModelWithItemNameWithXmsClientNameCreateRequest creates the GetPagingModelWithItemNameWithXmsClientName request.
-func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameCreateRequest(ctx context.Context, options *PagingGetPagingModelWithItemNameWithXmsClientNameOptions) (*azcore.Request, error) {
 	urlPath := "/paging/itemNameWithXMSClientName"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -741,11 +741,11 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientNameHandleErr
 }
 
 // GetSinglePages - A paging operation that finishes on the first call without a nextlink
-func (client *PagingClient) GetSinglePages() ProductResultPager {
+func (client *PagingClient) GetSinglePages(options *PagingGetSinglePagesOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetSinglePagesCreateRequest(ctx)
+			return client.GetSinglePagesCreateRequest(ctx, options)
 		},
 		responder: client.GetSinglePagesHandleResponse,
 		errorer:   client.GetSinglePagesHandleError,
@@ -756,7 +756,7 @@ func (client *PagingClient) GetSinglePages() ProductResultPager {
 }
 
 // GetSinglePagesCreateRequest creates the GetSinglePages request.
-func (client *PagingClient) GetSinglePagesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetSinglePagesCreateRequest(ctx context.Context, options *PagingGetSinglePagesOptions) (*azcore.Request, error) {
 	urlPath := "/paging/single"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -785,11 +785,11 @@ func (client *PagingClient) GetSinglePagesHandleError(resp *azcore.Response) err
 }
 
 // GetSinglePagesFailure - A paging operation that receives a 400 on the first call
-func (client *PagingClient) GetSinglePagesFailure() ProductResultPager {
+func (client *PagingClient) GetSinglePagesFailure(options *PagingGetSinglePagesFailureOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetSinglePagesFailureCreateRequest(ctx)
+			return client.GetSinglePagesFailureCreateRequest(ctx, options)
 		},
 		responder: client.GetSinglePagesFailureHandleResponse,
 		errorer:   client.GetSinglePagesFailureHandleError,
@@ -800,7 +800,7 @@ func (client *PagingClient) GetSinglePagesFailure() ProductResultPager {
 }
 
 // GetSinglePagesFailureCreateRequest creates the GetSinglePagesFailure request.
-func (client *PagingClient) GetSinglePagesFailureCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) GetSinglePagesFailureCreateRequest(ctx context.Context, options *PagingGetSinglePagesFailureOptions) (*azcore.Request, error) {
 	urlPath := "/paging/single/failure"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -829,22 +829,22 @@ func (client *PagingClient) GetSinglePagesFailureHandleError(resp *azcore.Respon
 }
 
 // GetWithQueryParams - A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult
-func (client *PagingClient) GetWithQueryParams(requiredQueryParameter int32) ProductResultPager {
+func (client *PagingClient) GetWithQueryParams(requiredQueryParameter int32, options *PagingGetWithQueryParamsOptions) ProductResultPager {
 	return &productResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetWithQueryParamsCreateRequest(ctx, requiredQueryParameter)
+			return client.GetWithQueryParamsCreateRequest(ctx, requiredQueryParameter, options)
 		},
 		responder: client.GetWithQueryParamsHandleResponse,
 		errorer:   client.GetWithQueryParamsHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
-			return client.NextOperationWithQueryParamsCreateRequest(ctx)
+			return client.NextOperationWithQueryParamsCreateRequest(ctx, options)
 		},
 	}
 }
 
 // GetWithQueryParamsCreateRequest creates the GetWithQueryParams request.
-func (client *PagingClient) GetWithQueryParamsCreateRequest(ctx context.Context, requiredQueryParameter int32) (*azcore.Request, error) {
+func (client *PagingClient) GetWithQueryParamsCreateRequest(ctx context.Context, requiredQueryParameter int32, options *PagingGetWithQueryParamsOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/getWithQueryParams"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -877,7 +877,7 @@ func (client *PagingClient) GetWithQueryParamsHandleError(resp *azcore.Response)
 }
 
 // NextFragmentCreateRequest creates the NextFragment request.
-func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string) (*azcore.Request, error) {
+func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string, options *PagingNextFragmentOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
@@ -945,7 +945,7 @@ func (client *PagingClient) NextFragmentWithGroupingHandleError(resp *azcore.Res
 }
 
 // NextOperationWithQueryParamsCreateRequest creates the NextOperationWithQueryParams request.
-func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx context.Context, options *PagingNextOperationWithQueryParamsOptions) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -224,7 +224,7 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLink(apiVersion string, 
 		responder: client.GetMultiplePagesFragmentNextLinkHandleResponse,
 		errorer:   client.GetMultiplePagesFragmentNextLinkHandleError,
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
-			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink, options)
+			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink)
 		},
 	}
 }
@@ -838,7 +838,7 @@ func (client *PagingClient) GetWithQueryParams(requiredQueryParameter int32, opt
 		responder: client.GetWithQueryParamsHandleResponse,
 		errorer:   client.GetWithQueryParamsHandleError,
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
-			return client.NextOperationWithQueryParamsCreateRequest(ctx, options)
+			return client.NextOperationWithQueryParamsCreateRequest(ctx)
 		},
 	}
 }
@@ -877,7 +877,7 @@ func (client *PagingClient) GetWithQueryParamsHandleError(resp *azcore.Response)
 }
 
 // NextFragmentCreateRequest creates the NextFragment request.
-func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string, options *PagingNextFragmentOptions) (*azcore.Request, error) {
+func (client *PagingClient) NextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
@@ -945,7 +945,7 @@ func (client *PagingClient) NextFragmentWithGroupingHandleError(resp *azcore.Res
 }
 
 // NextOperationWithQueryParamsCreateRequest creates the NextOperationWithQueryParams request.
-func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx context.Context, options *PagingNextOperationWithQueryParamsOptions) (*azcore.Request, error) {
+func (client *PagingClient) NextOperationWithQueryParamsCreateRequest(ctx context.Context) (*azcore.Request, error) {
 	urlPath := "/paging/multiple/nextOperationWithQueryParams"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/paramgroupinggroup/zz_generated_models.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_models.go
@@ -34,6 +34,12 @@ type FirstParameterGroup struct {
 	QueryOne *int32
 }
 
+// ParameterGroupingPostMultiParamGroupsOptions contains the optional parameters for the ParameterGrouping.PostMultiParamGroups
+// method.
+type ParameterGroupingPostMultiParamGroupsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ParameterGroupingPostMultiParamGroupsSecondParamGroup contains a group of parameters for the ParameterGrouping.PostMultiParamGroups
 // method.
 type ParameterGroupingPostMultiParamGroupsSecondParamGroup struct {
@@ -42,11 +48,21 @@ type ParameterGroupingPostMultiParamGroupsSecondParamGroup struct {
 	QueryTwo *int32
 }
 
+// ParameterGroupingPostOptionalOptions contains the optional parameters for the ParameterGrouping.PostOptional method.
+type ParameterGroupingPostOptionalOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ParameterGroupingPostOptionalParameters contains a group of parameters for the ParameterGrouping.PostOptional method.
 type ParameterGroupingPostOptionalParameters struct {
 	CustomHeader *string
 	// Query parameter with default
 	Query *int32
+}
+
+// ParameterGroupingPostRequiredOptions contains the optional parameters for the ParameterGrouping.PostRequired method.
+type ParameterGroupingPostRequiredOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ParameterGroupingPostRequiredParameters contains a group of parameters for the ParameterGrouping.PostRequired method.
@@ -57,4 +73,10 @@ type ParameterGroupingPostRequiredParameters struct {
 	PathParameter string
 	// Query parameter with default
 	Query *int32
+}
+
+// ParameterGroupingPostSharedParameterGroupObjectOptions contains the optional parameters for the ParameterGrouping.PostSharedParameterGroupObject
+// method.
+type ParameterGroupingPostSharedParameterGroupObjectOptions struct {
+	// placeholder for future optional parameters
 }

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping.go
@@ -17,13 +17,13 @@ import (
 // ParameterGroupingOperations contains the methods for the ParameterGrouping group.
 type ParameterGroupingOperations interface {
 	// PostMultiParamGroups - Post parameters from multiple different parameter groups
-	PostMultiParamGroups(ctx context.Context, firstParameterGroup *FirstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup *ParameterGroupingPostMultiParamGroupsSecondParamGroup) (*http.Response, error)
+	PostMultiParamGroups(ctx context.Context, options *FirstParameterGroup, parameterGroupingPostMultiParamGroupsSecondParamGroup *ParameterGroupingPostMultiParamGroupsSecondParamGroup) (*http.Response, error)
 	// PostOptional - Post a bunch of optional parameters grouped
-	PostOptional(ctx context.Context, parameterGroupingPostOptionalParameters *ParameterGroupingPostOptionalParameters) (*http.Response, error)
+	PostOptional(ctx context.Context, options *ParameterGroupingPostOptionalParameters) (*http.Response, error)
 	// PostRequired - Post a bunch of required parameters grouped
 	PostRequired(ctx context.Context, parameterGroupingPostRequiredParameters ParameterGroupingPostRequiredParameters) (*http.Response, error)
 	// PostSharedParameterGroupObject - Post parameters with a shared parameter group object
-	PostSharedParameterGroupObject(ctx context.Context, firstParameterGroup *FirstParameterGroup) (*http.Response, error)
+	PostSharedParameterGroupObject(ctx context.Context, options *FirstParameterGroup) (*http.Response, error)
 }
 
 // ParameterGroupingClient implements the ParameterGroupingOperations interface.
@@ -93,8 +93,8 @@ func (client *ParameterGroupingClient) PostMultiParamGroupsHandleError(resp *azc
 }
 
 // PostOptional - Post a bunch of optional parameters grouped
-func (client *ParameterGroupingClient) PostOptional(ctx context.Context, parameterGroupingPostOptionalParameters *ParameterGroupingPostOptionalParameters) (*http.Response, error) {
-	req, err := client.PostOptionalCreateRequest(ctx, parameterGroupingPostOptionalParameters)
+func (client *ParameterGroupingClient) PostOptional(ctx context.Context, options *ParameterGroupingPostOptionalParameters) (*http.Response, error) {
+	req, err := client.PostOptionalCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -109,19 +109,19 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, paramet
 }
 
 // PostOptionalCreateRequest creates the PostOptional request.
-func (client *ParameterGroupingClient) PostOptionalCreateRequest(ctx context.Context, parameterGroupingPostOptionalParameters *ParameterGroupingPostOptionalParameters) (*azcore.Request, error) {
+func (client *ParameterGroupingClient) PostOptionalCreateRequest(ctx context.Context, options *ParameterGroupingPostOptionalParameters) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/postOptional"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if parameterGroupingPostOptionalParameters != nil && parameterGroupingPostOptionalParameters.Query != nil {
-		query.Set("query", strconv.FormatInt(int64(*parameterGroupingPostOptionalParameters.Query), 10))
+	if options != nil && options.Query != nil {
+		query.Set("query", strconv.FormatInt(int64(*options.Query), 10))
 	}
 	req.URL.RawQuery = query.Encode()
-	if parameterGroupingPostOptionalParameters != nil && parameterGroupingPostOptionalParameters.CustomHeader != nil {
-		req.Header.Set("customHeader", *parameterGroupingPostOptionalParameters.CustomHeader)
+	if options != nil && options.CustomHeader != nil {
+		req.Header.Set("customHeader", *options.CustomHeader)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -182,8 +182,8 @@ func (client *ParameterGroupingClient) PostRequiredHandleError(resp *azcore.Resp
 }
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
-func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx context.Context, firstParameterGroup *FirstParameterGroup) (*http.Response, error) {
-	req, err := client.PostSharedParameterGroupObjectCreateRequest(ctx, firstParameterGroup)
+func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx context.Context, options *FirstParameterGroup) (*http.Response, error) {
+	req, err := client.PostSharedParameterGroupObjectCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -198,19 +198,19 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 }
 
 // PostSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.
-func (client *ParameterGroupingClient) PostSharedParameterGroupObjectCreateRequest(ctx context.Context, firstParameterGroup *FirstParameterGroup) (*azcore.Request, error) {
+func (client *ParameterGroupingClient) PostSharedParameterGroupObjectCreateRequest(ctx context.Context, options *FirstParameterGroup) (*azcore.Request, error) {
 	urlPath := "/parameterGrouping/sharedParameterGroupObject"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if firstParameterGroup != nil && firstParameterGroup.QueryOne != nil {
-		query.Set("query-one", strconv.FormatInt(int64(*firstParameterGroup.QueryOne), 10))
+	if options != nil && options.QueryOne != nil {
+		query.Set("query-one", strconv.FormatInt(int64(*options.QueryOne), 10))
 	}
 	req.URL.RawQuery = query.Encode()
-	if firstParameterGroup != nil && firstParameterGroup.HeaderOne != nil {
-		req.Header.Set("header-one", *firstParameterGroup.HeaderOne)
+	if options != nil && options.HeaderOne != nil {
+		req.Header.Set("header-one", *options.HeaderOne)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -14,9 +14,9 @@ import (
 // AutoRestReportServiceOperations contains the methods for the AutoRestReportService group.
 type AutoRestReportServiceOperations interface {
 	// GetOptionalReport - Get optional test coverage report
-	GetOptionalReport(ctx context.Context, autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error)
+	GetOptionalReport(ctx context.Context, options *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error)
 	// GetReport - Get test coverage report
-	GetReport(ctx context.Context, autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error)
+	GetReport(ctx context.Context, options *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error)
 }
 
 // AutoRestReportServiceClient implements the AutoRestReportServiceOperations interface.
@@ -36,8 +36,8 @@ func (client *AutoRestReportServiceClient) Do(req *azcore.Request) (*azcore.Resp
 }
 
 // GetOptionalReport - Get optional test coverage report
-func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context, autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.GetOptionalReportCreateRequest(ctx, autoRestReportServiceGetOptionalReportOptions)
+func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context, options *AutoRestReportServiceGetOptionalReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetOptionalReportCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -56,15 +56,15 @@ func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context
 }
 
 // GetOptionalReportCreateRequest creates the GetOptionalReport request.
-func (client *AutoRestReportServiceClient) GetOptionalReportCreateRequest(ctx context.Context, autoRestReportServiceGetOptionalReportOptions *AutoRestReportServiceGetOptionalReportOptions) (*azcore.Request, error) {
+func (client *AutoRestReportServiceClient) GetOptionalReportCreateRequest(ctx context.Context, options *AutoRestReportServiceGetOptionalReportOptions) (*azcore.Request, error) {
 	urlPath := "/report/optional"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if autoRestReportServiceGetOptionalReportOptions != nil && autoRestReportServiceGetOptionalReportOptions.Qualifier != nil {
-		query.Set("qualifier", *autoRestReportServiceGetOptionalReportOptions.Qualifier)
+	if options != nil && options.Qualifier != nil {
+		query.Set("qualifier", *options.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -87,8 +87,8 @@ func (client *AutoRestReportServiceClient) GetOptionalReportHandleError(resp *az
 }
 
 // GetReport - Get test coverage report
-func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error) {
-	req, err := client.GetReportCreateRequest(ctx, autoRestReportServiceGetReportOptions)
+func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, options *AutoRestReportServiceGetReportOptions) (*MapOfInt32Response, error) {
+	req, err := client.GetReportCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,15 +107,15 @@ func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, autoRe
 }
 
 // GetReportCreateRequest creates the GetReport request.
-func (client *AutoRestReportServiceClient) GetReportCreateRequest(ctx context.Context, autoRestReportServiceGetReportOptions *AutoRestReportServiceGetReportOptions) (*azcore.Request, error) {
+func (client *AutoRestReportServiceClient) GetReportCreateRequest(ctx context.Context, options *AutoRestReportServiceGetReportOptions) (*azcore.Request, error) {
 	urlPath := "/report"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if autoRestReportServiceGetReportOptions != nil && autoRestReportServiceGetReportOptions.Qualifier != nil {
-		query.Set("qualifier", *autoRestReportServiceGetReportOptions.Qualifier)
+	if options != nil && options.Qualifier != nil {
+		query.Set("qualifier", *options.Qualifier)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -16,7 +16,7 @@ func newEnumClient() EnumOperations {
 
 func TestEnumGetNotExpandable(t *testing.T) {
 	client := newEnumClient()
-	result, err := client.GetNotExpandable(context.Background())
+	result, err := client.GetNotExpandable(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNotExpandable: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestEnumGetNotExpandable(t *testing.T) {
 
 func TestEnumGetReferenced(t *testing.T) {
 	client := newEnumClient()
-	result, err := client.GetReferenced(context.Background())
+	result, err := client.GetReferenced(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetReferenced: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestEnumGetReferenced(t *testing.T) {
 
 func TestEnumGetReferencedConstant(t *testing.T) {
 	client := newEnumClient()
-	result, err := client.GetReferencedConstant(context.Background())
+	result, err := client.GetReferencedConstant(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetReferencedConstant: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestEnumGetReferencedConstant(t *testing.T) {
 
 func TestEnumPutNotExpandable(t *testing.T) {
 	client := newEnumClient()
-	result, err := client.PutNotExpandable(context.Background(), ColorsRedColor)
+	result, err := client.PutNotExpandable(context.Background(), ColorsRedColor, nil)
 	if err != nil {
 		t.Fatalf("PutNotExpandable: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestEnumPutNotExpandable(t *testing.T) {
 
 func TestEnumPutReferenced(t *testing.T) {
 	client := newEnumClient()
-	result, err := client.PutReferenced(context.Background(), ColorsRedColor)
+	result, err := client.PutReferenced(context.Background(), ColorsRedColor, nil)
 	if err != nil {
 		t.Fatalf("PutReferenced: %v", err)
 	}
@@ -66,7 +66,7 @@ func TestEnumPutReferenced(t *testing.T) {
 func TestEnumPutReferencedConstant(t *testing.T) {
 	client := newEnumClient()
 	val := string(ColorsGreenColor)
-	result, err := client.PutReferencedConstant(context.Background(), RefColorConstant{ColorConstant: &val})
+	result, err := client.PutReferencedConstant(context.Background(), RefColorConstant{ColorConstant: &val}, nil)
 	if err != nil {
 		t.Fatalf("PutReferencedConstant: %v", err)
 	}

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -18,7 +18,7 @@ func newStringClient() StringOperations {
 
 func TestStringGetMBCS(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetMBCS(context.Background())
+	result, err := client.GetMBCS(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetMBCS: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestStringGetMBCS(t *testing.T) {
 
 func TestStringPutMBCS(t *testing.T) {
 	client := newStringClient()
-	result, err := client.PutMBCS(context.Background())
+	result, err := client.PutMBCS(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutMBCS: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestStringPutMBCS(t *testing.T) {
 
 func TestStringGetBase64Encoded(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetBase64Encoded(context.Background())
+	result, err := client.GetBase64Encoded(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBase64Encoded: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestStringGetBase64Encoded(t *testing.T) {
 
 func TestStringGetBase64URLEncoded(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetBase64URLEncoded(context.Background())
+	result, err := client.GetBase64URLEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetBase64URLEncoded: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestStringGetBase64URLEncoded(t *testing.T) {
 
 func TestStringGetEmpty(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetEmpty(context.Background())
+	result, err := client.GetEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestStringGetEmpty(t *testing.T) {
 
 func TestStringGetNotProvided(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetNotProvided(context.Background())
+	result, err := client.GetNotProvided(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNotProvided: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestStringGetNotProvided(t *testing.T) {
 
 func TestStringGetNull(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetNull(context.Background())
+	result, err := client.GetNull(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNull: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestStringGetNull(t *testing.T) {
 
 func TestStringGetNullBase64URLEncoded(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetNullBase64URLEncoded(context.Background())
+	result, err := client.GetNullBase64URLEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetNullBase64URLEncoded: %v", err)
 	}
@@ -96,7 +96,7 @@ func TestStringGetNullBase64URLEncoded(t *testing.T) {
 
 func TestStringGetWhitespace(t *testing.T) {
 	client := newStringClient()
-	result, err := client.GetWhitespace(context.Background())
+	result, err := client.GetWhitespace(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetWhitespace: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestStringGetWhitespace(t *testing.T) {
 
 func TestStringPutBase64URLEncoded(t *testing.T) {
 	client := newStringClient()
-	result, err := client.PutBase64URLEncoded(context.Background(), []byte("a string that gets encoded with base64url"))
+	result, err := client.PutBase64URLEncoded(context.Background(), []byte("a string that gets encoded with base64url"), nil)
 	if err != nil {
 		t.Fatalf("PutBase64URLEncoded: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestStringPutBase64URLEncoded(t *testing.T) {
 
 func TestStringPutEmpty(t *testing.T) {
 	client := newStringClient()
-	result, err := client.PutEmpty(context.Background())
+	result, err := client.PutEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestStringPutNull(t *testing.T) {
 
 func TestStringPutWhitespace(t *testing.T) {
 	client := newStringClient()
-	result, err := client.PutWhitespace(context.Background())
+	result, err := client.PutWhitespace(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("PutWhitespace: %v", err)
 	}

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -14,17 +14,17 @@ import (
 // EnumOperations contains the methods for the Enum group.
 type EnumOperations interface {
 	// GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-	GetNotExpandable(ctx context.Context) (*ColorsResponse, error)
+	GetNotExpandable(ctx context.Context, options *EnumGetNotExpandableOptions) (*ColorsResponse, error)
 	// GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-	GetReferenced(ctx context.Context) (*ColorsResponse, error)
+	GetReferenced(ctx context.Context, options *EnumGetReferencedOptions) (*ColorsResponse, error)
 	// GetReferencedConstant - Get value 'green-color' from the constant.
-	GetReferencedConstant(ctx context.Context) (*RefColorConstantResponse, error)
+	GetReferencedConstant(ctx context.Context, options *EnumGetReferencedConstantOptions) (*RefColorConstantResponse, error)
 	// PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-	PutNotExpandable(ctx context.Context, stringBody Colors) (*http.Response, error)
+	PutNotExpandable(ctx context.Context, stringBody Colors, options *EnumPutNotExpandableOptions) (*http.Response, error)
 	// PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-	PutReferenced(ctx context.Context, enumStringBody Colors) (*http.Response, error)
+	PutReferenced(ctx context.Context, enumStringBody Colors, options *EnumPutReferencedOptions) (*http.Response, error)
 	// PutReferencedConstant - Sends value 'green-color' from a constant
-	PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error)
+	PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant, options *EnumPutReferencedConstantOptions) (*http.Response, error)
 }
 
 // EnumClient implements the EnumOperations interface.
@@ -44,8 +44,8 @@ func (client *EnumClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-func (client *EnumClient) GetNotExpandable(ctx context.Context) (*ColorsResponse, error) {
-	req, err := client.GetNotExpandableCreateRequest(ctx)
+func (client *EnumClient) GetNotExpandable(ctx context.Context, options *EnumGetNotExpandableOptions) (*ColorsResponse, error) {
+	req, err := client.GetNotExpandableCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (client *EnumClient) GetNotExpandable(ctx context.Context) (*ColorsResponse
 }
 
 // GetNotExpandableCreateRequest creates the GetNotExpandable request.
-func (client *EnumClient) GetNotExpandableCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *EnumClient) GetNotExpandableCreateRequest(ctx context.Context, options *EnumGetNotExpandableOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -90,8 +90,8 @@ func (client *EnumClient) GetNotExpandableHandleError(resp *azcore.Response) err
 }
 
 // GetReferenced - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
-func (client *EnumClient) GetReferenced(ctx context.Context) (*ColorsResponse, error) {
-	req, err := client.GetReferencedCreateRequest(ctx)
+func (client *EnumClient) GetReferenced(ctx context.Context, options *EnumGetReferencedOptions) (*ColorsResponse, error) {
+	req, err := client.GetReferencedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *EnumClient) GetReferenced(ctx context.Context) (*ColorsResponse, e
 }
 
 // GetReferencedCreateRequest creates the GetReferenced request.
-func (client *EnumClient) GetReferencedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *EnumClient) GetReferencedCreateRequest(ctx context.Context, options *EnumGetReferencedOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -136,8 +136,8 @@ func (client *EnumClient) GetReferencedHandleError(resp *azcore.Response) error 
 }
 
 // GetReferencedConstant - Get value 'green-color' from the constant.
-func (client *EnumClient) GetReferencedConstant(ctx context.Context) (*RefColorConstantResponse, error) {
-	req, err := client.GetReferencedConstantCreateRequest(ctx)
+func (client *EnumClient) GetReferencedConstant(ctx context.Context, options *EnumGetReferencedConstantOptions) (*RefColorConstantResponse, error) {
+	req, err := client.GetReferencedConstantCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (client *EnumClient) GetReferencedConstant(ctx context.Context) (*RefColorC
 }
 
 // GetReferencedConstantCreateRequest creates the GetReferencedConstant request.
-func (client *EnumClient) GetReferencedConstantCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *EnumClient) GetReferencedConstantCreateRequest(ctx context.Context, options *EnumGetReferencedConstantOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -182,8 +182,8 @@ func (client *EnumClient) GetReferencedConstantHandleError(resp *azcore.Response
 }
 
 // PutNotExpandable - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Colors) (*http.Response, error) {
-	req, err := client.PutNotExpandableCreateRequest(ctx, stringBody)
+func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Colors, options *EnumPutNotExpandableOptions) (*http.Response, error) {
+	req, err := client.PutNotExpandableCreateRequest(ctx, stringBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Color
 }
 
 // PutNotExpandableCreateRequest creates the PutNotExpandable request.
-func (client *EnumClient) PutNotExpandableCreateRequest(ctx context.Context, stringBody Colors) (*azcore.Request, error) {
+func (client *EnumClient) PutNotExpandableCreateRequest(ctx context.Context, stringBody Colors, options *EnumPutNotExpandableOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/notExpandable"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -218,8 +218,8 @@ func (client *EnumClient) PutNotExpandableHandleError(resp *azcore.Response) err
 }
 
 // PutReferenced - Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
-func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colors) (*http.Response, error) {
-	req, err := client.PutReferencedCreateRequest(ctx, enumStringBody)
+func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colors, options *EnumPutReferencedOptions) (*http.Response, error) {
+	req, err := client.PutReferencedCreateRequest(ctx, enumStringBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +234,7 @@ func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colo
 }
 
 // PutReferencedCreateRequest creates the PutReferenced request.
-func (client *EnumClient) PutReferencedCreateRequest(ctx context.Context, enumStringBody Colors) (*azcore.Request, error) {
+func (client *EnumClient) PutReferencedCreateRequest(ctx context.Context, enumStringBody Colors, options *EnumPutReferencedOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/Referenced"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -254,8 +254,8 @@ func (client *EnumClient) PutReferencedHandleError(resp *azcore.Response) error 
 }
 
 // PutReferencedConstant - Sends value 'green-color' from a constant
-func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant) (*http.Response, error) {
-	req, err := client.PutReferencedConstantCreateRequest(ctx, enumStringBody)
+func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringBody RefColorConstant, options *EnumPutReferencedConstantOptions) (*http.Response, error) {
+	req, err := client.PutReferencedConstantCreateRequest(ctx, enumStringBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringB
 }
 
 // PutReferencedConstantCreateRequest creates the PutReferencedConstant request.
-func (client *EnumClient) PutReferencedConstantCreateRequest(ctx context.Context, enumStringBody RefColorConstant) (*azcore.Request, error) {
+func (client *EnumClient) PutReferencedConstantCreateRequest(ctx context.Context, enumStringBody RefColorConstant, options *EnumPutReferencedConstantOptions) (*azcore.Request, error) {
 	urlPath := "/string/enum/ReferencedConstant"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/stringgroup/zz_generated_models.go
+++ b/test/autorest/stringgroup/zz_generated_models.go
@@ -24,6 +24,36 @@ type ColorsResponse struct {
 	Value       *Colors
 }
 
+// EnumGetNotExpandableOptions contains the optional parameters for the Enum.GetNotExpandable method.
+type EnumGetNotExpandableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// EnumGetReferencedConstantOptions contains the optional parameters for the Enum.GetReferencedConstant method.
+type EnumGetReferencedConstantOptions struct {
+	// placeholder for future optional parameters
+}
+
+// EnumGetReferencedOptions contains the optional parameters for the Enum.GetReferenced method.
+type EnumGetReferencedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// EnumPutNotExpandableOptions contains the optional parameters for the Enum.PutNotExpandable method.
+type EnumPutNotExpandableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// EnumPutReferencedConstantOptions contains the optional parameters for the Enum.PutReferencedConstant method.
+type EnumPutReferencedConstantOptions struct {
+	// placeholder for future optional parameters
+}
+
+// EnumPutReferencedOptions contains the optional parameters for the Enum.PutReferenced method.
+type EnumPutReferencedOptions struct {
+	// placeholder for future optional parameters
+}
+
 type Error struct {
 	Message *string `json:"message,omitempty"`
 	Status  *int32  `json:"status,omitempty"`
@@ -59,10 +89,70 @@ type RefColorConstantResponse struct {
 	RefColorConstant *RefColorConstant
 }
 
+// StringGetBase64EncodedOptions contains the optional parameters for the String.GetBase64Encoded method.
+type StringGetBase64EncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetBase64URLEncodedOptions contains the optional parameters for the String.GetBase64URLEncoded method.
+type StringGetBase64URLEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetEmptyOptions contains the optional parameters for the String.GetEmpty method.
+type StringGetEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetMBCSOptions contains the optional parameters for the String.GetMBCS method.
+type StringGetMBCSOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetNotProvidedOptions contains the optional parameters for the String.GetNotProvided method.
+type StringGetNotProvidedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetNullBase64URLEncodedOptions contains the optional parameters for the String.GetNullBase64URLEncoded method.
+type StringGetNullBase64URLEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetNullOptions contains the optional parameters for the String.GetNull method.
+type StringGetNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringGetWhitespaceOptions contains the optional parameters for the String.GetWhitespace method.
+type StringGetWhitespaceOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringPutBase64URLEncodedOptions contains the optional parameters for the String.PutBase64URLEncoded method.
+type StringPutBase64URLEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringPutEmptyOptions contains the optional parameters for the String.PutEmpty method.
+type StringPutEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// StringPutMBCSOptions contains the optional parameters for the String.PutMBCS method.
+type StringPutMBCSOptions struct {
+	// placeholder for future optional parameters
+}
+
 // StringPutNullOptions contains the optional parameters for the String.PutNull method.
 type StringPutNullOptions struct {
 	// string body
 	StringBody *string
+}
+
+// StringPutWhitespaceOptions contains the optional parameters for the String.PutWhitespace method.
+type StringPutWhitespaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // StringResponse is the response envelope for operations that return a string type.

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -14,31 +14,31 @@ import (
 // StringOperations contains the methods for the String group.
 type StringOperations interface {
 	// GetBase64Encoded - Get value that is base64 encoded
-	GetBase64Encoded(ctx context.Context) (*ByteArrayResponse, error)
+	GetBase64Encoded(ctx context.Context, options *StringGetBase64EncodedOptions) (*ByteArrayResponse, error)
 	// GetBase64URLEncoded - Get value that is base64url encoded
-	GetBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error)
+	GetBase64URLEncoded(ctx context.Context, options *StringGetBase64URLEncodedOptions) (*ByteArrayResponse, error)
 	// GetEmpty - Get empty string value value ''
-	GetEmpty(ctx context.Context) (*StringResponse, error)
+	GetEmpty(ctx context.Context, options *StringGetEmptyOptions) (*StringResponse, error)
 	// GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-	GetMBCS(ctx context.Context) (*StringResponse, error)
+	GetMBCS(ctx context.Context, options *StringGetMBCSOptions) (*StringResponse, error)
 	// GetNotProvided - Get String value when no string value is sent in response payload
-	GetNotProvided(ctx context.Context) (*StringResponse, error)
+	GetNotProvided(ctx context.Context, options *StringGetNotProvidedOptions) (*StringResponse, error)
 	// GetNull - Get null string value value
-	GetNull(ctx context.Context) (*StringResponse, error)
+	GetNull(ctx context.Context, options *StringGetNullOptions) (*StringResponse, error)
 	// GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
-	GetNullBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error)
+	GetNullBase64URLEncoded(ctx context.Context, options *StringGetNullBase64URLEncodedOptions) (*ByteArrayResponse, error)
 	// GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-	GetWhitespace(ctx context.Context) (*StringResponse, error)
+	GetWhitespace(ctx context.Context, options *StringGetWhitespaceOptions) (*StringResponse, error)
 	// PutBase64URLEncoded - Put value that is base64url encoded
-	PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error)
+	PutBase64URLEncoded(ctx context.Context, stringBody []byte, options *StringPutBase64URLEncodedOptions) (*http.Response, error)
 	// PutEmpty - Set string value empty ''
-	PutEmpty(ctx context.Context) (*http.Response, error)
+	PutEmpty(ctx context.Context, options *StringPutEmptyOptions) (*http.Response, error)
 	// PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-	PutMBCS(ctx context.Context) (*http.Response, error)
+	PutMBCS(ctx context.Context, options *StringPutMBCSOptions) (*http.Response, error)
 	// PutNull - Set string value null
-	PutNull(ctx context.Context, stringPutNullOptions *StringPutNullOptions) (*http.Response, error)
+	PutNull(ctx context.Context, options *StringPutNullOptions) (*http.Response, error)
 	// PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-	PutWhitespace(ctx context.Context) (*http.Response, error)
+	PutWhitespace(ctx context.Context, options *StringPutWhitespaceOptions) (*http.Response, error)
 }
 
 // StringClient implements the StringOperations interface.
@@ -58,8 +58,8 @@ func (client *StringClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetBase64Encoded - Get value that is base64 encoded
-func (client *StringClient) GetBase64Encoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetBase64EncodedCreateRequest(ctx)
+func (client *StringClient) GetBase64Encoded(ctx context.Context, options *StringGetBase64EncodedOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetBase64EncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (client *StringClient) GetBase64Encoded(ctx context.Context) (*ByteArrayRes
 }
 
 // GetBase64EncodedCreateRequest creates the GetBase64Encoded request.
-func (client *StringClient) GetBase64EncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetBase64EncodedCreateRequest(ctx context.Context, options *StringGetBase64EncodedOptions) (*azcore.Request, error) {
 	urlPath := "/string/base64Encoding"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -104,8 +104,8 @@ func (client *StringClient) GetBase64EncodedHandleError(resp *azcore.Response) e
 }
 
 // GetBase64URLEncoded - Get value that is base64url encoded
-func (client *StringClient) GetBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetBase64URLEncodedCreateRequest(ctx)
+func (client *StringClient) GetBase64URLEncoded(ctx context.Context, options *StringGetBase64URLEncodedOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetBase64URLEncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (client *StringClient) GetBase64URLEncoded(ctx context.Context) (*ByteArray
 }
 
 // GetBase64URLEncodedCreateRequest creates the GetBase64URLEncoded request.
-func (client *StringClient) GetBase64URLEncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetBase64URLEncodedCreateRequest(ctx context.Context, options *StringGetBase64URLEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -150,8 +150,8 @@ func (client *StringClient) GetBase64URLEncodedHandleError(resp *azcore.Response
 }
 
 // GetEmpty - Get empty string value value ''
-func (client *StringClient) GetEmpty(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetEmptyCreateRequest(ctx)
+func (client *StringClient) GetEmpty(ctx context.Context, options *StringGetEmptyOptions) (*StringResponse, error) {
+	req, err := client.GetEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (client *StringClient) GetEmpty(ctx context.Context) (*StringResponse, erro
 }
 
 // GetEmptyCreateRequest creates the GetEmpty request.
-func (client *StringClient) GetEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetEmptyCreateRequest(ctx context.Context, options *StringGetEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -196,8 +196,8 @@ func (client *StringClient) GetEmptyHandleError(resp *azcore.Response) error {
 }
 
 // GetMBCS - Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-func (client *StringClient) GetMBCS(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetMBCSCreateRequest(ctx)
+func (client *StringClient) GetMBCS(ctx context.Context, options *StringGetMBCSOptions) (*StringResponse, error) {
+	req, err := client.GetMBCSCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (client *StringClient) GetMBCS(ctx context.Context) (*StringResponse, error
 }
 
 // GetMBCSCreateRequest creates the GetMBCS request.
-func (client *StringClient) GetMBCSCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetMBCSCreateRequest(ctx context.Context, options *StringGetMBCSOptions) (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -242,8 +242,8 @@ func (client *StringClient) GetMBCSHandleError(resp *azcore.Response) error {
 }
 
 // GetNotProvided - Get String value when no string value is sent in response payload
-func (client *StringClient) GetNotProvided(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetNotProvidedCreateRequest(ctx)
+func (client *StringClient) GetNotProvided(ctx context.Context, options *StringGetNotProvidedOptions) (*StringResponse, error) {
+	req, err := client.GetNotProvidedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (client *StringClient) GetNotProvided(ctx context.Context) (*StringResponse
 }
 
 // GetNotProvidedCreateRequest creates the GetNotProvided request.
-func (client *StringClient) GetNotProvidedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetNotProvidedCreateRequest(ctx context.Context, options *StringGetNotProvidedOptions) (*azcore.Request, error) {
 	urlPath := "/string/notProvided"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -288,8 +288,8 @@ func (client *StringClient) GetNotProvidedHandleError(resp *azcore.Response) err
 }
 
 // GetNull - Get null string value value
-func (client *StringClient) GetNull(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetNullCreateRequest(ctx)
+func (client *StringClient) GetNull(ctx context.Context, options *StringGetNullOptions) (*StringResponse, error) {
+	req, err := client.GetNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (client *StringClient) GetNull(ctx context.Context) (*StringResponse, error
 }
 
 // GetNullCreateRequest creates the GetNull request.
-func (client *StringClient) GetNullCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetNullCreateRequest(ctx context.Context, options *StringGetNullOptions) (*azcore.Request, error) {
 	urlPath := "/string/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -334,8 +334,8 @@ func (client *StringClient) GetNullHandleError(resp *azcore.Response) error {
 }
 
 // GetNullBase64URLEncoded - Get null value that is expected to be base64url encoded
-func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context) (*ByteArrayResponse, error) {
-	req, err := client.GetNullBase64URLEncodedCreateRequest(ctx)
+func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context, options *StringGetNullBase64URLEncodedOptions) (*ByteArrayResponse, error) {
+	req, err := client.GetNullBase64URLEncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context) (*ByteA
 }
 
 // GetNullBase64URLEncodedCreateRequest creates the GetNullBase64URLEncoded request.
-func (client *StringClient) GetNullBase64URLEncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetNullBase64URLEncodedCreateRequest(ctx context.Context, options *StringGetNullBase64URLEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/string/nullBase64UrlEncoding"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -380,8 +380,8 @@ func (client *StringClient) GetNullBase64URLEncodedHandleError(resp *azcore.Resp
 }
 
 // GetWhitespace - Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-func (client *StringClient) GetWhitespace(ctx context.Context) (*StringResponse, error) {
-	req, err := client.GetWhitespaceCreateRequest(ctx)
+func (client *StringClient) GetWhitespace(ctx context.Context, options *StringGetWhitespaceOptions) (*StringResponse, error) {
+	req, err := client.GetWhitespaceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +400,7 @@ func (client *StringClient) GetWhitespace(ctx context.Context) (*StringResponse,
 }
 
 // GetWhitespaceCreateRequest creates the GetWhitespace request.
-func (client *StringClient) GetWhitespaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) GetWhitespaceCreateRequest(ctx context.Context, options *StringGetWhitespaceOptions) (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -426,8 +426,8 @@ func (client *StringClient) GetWhitespaceHandleError(resp *azcore.Response) erro
 }
 
 // PutBase64URLEncoded - Put value that is base64url encoded
-func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody []byte) (*http.Response, error) {
-	req, err := client.PutBase64URLEncodedCreateRequest(ctx, stringBody)
+func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody []byte, options *StringPutBase64URLEncodedOptions) (*http.Response, error) {
+	req, err := client.PutBase64URLEncodedCreateRequest(ctx, stringBody, options)
 	if err != nil {
 		return nil, err
 	}
@@ -442,7 +442,7 @@ func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody 
 }
 
 // PutBase64URLEncodedCreateRequest creates the PutBase64URLEncoded request.
-func (client *StringClient) PutBase64URLEncodedCreateRequest(ctx context.Context, stringBody []byte) (*azcore.Request, error) {
+func (client *StringClient) PutBase64URLEncodedCreateRequest(ctx context.Context, stringBody []byte, options *StringPutBase64URLEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/string/base64UrlEncoding"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -462,8 +462,8 @@ func (client *StringClient) PutBase64URLEncodedHandleError(resp *azcore.Response
 }
 
 // PutEmpty - Set string value empty ''
-func (client *StringClient) PutEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutEmptyCreateRequest(ctx)
+func (client *StringClient) PutEmpty(ctx context.Context, options *StringPutEmptyOptions) (*http.Response, error) {
+	req, err := client.PutEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +478,7 @@ func (client *StringClient) PutEmpty(ctx context.Context) (*http.Response, error
 }
 
 // PutEmptyCreateRequest creates the PutEmpty request.
-func (client *StringClient) PutEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) PutEmptyCreateRequest(ctx context.Context, options *StringPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -498,8 +498,8 @@ func (client *StringClient) PutEmptyHandleError(resp *azcore.Response) error {
 }
 
 // PutMBCS - Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-func (client *StringClient) PutMBCS(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutMBCSCreateRequest(ctx)
+func (client *StringClient) PutMBCS(ctx context.Context, options *StringPutMBCSOptions) (*http.Response, error) {
+	req, err := client.PutMBCSCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (client *StringClient) PutMBCS(ctx context.Context) (*http.Response, error)
 }
 
 // PutMBCSCreateRequest creates the PutMBCS request.
-func (client *StringClient) PutMBCSCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) PutMBCSCreateRequest(ctx context.Context, options *StringPutMBCSOptions) (*azcore.Request, error) {
 	urlPath := "/string/mbcs"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -534,8 +534,8 @@ func (client *StringClient) PutMBCSHandleError(resp *azcore.Response) error {
 }
 
 // PutNull - Set string value null
-func (client *StringClient) PutNull(ctx context.Context, stringPutNullOptions *StringPutNullOptions) (*http.Response, error) {
-	req, err := client.PutNullCreateRequest(ctx, stringPutNullOptions)
+func (client *StringClient) PutNull(ctx context.Context, options *StringPutNullOptions) (*http.Response, error) {
+	req, err := client.PutNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -550,15 +550,15 @@ func (client *StringClient) PutNull(ctx context.Context, stringPutNullOptions *S
 }
 
 // PutNullCreateRequest creates the PutNull request.
-func (client *StringClient) PutNullCreateRequest(ctx context.Context, stringPutNullOptions *StringPutNullOptions) (*azcore.Request, error) {
+func (client *StringClient) PutNullCreateRequest(ctx context.Context, options *StringPutNullOptions) (*azcore.Request, error) {
 	urlPath := "/string/null"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if stringPutNullOptions != nil {
-		return req, req.MarshalAsJSON(stringPutNullOptions.StringBody)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.StringBody)
 	}
 	return req, nil
 }
@@ -573,8 +573,8 @@ func (client *StringClient) PutNullHandleError(resp *azcore.Response) error {
 }
 
 // PutWhitespace - Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
-func (client *StringClient) PutWhitespace(ctx context.Context) (*http.Response, error) {
-	req, err := client.PutWhitespaceCreateRequest(ctx)
+func (client *StringClient) PutWhitespace(ctx context.Context, options *StringPutWhitespaceOptions) (*http.Response, error) {
+	req, err := client.PutWhitespaceCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -589,7 +589,7 @@ func (client *StringClient) PutWhitespace(ctx context.Context) (*http.Response, 
 }
 
 // PutWhitespaceCreateRequest creates the PutWhitespace request.
-func (client *StringClient) PutWhitespaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *StringClient) PutWhitespaceCreateRequest(ctx context.Context, options *StringPutWhitespaceOptions) (*azcore.Request, error) {
 	urlPath := "/string/whitespace"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -17,7 +17,7 @@ func newPathsClient() PathsOperations {
 
 func TestArrayCSVInPath(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.ArrayCSVInPath(context.Background(), []string{"ArrayPath1", "begin!*'();:@ &=+$,/?#[]end", "", ""})
+	result, err := client.ArrayCSVInPath(context.Background(), []string{"ArrayPath1", "begin!*'();:@ &=+$,/?#[]end", "", ""}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func TestArrayCSVInPath(t *testing.T) {
 
 func TestPathsBase64URL(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.Base64URL(context.Background(), []byte("lorem"))
+	result, err := client.Base64URL(context.Background(), []byte("lorem"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestPathsBase64URL(t *testing.T) {
 
 func TestPathsByteEmpty(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.ByteEmpty(context.Background())
+	result, err := client.ByteEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestPathsByteEmpty(t *testing.T) {
 
 func TestPathsByteMultiByte(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.ByteMultiByte(context.Background(), []byte("啊齄丂狛狜隣郎隣兀﨩"))
+	result, err := client.ByteMultiByte(context.Background(), []byte("啊齄丂狛狜隣郎隣兀﨩"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestPathsByteMultiByte(t *testing.T) {
 // TODO: check
 func TestPathsByteNull(t *testing.T) {
 	client := newPathsClient()
-	_, err := client.ByteNull(context.Background(), nil)
+	_, err := client.ByteNull(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatalf("Did not receive an error, but expected one")
 	}
@@ -63,7 +63,7 @@ func TestPathsByteNull(t *testing.T) {
 func TestPathsDateNull(t *testing.T) {
 	client := newPathsClient()
 	var time time.Time
-	result, err := client.DateNull(context.Background(), time)
+	result, err := client.DateNull(context.Background(), time, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestPathsDateNull(t *testing.T) {
 func TestPathsDateTimeNull(t *testing.T) {
 	client := newPathsClient()
 	var time time.Time
-	result, err := client.DateTimeNull(context.Background(), time)
+	result, err := client.DateTimeNull(context.Background(), time, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestPathsDateTimeNull(t *testing.T) {
 
 func TestPathsDateTimeValid(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.DateTimeValid(context.Background())
+	result, err := client.DateTimeValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestPathsDateTimeValid(t *testing.T) {
 
 func TestPathsDateValid(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.DateValid(context.Background())
+	result, err := client.DateValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestPathsDateValid(t *testing.T) {
 
 func TestPathsDoubleDecimalNegative(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.DoubleDecimalNegative(context.Background())
+	result, err := client.DoubleDecimalNegative(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestPathsDoubleDecimalNegative(t *testing.T) {
 
 func TestPathsDoubleDecimalPositive(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.DoubleDecimalPositive(context.Background())
+	result, err := client.DoubleDecimalPositive(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestPathsDoubleDecimalPositive(t *testing.T) {
 func TestPathsEnumNull(t *testing.T) {
 	client := newPathsClient()
 	var color URIColor
-	_, err := client.EnumNull(context.Background(), color)
+	_, err := client.EnumNull(context.Background(), color, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -128,7 +128,7 @@ func TestPathsEnumNull(t *testing.T) {
 func TestPathsEnumValid(t *testing.T) {
 	client := newPathsClient()
 	color := URIColorGreenColor
-	result, err := client.EnumValid(context.Background(), color)
+	result, err := client.EnumValid(context.Background(), color, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestPathsEnumValid(t *testing.T) {
 
 func TestPathsFloatScientificNegative(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.FloatScientificNegative(context.Background())
+	result, err := client.FloatScientificNegative(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestPathsFloatScientificNegative(t *testing.T) {
 
 func TestPathsFloatScientificPositive(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.FloatScientificPositive(context.Background())
+	result, err := client.FloatScientificPositive(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -155,7 +155,7 @@ func TestPathsFloatScientificPositive(t *testing.T) {
 
 func TestPathsGetBooleanFalse(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetBooleanFalse(context.Background())
+	result, err := client.GetBooleanFalse(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +164,7 @@ func TestPathsGetBooleanFalse(t *testing.T) {
 
 func TestPathsGetBooleanTrue(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetBooleanTrue(context.Background())
+	result, err := client.GetBooleanTrue(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestPathsGetBooleanTrue(t *testing.T) {
 
 func TestPathsGetIntNegativeOneMillion(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetIntNegativeOneMillion(context.Background())
+	result, err := client.GetIntNegativeOneMillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestPathsGetIntNegativeOneMillion(t *testing.T) {
 
 func TestPathsGetIntOneMillion(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetIntOneMillion(context.Background())
+	result, err := client.GetIntOneMillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestPathsGetIntOneMillion(t *testing.T) {
 
 func TestPathsGetNegativeTenBillion(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetNegativeTenBillion(context.Background())
+	result, err := client.GetNegativeTenBillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestPathsGetNegativeTenBillion(t *testing.T) {
 
 func TestPathsGetTenBillion(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.GetTenBillion(context.Background())
+	result, err := client.GetTenBillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestPathsGetTenBillion(t *testing.T) {
 
 func TestPathsStringEmpty(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.StringEmpty(context.Background())
+	result, err := client.StringEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestPathsStringEmpty(t *testing.T) {
 func TestPathsStringNull(t *testing.T) {
 	client := newPathsClient()
 	var s string
-	_, err := client.StringNull(context.Background(), s)
+	_, err := client.StringNull(context.Background(), s, nil)
 	if err == nil {
 		t.Fatalf("Expected an error but did not receive one")
 	}
@@ -227,7 +227,7 @@ func TestPathsStringNull(t *testing.T) {
 
 func TestPathsStringURLEncoded(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.StringURLEncoded(context.Background())
+	result, err := client.StringURLEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestPathsStringURLEncoded(t *testing.T) {
 
 func TestPathsStringURLNonEncoded(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.StringURLNonEncoded(context.Background())
+	result, err := client.StringURLNonEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestPathsStringURLNonEncoded(t *testing.T) {
 
 func TestPathsStringUnicode(t *testing.T) {
 	client := newPathsClient()
-	result, err := client.StringUnicode(context.Background())
+	result, err := client.StringUnicode(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestPathsUnixTimeURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result, err := client.UnixTimeURL(context.Background(), d)
+	result, err := client.UnixTimeURL(context.Background(), d, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -87,7 +87,7 @@ func TestArrayStringTsvValid(t *testing.T) {
 // ByteEmpty - Get '' as byte array
 func TestByteEmpty(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.ByteEmpty(context.Background())
+	result, err := client.ByteEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +139,7 @@ func TestDateTimeNull(t *testing.T) {
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 func TestDateTimeValid(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.DateTimeValid(context.Background())
+	result, err := client.DateTimeValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestDateTimeValid(t *testing.T) {
 // DateValid - Get '2012-01-01' as date
 func TestDateValid(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.DateValid(context.Background())
+	result, err := client.DateValid(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestDateValid(t *testing.T) {
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
 func TestDoubleDecimalNegative(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.DoubleDecimalNegative(context.Background())
+	result, err := client.DoubleDecimalNegative(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestDoubleDecimalNegative(t *testing.T) {
 // DoubleDecimalPositive - Get '9999999.999' numeric value
 func TestDoubleDecimalPositive(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.DoubleDecimalPositive(context.Background())
+	result, err := client.DoubleDecimalPositive(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestFloatNull(t *testing.T) {
 // FloatScientificNegative - Get '-1.034E-20' numeric value
 func TestFloatScientificNegative(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.FloatScientificNegative(context.Background())
+	result, err := client.FloatScientificNegative(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestFloatScientificNegative(t *testing.T) {
 // FloatScientificPositive - Get '1.034E+20' numeric value
 func TestFloatScientificPositive(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.FloatScientificPositive(context.Background())
+	result, err := client.FloatScientificPositive(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestFloatScientificPositive(t *testing.T) {
 // GetBooleanFalse - Get false Boolean value on path
 func TestGetBooleanFalse(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetBooleanFalse(context.Background())
+	result, err := client.GetBooleanFalse(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestGetBooleanNull(t *testing.T) {
 // GetBooleanTrue - Get true Boolean value on path
 func TestGetBooleanTrue(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetBooleanTrue(context.Background())
+	result, err := client.GetBooleanTrue(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestGetBooleanTrue(t *testing.T) {
 // GetIntNegativeOneMillion - Get '-1000000' integer value
 func TestGetIntNegativeOneMillion(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetIntNegativeOneMillion(context.Background())
+	result, err := client.GetIntNegativeOneMillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestGetIntNull(t *testing.T) {
 // GetIntOneMillion - Get '1000000' integer value
 func TestGetIntOneMillion(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetIntOneMillion(context.Background())
+	result, err := client.GetIntOneMillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func TestGetLongNull(t *testing.T) {
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 func TestGetNegativeTenBillion(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetNegativeTenBillion(context.Background())
+	result, err := client.GetNegativeTenBillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestGetNegativeTenBillion(t *testing.T) {
 // GetTenBillion - Get '10000000000' 64 bit integer value
 func TestGetTenBillion(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.GetTenBillion(context.Background())
+	result, err := client.GetTenBillion(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestGetTenBillion(t *testing.T) {
 // StringEmpty - Get ''
 func TestStringEmpty(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.StringEmpty(context.Background())
+	result, err := client.StringEmpty(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -351,7 +351,7 @@ func TestStringNull(t *testing.T) {
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 func TestStringURLEncoded(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.StringURLEncoded(context.Background())
+	result, err := client.StringURLEncoded(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestStringURLEncoded(t *testing.T) {
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
 func TestStringUnicode(t *testing.T) {
 	client := newQueriesClient()
-	result, err := client.StringUnicode(context.Background())
+	result, err := client.StringUnicode(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/urlgroup/zz_generated_models.go
+++ b/test/autorest/urlgroup/zz_generated_models.go
@@ -64,6 +64,141 @@ type PathItemsGetLocalPathItemQueryNullOptions struct {
 	PathItemStringQuery *string
 }
 
+// PathsArrayCSVInPathOptions contains the optional parameters for the Paths.ArrayCSVInPath method.
+type PathsArrayCSVInPathOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsBase64URLOptions contains the optional parameters for the Paths.Base64URL method.
+type PathsBase64URLOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsByteEmptyOptions contains the optional parameters for the Paths.ByteEmpty method.
+type PathsByteEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsByteMultiByteOptions contains the optional parameters for the Paths.ByteMultiByte method.
+type PathsByteMultiByteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsByteNullOptions contains the optional parameters for the Paths.ByteNull method.
+type PathsByteNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDateNullOptions contains the optional parameters for the Paths.DateNull method.
+type PathsDateNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDateTimeNullOptions contains the optional parameters for the Paths.DateTimeNull method.
+type PathsDateTimeNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDateTimeValidOptions contains the optional parameters for the Paths.DateTimeValid method.
+type PathsDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDateValidOptions contains the optional parameters for the Paths.DateValid method.
+type PathsDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDoubleDecimalNegativeOptions contains the optional parameters for the Paths.DoubleDecimalNegative method.
+type PathsDoubleDecimalNegativeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsDoubleDecimalPositiveOptions contains the optional parameters for the Paths.DoubleDecimalPositive method.
+type PathsDoubleDecimalPositiveOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsEnumNullOptions contains the optional parameters for the Paths.EnumNull method.
+type PathsEnumNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsEnumValidOptions contains the optional parameters for the Paths.EnumValid method.
+type PathsEnumValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsFloatScientificNegativeOptions contains the optional parameters for the Paths.FloatScientificNegative method.
+type PathsFloatScientificNegativeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsFloatScientificPositiveOptions contains the optional parameters for the Paths.FloatScientificPositive method.
+type PathsFloatScientificPositiveOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetBooleanFalseOptions contains the optional parameters for the Paths.GetBooleanFalse method.
+type PathsGetBooleanFalseOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetBooleanTrueOptions contains the optional parameters for the Paths.GetBooleanTrue method.
+type PathsGetBooleanTrueOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetIntNegativeOneMillionOptions contains the optional parameters for the Paths.GetIntNegativeOneMillion method.
+type PathsGetIntNegativeOneMillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetIntOneMillionOptions contains the optional parameters for the Paths.GetIntOneMillion method.
+type PathsGetIntOneMillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetNegativeTenBillionOptions contains the optional parameters for the Paths.GetNegativeTenBillion method.
+type PathsGetNegativeTenBillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsGetTenBillionOptions contains the optional parameters for the Paths.GetTenBillion method.
+type PathsGetTenBillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsStringEmptyOptions contains the optional parameters for the Paths.StringEmpty method.
+type PathsStringEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsStringNullOptions contains the optional parameters for the Paths.StringNull method.
+type PathsStringNullOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsStringURLEncodedOptions contains the optional parameters for the Paths.StringURLEncoded method.
+type PathsStringURLEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsStringURLNonEncodedOptions contains the optional parameters for the Paths.StringURLNonEncoded method.
+type PathsStringURLNonEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsStringUnicodeOptions contains the optional parameters for the Paths.StringUnicode method.
+type PathsStringUnicodeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PathsUnixTimeURLOptions contains the optional parameters for the Paths.UnixTimeURL method.
+type PathsUnixTimeURLOptions struct {
+	// placeholder for future optional parameters
+}
+
 // QueriesArrayStringCSVEmptyOptions contains the optional parameters for the Queries.ArrayStringCSVEmpty method.
 type QueriesArrayStringCSVEmptyOptions struct {
 	// an empty array [] of string using the csv-array format
@@ -107,6 +242,11 @@ type QueriesArrayStringTsvValidOptions struct {
 	ArrayQuery *[]string
 }
 
+// QueriesByteEmptyOptions contains the optional parameters for the Queries.ByteEmpty method.
+type QueriesByteEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // QueriesByteMultiByteOptions contains the optional parameters for the Queries.ByteMultiByte method.
 type QueriesByteMultiByteOptions struct {
 	// '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
@@ -129,6 +269,26 @@ type QueriesDateNullOptions struct {
 type QueriesDateTimeNullOptions struct {
 	// null as date-time (no query parameters)
 	DateTimeQuery *time.Time
+}
+
+// QueriesDateTimeValidOptions contains the optional parameters for the Queries.DateTimeValid method.
+type QueriesDateTimeValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesDateValidOptions contains the optional parameters for the Queries.DateValid method.
+type QueriesDateValidOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesDoubleDecimalNegativeOptions contains the optional parameters for the Queries.DoubleDecimalNegative method.
+type QueriesDoubleDecimalNegativeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesDoubleDecimalPositiveOptions contains the optional parameters for the Queries.DoubleDecimalPositive method.
+type QueriesDoubleDecimalPositiveOptions struct {
+	// placeholder for future optional parameters
 }
 
 // QueriesDoubleNullOptions contains the optional parameters for the Queries.DoubleNull method.
@@ -155,10 +315,35 @@ type QueriesFloatNullOptions struct {
 	FloatQuery *float32
 }
 
+// QueriesFloatScientificNegativeOptions contains the optional parameters for the Queries.FloatScientificNegative method.
+type QueriesFloatScientificNegativeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesFloatScientificPositiveOptions contains the optional parameters for the Queries.FloatScientificPositive method.
+type QueriesFloatScientificPositiveOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesGetBooleanFalseOptions contains the optional parameters for the Queries.GetBooleanFalse method.
+type QueriesGetBooleanFalseOptions struct {
+	// placeholder for future optional parameters
+}
+
 // QueriesGetBooleanNullOptions contains the optional parameters for the Queries.GetBooleanNull method.
 type QueriesGetBooleanNullOptions struct {
 	// null boolean value
 	BoolQuery *bool
+}
+
+// QueriesGetBooleanTrueOptions contains the optional parameters for the Queries.GetBooleanTrue method.
+type QueriesGetBooleanTrueOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesGetIntNegativeOneMillionOptions contains the optional parameters for the Queries.GetIntNegativeOneMillion method.
+type QueriesGetIntNegativeOneMillionOptions struct {
+	// placeholder for future optional parameters
 }
 
 // QueriesGetIntNullOptions contains the optional parameters for the Queries.GetIntNull method.
@@ -167,14 +352,44 @@ type QueriesGetIntNullOptions struct {
 	IntQuery *int32
 }
 
+// QueriesGetIntOneMillionOptions contains the optional parameters for the Queries.GetIntOneMillion method.
+type QueriesGetIntOneMillionOptions struct {
+	// placeholder for future optional parameters
+}
+
 // QueriesGetLongNullOptions contains the optional parameters for the Queries.GetLongNull method.
 type QueriesGetLongNullOptions struct {
 	// null 64 bit integer value
 	LongQuery *int64
 }
 
+// QueriesGetNegativeTenBillionOptions contains the optional parameters for the Queries.GetNegativeTenBillion method.
+type QueriesGetNegativeTenBillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesGetTenBillionOptions contains the optional parameters for the Queries.GetTenBillion method.
+type QueriesGetTenBillionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesStringEmptyOptions contains the optional parameters for the Queries.StringEmpty method.
+type QueriesStringEmptyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // QueriesStringNullOptions contains the optional parameters for the Queries.StringNull method.
 type QueriesStringNullOptions struct {
 	// null string value
 	StringQuery *string
+}
+
+// QueriesStringURLEncodedOptions contains the optional parameters for the Queries.StringURLEncoded method.
+type QueriesStringURLEncodedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// QueriesStringUnicodeOptions contains the optional parameters for the Queries.StringUnicode method.
+type QueriesStringUnicodeOptions struct {
+	// placeholder for future optional parameters
 }

--- a/test/autorest/urlgroup/zz_generated_pathitems.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems.go
@@ -16,13 +16,13 @@ import (
 // PathItemsOperations contains the methods for the PathItems group.
 type PathItemsOperations interface {
 	// GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetAllWithValuesOptions *PathItemsGetAllWithValuesOptions) (*http.Response, error)
+	GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error)
 	// GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalAndLocalQueryNullOptions *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error)
+	GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error)
 	// GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalQueryNullOptions *PathItemsGetGlobalQueryNullOptions) (*http.Response, error)
+	GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error)
 	// GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetLocalPathItemQueryNullOptions *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error)
+	GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error)
 }
 
 // PathItemsClient implements the PathItemsOperations interface.
@@ -44,8 +44,8 @@ func (client *PathItemsClient) Do(req *azcore.Request) (*azcore.Response, error)
 }
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetAllWithValuesOptions *PathItemsGetAllWithValuesOptions) (*http.Response, error) {
-	req, err := client.GetAllWithValuesCreateRequest(ctx, pathItemStringPath, localStringPath, pathItemsGetAllWithValuesOptions)
+func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*http.Response, error) {
+	req, err := client.GetAllWithValuesCreateRequest(ctx, pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStr
 }
 
 // GetAllWithValuesCreateRequest creates the GetAllWithValues request.
-func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetAllWithValuesOptions *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
+func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetAllWithValuesOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
@@ -70,14 +70,14 @@ func (client *PathItemsClient) GetAllWithValuesCreateRequest(ctx context.Context
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pathItemsGetAllWithValuesOptions != nil && pathItemsGetAllWithValuesOptions.PathItemStringQuery != nil {
-		query.Set("pathItemStringQuery", *pathItemsGetAllWithValuesOptions.PathItemStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
 	if client.globalStringQuery != nil {
 		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
-	if pathItemsGetAllWithValuesOptions != nil && pathItemsGetAllWithValuesOptions.LocalStringQuery != nil {
-		query.Set("localStringQuery", *pathItemsGetAllWithValuesOptions.LocalStringQuery)
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -94,8 +94,8 @@ func (client *PathItemsClient) GetAllWithValuesHandleError(resp *azcore.Response
 }
 
 // GetGlobalAndLocalQueryNull - send globalStringPath=globalStringPath, pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery=null
-func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalAndLocalQueryNullOptions *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error) {
-	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, pathItemsGetGlobalAndLocalQueryNullOptions)
+func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*http.Response, error) {
+	req, err := client.GetGlobalAndLocalQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, p
 }
 
 // GetGlobalAndLocalQueryNullCreateRequest creates the GetGlobalAndLocalQueryNull request.
-func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalAndLocalQueryNullOptions *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
+func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalAndLocalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
@@ -120,14 +120,14 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullCreateRequest(ctx conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pathItemsGetGlobalAndLocalQueryNullOptions != nil && pathItemsGetGlobalAndLocalQueryNullOptions.PathItemStringQuery != nil {
-		query.Set("pathItemStringQuery", *pathItemsGetGlobalAndLocalQueryNullOptions.PathItemStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
 	if client.globalStringQuery != nil {
 		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
-	if pathItemsGetGlobalAndLocalQueryNullOptions != nil && pathItemsGetGlobalAndLocalQueryNullOptions.LocalStringQuery != nil {
-		query.Set("localStringQuery", *pathItemsGetGlobalAndLocalQueryNullOptions.LocalStringQuery)
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -144,8 +144,8 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNullHandleError(resp *azcor
 }
 
 // GetGlobalQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery=null, pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
-func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalQueryNullOptions *PathItemsGetGlobalQueryNullOptions) (*http.Response, error) {
-	req, err := client.GetGlobalQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, pathItemsGetGlobalQueryNullOptions)
+func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*http.Response, error) {
+	req, err := client.GetGlobalQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemS
 }
 
 // GetGlobalQueryNullCreateRequest creates the GetGlobalQueryNull request.
-func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetGlobalQueryNullOptions *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
+func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetGlobalQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
@@ -170,14 +170,14 @@ func (client *PathItemsClient) GetGlobalQueryNullCreateRequest(ctx context.Conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pathItemsGetGlobalQueryNullOptions != nil && pathItemsGetGlobalQueryNullOptions.PathItemStringQuery != nil {
-		query.Set("pathItemStringQuery", *pathItemsGetGlobalQueryNullOptions.PathItemStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
 	if client.globalStringQuery != nil {
 		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
-	if pathItemsGetGlobalQueryNullOptions != nil && pathItemsGetGlobalQueryNullOptions.LocalStringQuery != nil {
-		query.Set("localStringQuery", *pathItemsGetGlobalQueryNullOptions.LocalStringQuery)
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -194,8 +194,8 @@ func (client *PathItemsClient) GetGlobalQueryNullHandleError(resp *azcore.Respon
 }
 
 // GetLocalPathItemQueryNull - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath', globalStringQuery='globalStringQuery', pathItemStringQuery=null, localStringQuery=null
-func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetLocalPathItemQueryNullOptions *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error) {
-	req, err := client.GetLocalPathItemQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, pathItemsGetLocalPathItemQueryNullOptions)
+func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*http.Response, error) {
+	req, err := client.GetLocalPathItemQueryNullCreateRequest(ctx, pathItemStringPath, localStringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pa
 }
 
 // GetLocalPathItemQueryNullCreateRequest creates the GetLocalPathItemQueryNull request.
-func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, pathItemsGetLocalPathItemQueryNullOptions *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
+func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx context.Context, pathItemStringPath string, localStringPath string, options *PathItemsGetLocalPathItemQueryNullOptions) (*azcore.Request, error) {
 	urlPath := "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null"
 	urlPath = strings.ReplaceAll(urlPath, "{pathItemStringPath}", url.PathEscape(pathItemStringPath))
 	urlPath = strings.ReplaceAll(urlPath, "{globalStringPath}", url.PathEscape(client.globalStringPath))
@@ -220,14 +220,14 @@ func (client *PathItemsClient) GetLocalPathItemQueryNullCreateRequest(ctx contex
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pathItemsGetLocalPathItemQueryNullOptions != nil && pathItemsGetLocalPathItemQueryNullOptions.PathItemStringQuery != nil {
-		query.Set("pathItemStringQuery", *pathItemsGetLocalPathItemQueryNullOptions.PathItemStringQuery)
+	if options != nil && options.PathItemStringQuery != nil {
+		query.Set("pathItemStringQuery", *options.PathItemStringQuery)
 	}
 	if client.globalStringQuery != nil {
 		query.Set("globalStringQuery", *client.globalStringQuery)
 	}
-	if pathItemsGetLocalPathItemQueryNullOptions != nil && pathItemsGetLocalPathItemQueryNullOptions.LocalStringQuery != nil {
-		query.Set("localStringQuery", *pathItemsGetLocalPathItemQueryNullOptions.LocalStringQuery)
+	if options != nil && options.LocalStringQuery != nil {
+		query.Set("localStringQuery", *options.LocalStringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/autorest/urlgroup/zz_generated_paths.go
+++ b/test/autorest/urlgroup/zz_generated_paths.go
@@ -18,59 +18,59 @@ import (
 // PathsOperations contains the methods for the Paths group.
 type PathsOperations interface {
 	// ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-	ArrayCSVInPath(ctx context.Context, arrayPath []string) (*http.Response, error)
+	ArrayCSVInPath(ctx context.Context, arrayPath []string, options *PathsArrayCSVInPathOptions) (*http.Response, error)
 	// Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
-	Base64URL(ctx context.Context, base64UrlPath []byte) (*http.Response, error)
+	Base64URL(ctx context.Context, base64UrlPath []byte, options *PathsBase64URLOptions) (*http.Response, error)
 	// ByteEmpty - Get '' as byte array
-	ByteEmpty(ctx context.Context) (*http.Response, error)
+	ByteEmpty(ctx context.Context, options *PathsByteEmptyOptions) (*http.Response, error)
 	// ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-	ByteMultiByte(ctx context.Context, bytePath []byte) (*http.Response, error)
+	ByteMultiByte(ctx context.Context, bytePath []byte, options *PathsByteMultiByteOptions) (*http.Response, error)
 	// ByteNull - Get null as byte array (should throw)
-	ByteNull(ctx context.Context, bytePath []byte) (*http.Response, error)
+	ByteNull(ctx context.Context, bytePath []byte, options *PathsByteNullOptions) (*http.Response, error)
 	// DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
-	DateNull(ctx context.Context, datePath time.Time) (*http.Response, error)
+	DateNull(ctx context.Context, datePath time.Time, options *PathsDateNullOptions) (*http.Response, error)
 	// DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
-	DateTimeNull(ctx context.Context, dateTimePath time.Time) (*http.Response, error)
+	DateTimeNull(ctx context.Context, dateTimePath time.Time, options *PathsDateTimeNullOptions) (*http.Response, error)
 	// DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-	DateTimeValid(ctx context.Context) (*http.Response, error)
+	DateTimeValid(ctx context.Context, options *PathsDateTimeValidOptions) (*http.Response, error)
 	// DateValid - Get '2012-01-01' as date
-	DateValid(ctx context.Context) (*http.Response, error)
+	DateValid(ctx context.Context, options *PathsDateValidOptions) (*http.Response, error)
 	// DoubleDecimalNegative - Get '-9999999.999' numeric value
-	DoubleDecimalNegative(ctx context.Context) (*http.Response, error)
+	DoubleDecimalNegative(ctx context.Context, options *PathsDoubleDecimalNegativeOptions) (*http.Response, error)
 	// DoubleDecimalPositive - Get '9999999.999' numeric value
-	DoubleDecimalPositive(ctx context.Context) (*http.Response, error)
+	DoubleDecimalPositive(ctx context.Context, options *PathsDoubleDecimalPositiveOptions) (*http.Response, error)
 	// EnumNull - Get null (should throw on the client before the request is sent on wire)
-	EnumNull(ctx context.Context, enumPath URIColor) (*http.Response, error)
+	EnumNull(ctx context.Context, enumPath URIColor, options *PathsEnumNullOptions) (*http.Response, error)
 	// EnumValid - Get using uri with 'green color' in path parameter
-	EnumValid(ctx context.Context, enumPath URIColor) (*http.Response, error)
+	EnumValid(ctx context.Context, enumPath URIColor, options *PathsEnumValidOptions) (*http.Response, error)
 	// FloatScientificNegative - Get '-1.034E-20' numeric value
-	FloatScientificNegative(ctx context.Context) (*http.Response, error)
+	FloatScientificNegative(ctx context.Context, options *PathsFloatScientificNegativeOptions) (*http.Response, error)
 	// FloatScientificPositive - Get '1.034E+20' numeric value
-	FloatScientificPositive(ctx context.Context) (*http.Response, error)
+	FloatScientificPositive(ctx context.Context, options *PathsFloatScientificPositiveOptions) (*http.Response, error)
 	// GetBooleanFalse - Get false Boolean value on path
-	GetBooleanFalse(ctx context.Context) (*http.Response, error)
+	GetBooleanFalse(ctx context.Context, options *PathsGetBooleanFalseOptions) (*http.Response, error)
 	// GetBooleanTrue - Get true Boolean value on path
-	GetBooleanTrue(ctx context.Context) (*http.Response, error)
+	GetBooleanTrue(ctx context.Context, options *PathsGetBooleanTrueOptions) (*http.Response, error)
 	// GetIntNegativeOneMillion - Get '-1000000' integer value
-	GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error)
+	GetIntNegativeOneMillion(ctx context.Context, options *PathsGetIntNegativeOneMillionOptions) (*http.Response, error)
 	// GetIntOneMillion - Get '1000000' integer value
-	GetIntOneMillion(ctx context.Context) (*http.Response, error)
+	GetIntOneMillion(ctx context.Context, options *PathsGetIntOneMillionOptions) (*http.Response, error)
 	// GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-	GetNegativeTenBillion(ctx context.Context) (*http.Response, error)
+	GetNegativeTenBillion(ctx context.Context, options *PathsGetNegativeTenBillionOptions) (*http.Response, error)
 	// GetTenBillion - Get '10000000000' 64 bit integer value
-	GetTenBillion(ctx context.Context) (*http.Response, error)
+	GetTenBillion(ctx context.Context, options *PathsGetTenBillionOptions) (*http.Response, error)
 	// StringEmpty - Get ''
-	StringEmpty(ctx context.Context) (*http.Response, error)
+	StringEmpty(ctx context.Context, options *PathsStringEmptyOptions) (*http.Response, error)
 	// StringNull - Get null (should throw)
-	StringNull(ctx context.Context, stringPath string) (*http.Response, error)
+	StringNull(ctx context.Context, stringPath string, options *PathsStringNullOptions) (*http.Response, error)
 	// StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-	StringURLEncoded(ctx context.Context) (*http.Response, error)
+	StringURLEncoded(ctx context.Context, options *PathsStringURLEncodedOptions) (*http.Response, error)
 	// StringURLNonEncoded - https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded
-	StringURLNonEncoded(ctx context.Context) (*http.Response, error)
+	StringURLNonEncoded(ctx context.Context, options *PathsStringURLNonEncodedOptions) (*http.Response, error)
 	// StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-	StringUnicode(ctx context.Context) (*http.Response, error)
+	StringUnicode(ctx context.Context, options *PathsStringUnicodeOptions) (*http.Response, error)
 	// UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
-	UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*http.Response, error)
+	UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time, options *PathsUnixTimeURLOptions) (*http.Response, error)
 }
 
 // PathsClient implements the PathsOperations interface.
@@ -90,8 +90,8 @@ func (client *PathsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []string) (*http.Response, error) {
-	req, err := client.ArrayCSVInPathCreateRequest(ctx, arrayPath)
+func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []string, options *PathsArrayCSVInPathOptions) (*http.Response, error) {
+	req, err := client.ArrayCSVInPathCreateRequest(ctx, arrayPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 }
 
 // ArrayCSVInPathCreateRequest creates the ArrayCSVInPath request.
-func (client *PathsClient) ArrayCSVInPathCreateRequest(ctx context.Context, arrayPath []string) (*azcore.Request, error) {
+func (client *PathsClient) ArrayCSVInPathCreateRequest(ctx context.Context, arrayPath []string, options *PathsArrayCSVInPathOptions) (*azcore.Request, error) {
 	urlPath := "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{arrayPath}", url.PathEscape(strings.Join(arrayPath, ",")))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -127,8 +127,8 @@ func (client *PathsClient) ArrayCSVInPathHandleError(resp *azcore.Response) erro
 }
 
 // Base64URL - Get 'lorem' encoded value as 'bG9yZW0' (base64url)
-func (client *PathsClient) Base64URL(ctx context.Context, base64UrlPath []byte) (*http.Response, error) {
-	req, err := client.Base64URLCreateRequest(ctx, base64UrlPath)
+func (client *PathsClient) Base64URL(ctx context.Context, base64UrlPath []byte, options *PathsBase64URLOptions) (*http.Response, error) {
+	req, err := client.Base64URLCreateRequest(ctx, base64UrlPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (client *PathsClient) Base64URL(ctx context.Context, base64UrlPath []byte) 
 }
 
 // Base64URLCreateRequest creates the Base64URL request.
-func (client *PathsClient) Base64URLCreateRequest(ctx context.Context, base64UrlPath []byte) (*azcore.Request, error) {
+func (client *PathsClient) Base64URLCreateRequest(ctx context.Context, base64UrlPath []byte, options *PathsBase64URLOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/bG9yZW0/{base64UrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{base64UrlPath}", url.PathEscape(base64.RawURLEncoding.EncodeToString(base64UrlPath)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -164,8 +164,8 @@ func (client *PathsClient) Base64URLHandleError(resp *azcore.Response) error {
 }
 
 // ByteEmpty - Get '' as byte array
-func (client *PathsClient) ByteEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.ByteEmptyCreateRequest(ctx)
+func (client *PathsClient) ByteEmpty(ctx context.Context, options *PathsByteEmptyOptions) (*http.Response, error) {
+	req, err := client.ByteEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (client *PathsClient) ByteEmpty(ctx context.Context) (*http.Response, error
 }
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
-func (client *PathsClient) ByteEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) ByteEmptyCreateRequest(ctx context.Context, options *PathsByteEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/paths/byte/empty/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(""))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -201,8 +201,8 @@ func (client *PathsClient) ByteEmptyHandleError(resp *azcore.Response) error {
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte) (*http.Response, error) {
-	req, err := client.ByteMultiByteCreateRequest(ctx, bytePath)
+func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte, options *PathsByteMultiByteOptions) (*http.Response, error) {
+	req, err := client.ByteMultiByteCreateRequest(ctx, bytePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte) (
 }
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
-func (client *PathsClient) ByteMultiByteCreateRequest(ctx context.Context, bytePath []byte) (*azcore.Request, error) {
+func (client *PathsClient) ByteMultiByteCreateRequest(ctx context.Context, bytePath []byte, options *PathsByteMultiByteOptions) (*azcore.Request, error) {
 	urlPath := "/paths/byte/multibyte/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -238,8 +238,8 @@ func (client *PathsClient) ByteMultiByteHandleError(resp *azcore.Response) error
 }
 
 // ByteNull - Get null as byte array (should throw)
-func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte) (*http.Response, error) {
-	req, err := client.ByteNullCreateRequest(ctx, bytePath)
+func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte, options *PathsByteNullOptions) (*http.Response, error) {
+	req, err := client.ByteNullCreateRequest(ctx, bytePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte) (*http
 }
 
 // ByteNullCreateRequest creates the ByteNull request.
-func (client *PathsClient) ByteNullCreateRequest(ctx context.Context, bytePath []byte) (*azcore.Request, error) {
+func (client *PathsClient) ByteNullCreateRequest(ctx context.Context, bytePath []byte, options *PathsByteNullOptions) (*azcore.Request, error) {
 	urlPath := "/paths/byte/null/{bytePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{bytePath}", url.PathEscape(base64.StdEncoding.EncodeToString(bytePath)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -275,8 +275,8 @@ func (client *PathsClient) ByteNullHandleError(resp *azcore.Response) error {
 }
 
 // DateNull - Get null as date - this should throw or be unusable on the client side, depending on date representation
-func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time) (*http.Response, error) {
-	req, err := client.DateNullCreateRequest(ctx, datePath)
+func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time, options *PathsDateNullOptions) (*http.Response, error) {
+	req, err := client.DateNullCreateRequest(ctx, datePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time) (*h
 }
 
 // DateNullCreateRequest creates the DateNull request.
-func (client *PathsClient) DateNullCreateRequest(ctx context.Context, datePath time.Time) (*azcore.Request, error) {
+func (client *PathsClient) DateNullCreateRequest(ctx context.Context, datePath time.Time, options *PathsDateNullOptions) (*azcore.Request, error) {
 	urlPath := "/paths/date/null/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape(datePath.Format("2006-01-02")))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -312,8 +312,8 @@ func (client *PathsClient) DateNullHandleError(resp *azcore.Response) error {
 }
 
 // DateTimeNull - Get null as date-time, should be disallowed or throw depending on representation of date-time
-func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.Time) (*http.Response, error) {
-	req, err := client.DateTimeNullCreateRequest(ctx, dateTimePath)
+func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.Time, options *PathsDateTimeNullOptions) (*http.Response, error) {
+	req, err := client.DateTimeNullCreateRequest(ctx, dateTimePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +328,7 @@ func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.T
 }
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
-func (client *PathsClient) DateTimeNullCreateRequest(ctx context.Context, dateTimePath time.Time) (*azcore.Request, error) {
+func (client *PathsClient) DateTimeNullCreateRequest(ctx context.Context, dateTimePath time.Time, options *PathsDateTimeNullOptions) (*azcore.Request, error) {
 	urlPath := "/paths/datetime/null/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape(dateTimePath.Format(time.RFC3339Nano)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -349,8 +349,8 @@ func (client *PathsClient) DateTimeNullHandleError(resp *azcore.Response) error 
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-func (client *PathsClient) DateTimeValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.DateTimeValidCreateRequest(ctx)
+func (client *PathsClient) DateTimeValid(ctx context.Context, options *PathsDateTimeValidOptions) (*http.Response, error) {
+	req, err := client.DateTimeValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (client *PathsClient) DateTimeValid(ctx context.Context) (*http.Response, e
 }
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
-func (client *PathsClient) DateTimeValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) DateTimeValidCreateRequest(ctx context.Context, options *PathsDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{dateTimePath}", url.PathEscape("2012-01-01T01:01:01Z"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -386,8 +386,8 @@ func (client *PathsClient) DateTimeValidHandleError(resp *azcore.Response) error
 }
 
 // DateValid - Get '2012-01-01' as date
-func (client *PathsClient) DateValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.DateValidCreateRequest(ctx)
+func (client *PathsClient) DateValid(ctx context.Context, options *PathsDateValidOptions) (*http.Response, error) {
+	req, err := client.DateValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (client *PathsClient) DateValid(ctx context.Context) (*http.Response, error
 }
 
 // DateValidCreateRequest creates the DateValid request.
-func (client *PathsClient) DateValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) DateValidCreateRequest(ctx context.Context, options *PathsDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/paths/date/2012-01-01/{datePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{datePath}", url.PathEscape("2012-01-01"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -423,8 +423,8 @@ func (client *PathsClient) DateValidHandleError(resp *azcore.Response) error {
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
-func (client *PathsClient) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.DoubleDecimalNegativeCreateRequest(ctx)
+func (client *PathsClient) DoubleDecimalNegative(ctx context.Context, options *PathsDoubleDecimalNegativeOptions) (*http.Response, error) {
+	req, err := client.DoubleDecimalNegativeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +439,7 @@ func (client *PathsClient) DoubleDecimalNegative(ctx context.Context) (*http.Res
 }
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
-func (client *PathsClient) DoubleDecimalNegativeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) DoubleDecimalNegativeCreateRequest(ctx context.Context, options *PathsDoubleDecimalNegativeOptions) (*azcore.Request, error) {
 	urlPath := "/paths/double/-9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("-9999999.999"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -460,8 +460,8 @@ func (client *PathsClient) DoubleDecimalNegativeHandleError(resp *azcore.Respons
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
-func (client *PathsClient) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.DoubleDecimalPositiveCreateRequest(ctx)
+func (client *PathsClient) DoubleDecimalPositive(ctx context.Context, options *PathsDoubleDecimalPositiveOptions) (*http.Response, error) {
+	req, err := client.DoubleDecimalPositiveCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +476,7 @@ func (client *PathsClient) DoubleDecimalPositive(ctx context.Context) (*http.Res
 }
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
-func (client *PathsClient) DoubleDecimalPositiveCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) DoubleDecimalPositiveCreateRequest(ctx context.Context, options *PathsDoubleDecimalPositiveOptions) (*azcore.Request, error) {
 	urlPath := "/paths/double/9999999.999/{doublePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{doublePath}", url.PathEscape("9999999.999"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -497,8 +497,8 @@ func (client *PathsClient) DoubleDecimalPositiveHandleError(resp *azcore.Respons
 }
 
 // EnumNull - Get null (should throw on the client before the request is sent on wire)
-func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor) (*http.Response, error) {
-	req, err := client.EnumNullCreateRequest(ctx, enumPath)
+func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor, options *PathsEnumNullOptions) (*http.Response, error) {
+	req, err := client.EnumNullCreateRequest(ctx, enumPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +513,7 @@ func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor) (*ht
 }
 
 // EnumNullCreateRequest creates the EnumNull request.
-func (client *PathsClient) EnumNullCreateRequest(ctx context.Context, enumPath URIColor) (*azcore.Request, error) {
+func (client *PathsClient) EnumNullCreateRequest(ctx context.Context, enumPath URIColor, options *PathsEnumNullOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -534,8 +534,8 @@ func (client *PathsClient) EnumNullHandleError(resp *azcore.Response) error {
 }
 
 // EnumValid - Get using uri with 'green color' in path parameter
-func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor) (*http.Response, error) {
-	req, err := client.EnumValidCreateRequest(ctx, enumPath)
+func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor, options *PathsEnumValidOptions) (*http.Response, error) {
+	req, err := client.EnumValidCreateRequest(ctx, enumPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +550,7 @@ func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor) (*h
 }
 
 // EnumValidCreateRequest creates the EnumValid request.
-func (client *PathsClient) EnumValidCreateRequest(ctx context.Context, enumPath URIColor) (*azcore.Request, error) {
+func (client *PathsClient) EnumValidCreateRequest(ctx context.Context, enumPath URIColor, options *PathsEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/paths/enum/green%20color/{enumPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{enumPath}", url.PathEscape(string(enumPath)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -571,8 +571,8 @@ func (client *PathsClient) EnumValidHandleError(resp *azcore.Response) error {
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
-func (client *PathsClient) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.FloatScientificNegativeCreateRequest(ctx)
+func (client *PathsClient) FloatScientificNegative(ctx context.Context, options *PathsFloatScientificNegativeOptions) (*http.Response, error) {
+	req, err := client.FloatScientificNegativeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +587,7 @@ func (client *PathsClient) FloatScientificNegative(ctx context.Context) (*http.R
 }
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
-func (client *PathsClient) FloatScientificNegativeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) FloatScientificNegativeCreateRequest(ctx context.Context, options *PathsFloatScientificNegativeOptions) (*azcore.Request, error) {
 	urlPath := "/paths/float/-1.034E-20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("-1.034e-20"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -608,8 +608,8 @@ func (client *PathsClient) FloatScientificNegativeHandleError(resp *azcore.Respo
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
-func (client *PathsClient) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.FloatScientificPositiveCreateRequest(ctx)
+func (client *PathsClient) FloatScientificPositive(ctx context.Context, options *PathsFloatScientificPositiveOptions) (*http.Response, error) {
+	req, err := client.FloatScientificPositiveCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +624,7 @@ func (client *PathsClient) FloatScientificPositive(ctx context.Context) (*http.R
 }
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
-func (client *PathsClient) FloatScientificPositiveCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) FloatScientificPositiveCreateRequest(ctx context.Context, options *PathsFloatScientificPositiveOptions) (*azcore.Request, error) {
 	urlPath := "/paths/float/1.034E+20/{floatPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{floatPath}", url.PathEscape("103400000000000000000"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -645,8 +645,8 @@ func (client *PathsClient) FloatScientificPositiveHandleError(resp *azcore.Respo
 }
 
 // GetBooleanFalse - Get false Boolean value on path
-func (client *PathsClient) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetBooleanFalseCreateRequest(ctx)
+func (client *PathsClient) GetBooleanFalse(ctx context.Context, options *PathsGetBooleanFalseOptions) (*http.Response, error) {
+	req, err := client.GetBooleanFalseCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +661,7 @@ func (client *PathsClient) GetBooleanFalse(ctx context.Context) (*http.Response,
 }
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
-func (client *PathsClient) GetBooleanFalseCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetBooleanFalseCreateRequest(ctx context.Context, options *PathsGetBooleanFalseOptions) (*azcore.Request, error) {
 	urlPath := "/paths/bool/false/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("false"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -682,8 +682,8 @@ func (client *PathsClient) GetBooleanFalseHandleError(resp *azcore.Response) err
 }
 
 // GetBooleanTrue - Get true Boolean value on path
-func (client *PathsClient) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetBooleanTrueCreateRequest(ctx)
+func (client *PathsClient) GetBooleanTrue(ctx context.Context, options *PathsGetBooleanTrueOptions) (*http.Response, error) {
+	req, err := client.GetBooleanTrueCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (client *PathsClient) GetBooleanTrue(ctx context.Context) (*http.Response, 
 }
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
-func (client *PathsClient) GetBooleanTrueCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetBooleanTrueCreateRequest(ctx context.Context, options *PathsGetBooleanTrueOptions) (*azcore.Request, error) {
 	urlPath := "/paths/bool/true/{boolPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{boolPath}", url.PathEscape("true"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -719,8 +719,8 @@ func (client *PathsClient) GetBooleanTrueHandleError(resp *azcore.Response) erro
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
-func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetIntNegativeOneMillionCreateRequest(ctx)
+func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context, options *PathsGetIntNegativeOneMillionOptions) (*http.Response, error) {
+	req, err := client.GetIntNegativeOneMillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -735,7 +735,7 @@ func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context) (*http.
 }
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
-func (client *PathsClient) GetIntNegativeOneMillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetIntNegativeOneMillionCreateRequest(ctx context.Context, options *PathsGetIntNegativeOneMillionOptions) (*azcore.Request, error) {
 	urlPath := "/paths/int/-1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("-1000000"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -756,8 +756,8 @@ func (client *PathsClient) GetIntNegativeOneMillionHandleError(resp *azcore.Resp
 }
 
 // GetIntOneMillion - Get '1000000' integer value
-func (client *PathsClient) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetIntOneMillionCreateRequest(ctx)
+func (client *PathsClient) GetIntOneMillion(ctx context.Context, options *PathsGetIntOneMillionOptions) (*http.Response, error) {
+	req, err := client.GetIntOneMillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +772,7 @@ func (client *PathsClient) GetIntOneMillion(ctx context.Context) (*http.Response
 }
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
-func (client *PathsClient) GetIntOneMillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetIntOneMillionCreateRequest(ctx context.Context, options *PathsGetIntOneMillionOptions) (*azcore.Request, error) {
 	urlPath := "/paths/int/1000000/{intPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{intPath}", url.PathEscape("1000000"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -793,8 +793,8 @@ func (client *PathsClient) GetIntOneMillionHandleError(resp *azcore.Response) er
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-func (client *PathsClient) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetNegativeTenBillionCreateRequest(ctx)
+func (client *PathsClient) GetNegativeTenBillion(ctx context.Context, options *PathsGetNegativeTenBillionOptions) (*http.Response, error) {
+	req, err := client.GetNegativeTenBillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -809,7 +809,7 @@ func (client *PathsClient) GetNegativeTenBillion(ctx context.Context) (*http.Res
 }
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
-func (client *PathsClient) GetNegativeTenBillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetNegativeTenBillionCreateRequest(ctx context.Context, options *PathsGetNegativeTenBillionOptions) (*azcore.Request, error) {
 	urlPath := "/paths/long/-10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("-10000000000"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -830,8 +830,8 @@ func (client *PathsClient) GetNegativeTenBillionHandleError(resp *azcore.Respons
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
-func (client *PathsClient) GetTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetTenBillionCreateRequest(ctx)
+func (client *PathsClient) GetTenBillion(ctx context.Context, options *PathsGetTenBillionOptions) (*http.Response, error) {
+	req, err := client.GetTenBillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -846,7 +846,7 @@ func (client *PathsClient) GetTenBillion(ctx context.Context) (*http.Response, e
 }
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
-func (client *PathsClient) GetTenBillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) GetTenBillionCreateRequest(ctx context.Context, options *PathsGetTenBillionOptions) (*azcore.Request, error) {
 	urlPath := "/paths/long/10000000000/{longPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{longPath}", url.PathEscape("10000000000"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -867,8 +867,8 @@ func (client *PathsClient) GetTenBillionHandleError(resp *azcore.Response) error
 }
 
 // StringEmpty - Get ''
-func (client *PathsClient) StringEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringEmptyCreateRequest(ctx)
+func (client *PathsClient) StringEmpty(ctx context.Context, options *PathsStringEmptyOptions) (*http.Response, error) {
+	req, err := client.StringEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -883,7 +883,7 @@ func (client *PathsClient) StringEmpty(ctx context.Context) (*http.Response, err
 }
 
 // StringEmptyCreateRequest creates the StringEmpty request.
-func (client *PathsClient) StringEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) StringEmptyCreateRequest(ctx context.Context, options *PathsStringEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/empty/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(""))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -904,8 +904,8 @@ func (client *PathsClient) StringEmptyHandleError(resp *azcore.Response) error {
 }
 
 // StringNull - Get null (should throw)
-func (client *PathsClient) StringNull(ctx context.Context, stringPath string) (*http.Response, error) {
-	req, err := client.StringNullCreateRequest(ctx, stringPath)
+func (client *PathsClient) StringNull(ctx context.Context, stringPath string, options *PathsStringNullOptions) (*http.Response, error) {
+	req, err := client.StringNullCreateRequest(ctx, stringPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -920,7 +920,7 @@ func (client *PathsClient) StringNull(ctx context.Context, stringPath string) (*
 }
 
 // StringNullCreateRequest creates the StringNull request.
-func (client *PathsClient) StringNullCreateRequest(ctx context.Context, stringPath string) (*azcore.Request, error) {
+func (client *PathsClient) StringNullCreateRequest(ctx context.Context, stringPath string, options *PathsStringNullOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/null/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape(stringPath))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -941,8 +941,8 @@ func (client *PathsClient) StringNullHandleError(resp *azcore.Response) error {
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-func (client *PathsClient) StringURLEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringURLEncodedCreateRequest(ctx)
+func (client *PathsClient) StringURLEncoded(ctx context.Context, options *PathsStringURLEncodedOptions) (*http.Response, error) {
+	req, err := client.StringURLEncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -957,7 +957,7 @@ func (client *PathsClient) StringURLEncoded(ctx context.Context) (*http.Response
 }
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
-func (client *PathsClient) StringURLEncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) StringURLEncodedCreateRequest(ctx context.Context, options *PathsStringURLEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("begin!*'();:@ &=+$,/?#[]end"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -978,8 +978,8 @@ func (client *PathsClient) StringURLEncodedHandleError(resp *azcore.Response) er
 }
 
 // StringURLNonEncoded - https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded
-func (client *PathsClient) StringURLNonEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringURLNonEncodedCreateRequest(ctx)
+func (client *PathsClient) StringURLNonEncoded(ctx context.Context, options *PathsStringURLNonEncodedOptions) (*http.Response, error) {
+	req, err := client.StringURLNonEncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -994,7 +994,7 @@ func (client *PathsClient) StringURLNonEncoded(ctx context.Context) (*http.Respo
 }
 
 // StringURLNonEncodedCreateRequest creates the StringURLNonEncoded request.
-func (client *PathsClient) StringURLNonEncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) StringURLNonEncodedCreateRequest(ctx context.Context, options *PathsStringURLNonEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/begin!*'();:@&=+$,end/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", "begin!*'();:@&=+$,end")
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -1015,8 +1015,8 @@ func (client *PathsClient) StringURLNonEncodedHandleError(resp *azcore.Response)
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-func (client *PathsClient) StringUnicode(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringUnicodeCreateRequest(ctx)
+func (client *PathsClient) StringUnicode(ctx context.Context, options *PathsStringUnicodeOptions) (*http.Response, error) {
+	req, err := client.StringUnicodeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1031,7 +1031,7 @@ func (client *PathsClient) StringUnicode(ctx context.Context) (*http.Response, e
 }
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
-func (client *PathsClient) StringUnicodeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PathsClient) StringUnicodeCreateRequest(ctx context.Context, options *PathsStringUnicodeOptions) (*azcore.Request, error) {
 	urlPath := "/paths/string/unicode/{stringPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{stringPath}", url.PathEscape("啊齄丂狛狜隣郎隣兀﨩"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -1052,8 +1052,8 @@ func (client *PathsClient) StringUnicodeHandleError(resp *azcore.Response) error
 }
 
 // UnixTimeURL - Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
-func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time) (*http.Response, error) {
-	req, err := client.UnixTimeURLCreateRequest(ctx, unixTimeUrlPath)
+func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeUrlPath time.Time, options *PathsUnixTimeURLOptions) (*http.Response, error) {
+	req, err := client.UnixTimeURLCreateRequest(ctx, unixTimeUrlPath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1068,7 +1068,7 @@ func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeUrlPath time
 }
 
 // UnixTimeURLCreateRequest creates the UnixTimeURL request.
-func (client *PathsClient) UnixTimeURLCreateRequest(ctx context.Context, unixTimeUrlPath time.Time) (*azcore.Request, error) {
+func (client *PathsClient) UnixTimeURLCreateRequest(ctx context.Context, unixTimeUrlPath time.Time, options *PathsUnixTimeURLOptions) (*azcore.Request, error) {
 	urlPath := "/paths/int/1460505600/{unixTimeUrlPath}"
 	urlPath = strings.ReplaceAll(urlPath, "{unixTimeUrlPath}", url.PathEscape(timeUnix(unixTimeUrlPath).String()))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/autorest/urlgroup/zz_generated_queries.go
+++ b/test/autorest/urlgroup/zz_generated_queries.go
@@ -18,75 +18,75 @@ import (
 // QueriesOperations contains the methods for the Queries group.
 type QueriesOperations interface {
 	// ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
-	ArrayStringCSVEmpty(ctx context.Context, queriesArrayStringCsvEmptyOptions *QueriesArrayStringCSVEmptyOptions) (*http.Response, error)
+	ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*http.Response, error)
 	// ArrayStringCSVNull - Get a null array of string using the csv-array format
-	ArrayStringCSVNull(ctx context.Context, queriesArrayStringCsvNullOptions *QueriesArrayStringCSVNullOptions) (*http.Response, error)
+	ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*http.Response, error)
 	// ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-	ArrayStringCSVValid(ctx context.Context, queriesArrayStringCsvValidOptions *QueriesArrayStringCSVValidOptions) (*http.Response, error)
+	ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*http.Response, error)
 	// ArrayStringNoCollectionFormatEmpty - Array query has no defined collection format, should default to csv. Pass in ['hello', 'nihao', 'bonjour'] for the 'arrayQuery' parameter to the service
-	ArrayStringNoCollectionFormatEmpty(ctx context.Context, queriesArrayStringNoCollectionFormatEmptyOptions *QueriesArrayStringNoCollectionFormatEmptyOptions) (*http.Response, error)
+	ArrayStringNoCollectionFormatEmpty(ctx context.Context, options *QueriesArrayStringNoCollectionFormatEmptyOptions) (*http.Response, error)
 	// ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-	ArrayStringPipesValid(ctx context.Context, queriesArrayStringPipesValidOptions *QueriesArrayStringPipesValidOptions) (*http.Response, error)
+	ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*http.Response, error)
 	// ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-	ArrayStringSsvValid(ctx context.Context, queriesArrayStringSsvValidOptions *QueriesArrayStringSsvValidOptions) (*http.Response, error)
+	ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*http.Response, error)
 	// ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-	ArrayStringTsvValid(ctx context.Context, queriesArrayStringTsvValidOptions *QueriesArrayStringTsvValidOptions) (*http.Response, error)
+	ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*http.Response, error)
 	// ByteEmpty - Get '' as byte array
-	ByteEmpty(ctx context.Context) (*http.Response, error)
+	ByteEmpty(ctx context.Context, options *QueriesByteEmptyOptions) (*http.Response, error)
 	// ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-	ByteMultiByte(ctx context.Context, queriesByteMultiByteOptions *QueriesByteMultiByteOptions) (*http.Response, error)
+	ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*http.Response, error)
 	// ByteNull - Get null as byte array (no query parameters in uri)
-	ByteNull(ctx context.Context, queriesByteNullOptions *QueriesByteNullOptions) (*http.Response, error)
+	ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*http.Response, error)
 	// DateNull - Get null as date - this should result in no query parameters in uri
-	DateNull(ctx context.Context, queriesDateNullOptions *QueriesDateNullOptions) (*http.Response, error)
+	DateNull(ctx context.Context, options *QueriesDateNullOptions) (*http.Response, error)
 	// DateTimeNull - Get null as date-time, should result in no query parameters in uri
-	DateTimeNull(ctx context.Context, queriesDateTimeNullOptions *QueriesDateTimeNullOptions) (*http.Response, error)
+	DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*http.Response, error)
 	// DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-	DateTimeValid(ctx context.Context) (*http.Response, error)
+	DateTimeValid(ctx context.Context, options *QueriesDateTimeValidOptions) (*http.Response, error)
 	// DateValid - Get '2012-01-01' as date
-	DateValid(ctx context.Context) (*http.Response, error)
+	DateValid(ctx context.Context, options *QueriesDateValidOptions) (*http.Response, error)
 	// DoubleDecimalNegative - Get '-9999999.999' numeric value
-	DoubleDecimalNegative(ctx context.Context) (*http.Response, error)
+	DoubleDecimalNegative(ctx context.Context, options *QueriesDoubleDecimalNegativeOptions) (*http.Response, error)
 	// DoubleDecimalPositive - Get '9999999.999' numeric value
-	DoubleDecimalPositive(ctx context.Context) (*http.Response, error)
+	DoubleDecimalPositive(ctx context.Context, options *QueriesDoubleDecimalPositiveOptions) (*http.Response, error)
 	// DoubleNull - Get null numeric value (no query parameter)
-	DoubleNull(ctx context.Context, queriesDoubleNullOptions *QueriesDoubleNullOptions) (*http.Response, error)
+	DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*http.Response, error)
 	// EnumNull - Get null (no query parameter in url)
-	EnumNull(ctx context.Context, queriesEnumNullOptions *QueriesEnumNullOptions) (*http.Response, error)
+	EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*http.Response, error)
 	// EnumValid - Get using uri with query parameter 'green color'
-	EnumValid(ctx context.Context, queriesEnumValidOptions *QueriesEnumValidOptions) (*http.Response, error)
+	EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*http.Response, error)
 	// FloatNull - Get null numeric value (no query parameter)
-	FloatNull(ctx context.Context, queriesFloatNullOptions *QueriesFloatNullOptions) (*http.Response, error)
+	FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*http.Response, error)
 	// FloatScientificNegative - Get '-1.034E-20' numeric value
-	FloatScientificNegative(ctx context.Context) (*http.Response, error)
+	FloatScientificNegative(ctx context.Context, options *QueriesFloatScientificNegativeOptions) (*http.Response, error)
 	// FloatScientificPositive - Get '1.034E+20' numeric value
-	FloatScientificPositive(ctx context.Context) (*http.Response, error)
+	FloatScientificPositive(ctx context.Context, options *QueriesFloatScientificPositiveOptions) (*http.Response, error)
 	// GetBooleanFalse - Get false Boolean value on path
-	GetBooleanFalse(ctx context.Context) (*http.Response, error)
+	GetBooleanFalse(ctx context.Context, options *QueriesGetBooleanFalseOptions) (*http.Response, error)
 	// GetBooleanNull - Get null Boolean value on query (query string should be absent)
-	GetBooleanNull(ctx context.Context, queriesGetBooleanNullOptions *QueriesGetBooleanNullOptions) (*http.Response, error)
+	GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*http.Response, error)
 	// GetBooleanTrue - Get true Boolean value on path
-	GetBooleanTrue(ctx context.Context) (*http.Response, error)
+	GetBooleanTrue(ctx context.Context, options *QueriesGetBooleanTrueOptions) (*http.Response, error)
 	// GetIntNegativeOneMillion - Get '-1000000' integer value
-	GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error)
+	GetIntNegativeOneMillion(ctx context.Context, options *QueriesGetIntNegativeOneMillionOptions) (*http.Response, error)
 	// GetIntNull - Get null integer value (no query parameter)
-	GetIntNull(ctx context.Context, queriesGetIntNullOptions *QueriesGetIntNullOptions) (*http.Response, error)
+	GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*http.Response, error)
 	// GetIntOneMillion - Get '1000000' integer value
-	GetIntOneMillion(ctx context.Context) (*http.Response, error)
+	GetIntOneMillion(ctx context.Context, options *QueriesGetIntOneMillionOptions) (*http.Response, error)
 	// GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-	GetLongNull(ctx context.Context, queriesGetLongNullOptions *QueriesGetLongNullOptions) (*http.Response, error)
+	GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*http.Response, error)
 	// GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-	GetNegativeTenBillion(ctx context.Context) (*http.Response, error)
+	GetNegativeTenBillion(ctx context.Context, options *QueriesGetNegativeTenBillionOptions) (*http.Response, error)
 	// GetTenBillion - Get '10000000000' 64 bit integer value
-	GetTenBillion(ctx context.Context) (*http.Response, error)
+	GetTenBillion(ctx context.Context, options *QueriesGetTenBillionOptions) (*http.Response, error)
 	// StringEmpty - Get ''
-	StringEmpty(ctx context.Context) (*http.Response, error)
+	StringEmpty(ctx context.Context, options *QueriesStringEmptyOptions) (*http.Response, error)
 	// StringNull - Get null (no query parameter in url)
-	StringNull(ctx context.Context, queriesStringNullOptions *QueriesStringNullOptions) (*http.Response, error)
+	StringNull(ctx context.Context, options *QueriesStringNullOptions) (*http.Response, error)
 	// StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-	StringURLEncoded(ctx context.Context) (*http.Response, error)
+	StringURLEncoded(ctx context.Context, options *QueriesStringURLEncodedOptions) (*http.Response, error)
 	// StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-	StringUnicode(ctx context.Context) (*http.Response, error)
+	StringUnicode(ctx context.Context, options *QueriesStringUnicodeOptions) (*http.Response, error)
 }
 
 // QueriesClient implements the QueriesOperations interface.
@@ -106,8 +106,8 @@ func (client *QueriesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
-func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, queriesArrayStringCsvEmptyOptions *QueriesArrayStringCSVEmptyOptions) (*http.Response, error) {
-	req, err := client.ArrayStringCSVEmptyCreateRequest(ctx, queriesArrayStringCsvEmptyOptions)
+func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*http.Response, error) {
+	req, err := client.ArrayStringCSVEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -122,15 +122,15 @@ func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, queriesArr
 }
 
 // ArrayStringCSVEmptyCreateRequest creates the ArrayStringCSVEmpty request.
-func (client *QueriesClient) ArrayStringCSVEmptyCreateRequest(ctx context.Context, queriesArrayStringCsvEmptyOptions *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringCSVEmptyCreateRequest(ctx context.Context, options *QueriesArrayStringCSVEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringCsvEmptyOptions != nil && queriesArrayStringCsvEmptyOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvEmptyOptions.ArrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -147,8 +147,8 @@ func (client *QueriesClient) ArrayStringCSVEmptyHandleError(resp *azcore.Respons
 }
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
-func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, queriesArrayStringCsvNullOptions *QueriesArrayStringCSVNullOptions) (*http.Response, error) {
-	req, err := client.ArrayStringCSVNullCreateRequest(ctx, queriesArrayStringCsvNullOptions)
+func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*http.Response, error) {
+	req, err := client.ArrayStringCSVNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -163,15 +163,15 @@ func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, queriesArra
 }
 
 // ArrayStringCSVNullCreateRequest creates the ArrayStringCSVNull request.
-func (client *QueriesClient) ArrayStringCSVNullCreateRequest(ctx context.Context, queriesArrayStringCsvNullOptions *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringCSVNullCreateRequest(ctx context.Context, options *QueriesArrayStringCSVNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringCsvNullOptions != nil && queriesArrayStringCsvNullOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvNullOptions.ArrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -188,8 +188,8 @@ func (client *QueriesClient) ArrayStringCSVNullHandleError(resp *azcore.Response
 }
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, queriesArrayStringCsvValidOptions *QueriesArrayStringCSVValidOptions) (*http.Response, error) {
-	req, err := client.ArrayStringCSVValidCreateRequest(ctx, queriesArrayStringCsvValidOptions)
+func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*http.Response, error) {
+	req, err := client.ArrayStringCSVValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -204,15 +204,15 @@ func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, queriesArr
 }
 
 // ArrayStringCSVValidCreateRequest creates the ArrayStringCSVValid request.
-func (client *QueriesClient) ArrayStringCSVValidCreateRequest(ctx context.Context, queriesArrayStringCsvValidOptions *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringCSVValidCreateRequest(ctx context.Context, options *QueriesArrayStringCSVValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/csv/string/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringCsvValidOptions != nil && queriesArrayStringCsvValidOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringCsvValidOptions.ArrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -229,8 +229,8 @@ func (client *QueriesClient) ArrayStringCSVValidHandleError(resp *azcore.Respons
 }
 
 // ArrayStringNoCollectionFormatEmpty - Array query has no defined collection format, should default to csv. Pass in ['hello', 'nihao', 'bonjour'] for the 'arrayQuery' parameter to the service
-func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Context, queriesArrayStringNoCollectionFormatEmptyOptions *QueriesArrayStringNoCollectionFormatEmptyOptions) (*http.Response, error) {
-	req, err := client.ArrayStringNoCollectionFormatEmptyCreateRequest(ctx, queriesArrayStringNoCollectionFormatEmptyOptions)
+func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Context, options *QueriesArrayStringNoCollectionFormatEmptyOptions) (*http.Response, error) {
+	req, err := client.ArrayStringNoCollectionFormatEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -245,15 +245,15 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Cont
 }
 
 // ArrayStringNoCollectionFormatEmptyCreateRequest creates the ArrayStringNoCollectionFormatEmpty request.
-func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyCreateRequest(ctx context.Context, queriesArrayStringNoCollectionFormatEmptyOptions *QueriesArrayStringNoCollectionFormatEmptyOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyCreateRequest(ctx context.Context, options *QueriesArrayStringNoCollectionFormatEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/none/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringNoCollectionFormatEmptyOptions != nil && queriesArrayStringNoCollectionFormatEmptyOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringNoCollectionFormatEmptyOptions.ArrayQuery, ","))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, ","))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -270,8 +270,8 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmptyHandleError(resp 
 }
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
-func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, queriesArrayStringPipesValidOptions *QueriesArrayStringPipesValidOptions) (*http.Response, error) {
-	req, err := client.ArrayStringPipesValidCreateRequest(ctx, queriesArrayStringPipesValidOptions)
+func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*http.Response, error) {
+	req, err := client.ArrayStringPipesValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -286,15 +286,15 @@ func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, queriesA
 }
 
 // ArrayStringPipesValidCreateRequest creates the ArrayStringPipesValid request.
-func (client *QueriesClient) ArrayStringPipesValidCreateRequest(ctx context.Context, queriesArrayStringPipesValidOptions *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringPipesValidCreateRequest(ctx context.Context, options *QueriesArrayStringPipesValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/pipes/string/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringPipesValidOptions != nil && queriesArrayStringPipesValidOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringPipesValidOptions.ArrayQuery, "|"))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "|"))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -311,8 +311,8 @@ func (client *QueriesClient) ArrayStringPipesValidHandleError(resp *azcore.Respo
 }
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
-func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, queriesArrayStringSsvValidOptions *QueriesArrayStringSsvValidOptions) (*http.Response, error) {
-	req, err := client.ArrayStringSsvValidCreateRequest(ctx, queriesArrayStringSsvValidOptions)
+func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*http.Response, error) {
+	req, err := client.ArrayStringSsvValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -327,15 +327,15 @@ func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, queriesArr
 }
 
 // ArrayStringSsvValidCreateRequest creates the ArrayStringSsvValid request.
-func (client *QueriesClient) ArrayStringSsvValidCreateRequest(ctx context.Context, queriesArrayStringSsvValidOptions *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringSsvValidCreateRequest(ctx context.Context, options *QueriesArrayStringSsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/ssv/string/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringSsvValidOptions != nil && queriesArrayStringSsvValidOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringSsvValidOptions.ArrayQuery, " "))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, " "))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -352,8 +352,8 @@ func (client *QueriesClient) ArrayStringSsvValidHandleError(resp *azcore.Respons
 }
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
-func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, queriesArrayStringTsvValidOptions *QueriesArrayStringTsvValidOptions) (*http.Response, error) {
-	req, err := client.ArrayStringTsvValidCreateRequest(ctx, queriesArrayStringTsvValidOptions)
+func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*http.Response, error) {
+	req, err := client.ArrayStringTsvValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -368,15 +368,15 @@ func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, queriesArr
 }
 
 // ArrayStringTsvValidCreateRequest creates the ArrayStringTsvValid request.
-func (client *QueriesClient) ArrayStringTsvValidCreateRequest(ctx context.Context, queriesArrayStringTsvValidOptions *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringTsvValidCreateRequest(ctx context.Context, options *QueriesArrayStringTsvValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/tsv/string/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringTsvValidOptions != nil && queriesArrayStringTsvValidOptions.ArrayQuery != nil {
-		query.Set("arrayQuery", strings.Join(*queriesArrayStringTsvValidOptions.ArrayQuery, "\t"))
+	if options != nil && options.ArrayQuery != nil {
+		query.Set("arrayQuery", strings.Join(*options.ArrayQuery, "\t"))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -393,8 +393,8 @@ func (client *QueriesClient) ArrayStringTsvValidHandleError(resp *azcore.Respons
 }
 
 // ByteEmpty - Get '' as byte array
-func (client *QueriesClient) ByteEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.ByteEmptyCreateRequest(ctx)
+func (client *QueriesClient) ByteEmpty(ctx context.Context, options *QueriesByteEmptyOptions) (*http.Response, error) {
+	req, err := client.ByteEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (client *QueriesClient) ByteEmpty(ctx context.Context) (*http.Response, err
 }
 
 // ByteEmptyCreateRequest creates the ByteEmpty request.
-func (client *QueriesClient) ByteEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) ByteEmptyCreateRequest(ctx context.Context, options *QueriesByteEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -432,8 +432,8 @@ func (client *QueriesClient) ByteEmptyHandleError(resp *azcore.Response) error {
 }
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-func (client *QueriesClient) ByteMultiByte(ctx context.Context, queriesByteMultiByteOptions *QueriesByteMultiByteOptions) (*http.Response, error) {
-	req, err := client.ByteMultiByteCreateRequest(ctx, queriesByteMultiByteOptions)
+func (client *QueriesClient) ByteMultiByte(ctx context.Context, options *QueriesByteMultiByteOptions) (*http.Response, error) {
+	req, err := client.ByteMultiByteCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -448,15 +448,15 @@ func (client *QueriesClient) ByteMultiByte(ctx context.Context, queriesByteMulti
 }
 
 // ByteMultiByteCreateRequest creates the ByteMultiByte request.
-func (client *QueriesClient) ByteMultiByteCreateRequest(ctx context.Context, queriesByteMultiByteOptions *QueriesByteMultiByteOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ByteMultiByteCreateRequest(ctx context.Context, options *QueriesByteMultiByteOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/multibyte"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesByteMultiByteOptions != nil && queriesByteMultiByteOptions.ByteQuery != nil {
-		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*queriesByteMultiByteOptions.ByteQuery))
+	if options != nil && options.ByteQuery != nil {
+		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*options.ByteQuery))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -473,8 +473,8 @@ func (client *QueriesClient) ByteMultiByteHandleError(resp *azcore.Response) err
 }
 
 // ByteNull - Get null as byte array (no query parameters in uri)
-func (client *QueriesClient) ByteNull(ctx context.Context, queriesByteNullOptions *QueriesByteNullOptions) (*http.Response, error) {
-	req, err := client.ByteNullCreateRequest(ctx, queriesByteNullOptions)
+func (client *QueriesClient) ByteNull(ctx context.Context, options *QueriesByteNullOptions) (*http.Response, error) {
+	req, err := client.ByteNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -489,15 +489,15 @@ func (client *QueriesClient) ByteNull(ctx context.Context, queriesByteNullOption
 }
 
 // ByteNullCreateRequest creates the ByteNull request.
-func (client *QueriesClient) ByteNullCreateRequest(ctx context.Context, queriesByteNullOptions *QueriesByteNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ByteNullCreateRequest(ctx context.Context, options *QueriesByteNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/byte/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesByteNullOptions != nil && queriesByteNullOptions.ByteQuery != nil {
-		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*queriesByteNullOptions.ByteQuery))
+	if options != nil && options.ByteQuery != nil {
+		query.Set("byteQuery", base64.StdEncoding.EncodeToString(*options.ByteQuery))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -514,8 +514,8 @@ func (client *QueriesClient) ByteNullHandleError(resp *azcore.Response) error {
 }
 
 // DateNull - Get null as date - this should result in no query parameters in uri
-func (client *QueriesClient) DateNull(ctx context.Context, queriesDateNullOptions *QueriesDateNullOptions) (*http.Response, error) {
-	req, err := client.DateNullCreateRequest(ctx, queriesDateNullOptions)
+func (client *QueriesClient) DateNull(ctx context.Context, options *QueriesDateNullOptions) (*http.Response, error) {
+	req, err := client.DateNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -530,15 +530,15 @@ func (client *QueriesClient) DateNull(ctx context.Context, queriesDateNullOption
 }
 
 // DateNullCreateRequest creates the DateNull request.
-func (client *QueriesClient) DateNullCreateRequest(ctx context.Context, queriesDateNullOptions *QueriesDateNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) DateNullCreateRequest(ctx context.Context, options *QueriesDateNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/date/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesDateNullOptions != nil && queriesDateNullOptions.DateQuery != nil {
-		query.Set("dateQuery", queriesDateNullOptions.DateQuery.Format("2006-01-02"))
+	if options != nil && options.DateQuery != nil {
+		query.Set("dateQuery", options.DateQuery.Format("2006-01-02"))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -555,8 +555,8 @@ func (client *QueriesClient) DateNullHandleError(resp *azcore.Response) error {
 }
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
-func (client *QueriesClient) DateTimeNull(ctx context.Context, queriesDateTimeNullOptions *QueriesDateTimeNullOptions) (*http.Response, error) {
-	req, err := client.DateTimeNullCreateRequest(ctx, queriesDateTimeNullOptions)
+func (client *QueriesClient) DateTimeNull(ctx context.Context, options *QueriesDateTimeNullOptions) (*http.Response, error) {
+	req, err := client.DateTimeNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -571,15 +571,15 @@ func (client *QueriesClient) DateTimeNull(ctx context.Context, queriesDateTimeNu
 }
 
 // DateTimeNullCreateRequest creates the DateTimeNull request.
-func (client *QueriesClient) DateTimeNullCreateRequest(ctx context.Context, queriesDateTimeNullOptions *QueriesDateTimeNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) DateTimeNullCreateRequest(ctx context.Context, options *QueriesDateTimeNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/datetime/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesDateTimeNullOptions != nil && queriesDateTimeNullOptions.DateTimeQuery != nil {
-		query.Set("dateTimeQuery", queriesDateTimeNullOptions.DateTimeQuery.Format(time.RFC3339Nano))
+	if options != nil && options.DateTimeQuery != nil {
+		query.Set("dateTimeQuery", options.DateTimeQuery.Format(time.RFC3339Nano))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -596,8 +596,8 @@ func (client *QueriesClient) DateTimeNullHandleError(resp *azcore.Response) erro
 }
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
-func (client *QueriesClient) DateTimeValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.DateTimeValidCreateRequest(ctx)
+func (client *QueriesClient) DateTimeValid(ctx context.Context, options *QueriesDateTimeValidOptions) (*http.Response, error) {
+	req, err := client.DateTimeValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +612,7 @@ func (client *QueriesClient) DateTimeValid(ctx context.Context) (*http.Response,
 }
 
 // DateTimeValidCreateRequest creates the DateTimeValid request.
-func (client *QueriesClient) DateTimeValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) DateTimeValidCreateRequest(ctx context.Context, options *QueriesDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/datetime/2012-01-01T01%3A01%3A01Z"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -635,8 +635,8 @@ func (client *QueriesClient) DateTimeValidHandleError(resp *azcore.Response) err
 }
 
 // DateValid - Get '2012-01-01' as date
-func (client *QueriesClient) DateValid(ctx context.Context) (*http.Response, error) {
-	req, err := client.DateValidCreateRequest(ctx)
+func (client *QueriesClient) DateValid(ctx context.Context, options *QueriesDateValidOptions) (*http.Response, error) {
+	req, err := client.DateValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (client *QueriesClient) DateValid(ctx context.Context) (*http.Response, err
 }
 
 // DateValidCreateRequest creates the DateValid request.
-func (client *QueriesClient) DateValidCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) DateValidCreateRequest(ctx context.Context, options *QueriesDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/date/2012-01-01"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -674,8 +674,8 @@ func (client *QueriesClient) DateValidHandleError(resp *azcore.Response) error {
 }
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
-func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.DoubleDecimalNegativeCreateRequest(ctx)
+func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context, options *QueriesDoubleDecimalNegativeOptions) (*http.Response, error) {
+	req, err := client.DoubleDecimalNegativeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -690,7 +690,7 @@ func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context) (*http.R
 }
 
 // DoubleDecimalNegativeCreateRequest creates the DoubleDecimalNegative request.
-func (client *QueriesClient) DoubleDecimalNegativeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) DoubleDecimalNegativeCreateRequest(ctx context.Context, options *QueriesDoubleDecimalNegativeOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/-9999999.999"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -713,8 +713,8 @@ func (client *QueriesClient) DoubleDecimalNegativeHandleError(resp *azcore.Respo
 }
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
-func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.DoubleDecimalPositiveCreateRequest(ctx)
+func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context, options *QueriesDoubleDecimalPositiveOptions) (*http.Response, error) {
+	req, err := client.DoubleDecimalPositiveCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -729,7 +729,7 @@ func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context) (*http.R
 }
 
 // DoubleDecimalPositiveCreateRequest creates the DoubleDecimalPositive request.
-func (client *QueriesClient) DoubleDecimalPositiveCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) DoubleDecimalPositiveCreateRequest(ctx context.Context, options *QueriesDoubleDecimalPositiveOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/9999999.999"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -752,8 +752,8 @@ func (client *QueriesClient) DoubleDecimalPositiveHandleError(resp *azcore.Respo
 }
 
 // DoubleNull - Get null numeric value (no query parameter)
-func (client *QueriesClient) DoubleNull(ctx context.Context, queriesDoubleNullOptions *QueriesDoubleNullOptions) (*http.Response, error) {
-	req, err := client.DoubleNullCreateRequest(ctx, queriesDoubleNullOptions)
+func (client *QueriesClient) DoubleNull(ctx context.Context, options *QueriesDoubleNullOptions) (*http.Response, error) {
+	req, err := client.DoubleNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -768,15 +768,15 @@ func (client *QueriesClient) DoubleNull(ctx context.Context, queriesDoubleNullOp
 }
 
 // DoubleNullCreateRequest creates the DoubleNull request.
-func (client *QueriesClient) DoubleNullCreateRequest(ctx context.Context, queriesDoubleNullOptions *QueriesDoubleNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) DoubleNullCreateRequest(ctx context.Context, options *QueriesDoubleNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/double/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesDoubleNullOptions != nil && queriesDoubleNullOptions.DoubleQuery != nil {
-		query.Set("doubleQuery", strconv.FormatFloat(*queriesDoubleNullOptions.DoubleQuery, 'f', -1, 64))
+	if options != nil && options.DoubleQuery != nil {
+		query.Set("doubleQuery", strconv.FormatFloat(*options.DoubleQuery, 'f', -1, 64))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -793,8 +793,8 @@ func (client *QueriesClient) DoubleNullHandleError(resp *azcore.Response) error 
 }
 
 // EnumNull - Get null (no query parameter in url)
-func (client *QueriesClient) EnumNull(ctx context.Context, queriesEnumNullOptions *QueriesEnumNullOptions) (*http.Response, error) {
-	req, err := client.EnumNullCreateRequest(ctx, queriesEnumNullOptions)
+func (client *QueriesClient) EnumNull(ctx context.Context, options *QueriesEnumNullOptions) (*http.Response, error) {
+	req, err := client.EnumNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -809,15 +809,15 @@ func (client *QueriesClient) EnumNull(ctx context.Context, queriesEnumNullOption
 }
 
 // EnumNullCreateRequest creates the EnumNull request.
-func (client *QueriesClient) EnumNullCreateRequest(ctx context.Context, queriesEnumNullOptions *QueriesEnumNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) EnumNullCreateRequest(ctx context.Context, options *QueriesEnumNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesEnumNullOptions != nil && queriesEnumNullOptions.EnumQuery != nil {
-		query.Set("enumQuery", string(*queriesEnumNullOptions.EnumQuery))
+	if options != nil && options.EnumQuery != nil {
+		query.Set("enumQuery", string(*options.EnumQuery))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -834,8 +834,8 @@ func (client *QueriesClient) EnumNullHandleError(resp *azcore.Response) error {
 }
 
 // EnumValid - Get using uri with query parameter 'green color'
-func (client *QueriesClient) EnumValid(ctx context.Context, queriesEnumValidOptions *QueriesEnumValidOptions) (*http.Response, error) {
-	req, err := client.EnumValidCreateRequest(ctx, queriesEnumValidOptions)
+func (client *QueriesClient) EnumValid(ctx context.Context, options *QueriesEnumValidOptions) (*http.Response, error) {
+	req, err := client.EnumValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -850,15 +850,15 @@ func (client *QueriesClient) EnumValid(ctx context.Context, queriesEnumValidOpti
 }
 
 // EnumValidCreateRequest creates the EnumValid request.
-func (client *QueriesClient) EnumValidCreateRequest(ctx context.Context, queriesEnumValidOptions *QueriesEnumValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) EnumValidCreateRequest(ctx context.Context, options *QueriesEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/enum/green%20color"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesEnumValidOptions != nil && queriesEnumValidOptions.EnumQuery != nil {
-		query.Set("enumQuery", string(*queriesEnumValidOptions.EnumQuery))
+	if options != nil && options.EnumQuery != nil {
+		query.Set("enumQuery", string(*options.EnumQuery))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -875,8 +875,8 @@ func (client *QueriesClient) EnumValidHandleError(resp *azcore.Response) error {
 }
 
 // FloatNull - Get null numeric value (no query parameter)
-func (client *QueriesClient) FloatNull(ctx context.Context, queriesFloatNullOptions *QueriesFloatNullOptions) (*http.Response, error) {
-	req, err := client.FloatNullCreateRequest(ctx, queriesFloatNullOptions)
+func (client *QueriesClient) FloatNull(ctx context.Context, options *QueriesFloatNullOptions) (*http.Response, error) {
+	req, err := client.FloatNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -891,15 +891,15 @@ func (client *QueriesClient) FloatNull(ctx context.Context, queriesFloatNullOpti
 }
 
 // FloatNullCreateRequest creates the FloatNull request.
-func (client *QueriesClient) FloatNullCreateRequest(ctx context.Context, queriesFloatNullOptions *QueriesFloatNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) FloatNullCreateRequest(ctx context.Context, options *QueriesFloatNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesFloatNullOptions != nil && queriesFloatNullOptions.FloatQuery != nil {
-		query.Set("floatQuery", strconv.FormatFloat(float64(*queriesFloatNullOptions.FloatQuery), 'f', -1, 32))
+	if options != nil && options.FloatQuery != nil {
+		query.Set("floatQuery", strconv.FormatFloat(float64(*options.FloatQuery), 'f', -1, 32))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -916,8 +916,8 @@ func (client *QueriesClient) FloatNullHandleError(resp *azcore.Response) error {
 }
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
-func (client *QueriesClient) FloatScientificNegative(ctx context.Context) (*http.Response, error) {
-	req, err := client.FloatScientificNegativeCreateRequest(ctx)
+func (client *QueriesClient) FloatScientificNegative(ctx context.Context, options *QueriesFloatScientificNegativeOptions) (*http.Response, error) {
+	req, err := client.FloatScientificNegativeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (client *QueriesClient) FloatScientificNegative(ctx context.Context) (*http
 }
 
 // FloatScientificNegativeCreateRequest creates the FloatScientificNegative request.
-func (client *QueriesClient) FloatScientificNegativeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) FloatScientificNegativeCreateRequest(ctx context.Context, options *QueriesFloatScientificNegativeOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/-1.034E-20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -955,8 +955,8 @@ func (client *QueriesClient) FloatScientificNegativeHandleError(resp *azcore.Res
 }
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
-func (client *QueriesClient) FloatScientificPositive(ctx context.Context) (*http.Response, error) {
-	req, err := client.FloatScientificPositiveCreateRequest(ctx)
+func (client *QueriesClient) FloatScientificPositive(ctx context.Context, options *QueriesFloatScientificPositiveOptions) (*http.Response, error) {
+	req, err := client.FloatScientificPositiveCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -971,7 +971,7 @@ func (client *QueriesClient) FloatScientificPositive(ctx context.Context) (*http
 }
 
 // FloatScientificPositiveCreateRequest creates the FloatScientificPositive request.
-func (client *QueriesClient) FloatScientificPositiveCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) FloatScientificPositiveCreateRequest(ctx context.Context, options *QueriesFloatScientificPositiveOptions) (*azcore.Request, error) {
 	urlPath := "/queries/float/1.034E+20"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -994,8 +994,8 @@ func (client *QueriesClient) FloatScientificPositiveHandleError(resp *azcore.Res
 }
 
 // GetBooleanFalse - Get false Boolean value on path
-func (client *QueriesClient) GetBooleanFalse(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetBooleanFalseCreateRequest(ctx)
+func (client *QueriesClient) GetBooleanFalse(ctx context.Context, options *QueriesGetBooleanFalseOptions) (*http.Response, error) {
+	req, err := client.GetBooleanFalseCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,7 +1010,7 @@ func (client *QueriesClient) GetBooleanFalse(ctx context.Context) (*http.Respons
 }
 
 // GetBooleanFalseCreateRequest creates the GetBooleanFalse request.
-func (client *QueriesClient) GetBooleanFalseCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetBooleanFalseCreateRequest(ctx context.Context, options *QueriesGetBooleanFalseOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/false"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1033,8 +1033,8 @@ func (client *QueriesClient) GetBooleanFalseHandleError(resp *azcore.Response) e
 }
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
-func (client *QueriesClient) GetBooleanNull(ctx context.Context, queriesGetBooleanNullOptions *QueriesGetBooleanNullOptions) (*http.Response, error) {
-	req, err := client.GetBooleanNullCreateRequest(ctx, queriesGetBooleanNullOptions)
+func (client *QueriesClient) GetBooleanNull(ctx context.Context, options *QueriesGetBooleanNullOptions) (*http.Response, error) {
+	req, err := client.GetBooleanNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1049,15 +1049,15 @@ func (client *QueriesClient) GetBooleanNull(ctx context.Context, queriesGetBoole
 }
 
 // GetBooleanNullCreateRequest creates the GetBooleanNull request.
-func (client *QueriesClient) GetBooleanNullCreateRequest(ctx context.Context, queriesGetBooleanNullOptions *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) GetBooleanNullCreateRequest(ctx context.Context, options *QueriesGetBooleanNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesGetBooleanNullOptions != nil && queriesGetBooleanNullOptions.BoolQuery != nil {
-		query.Set("boolQuery", strconv.FormatBool(*queriesGetBooleanNullOptions.BoolQuery))
+	if options != nil && options.BoolQuery != nil {
+		query.Set("boolQuery", strconv.FormatBool(*options.BoolQuery))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -1074,8 +1074,8 @@ func (client *QueriesClient) GetBooleanNullHandleError(resp *azcore.Response) er
 }
 
 // GetBooleanTrue - Get true Boolean value on path
-func (client *QueriesClient) GetBooleanTrue(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetBooleanTrueCreateRequest(ctx)
+func (client *QueriesClient) GetBooleanTrue(ctx context.Context, options *QueriesGetBooleanTrueOptions) (*http.Response, error) {
+	req, err := client.GetBooleanTrueCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1090,7 +1090,7 @@ func (client *QueriesClient) GetBooleanTrue(ctx context.Context) (*http.Response
 }
 
 // GetBooleanTrueCreateRequest creates the GetBooleanTrue request.
-func (client *QueriesClient) GetBooleanTrueCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetBooleanTrueCreateRequest(ctx context.Context, options *QueriesGetBooleanTrueOptions) (*azcore.Request, error) {
 	urlPath := "/queries/bool/true"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1113,8 +1113,8 @@ func (client *QueriesClient) GetBooleanTrueHandleError(resp *azcore.Response) er
 }
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
-func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetIntNegativeOneMillionCreateRequest(ctx)
+func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context, options *QueriesGetIntNegativeOneMillionOptions) (*http.Response, error) {
+	req, err := client.GetIntNegativeOneMillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1129,7 +1129,7 @@ func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context) (*htt
 }
 
 // GetIntNegativeOneMillionCreateRequest creates the GetIntNegativeOneMillion request.
-func (client *QueriesClient) GetIntNegativeOneMillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetIntNegativeOneMillionCreateRequest(ctx context.Context, options *QueriesGetIntNegativeOneMillionOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/-1000000"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1152,8 +1152,8 @@ func (client *QueriesClient) GetIntNegativeOneMillionHandleError(resp *azcore.Re
 }
 
 // GetIntNull - Get null integer value (no query parameter)
-func (client *QueriesClient) GetIntNull(ctx context.Context, queriesGetIntNullOptions *QueriesGetIntNullOptions) (*http.Response, error) {
-	req, err := client.GetIntNullCreateRequest(ctx, queriesGetIntNullOptions)
+func (client *QueriesClient) GetIntNull(ctx context.Context, options *QueriesGetIntNullOptions) (*http.Response, error) {
+	req, err := client.GetIntNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1168,15 +1168,15 @@ func (client *QueriesClient) GetIntNull(ctx context.Context, queriesGetIntNullOp
 }
 
 // GetIntNullCreateRequest creates the GetIntNull request.
-func (client *QueriesClient) GetIntNullCreateRequest(ctx context.Context, queriesGetIntNullOptions *QueriesGetIntNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) GetIntNullCreateRequest(ctx context.Context, options *QueriesGetIntNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesGetIntNullOptions != nil && queriesGetIntNullOptions.IntQuery != nil {
-		query.Set("intQuery", strconv.FormatInt(int64(*queriesGetIntNullOptions.IntQuery), 10))
+	if options != nil && options.IntQuery != nil {
+		query.Set("intQuery", strconv.FormatInt(int64(*options.IntQuery), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -1193,8 +1193,8 @@ func (client *QueriesClient) GetIntNullHandleError(resp *azcore.Response) error 
 }
 
 // GetIntOneMillion - Get '1000000' integer value
-func (client *QueriesClient) GetIntOneMillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetIntOneMillionCreateRequest(ctx)
+func (client *QueriesClient) GetIntOneMillion(ctx context.Context, options *QueriesGetIntOneMillionOptions) (*http.Response, error) {
+	req, err := client.GetIntOneMillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1209,7 +1209,7 @@ func (client *QueriesClient) GetIntOneMillion(ctx context.Context) (*http.Respon
 }
 
 // GetIntOneMillionCreateRequest creates the GetIntOneMillion request.
-func (client *QueriesClient) GetIntOneMillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetIntOneMillionCreateRequest(ctx context.Context, options *QueriesGetIntOneMillionOptions) (*azcore.Request, error) {
 	urlPath := "/queries/int/1000000"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1232,8 +1232,8 @@ func (client *QueriesClient) GetIntOneMillionHandleError(resp *azcore.Response) 
 }
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
-func (client *QueriesClient) GetLongNull(ctx context.Context, queriesGetLongNullOptions *QueriesGetLongNullOptions) (*http.Response, error) {
-	req, err := client.GetLongNullCreateRequest(ctx, queriesGetLongNullOptions)
+func (client *QueriesClient) GetLongNull(ctx context.Context, options *QueriesGetLongNullOptions) (*http.Response, error) {
+	req, err := client.GetLongNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1248,15 +1248,15 @@ func (client *QueriesClient) GetLongNull(ctx context.Context, queriesGetLongNull
 }
 
 // GetLongNullCreateRequest creates the GetLongNull request.
-func (client *QueriesClient) GetLongNullCreateRequest(ctx context.Context, queriesGetLongNullOptions *QueriesGetLongNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) GetLongNullCreateRequest(ctx context.Context, options *QueriesGetLongNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesGetLongNullOptions != nil && queriesGetLongNullOptions.LongQuery != nil {
-		query.Set("longQuery", strconv.FormatInt(*queriesGetLongNullOptions.LongQuery, 10))
+	if options != nil && options.LongQuery != nil {
+		query.Set("longQuery", strconv.FormatInt(*options.LongQuery, 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -1273,8 +1273,8 @@ func (client *QueriesClient) GetLongNullHandleError(resp *azcore.Response) error
 }
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
-func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetNegativeTenBillionCreateRequest(ctx)
+func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context, options *QueriesGetNegativeTenBillionOptions) (*http.Response, error) {
+	req, err := client.GetNegativeTenBillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1289,7 +1289,7 @@ func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context) (*http.R
 }
 
 // GetNegativeTenBillionCreateRequest creates the GetNegativeTenBillion request.
-func (client *QueriesClient) GetNegativeTenBillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetNegativeTenBillionCreateRequest(ctx context.Context, options *QueriesGetNegativeTenBillionOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/-10000000000"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1312,8 +1312,8 @@ func (client *QueriesClient) GetNegativeTenBillionHandleError(resp *azcore.Respo
 }
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
-func (client *QueriesClient) GetTenBillion(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetTenBillionCreateRequest(ctx)
+func (client *QueriesClient) GetTenBillion(ctx context.Context, options *QueriesGetTenBillionOptions) (*http.Response, error) {
+	req, err := client.GetTenBillionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1328,7 +1328,7 @@ func (client *QueriesClient) GetTenBillion(ctx context.Context) (*http.Response,
 }
 
 // GetTenBillionCreateRequest creates the GetTenBillion request.
-func (client *QueriesClient) GetTenBillionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) GetTenBillionCreateRequest(ctx context.Context, options *QueriesGetTenBillionOptions) (*azcore.Request, error) {
 	urlPath := "/queries/long/10000000000"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1351,8 +1351,8 @@ func (client *QueriesClient) GetTenBillionHandleError(resp *azcore.Response) err
 }
 
 // StringEmpty - Get ''
-func (client *QueriesClient) StringEmpty(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringEmptyCreateRequest(ctx)
+func (client *QueriesClient) StringEmpty(ctx context.Context, options *QueriesStringEmptyOptions) (*http.Response, error) {
+	req, err := client.StringEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1367,7 +1367,7 @@ func (client *QueriesClient) StringEmpty(ctx context.Context) (*http.Response, e
 }
 
 // StringEmptyCreateRequest creates the StringEmpty request.
-func (client *QueriesClient) StringEmptyCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) StringEmptyCreateRequest(ctx context.Context, options *QueriesStringEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1390,8 +1390,8 @@ func (client *QueriesClient) StringEmptyHandleError(resp *azcore.Response) error
 }
 
 // StringNull - Get null (no query parameter in url)
-func (client *QueriesClient) StringNull(ctx context.Context, queriesStringNullOptions *QueriesStringNullOptions) (*http.Response, error) {
-	req, err := client.StringNullCreateRequest(ctx, queriesStringNullOptions)
+func (client *QueriesClient) StringNull(ctx context.Context, options *QueriesStringNullOptions) (*http.Response, error) {
+	req, err := client.StringNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1406,15 +1406,15 @@ func (client *QueriesClient) StringNull(ctx context.Context, queriesStringNullOp
 }
 
 // StringNullCreateRequest creates the StringNull request.
-func (client *QueriesClient) StringNullCreateRequest(ctx context.Context, queriesStringNullOptions *QueriesStringNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) StringNullCreateRequest(ctx context.Context, options *QueriesStringNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesStringNullOptions != nil && queriesStringNullOptions.StringQuery != nil {
-		query.Set("stringQuery", *queriesStringNullOptions.StringQuery)
+	if options != nil && options.StringQuery != nil {
+		query.Set("stringQuery", *options.StringQuery)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -1431,8 +1431,8 @@ func (client *QueriesClient) StringNullHandleError(resp *azcore.Response) error 
 }
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
-func (client *QueriesClient) StringURLEncoded(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringURLEncodedCreateRequest(ctx)
+func (client *QueriesClient) StringURLEncoded(ctx context.Context, options *QueriesStringURLEncodedOptions) (*http.Response, error) {
+	req, err := client.StringURLEncodedCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1447,7 +1447,7 @@ func (client *QueriesClient) StringURLEncoded(ctx context.Context) (*http.Respon
 }
 
 // StringURLEncodedCreateRequest creates the StringURLEncoded request.
-func (client *QueriesClient) StringURLEncodedCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) StringURLEncodedCreateRequest(ctx context.Context, options *QueriesStringURLEncodedOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1470,8 +1470,8 @@ func (client *QueriesClient) StringURLEncodedHandleError(resp *azcore.Response) 
 }
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
-func (client *QueriesClient) StringUnicode(ctx context.Context) (*http.Response, error) {
-	req, err := client.StringUnicodeCreateRequest(ctx)
+func (client *QueriesClient) StringUnicode(ctx context.Context, options *QueriesStringUnicodeOptions) (*http.Response, error) {
+	req, err := client.StringUnicodeCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1486,7 +1486,7 @@ func (client *QueriesClient) StringUnicode(ctx context.Context) (*http.Response,
 }
 
 // StringUnicodeCreateRequest creates the StringUnicode request.
-func (client *QueriesClient) StringUnicodeCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *QueriesClient) StringUnicodeCreateRequest(ctx context.Context, options *QueriesStringUnicodeOptions) (*azcore.Request, error) {
 	urlPath := "/queries/string/unicode/"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/autorest/urlmultigroup/zz_generated_queries.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries.go
@@ -14,11 +14,11 @@ import (
 // QueriesOperations contains the methods for the Queries group.
 type QueriesOperations interface {
 	// ArrayStringMultiEmpty - Get an empty array [] of string using the multi-array format
-	ArrayStringMultiEmpty(ctx context.Context, queriesArrayStringMultiEmptyOptions *QueriesArrayStringMultiEmptyOptions) (*http.Response, error)
+	ArrayStringMultiEmpty(ctx context.Context, options *QueriesArrayStringMultiEmptyOptions) (*http.Response, error)
 	// ArrayStringMultiNull - Get a null array of string using the multi-array format
-	ArrayStringMultiNull(ctx context.Context, queriesArrayStringMultiNullOptions *QueriesArrayStringMultiNullOptions) (*http.Response, error)
+	ArrayStringMultiNull(ctx context.Context, options *QueriesArrayStringMultiNullOptions) (*http.Response, error)
 	// ArrayStringMultiValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format
-	ArrayStringMultiValid(ctx context.Context, queriesArrayStringMultiValidOptions *QueriesArrayStringMultiValidOptions) (*http.Response, error)
+	ArrayStringMultiValid(ctx context.Context, options *QueriesArrayStringMultiValidOptions) (*http.Response, error)
 }
 
 // QueriesClient implements the QueriesOperations interface.
@@ -38,8 +38,8 @@ func (client *QueriesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // ArrayStringMultiEmpty - Get an empty array [] of string using the multi-array format
-func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, queriesArrayStringMultiEmptyOptions *QueriesArrayStringMultiEmptyOptions) (*http.Response, error) {
-	req, err := client.ArrayStringMultiEmptyCreateRequest(ctx, queriesArrayStringMultiEmptyOptions)
+func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, options *QueriesArrayStringMultiEmptyOptions) (*http.Response, error) {
+	req, err := client.ArrayStringMultiEmptyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -54,15 +54,15 @@ func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, queriesA
 }
 
 // ArrayStringMultiEmptyCreateRequest creates the ArrayStringMultiEmpty request.
-func (client *QueriesClient) ArrayStringMultiEmptyCreateRequest(ctx context.Context, queriesArrayStringMultiEmptyOptions *QueriesArrayStringMultiEmptyOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringMultiEmptyCreateRequest(ctx context.Context, options *QueriesArrayStringMultiEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringMultiEmptyOptions != nil && queriesArrayStringMultiEmptyOptions.ArrayQuery != nil {
-		for _, qv := range *queriesArrayStringMultiEmptyOptions.ArrayQuery {
+	if options != nil && options.ArrayQuery != nil {
+		for _, qv := range *options.ArrayQuery {
 			query.Add("arrayQuery", qv)
 		}
 	}
@@ -81,8 +81,8 @@ func (client *QueriesClient) ArrayStringMultiEmptyHandleError(resp *azcore.Respo
 }
 
 // ArrayStringMultiNull - Get a null array of string using the multi-array format
-func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, queriesArrayStringMultiNullOptions *QueriesArrayStringMultiNullOptions) (*http.Response, error) {
-	req, err := client.ArrayStringMultiNullCreateRequest(ctx, queriesArrayStringMultiNullOptions)
+func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, options *QueriesArrayStringMultiNullOptions) (*http.Response, error) {
+	req, err := client.ArrayStringMultiNullCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -97,15 +97,15 @@ func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, queriesAr
 }
 
 // ArrayStringMultiNullCreateRequest creates the ArrayStringMultiNull request.
-func (client *QueriesClient) ArrayStringMultiNullCreateRequest(ctx context.Context, queriesArrayStringMultiNullOptions *QueriesArrayStringMultiNullOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringMultiNullCreateRequest(ctx context.Context, options *QueriesArrayStringMultiNullOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/null"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringMultiNullOptions != nil && queriesArrayStringMultiNullOptions.ArrayQuery != nil {
-		for _, qv := range *queriesArrayStringMultiNullOptions.ArrayQuery {
+	if options != nil && options.ArrayQuery != nil {
+		for _, qv := range *options.ArrayQuery {
 			query.Add("arrayQuery", qv)
 		}
 	}
@@ -124,8 +124,8 @@ func (client *QueriesClient) ArrayStringMultiNullHandleError(resp *azcore.Respon
 }
 
 // ArrayStringMultiValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the mult-array format
-func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, queriesArrayStringMultiValidOptions *QueriesArrayStringMultiValidOptions) (*http.Response, error) {
-	req, err := client.ArrayStringMultiValidCreateRequest(ctx, queriesArrayStringMultiValidOptions)
+func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, options *QueriesArrayStringMultiValidOptions) (*http.Response, error) {
+	req, err := client.ArrayStringMultiValidCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -140,15 +140,15 @@ func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, queriesA
 }
 
 // ArrayStringMultiValidCreateRequest creates the ArrayStringMultiValid request.
-func (client *QueriesClient) ArrayStringMultiValidCreateRequest(ctx context.Context, queriesArrayStringMultiValidOptions *QueriesArrayStringMultiValidOptions) (*azcore.Request, error) {
+func (client *QueriesClient) ArrayStringMultiValidCreateRequest(ctx context.Context, options *QueriesArrayStringMultiValidOptions) (*azcore.Request, error) {
 	urlPath := "/queries/array/multi/string/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if queriesArrayStringMultiValidOptions != nil && queriesArrayStringMultiValidOptions.ArrayQuery != nil {
-		for _, qv := range *queriesArrayStringMultiValidOptions.ArrayQuery {
+	if options != nil && options.ArrayQuery != nil {
+		for _, qv := range *options.ArrayQuery {
 			query.Add("arrayQuery", qv)
 		}
 	}

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -18,7 +18,7 @@ func newAutoRestValidationTestClient() AutoRestValidationTestOperations {
 
 func TestValidationGetWithConstantInPath(t *testing.T) {
 	client := newAutoRestValidationTestClient()
-	result, err := client.GetWithConstantInPath(context.Background())
+	result, err := client.GetWithConstantInPath(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("GetWithConstantInPath: %v", err)
 	}

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -19,12 +19,12 @@ import (
 
 // AutoRestValidationTestOperations contains the methods for the AutoRestValidationTest group.
 type AutoRestValidationTestOperations interface {
-	GetWithConstantInPath(ctx context.Context) (*http.Response, error)
-	PostWithConstantInBody(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error)
+	GetWithConstantInPath(ctx context.Context, options *AutoRestValidationTestGetWithConstantInPathOptions) (*http.Response, error)
+	PostWithConstantInBody(ctx context.Context, options *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error)
 	// ValidationOfBody - Validates body parameters on the method. See swagger for details.
-	ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error)
+	ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error)
 	// ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
-	ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32) (*ProductResponse, error)
+	ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfMethodParametersOptions) (*ProductResponse, error)
 }
 
 // AutoRestValidationTestClient implements the AutoRestValidationTestOperations interface.
@@ -44,8 +44,8 @@ func (client *AutoRestValidationTestClient) Do(req *azcore.Request) (*azcore.Res
 	return client.p.Do(req)
 }
 
-func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Context) (*http.Response, error) {
-	req, err := client.GetWithConstantInPathCreateRequest(ctx)
+func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Context, options *AutoRestValidationTestGetWithConstantInPathOptions) (*http.Response, error) {
+	req, err := client.GetWithConstantInPathCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Co
 }
 
 // GetWithConstantInPathCreateRequest creates the GetWithConstantInPath request.
-func (client *AutoRestValidationTestClient) GetWithConstantInPathCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *AutoRestValidationTestClient) GetWithConstantInPathCreateRequest(ctx context.Context, options *AutoRestValidationTestGetWithConstantInPathOptions) (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -82,8 +82,8 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPathHandleError(res
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error) {
-	req, err := client.PostWithConstantInBodyCreateRequest(ctx, autoRestValidationTestPostWithConstantInBodyOptions)
+func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.Context, options *AutoRestValidationTestPostWithConstantInBodyOptions) (*ProductResponse, error) {
+	req, err := client.PostWithConstantInBodyCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.C
 }
 
 // PostWithConstantInBodyCreateRequest creates the PostWithConstantInBody request.
-func (client *AutoRestValidationTestClient) PostWithConstantInBodyCreateRequest(ctx context.Context, autoRestValidationTestPostWithConstantInBodyOptions *AutoRestValidationTestPostWithConstantInBodyOptions) (*azcore.Request, error) {
+func (client *AutoRestValidationTestClient) PostWithConstantInBodyCreateRequest(ctx context.Context, options *AutoRestValidationTestPostWithConstantInBodyOptions) (*azcore.Request, error) {
 	urlPath := "/validation/constantsInPath/{constantParam}/value"
 	urlPath = strings.ReplaceAll(urlPath, "{constantParam}", url.PathEscape("constant"))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -110,8 +110,8 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyCreateRequest(
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	if autoRestValidationTestPostWithConstantInBodyOptions != nil {
-		return req, req.MarshalAsJSON(autoRestValidationTestPostWithConstantInBodyOptions.Body)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Body)
 	}
 	return req, nil
 }
@@ -135,8 +135,8 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBodyHandleError(re
 }
 
 // ValidationOfBody - Validates body parameters on the method. See swagger for details.
-func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error) {
-	req, err := client.ValidationOfBodyCreateRequest(ctx, resourceGroupName, id, autoRestValidationTestValidationOfBodyOptions)
+func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfBodyOptions) (*ProductResponse, error) {
+	req, err := client.ValidationOfBodyCreateRequest(ctx, resourceGroupName, id, options)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context
 }
 
 // ValidationOfBodyCreateRequest creates the ValidationOfBody request.
-func (client *AutoRestValidationTestClient) ValidationOfBodyCreateRequest(ctx context.Context, resourceGroupName string, id int32, autoRestValidationTestValidationOfBodyOptions *AutoRestValidationTestValidationOfBodyOptions) (*azcore.Request, error) {
+func (client *AutoRestValidationTestClient) ValidationOfBodyCreateRequest(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfBodyOptions) (*azcore.Request, error) {
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -168,8 +168,8 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyCreateRequest(ctx co
 	query.Set("apiVersion", "1.0.0")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if autoRestValidationTestValidationOfBodyOptions != nil {
-		return req, req.MarshalAsJSON(autoRestValidationTestValidationOfBodyOptions.Body)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Body)
 	}
 	return req, nil
 }
@@ -190,8 +190,8 @@ func (client *AutoRestValidationTestClient) ValidationOfBodyHandleError(resp *az
 }
 
 // ValidationOfMethodParameters - Validates input parameters on the method. See swagger for details.
-func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32) (*ProductResponse, error) {
-	req, err := client.ValidationOfMethodParametersCreateRequest(ctx, resourceGroupName, id)
+func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfMethodParametersOptions) (*ProductResponse, error) {
+	req, err := client.ValidationOfMethodParametersCreateRequest(ctx, resourceGroupName, id, options)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx con
 }
 
 // ValidationOfMethodParametersCreateRequest creates the ValidationOfMethodParameters request.
-func (client *AutoRestValidationTestClient) ValidationOfMethodParametersCreateRequest(ctx context.Context, resourceGroupName string, id int32) (*azcore.Request, error) {
+func (client *AutoRestValidationTestClient) ValidationOfMethodParametersCreateRequest(ctx context.Context, resourceGroupName string, id int32, options *AutoRestValidationTestValidationOfMethodParametersOptions) (*azcore.Request, error) {
 	urlPath := "/fakepath/{subscriptionId}/{resourceGroupName}/{id}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/autorest/validationgroup/zz_generated_models.go
+++ b/test/autorest/validationgroup/zz_generated_models.go
@@ -10,6 +10,12 @@ import (
 	"net/http"
 )
 
+// AutoRestValidationTestGetWithConstantInPathOptions contains the optional parameters for the AutoRestValidationTest.GetWithConstantInPath
+// method.
+type AutoRestValidationTestGetWithConstantInPathOptions struct {
+	// placeholder for future optional parameters
+}
+
 // AutoRestValidationTestPostWithConstantInBodyOptions contains the optional parameters for the AutoRestValidationTest.PostWithConstantInBody
 // method.
 type AutoRestValidationTestPostWithConstantInBodyOptions struct {
@@ -20,6 +26,12 @@ type AutoRestValidationTestPostWithConstantInBodyOptions struct {
 // method.
 type AutoRestValidationTestValidationOfBodyOptions struct {
 	Body *Product
+}
+
+// AutoRestValidationTestValidationOfMethodParametersOptions contains the optional parameters for the AutoRestValidationTest.ValidationOfMethodParameters
+// method.
+type AutoRestValidationTestValidationOfMethodParametersOptions struct {
+	// placeholder for future optional parameters
 }
 
 // The product documentation.

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -27,7 +27,7 @@ func newXMLClient() XMLOperations {
 
 func TestGetACLs(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetACLs(context.Background())
+	result, err := client.GetACLs(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestGetACLs(t *testing.T) {
 
 func TestGetComplexTypeRefNoMeta(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetComplexTypeRefNoMeta(context.Background())
+	result, err := client.GetComplexTypeRefNoMeta(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestGetComplexTypeRefNoMeta(t *testing.T) {
 
 func TestGetComplexTypeRefWithMeta(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetComplexTypeRefWithMeta(context.Background())
+	result, err := client.GetComplexTypeRefWithMeta(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestGetComplexTypeRefWithMeta(t *testing.T) {
 
 func TestGetEmptyChildElement(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetEmptyChildElement(context.Background())
+	result, err := client.GetEmptyChildElement(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestGetEmptyChildElement(t *testing.T) {
 
 func TestGetEmptyList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetEmptyList(context.Background())
+	result, err := client.GetEmptyList(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestGetEmptyList(t *testing.T) {
 
 func TestGetEmptyRootList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetEmptyRootList(context.Background())
+	result, err := client.GetEmptyRootList(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +116,7 @@ func TestGetEmptyRootList(t *testing.T) {
 
 func TestGetEmptyWrappedLists(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetEmptyWrappedLists(context.Background())
+	result, err := client.GetEmptyWrappedLists(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestGetEmptyWrappedLists(t *testing.T) {
 
 func TestGetHeaders(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetHeaders(context.Background())
+	result, err := client.GetHeaders(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestGetHeaders(t *testing.T) {
 
 func TestGetRootList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetRootList(context.Background())
+	result, err := client.GetRootList(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestGetRootList(t *testing.T) {
 
 func TestGetRootListSingleItem(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetRootListSingleItem(context.Background())
+	result, err := client.GetRootListSingleItem(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestGetRootListSingleItem(t *testing.T) {
 
 func TestGetServiceProperties(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetServiceProperties(context.Background())
+	result, err := client.GetServiceProperties(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestGetServiceProperties(t *testing.T) {
 
 func TestGetSimple(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetSimple(context.Background())
+	result, err := client.GetSimple(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestGetSimple(t *testing.T) {
 
 func TestGetWrappedLists(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.GetWrappedLists(context.Background())
+	result, err := client.GetWrappedLists(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestJSONInput(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.JSONInput(context.Background(), JSONInput{
 		ID: to.Int32Ptr(42),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -266,7 +266,7 @@ func TestJSONInput(t *testing.T) {
 
 func TestJSONOutput(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.JSONOutput(context.Background())
+	result, err := client.JSONOutput(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestJSONOutput(t *testing.T) {
 
 func TestListBlobs(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.ListBlobs(context.Background())
+	result, err := client.ListBlobs(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestListBlobs(t *testing.T) {
 
 func TestListContainers(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.ListContainers(context.Background())
+	result, err := client.ListContainers(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestPutACLs(t *testing.T) {
 				Permission: to.StringPtr("rwd"),
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +467,7 @@ func TestPutComplexTypeRefNoMeta(t *testing.T) {
 			ID: to.StringPtr("myid"),
 		},
 		Something: to.StringPtr("else"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestPutComplexTypeRefWithMeta(t *testing.T) {
 			ID: to.StringPtr("myid"),
 		},
 		Something: to.StringPtr("else"),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 		Name:       to.StringPtr("Unknown Banana"),
 		Expiration: toTimePtr(time.RFC3339Nano, "2012-02-24T00:53:52.789Z"),
 		Flavor:     to.StringPtr(""),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +505,7 @@ func TestPutEmptyList(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutEmptyList(context.Background(), Slideshow{
 		Slides: &[]Slide{},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +514,7 @@ func TestPutEmptyList(t *testing.T) {
 
 func TestPutEmptyRootList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.PutEmptyRootList(context.Background(), []Banana{})
+	result, err := client.PutEmptyRootList(context.Background(), []Banana{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -526,7 +526,7 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 	result, err := client.PutEmptyWrappedLists(context.Background(), AppleBarrel{
 		BadApples:  &[]string{},
 		GoodApples: &[]string{},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -546,7 +546,7 @@ func TestPutRootList(t *testing.T) {
 			Flavor:     to.StringPtr("Savory"),
 			Expiration: toTimePtr(time.RFC3339Nano, "2018-02-28T00:40:00.123Z"),
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,7 +561,7 @@ func TestPutRootListSingleItem(t *testing.T) {
 			Flavor:     to.StringPtr("Sweet"),
 			Expiration: toTimePtr(time.RFC3339Nano, "2018-02-28T00:40:00.123Z"),
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -599,7 +599,7 @@ func TestPutServiceProperties(t *testing.T) {
 				Days:    to.Int32Ptr(7),
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -623,7 +623,7 @@ func TestPutSimple(t *testing.T) {
 				Type:  to.StringPtr("all"),
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,7 +635,7 @@ func TestPutWrappedLists(t *testing.T) {
 	result, err := client.PutWrappedLists(context.Background(), AppleBarrel{
 		BadApples:  &[]string{"Red Delicious"},
 		GoodApples: &[]string{"Fuji", "Gala"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/xmlgroup/zz_generated_models.go
+++ b/test/autorest/xmlgroup/zz_generated_models.go
@@ -594,6 +594,46 @@ type StorageServicePropertiesResponse struct {
 	StorageServiceProperties *StorageServiceProperties `xml:"StorageServiceProperties"`
 }
 
+// XMLGetACLsOptions contains the optional parameters for the XML.GetACLs method.
+type XMLGetACLsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetComplexTypeRefNoMetaOptions contains the optional parameters for the XML.GetComplexTypeRefNoMeta method.
+type XMLGetComplexTypeRefNoMetaOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetComplexTypeRefWithMetaOptions contains the optional parameters for the XML.GetComplexTypeRefWithMeta method.
+type XMLGetComplexTypeRefWithMetaOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetEmptyChildElementOptions contains the optional parameters for the XML.GetEmptyChildElement method.
+type XMLGetEmptyChildElementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetEmptyListOptions contains the optional parameters for the XML.GetEmptyList method.
+type XMLGetEmptyListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetEmptyRootListOptions contains the optional parameters for the XML.GetEmptyRootList method.
+type XMLGetEmptyRootListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetEmptyWrappedListsOptions contains the optional parameters for the XML.GetEmptyWrappedLists method.
+type XMLGetEmptyWrappedListsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetHeadersOptions contains the optional parameters for the XML.GetHeaders method.
+type XMLGetHeadersOptions struct {
+	// placeholder for future optional parameters
+}
+
 // XMLGetHeadersResponse contains the response from method XML.GetHeaders.
 type XMLGetHeadersResponse struct {
 	// CustomHeader contains the information returned from the Custom-Header header response.
@@ -601,4 +641,114 @@ type XMLGetHeadersResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// XMLGetRootListOptions contains the optional parameters for the XML.GetRootList method.
+type XMLGetRootListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetRootListSingleItemOptions contains the optional parameters for the XML.GetRootListSingleItem method.
+type XMLGetRootListSingleItemOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetServicePropertiesOptions contains the optional parameters for the XML.GetServiceProperties method.
+type XMLGetServicePropertiesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetSimpleOptions contains the optional parameters for the XML.GetSimple method.
+type XMLGetSimpleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetWrappedListsOptions contains the optional parameters for the XML.GetWrappedLists method.
+type XMLGetWrappedListsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLGetXMSTextOptions contains the optional parameters for the XML.GetXMSText method.
+type XMLGetXMSTextOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLJSONInputOptions contains the optional parameters for the XML.JSONInput method.
+type XMLJSONInputOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLJSONOutputOptions contains the optional parameters for the XML.JSONOutput method.
+type XMLJSONOutputOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLListBlobsOptions contains the optional parameters for the XML.ListBlobs method.
+type XMLListBlobsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLListContainersOptions contains the optional parameters for the XML.ListContainers method.
+type XMLListContainersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutACLsOptions contains the optional parameters for the XML.PutACLs method.
+type XMLPutACLsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutComplexTypeRefNoMetaOptions contains the optional parameters for the XML.PutComplexTypeRefNoMeta method.
+type XMLPutComplexTypeRefNoMetaOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutComplexTypeRefWithMetaOptions contains the optional parameters for the XML.PutComplexTypeRefWithMeta method.
+type XMLPutComplexTypeRefWithMetaOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutEmptyChildElementOptions contains the optional parameters for the XML.PutEmptyChildElement method.
+type XMLPutEmptyChildElementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutEmptyListOptions contains the optional parameters for the XML.PutEmptyList method.
+type XMLPutEmptyListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutEmptyRootListOptions contains the optional parameters for the XML.PutEmptyRootList method.
+type XMLPutEmptyRootListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutEmptyWrappedListsOptions contains the optional parameters for the XML.PutEmptyWrappedLists method.
+type XMLPutEmptyWrappedListsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutRootListOptions contains the optional parameters for the XML.PutRootList method.
+type XMLPutRootListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutRootListSingleItemOptions contains the optional parameters for the XML.PutRootListSingleItem method.
+type XMLPutRootListSingleItemOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutServicePropertiesOptions contains the optional parameters for the XML.PutServiceProperties method.
+type XMLPutServicePropertiesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutSimpleOptions contains the optional parameters for the XML.PutSimple method.
+type XMLPutSimpleOptions struct {
+	// placeholder for future optional parameters
+}
+
+// XMLPutWrappedListsOptions contains the optional parameters for the XML.PutWrappedLists method.
+type XMLPutWrappedListsOptions struct {
+	// placeholder for future optional parameters
 }

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -18,65 +18,65 @@ import (
 // XMLOperations contains the methods for the XML group.
 type XMLOperations interface {
 	// GetACLs - Gets storage ACLs for a container.
-	GetACLs(ctx context.Context) (*SignedIDentifierArrayResponse, error)
+	GetACLs(ctx context.Context, options *XMLGetACLsOptions) (*SignedIDentifierArrayResponse, error)
 	// GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
-	GetComplexTypeRefNoMeta(ctx context.Context) (*RootWithRefAndNoMetaResponse, error)
+	GetComplexTypeRefNoMeta(ctx context.Context, options *XMLGetComplexTypeRefNoMetaOptions) (*RootWithRefAndNoMetaResponse, error)
 	// GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
-	GetComplexTypeRefWithMeta(ctx context.Context) (*RootWithRefAndMetaResponse, error)
+	GetComplexTypeRefWithMeta(ctx context.Context, options *XMLGetComplexTypeRefWithMetaOptions) (*RootWithRefAndMetaResponse, error)
 	// GetEmptyChildElement - Gets an XML document with an empty child element.
-	GetEmptyChildElement(ctx context.Context) (*BananaResponse, error)
+	GetEmptyChildElement(ctx context.Context, options *XMLGetEmptyChildElementOptions) (*BananaResponse, error)
 	// GetEmptyList - Get an empty list.
-	GetEmptyList(ctx context.Context) (*SlideshowResponse, error)
+	GetEmptyList(ctx context.Context, options *XMLGetEmptyListOptions) (*SlideshowResponse, error)
 	// GetEmptyRootList - Gets an empty list as the root element.
-	GetEmptyRootList(ctx context.Context) (*BananaArrayResponse, error)
+	GetEmptyRootList(ctx context.Context, options *XMLGetEmptyRootListOptions) (*BananaArrayResponse, error)
 	// GetEmptyWrappedLists - Gets some empty wrapped lists.
-	GetEmptyWrappedLists(ctx context.Context) (*AppleBarrelResponse, error)
+	GetEmptyWrappedLists(ctx context.Context, options *XMLGetEmptyWrappedListsOptions) (*AppleBarrelResponse, error)
 	// GetHeaders - Get strongly-typed response headers.
-	GetHeaders(ctx context.Context) (*XMLGetHeadersResponse, error)
+	GetHeaders(ctx context.Context, options *XMLGetHeadersOptions) (*XMLGetHeadersResponse, error)
 	// GetRootList - Gets a list as the root element.
-	GetRootList(ctx context.Context) (*BananaArrayResponse, error)
+	GetRootList(ctx context.Context, options *XMLGetRootListOptions) (*BananaArrayResponse, error)
 	// GetRootListSingleItem - Gets a list with a single item.
-	GetRootListSingleItem(ctx context.Context) (*BananaArrayResponse, error)
+	GetRootListSingleItem(ctx context.Context, options *XMLGetRootListSingleItemOptions) (*BananaArrayResponse, error)
 	// GetServiceProperties - Gets storage service properties.
-	GetServiceProperties(ctx context.Context) (*StorageServicePropertiesResponse, error)
+	GetServiceProperties(ctx context.Context, options *XMLGetServicePropertiesOptions) (*StorageServicePropertiesResponse, error)
 	// GetSimple - Get a simple XML document
-	GetSimple(ctx context.Context) (*SlideshowResponse, error)
+	GetSimple(ctx context.Context, options *XMLGetSimpleOptions) (*SlideshowResponse, error)
 	// GetWrappedLists - Get an XML document with multiple wrapped lists
-	GetWrappedLists(ctx context.Context) (*AppleBarrelResponse, error)
+	GetWrappedLists(ctx context.Context, options *XMLGetWrappedListsOptions) (*AppleBarrelResponse, error)
 	// GetXMSText - Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language' property being 'english' and its 'content' property being 'I am text'
-	GetXMSText(ctx context.Context) (*ObjectWithXMSTextPropertyResponse, error)
+	GetXMSText(ctx context.Context, options *XMLGetXMSTextOptions) (*ObjectWithXMSTextPropertyResponse, error)
 	// JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
-	JSONInput(ctx context.Context, properties JSONInput) (*http.Response, error)
+	JSONInput(ctx context.Context, properties JSONInput, options *XMLJSONInputOptions) (*http.Response, error)
 	// JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
-	JSONOutput(ctx context.Context) (*JSONOutputResponse, error)
+	JSONOutput(ctx context.Context, options *XMLJSONOutputOptions) (*JSONOutputResponse, error)
 	// ListBlobs - Lists blobs in a storage container.
-	ListBlobs(ctx context.Context) (*ListBlobsResponseResponse, error)
+	ListBlobs(ctx context.Context, options *XMLListBlobsOptions) (*ListBlobsResponseResponse, error)
 	// ListContainers - Lists containers in a storage account.
-	ListContainers(ctx context.Context) (*ListContainersResponseResponse, error)
+	ListContainers(ctx context.Context, options *XMLListContainersOptions) (*ListContainersResponseResponse, error)
 	// PutACLs - Puts storage ACLs for a container.
-	PutACLs(ctx context.Context, properties []SignedIDentifier) (*http.Response, error)
+	PutACLs(ctx context.Context, properties []SignedIDentifier, options *XMLPutACLsOptions) (*http.Response, error)
 	// PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
-	PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*http.Response, error)
+	PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta, options *XMLPutComplexTypeRefNoMetaOptions) (*http.Response, error)
 	// PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
-	PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*http.Response, error)
+	PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta, options *XMLPutComplexTypeRefWithMetaOptions) (*http.Response, error)
 	// PutEmptyChildElement - Puts a value with an empty child element.
-	PutEmptyChildElement(ctx context.Context, banana Banana) (*http.Response, error)
+	PutEmptyChildElement(ctx context.Context, banana Banana, options *XMLPutEmptyChildElementOptions) (*http.Response, error)
 	// PutEmptyList - Puts an empty list.
-	PutEmptyList(ctx context.Context, slideshow Slideshow) (*http.Response, error)
+	PutEmptyList(ctx context.Context, slideshow Slideshow, options *XMLPutEmptyListOptions) (*http.Response, error)
 	// PutEmptyRootList - Puts an empty list as the root element.
-	PutEmptyRootList(ctx context.Context, bananas []Banana) (*http.Response, error)
+	PutEmptyRootList(ctx context.Context, bananas []Banana, options *XMLPutEmptyRootListOptions) (*http.Response, error)
 	// PutEmptyWrappedLists - Puts some empty wrapped lists.
-	PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*http.Response, error)
+	PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel, options *XMLPutEmptyWrappedListsOptions) (*http.Response, error)
 	// PutRootList - Puts a list as the root element.
-	PutRootList(ctx context.Context, bananas []Banana) (*http.Response, error)
+	PutRootList(ctx context.Context, bananas []Banana, options *XMLPutRootListOptions) (*http.Response, error)
 	// PutRootListSingleItem - Puts a list with a single item.
-	PutRootListSingleItem(ctx context.Context, bananas []Banana) (*http.Response, error)
+	PutRootListSingleItem(ctx context.Context, bananas []Banana, options *XMLPutRootListSingleItemOptions) (*http.Response, error)
 	// PutServiceProperties - Puts storage service properties.
-	PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*http.Response, error)
+	PutServiceProperties(ctx context.Context, properties StorageServiceProperties, options *XMLPutServicePropertiesOptions) (*http.Response, error)
 	// PutSimple - Put a simple XML document
-	PutSimple(ctx context.Context, slideshow Slideshow) (*http.Response, error)
+	PutSimple(ctx context.Context, slideshow Slideshow, options *XMLPutSimpleOptions) (*http.Response, error)
 	// PutWrappedLists - Put an XML document with multiple wrapped lists
-	PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*http.Response, error)
+	PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel, options *XMLPutWrappedListsOptions) (*http.Response, error)
 }
 
 // XMLClient implements the XMLOperations interface.
@@ -96,8 +96,8 @@ func (client *XMLClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetACLs - Gets storage ACLs for a container.
-func (client *XMLClient) GetACLs(ctx context.Context) (*SignedIDentifierArrayResponse, error) {
-	req, err := client.GetACLsCreateRequest(ctx)
+func (client *XMLClient) GetACLs(ctx context.Context, options *XMLGetACLsOptions) (*SignedIDentifierArrayResponse, error) {
+	req, err := client.GetACLsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (client *XMLClient) GetACLs(ctx context.Context) (*SignedIDentifierArrayRes
 }
 
 // GetACLsCreateRequest creates the GetACLs request.
-func (client *XMLClient) GetACLsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetACLsCreateRequest(ctx context.Context, options *XMLGetACLsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -149,8 +149,8 @@ func (client *XMLClient) GetACLsHandleError(resp *azcore.Response) error {
 }
 
 // GetComplexTypeRefNoMeta - Get a complex type that has a ref to a complex type with no XML node
-func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWithRefAndNoMetaResponse, error) {
-	req, err := client.GetComplexTypeRefNoMetaCreateRequest(ctx)
+func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context, options *XMLGetComplexTypeRefNoMetaOptions) (*RootWithRefAndNoMetaResponse, error) {
+	req, err := client.GetComplexTypeRefNoMetaCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context) (*RootWith
 }
 
 // GetComplexTypeRefNoMetaCreateRequest creates the GetComplexTypeRefNoMeta request.
-func (client *XMLClient) GetComplexTypeRefNoMetaCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetComplexTypeRefNoMetaCreateRequest(ctx context.Context, options *XMLGetComplexTypeRefNoMetaOptions) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -198,8 +198,8 @@ func (client *XMLClient) GetComplexTypeRefNoMetaHandleError(resp *azcore.Respons
 }
 
 // GetComplexTypeRefWithMeta - Get a complex type that has a ref to a complex type with XML node
-func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWithRefAndMetaResponse, error) {
-	req, err := client.GetComplexTypeRefWithMetaCreateRequest(ctx)
+func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context, options *XMLGetComplexTypeRefWithMetaOptions) (*RootWithRefAndMetaResponse, error) {
+	req, err := client.GetComplexTypeRefWithMetaCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context) (*RootWi
 }
 
 // GetComplexTypeRefWithMetaCreateRequest creates the GetComplexTypeRefWithMeta request.
-func (client *XMLClient) GetComplexTypeRefWithMetaCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetComplexTypeRefWithMetaCreateRequest(ctx context.Context, options *XMLGetComplexTypeRefWithMetaOptions) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -247,8 +247,8 @@ func (client *XMLClient) GetComplexTypeRefWithMetaHandleError(resp *azcore.Respo
 }
 
 // GetEmptyChildElement - Gets an XML document with an empty child element.
-func (client *XMLClient) GetEmptyChildElement(ctx context.Context) (*BananaResponse, error) {
-	req, err := client.GetEmptyChildElementCreateRequest(ctx)
+func (client *XMLClient) GetEmptyChildElement(ctx context.Context, options *XMLGetEmptyChildElementOptions) (*BananaResponse, error) {
+	req, err := client.GetEmptyChildElementCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func (client *XMLClient) GetEmptyChildElement(ctx context.Context) (*BananaRespo
 }
 
 // GetEmptyChildElementCreateRequest creates the GetEmptyChildElement request.
-func (client *XMLClient) GetEmptyChildElementCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetEmptyChildElementCreateRequest(ctx context.Context, options *XMLGetEmptyChildElementOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -296,8 +296,8 @@ func (client *XMLClient) GetEmptyChildElementHandleError(resp *azcore.Response) 
 }
 
 // GetEmptyList - Get an empty list.
-func (client *XMLClient) GetEmptyList(ctx context.Context) (*SlideshowResponse, error) {
-	req, err := client.GetEmptyListCreateRequest(ctx)
+func (client *XMLClient) GetEmptyList(ctx context.Context, options *XMLGetEmptyListOptions) (*SlideshowResponse, error) {
+	req, err := client.GetEmptyListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (client *XMLClient) GetEmptyList(ctx context.Context) (*SlideshowResponse, 
 }
 
 // GetEmptyListCreateRequest creates the GetEmptyList request.
-func (client *XMLClient) GetEmptyListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetEmptyListCreateRequest(ctx context.Context, options *XMLGetEmptyListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -345,8 +345,8 @@ func (client *XMLClient) GetEmptyListHandleError(resp *azcore.Response) error {
 }
 
 // GetEmptyRootList - Gets an empty list as the root element.
-func (client *XMLClient) GetEmptyRootList(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.GetEmptyRootListCreateRequest(ctx)
+func (client *XMLClient) GetEmptyRootList(ctx context.Context, options *XMLGetEmptyRootListOptions) (*BananaArrayResponse, error) {
+	req, err := client.GetEmptyRootListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (client *XMLClient) GetEmptyRootList(ctx context.Context) (*BananaArrayResp
 }
 
 // GetEmptyRootListCreateRequest creates the GetEmptyRootList request.
-func (client *XMLClient) GetEmptyRootListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetEmptyRootListCreateRequest(ctx context.Context, options *XMLGetEmptyRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -394,8 +394,8 @@ func (client *XMLClient) GetEmptyRootListHandleError(resp *azcore.Response) erro
 }
 
 // GetEmptyWrappedLists - Gets some empty wrapped lists.
-func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
-	req, err := client.GetEmptyWrappedListsCreateRequest(ctx)
+func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context, options *XMLGetEmptyWrappedListsOptions) (*AppleBarrelResponse, error) {
+	req, err := client.GetEmptyWrappedListsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context) (*AppleBarrel
 }
 
 // GetEmptyWrappedListsCreateRequest creates the GetEmptyWrappedLists request.
-func (client *XMLClient) GetEmptyWrappedListsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetEmptyWrappedListsCreateRequest(ctx context.Context, options *XMLGetEmptyWrappedListsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -443,8 +443,8 @@ func (client *XMLClient) GetEmptyWrappedListsHandleError(resp *azcore.Response) 
 }
 
 // GetHeaders - Get strongly-typed response headers.
-func (client *XMLClient) GetHeaders(ctx context.Context) (*XMLGetHeadersResponse, error) {
-	req, err := client.GetHeadersCreateRequest(ctx)
+func (client *XMLClient) GetHeaders(ctx context.Context, options *XMLGetHeadersOptions) (*XMLGetHeadersResponse, error) {
+	req, err := client.GetHeadersCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +463,7 @@ func (client *XMLClient) GetHeaders(ctx context.Context) (*XMLGetHeadersResponse
 }
 
 // GetHeadersCreateRequest creates the GetHeaders request.
-func (client *XMLClient) GetHeadersCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetHeadersCreateRequest(ctx context.Context, options *XMLGetHeadersOptions) (*azcore.Request, error) {
 	urlPath := "/xml/headers"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -494,8 +494,8 @@ func (client *XMLClient) GetHeadersHandleError(resp *azcore.Response) error {
 }
 
 // GetRootList - Gets a list as the root element.
-func (client *XMLClient) GetRootList(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.GetRootListCreateRequest(ctx)
+func (client *XMLClient) GetRootList(ctx context.Context, options *XMLGetRootListOptions) (*BananaArrayResponse, error) {
+	req, err := client.GetRootListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,7 @@ func (client *XMLClient) GetRootList(ctx context.Context) (*BananaArrayResponse,
 }
 
 // GetRootListCreateRequest creates the GetRootList request.
-func (client *XMLClient) GetRootListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetRootListCreateRequest(ctx context.Context, options *XMLGetRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -543,8 +543,8 @@ func (client *XMLClient) GetRootListHandleError(resp *azcore.Response) error {
 }
 
 // GetRootListSingleItem - Gets a list with a single item.
-func (client *XMLClient) GetRootListSingleItem(ctx context.Context) (*BananaArrayResponse, error) {
-	req, err := client.GetRootListSingleItemCreateRequest(ctx)
+func (client *XMLClient) GetRootListSingleItem(ctx context.Context, options *XMLGetRootListSingleItemOptions) (*BananaArrayResponse, error) {
+	req, err := client.GetRootListSingleItemCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func (client *XMLClient) GetRootListSingleItem(ctx context.Context) (*BananaArra
 }
 
 // GetRootListSingleItemCreateRequest creates the GetRootListSingleItem request.
-func (client *XMLClient) GetRootListSingleItemCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetRootListSingleItemCreateRequest(ctx context.Context, options *XMLGetRootListSingleItemOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -592,8 +592,8 @@ func (client *XMLClient) GetRootListSingleItemHandleError(resp *azcore.Response)
 }
 
 // GetServiceProperties - Gets storage service properties.
-func (client *XMLClient) GetServiceProperties(ctx context.Context) (*StorageServicePropertiesResponse, error) {
-	req, err := client.GetServicePropertiesCreateRequest(ctx)
+func (client *XMLClient) GetServiceProperties(ctx context.Context, options *XMLGetServicePropertiesOptions) (*StorageServicePropertiesResponse, error) {
+	req, err := client.GetServicePropertiesCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +612,7 @@ func (client *XMLClient) GetServiceProperties(ctx context.Context) (*StorageServ
 }
 
 // GetServicePropertiesCreateRequest creates the GetServiceProperties request.
-func (client *XMLClient) GetServicePropertiesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetServicePropertiesCreateRequest(ctx context.Context, options *XMLGetServicePropertiesOptions) (*azcore.Request, error) {
 	urlPath := "/xml/"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -645,8 +645,8 @@ func (client *XMLClient) GetServicePropertiesHandleError(resp *azcore.Response) 
 }
 
 // GetSimple - Get a simple XML document
-func (client *XMLClient) GetSimple(ctx context.Context) (*SlideshowResponse, error) {
-	req, err := client.GetSimpleCreateRequest(ctx)
+func (client *XMLClient) GetSimple(ctx context.Context, options *XMLGetSimpleOptions) (*SlideshowResponse, error) {
+	req, err := client.GetSimpleCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +665,7 @@ func (client *XMLClient) GetSimple(ctx context.Context) (*SlideshowResponse, err
 }
 
 // GetSimpleCreateRequest creates the GetSimple request.
-func (client *XMLClient) GetSimpleCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetSimpleCreateRequest(ctx context.Context, options *XMLGetSimpleOptions) (*azcore.Request, error) {
 	urlPath := "/xml/simple"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -691,8 +691,8 @@ func (client *XMLClient) GetSimpleHandleError(resp *azcore.Response) error {
 }
 
 // GetWrappedLists - Get an XML document with multiple wrapped lists
-func (client *XMLClient) GetWrappedLists(ctx context.Context) (*AppleBarrelResponse, error) {
-	req, err := client.GetWrappedListsCreateRequest(ctx)
+func (client *XMLClient) GetWrappedLists(ctx context.Context, options *XMLGetWrappedListsOptions) (*AppleBarrelResponse, error) {
+	req, err := client.GetWrappedListsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -711,7 +711,7 @@ func (client *XMLClient) GetWrappedLists(ctx context.Context) (*AppleBarrelRespo
 }
 
 // GetWrappedListsCreateRequest creates the GetWrappedLists request.
-func (client *XMLClient) GetWrappedListsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetWrappedListsCreateRequest(ctx context.Context, options *XMLGetWrappedListsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -740,8 +740,8 @@ func (client *XMLClient) GetWrappedListsHandleError(resp *azcore.Response) error
 }
 
 // GetXMSText - Get back an XML object with an x-ms-text property, which should translate to the returned object's 'language' property being 'english' and its 'content' property being 'I am text'
-func (client *XMLClient) GetXMSText(ctx context.Context) (*ObjectWithXMSTextPropertyResponse, error) {
-	req, err := client.GetXMSTextCreateRequest(ctx)
+func (client *XMLClient) GetXMSText(ctx context.Context, options *XMLGetXMSTextOptions) (*ObjectWithXMSTextPropertyResponse, error) {
+	req, err := client.GetXMSTextCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +760,7 @@ func (client *XMLClient) GetXMSText(ctx context.Context) (*ObjectWithXMSTextProp
 }
 
 // GetXMSTextCreateRequest creates the GetXMSText request.
-func (client *XMLClient) GetXMSTextCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) GetXMSTextCreateRequest(ctx context.Context, options *XMLGetXMSTextOptions) (*azcore.Request, error) {
 	urlPath := "/xml/x-ms-text"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -789,8 +789,8 @@ func (client *XMLClient) GetXMSTextHandleError(resp *azcore.Response) error {
 }
 
 // JSONInput - A Swagger with XML that has one operation that takes JSON as input. You need to send the ID number 42
-func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput) (*http.Response, error) {
-	req, err := client.JSONInputCreateRequest(ctx, properties)
+func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput, options *XMLJSONInputOptions) (*http.Response, error) {
+	req, err := client.JSONInputCreateRequest(ctx, properties, options)
 	if err != nil {
 		return nil, err
 	}
@@ -805,7 +805,7 @@ func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput) (*
 }
 
 // JSONInputCreateRequest creates the JSONInput request.
-func (client *XMLClient) JSONInputCreateRequest(ctx context.Context, properties JSONInput) (*azcore.Request, error) {
+func (client *XMLClient) JSONInputCreateRequest(ctx context.Context, properties JSONInput, options *XMLJSONInputOptions) (*azcore.Request, error) {
 	urlPath := "/xml/jsoninput"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -827,8 +827,8 @@ func (client *XMLClient) JSONInputHandleError(resp *azcore.Response) error {
 }
 
 // JSONOutput - A Swagger with XML that has one operation that returns JSON. ID number 42
-func (client *XMLClient) JSONOutput(ctx context.Context) (*JSONOutputResponse, error) {
-	req, err := client.JSONOutputCreateRequest(ctx)
+func (client *XMLClient) JSONOutput(ctx context.Context, options *XMLJSONOutputOptions) (*JSONOutputResponse, error) {
+	req, err := client.JSONOutputCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -847,7 +847,7 @@ func (client *XMLClient) JSONOutput(ctx context.Context) (*JSONOutputResponse, e
 }
 
 // JSONOutputCreateRequest creates the JSONOutput request.
-func (client *XMLClient) JSONOutputCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) JSONOutputCreateRequest(ctx context.Context, options *XMLJSONOutputOptions) (*azcore.Request, error) {
 	urlPath := "/xml/jsonoutput"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -876,8 +876,8 @@ func (client *XMLClient) JSONOutputHandleError(resp *azcore.Response) error {
 }
 
 // ListBlobs - Lists blobs in a storage container.
-func (client *XMLClient) ListBlobs(ctx context.Context) (*ListBlobsResponseResponse, error) {
-	req, err := client.ListBlobsCreateRequest(ctx)
+func (client *XMLClient) ListBlobs(ctx context.Context, options *XMLListBlobsOptions) (*ListBlobsResponseResponse, error) {
+	req, err := client.ListBlobsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -896,7 +896,7 @@ func (client *XMLClient) ListBlobs(ctx context.Context) (*ListBlobsResponseRespo
 }
 
 // ListBlobsCreateRequest creates the ListBlobs request.
-func (client *XMLClient) ListBlobsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) ListBlobsCreateRequest(ctx context.Context, options *XMLListBlobsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -929,8 +929,8 @@ func (client *XMLClient) ListBlobsHandleError(resp *azcore.Response) error {
 }
 
 // ListContainers - Lists containers in a storage account.
-func (client *XMLClient) ListContainers(ctx context.Context) (*ListContainersResponseResponse, error) {
-	req, err := client.ListContainersCreateRequest(ctx)
+func (client *XMLClient) ListContainers(ctx context.Context, options *XMLListContainersOptions) (*ListContainersResponseResponse, error) {
+	req, err := client.ListContainersCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -949,7 +949,7 @@ func (client *XMLClient) ListContainers(ctx context.Context) (*ListContainersRes
 }
 
 // ListContainersCreateRequest creates the ListContainers request.
-func (client *XMLClient) ListContainersCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *XMLClient) ListContainersCreateRequest(ctx context.Context, options *XMLListContainersOptions) (*azcore.Request, error) {
 	urlPath := "/xml/"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -981,8 +981,8 @@ func (client *XMLClient) ListContainersHandleError(resp *azcore.Response) error 
 }
 
 // PutACLs - Puts storage ACLs for a container.
-func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIDentifier) (*http.Response, error) {
-	req, err := client.PutACLsCreateRequest(ctx, properties)
+func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIDentifier, options *XMLPutACLsOptions) (*http.Response, error) {
+	req, err := client.PutACLsCreateRequest(ctx, properties, options)
 	if err != nil {
 		return nil, err
 	}
@@ -997,7 +997,7 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIDentif
 }
 
 // PutACLsCreateRequest creates the PutACLs request.
-func (client *XMLClient) PutACLsCreateRequest(ctx context.Context, properties []SignedIDentifier) (*azcore.Request, error) {
+func (client *XMLClient) PutACLsCreateRequest(ctx context.Context, properties []SignedIDentifier, options *XMLPutACLsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1027,8 +1027,8 @@ func (client *XMLClient) PutACLsHandleError(resp *azcore.Response) error {
 }
 
 // PutComplexTypeRefNoMeta - Puts a complex type that has a ref to a complex type with no XML node
-func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta) (*http.Response, error) {
-	req, err := client.PutComplexTypeRefNoMetaCreateRequest(ctx, model)
+func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model RootWithRefAndNoMeta, options *XMLPutComplexTypeRefNoMetaOptions) (*http.Response, error) {
+	req, err := client.PutComplexTypeRefNoMetaCreateRequest(ctx, model, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1043,7 +1043,7 @@ func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model Root
 }
 
 // PutComplexTypeRefNoMetaCreateRequest creates the PutComplexTypeRefNoMeta request.
-func (client *XMLClient) PutComplexTypeRefNoMetaCreateRequest(ctx context.Context, model RootWithRefAndNoMeta) (*azcore.Request, error) {
+func (client *XMLClient) PutComplexTypeRefNoMetaCreateRequest(ctx context.Context, model RootWithRefAndNoMeta, options *XMLPutComplexTypeRefNoMetaOptions) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-no-meta"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1065,8 +1065,8 @@ func (client *XMLClient) PutComplexTypeRefNoMetaHandleError(resp *azcore.Respons
 }
 
 // PutComplexTypeRefWithMeta - Puts a complex type that has a ref to a complex type with XML node
-func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta) (*http.Response, error) {
-	req, err := client.PutComplexTypeRefWithMetaCreateRequest(ctx, model)
+func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model RootWithRefAndMeta, options *XMLPutComplexTypeRefWithMetaOptions) (*http.Response, error) {
+	req, err := client.PutComplexTypeRefWithMetaCreateRequest(ctx, model, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1081,7 +1081,7 @@ func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model Ro
 }
 
 // PutComplexTypeRefWithMetaCreateRequest creates the PutComplexTypeRefWithMeta request.
-func (client *XMLClient) PutComplexTypeRefWithMetaCreateRequest(ctx context.Context, model RootWithRefAndMeta) (*azcore.Request, error) {
+func (client *XMLClient) PutComplexTypeRefWithMetaCreateRequest(ctx context.Context, model RootWithRefAndMeta, options *XMLPutComplexTypeRefWithMetaOptions) (*azcore.Request, error) {
 	urlPath := "/xml/complex-type-ref-with-meta"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1103,8 +1103,8 @@ func (client *XMLClient) PutComplexTypeRefWithMetaHandleError(resp *azcore.Respo
 }
 
 // PutEmptyChildElement - Puts a value with an empty child element.
-func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana) (*http.Response, error) {
-	req, err := client.PutEmptyChildElementCreateRequest(ctx, banana)
+func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana, options *XMLPutEmptyChildElementOptions) (*http.Response, error) {
+	req, err := client.PutEmptyChildElementCreateRequest(ctx, banana, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1119,7 +1119,7 @@ func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana
 }
 
 // PutEmptyChildElementCreateRequest creates the PutEmptyChildElement request.
-func (client *XMLClient) PutEmptyChildElementCreateRequest(ctx context.Context, banana Banana) (*azcore.Request, error) {
+func (client *XMLClient) PutEmptyChildElementCreateRequest(ctx context.Context, banana Banana, options *XMLPutEmptyChildElementOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-child-element"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1141,8 +1141,8 @@ func (client *XMLClient) PutEmptyChildElementHandleError(resp *azcore.Response) 
 }
 
 // PutEmptyList - Puts an empty list.
-func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
-	req, err := client.PutEmptyListCreateRequest(ctx, slideshow)
+func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow, options *XMLPutEmptyListOptions) (*http.Response, error) {
+	req, err := client.PutEmptyListCreateRequest(ctx, slideshow, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1157,7 +1157,7 @@ func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow) 
 }
 
 // PutEmptyListCreateRequest creates the PutEmptyList request.
-func (client *XMLClient) PutEmptyListCreateRequest(ctx context.Context, slideshow Slideshow) (*azcore.Request, error) {
+func (client *XMLClient) PutEmptyListCreateRequest(ctx context.Context, slideshow Slideshow, options *XMLPutEmptyListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-list"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1179,8 +1179,8 @@ func (client *XMLClient) PutEmptyListHandleError(resp *azcore.Response) error {
 }
 
 // PutEmptyRootList - Puts an empty list as the root element.
-func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.PutEmptyRootListCreateRequest(ctx, bananas)
+func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana, options *XMLPutEmptyRootListOptions) (*http.Response, error) {
+	req, err := client.PutEmptyRootListCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1195,7 +1195,7 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana)
 }
 
 // PutEmptyRootListCreateRequest creates the PutEmptyRootList request.
-func (client *XMLClient) PutEmptyRootListCreateRequest(ctx context.Context, bananas []Banana) (*azcore.Request, error) {
+func (client *XMLClient) PutEmptyRootListCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutEmptyRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1221,8 +1221,8 @@ func (client *XMLClient) PutEmptyRootListHandleError(resp *azcore.Response) erro
 }
 
 // PutEmptyWrappedLists - Puts some empty wrapped lists.
-func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel) (*http.Response, error) {
-	req, err := client.PutEmptyWrappedListsCreateRequest(ctx, appleBarrel)
+func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel AppleBarrel, options *XMLPutEmptyWrappedListsOptions) (*http.Response, error) {
+	req, err := client.PutEmptyWrappedListsCreateRequest(ctx, appleBarrel, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1237,7 +1237,7 @@ func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel A
 }
 
 // PutEmptyWrappedListsCreateRequest creates the PutEmptyWrappedLists request.
-func (client *XMLClient) PutEmptyWrappedListsCreateRequest(ctx context.Context, appleBarrel AppleBarrel) (*azcore.Request, error) {
+func (client *XMLClient) PutEmptyWrappedListsCreateRequest(ctx context.Context, appleBarrel AppleBarrel, options *XMLPutEmptyWrappedListsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-wrapped-lists"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1259,8 +1259,8 @@ func (client *XMLClient) PutEmptyWrappedListsHandleError(resp *azcore.Response) 
 }
 
 // PutRootList - Puts a list as the root element.
-func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.PutRootListCreateRequest(ctx, bananas)
+func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana, options *XMLPutRootListOptions) (*http.Response, error) {
+	req, err := client.PutRootListCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1275,7 +1275,7 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana) (*ht
 }
 
 // PutRootListCreateRequest creates the PutRootList request.
-func (client *XMLClient) PutRootListCreateRequest(ctx context.Context, bananas []Banana) (*azcore.Request, error) {
+func (client *XMLClient) PutRootListCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1301,8 +1301,8 @@ func (client *XMLClient) PutRootListHandleError(resp *azcore.Response) error {
 }
 
 // PutRootListSingleItem - Puts a list with a single item.
-func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Banana) (*http.Response, error) {
-	req, err := client.PutRootListSingleItemCreateRequest(ctx, bananas)
+func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Banana, options *XMLPutRootListSingleItemOptions) (*http.Response, error) {
+	req, err := client.PutRootListSingleItemCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1317,7 +1317,7 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Ba
 }
 
 // PutRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
-func (client *XMLClient) PutRootListSingleItemCreateRequest(ctx context.Context, bananas []Banana) (*azcore.Request, error) {
+func (client *XMLClient) PutRootListSingleItemCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutRootListSingleItemOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1343,8 +1343,8 @@ func (client *XMLClient) PutRootListSingleItemHandleError(resp *azcore.Response)
 }
 
 // PutServiceProperties - Puts storage service properties.
-func (client *XMLClient) PutServiceProperties(ctx context.Context, properties StorageServiceProperties) (*http.Response, error) {
-	req, err := client.PutServicePropertiesCreateRequest(ctx, properties)
+func (client *XMLClient) PutServiceProperties(ctx context.Context, properties StorageServiceProperties, options *XMLPutServicePropertiesOptions) (*http.Response, error) {
+	req, err := client.PutServicePropertiesCreateRequest(ctx, properties, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1359,7 +1359,7 @@ func (client *XMLClient) PutServiceProperties(ctx context.Context, properties St
 }
 
 // PutServicePropertiesCreateRequest creates the PutServiceProperties request.
-func (client *XMLClient) PutServicePropertiesCreateRequest(ctx context.Context, properties StorageServiceProperties) (*azcore.Request, error) {
+func (client *XMLClient) PutServicePropertiesCreateRequest(ctx context.Context, properties StorageServiceProperties, options *XMLPutServicePropertiesOptions) (*azcore.Request, error) {
 	urlPath := "/xml/"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1385,8 +1385,8 @@ func (client *XMLClient) PutServicePropertiesHandleError(resp *azcore.Response) 
 }
 
 // PutSimple - Put a simple XML document
-func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow) (*http.Response, error) {
-	req, err := client.PutSimpleCreateRequest(ctx, slideshow)
+func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow, options *XMLPutSimpleOptions) (*http.Response, error) {
+	req, err := client.PutSimpleCreateRequest(ctx, slideshow, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1401,7 +1401,7 @@ func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow) (*h
 }
 
 // PutSimpleCreateRequest creates the PutSimple request.
-func (client *XMLClient) PutSimpleCreateRequest(ctx context.Context, slideshow Slideshow) (*azcore.Request, error) {
+func (client *XMLClient) PutSimpleCreateRequest(ctx context.Context, slideshow Slideshow, options *XMLPutSimpleOptions) (*azcore.Request, error) {
 	urlPath := "/xml/simple"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -1421,8 +1421,8 @@ func (client *XMLClient) PutSimpleHandleError(resp *azcore.Response) error {
 }
 
 // PutWrappedLists - Put an XML document with multiple wrapped lists
-func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel) (*http.Response, error) {
-	req, err := client.PutWrappedListsCreateRequest(ctx, wrappedLists)
+func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists AppleBarrel, options *XMLPutWrappedListsOptions) (*http.Response, error) {
+	req, err := client.PutWrappedListsCreateRequest(ctx, wrappedLists, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1437,7 +1437,7 @@ func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists Apple
 }
 
 // PutWrappedListsCreateRequest creates the PutWrappedLists request.
-func (client *XMLClient) PutWrappedListsCreateRequest(ctx context.Context, wrappedLists AppleBarrel) (*azcore.Request, error) {
+func (client *XMLClient) PutWrappedListsCreateRequest(ctx context.Context, wrappedLists AppleBarrel, options *XMLPutWrappedListsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/wrapped-lists"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
@@ -19,19 +19,19 @@ import (
 // AvailabilitySetsOperations contains the methods for the AvailabilitySets group.
 type AvailabilitySetsOperations interface {
 	// CreateOrUpdate - Create or update an availability set.
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet) (*AvailabilitySetResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet, options *AvailabilitySetsCreateOrUpdateOptions) (*AvailabilitySetResponse, error)
 	// Delete - Delete an availability set.
-	Delete(ctx context.Context, resourceGroupName string, availabilitySetName string) (*http.Response, error)
+	Delete(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsDeleteOptions) (*http.Response, error)
 	// Get - Retrieves information about an availability set.
-	Get(ctx context.Context, resourceGroupName string, availabilitySetName string) (*AvailabilitySetResponse, error)
+	Get(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsGetOptions) (*AvailabilitySetResponse, error)
 	// List - Lists all availability sets in a resource group.
-	List(resourceGroupName string) AvailabilitySetListResultPager
+	List(resourceGroupName string, options *AvailabilitySetsListOptions) AvailabilitySetListResultPager
 	// ListAvailableSizes - Lists all available virtual machine sizes that can be used to create a new virtual machine in an existing availability set.
-	ListAvailableSizes(ctx context.Context, resourceGroupName string, availabilitySetName string) (*VirtualMachineSizeListResultResponse, error)
+	ListAvailableSizes(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsListAvailableSizesOptions) (*VirtualMachineSizeListResultResponse, error)
 	// ListBySubscription - Lists all availability sets in a subscription.
-	ListBySubscription(availabilitySetsListBySubscriptionOptions *AvailabilitySetsListBySubscriptionOptions) AvailabilitySetListResultPager
+	ListBySubscription(options *AvailabilitySetsListBySubscriptionOptions) AvailabilitySetListResultPager
 	// Update - Update an availability set.
-	Update(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate) (*AvailabilitySetResponse, error)
+	Update(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate, options *AvailabilitySetsUpdateOptions) (*AvailabilitySetResponse, error)
 }
 
 // AvailabilitySetsClient implements the AvailabilitySetsOperations interface.
@@ -52,8 +52,8 @@ func (client *AvailabilitySetsClient) Do(req *azcore.Request) (*azcore.Response,
 }
 
 // CreateOrUpdate - Create or update an availability set.
-func (client *AvailabilitySetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet) (*AvailabilitySetResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, availabilitySetName, parameters)
+func (client *AvailabilitySetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet, options *AvailabilitySetsCreateOrUpdateOptions) (*AvailabilitySetResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, availabilitySetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (client *AvailabilitySetsClient) CreateOrUpdate(ctx context.Context, resour
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *AvailabilitySetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySet, options *AvailabilitySetsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{availabilitySetName}", url.PathEscape(availabilitySetName))
@@ -107,8 +107,8 @@ func (client *AvailabilitySetsClient) CreateOrUpdateHandleError(resp *azcore.Res
 }
 
 // Delete - Delete an availability set.
-func (client *AvailabilitySetsClient) Delete(ctx context.Context, resourceGroupName string, availabilitySetName string) (*http.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, availabilitySetName)
+func (client *AvailabilitySetsClient) Delete(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsDeleteOptions) (*http.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, availabilitySetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (client *AvailabilitySetsClient) Delete(ctx context.Context, resourceGroupN
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *AvailabilitySetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{availabilitySetName}", url.PathEscape(availabilitySetName))
@@ -151,8 +151,8 @@ func (client *AvailabilitySetsClient) DeleteHandleError(resp *azcore.Response) e
 }
 
 // Get - Retrieves information about an availability set.
-func (client *AvailabilitySetsClient) Get(ctx context.Context, resourceGroupName string, availabilitySetName string) (*AvailabilitySetResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, availabilitySetName)
+func (client *AvailabilitySetsClient) Get(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsGetOptions) (*AvailabilitySetResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, availabilitySetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (client *AvailabilitySetsClient) Get(ctx context.Context, resourceGroupName
 }
 
 // GetCreateRequest creates the Get request.
-func (client *AvailabilitySetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{availabilitySetName}", url.PathEscape(availabilitySetName))
@@ -206,11 +206,11 @@ func (client *AvailabilitySetsClient) GetHandleError(resp *azcore.Response) erro
 }
 
 // List - Lists all availability sets in a resource group.
-func (client *AvailabilitySetsClient) List(resourceGroupName string) AvailabilitySetListResultPager {
+func (client *AvailabilitySetsClient) List(resourceGroupName string, options *AvailabilitySetsListOptions) AvailabilitySetListResultPager {
 	return &availabilitySetListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -221,7 +221,7 @@ func (client *AvailabilitySetsClient) List(resourceGroupName string) Availabilit
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailabilitySetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *AvailabilitySetsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -255,8 +255,8 @@ func (client *AvailabilitySetsClient) ListHandleError(resp *azcore.Response) err
 }
 
 // ListAvailableSizes - Lists all available virtual machine sizes that can be used to create a new virtual machine in an existing availability set.
-func (client *AvailabilitySetsClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, availabilitySetName string) (*VirtualMachineSizeListResultResponse, error) {
-	req, err := client.ListAvailableSizesCreateRequest(ctx, resourceGroupName, availabilitySetName)
+func (client *AvailabilitySetsClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsListAvailableSizesOptions) (*VirtualMachineSizeListResultResponse, error) {
+	req, err := client.ListAvailableSizesCreateRequest(ctx, resourceGroupName, availabilitySetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (client *AvailabilitySetsClient) ListAvailableSizes(ctx context.Context, re
 }
 
 // ListAvailableSizesCreateRequest creates the ListAvailableSizes request.
-func (client *AvailabilitySetsClient) ListAvailableSizesCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) ListAvailableSizesCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, options *AvailabilitySetsListAvailableSizesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}/vmSizes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{availabilitySetName}", url.PathEscape(availabilitySetName))
@@ -310,11 +310,11 @@ func (client *AvailabilitySetsClient) ListAvailableSizesHandleError(resp *azcore
 }
 
 // ListBySubscription - Lists all availability sets in a subscription.
-func (client *AvailabilitySetsClient) ListBySubscription(availabilitySetsListBySubscriptionOptions *AvailabilitySetsListBySubscriptionOptions) AvailabilitySetListResultPager {
+func (client *AvailabilitySetsClient) ListBySubscription(options *AvailabilitySetsListBySubscriptionOptions) AvailabilitySetListResultPager {
 	return &availabilitySetListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx, availabilitySetsListBySubscriptionOptions)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -325,7 +325,7 @@ func (client *AvailabilitySetsClient) ListBySubscription(availabilitySetsListByS
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *AvailabilitySetsClient) ListBySubscriptionCreateRequest(ctx context.Context, availabilitySetsListBySubscriptionOptions *AvailabilitySetsListBySubscriptionOptions) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) ListBySubscriptionCreateRequest(ctx context.Context, options *AvailabilitySetsListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/availabilitySets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -334,8 +334,8 @@ func (client *AvailabilitySetsClient) ListBySubscriptionCreateRequest(ctx contex
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
-	if availabilitySetsListBySubscriptionOptions != nil && availabilitySetsListBySubscriptionOptions.Expand != nil {
-		query.Set("$expand", *availabilitySetsListBySubscriptionOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -361,8 +361,8 @@ func (client *AvailabilitySetsClient) ListBySubscriptionHandleError(resp *azcore
 }
 
 // Update - Update an availability set.
-func (client *AvailabilitySetsClient) Update(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate) (*AvailabilitySetResponse, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, availabilitySetName, parameters)
+func (client *AvailabilitySetsClient) Update(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate, options *AvailabilitySetsUpdateOptions) (*AvailabilitySetResponse, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, availabilitySetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (client *AvailabilitySetsClient) Update(ctx context.Context, resourceGroupN
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *AvailabilitySetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate) (*azcore.Request, error) {
+func (client *AvailabilitySetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, availabilitySetName string, parameters AvailabilitySetUpdate, options *AvailabilitySetsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{availabilitySetName}", url.PathEscape(availabilitySetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
@@ -21,19 +21,19 @@ import (
 // ContainerServicesOperations contains the methods for the ContainerServices group.
 type ContainerServicesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a container service with the specified configuration of orchestrator, masters, and agents.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService) (*ContainerServicePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesCreateOrUpdateOptions) (*ContainerServicePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ContainerServicePoller, error)
 	// BeginDelete - Deletes the specified container service in the specified subscription and resource group. The operation does not delete other resources created as part of creating a container service, including storage accounts, VMs, and availability sets. All the other resources created with the container service are part of the same resource group and can be deleted individually.
-	BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-	Get(ctx context.Context, resourceGroupName string, containerServiceName string) (*ContainerServiceResponse, error)
+	Get(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesGetOptions) (*ContainerServiceResponse, error)
 	// List - Gets a list of container services in the specified subscription. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-	List() ContainerServiceListResultPager
+	List(options *ContainerServicesListOptions) ContainerServiceListResultPager
 	// ListByResourceGroup - Gets a list of container services in the specified subscription and resource group. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-	ListByResourceGroup(resourceGroupName string) ContainerServiceListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ContainerServicesListByResourceGroupOptions) ContainerServiceListResultPager
 }
 
 // ContainerServicesClient implements the ContainerServicesOperations interface.
@@ -53,8 +53,8 @@ func (client *ContainerServicesClient) Do(req *azcore.Request) (*azcore.Response
 	return client.p.Do(req)
 }
 
-func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService) (*ContainerServicePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, containerServiceName, parameters)
+func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesCreateOrUpdateOptions) (*ContainerServicePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, containerServiceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ func (client *ContainerServicesClient) ResumeCreateOrUpdate(token string) (Conta
 }
 
 // CreateOrUpdate - Creates or updates a container service with the specified configuration of orchestrator, masters, and agents.
-func (client *ContainerServicesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, containerServiceName, parameters)
+func (client *ContainerServicesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, containerServiceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (client *ContainerServicesClient) CreateOrUpdate(ctx context.Context, resou
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ContainerServicesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService) (*azcore.Request, error) {
+func (client *ContainerServicesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string, parameters ContainerService, options *ContainerServicesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{containerServiceName}", url.PathEscape(containerServiceName))
@@ -138,8 +138,8 @@ func (client *ContainerServicesClient) CreateOrUpdateHandleError(resp *azcore.Re
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, containerServiceName)
+func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, containerServiceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -173,8 +173,8 @@ func (client *ContainerServicesClient) ResumeDelete(token string) (HTTPPoller, e
 }
 
 // Delete - Deletes the specified container service in the specified subscription and resource group. The operation does not delete other resources created as part of creating a container service, including storage accounts, VMs, and availability sets. All the other resources created with the container service are part of the same resource group and can be deleted individually.
-func (client *ContainerServicesClient) Delete(ctx context.Context, resourceGroupName string, containerServiceName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, containerServiceName)
+func (client *ContainerServicesClient) Delete(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, containerServiceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (client *ContainerServicesClient) Delete(ctx context.Context, resourceGroup
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ContainerServicesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string) (*azcore.Request, error) {
+func (client *ContainerServicesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{containerServiceName}", url.PathEscape(containerServiceName))
@@ -217,8 +217,8 @@ func (client *ContainerServicesClient) DeleteHandleError(resp *azcore.Response) 
 }
 
 // Get - Gets the properties of the specified container service in the specified subscription and resource group. The operation returns the properties including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-func (client *ContainerServicesClient) Get(ctx context.Context, resourceGroupName string, containerServiceName string) (*ContainerServiceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, containerServiceName)
+func (client *ContainerServicesClient) Get(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesGetOptions) (*ContainerServiceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, containerServiceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *ContainerServicesClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ContainerServicesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string) (*azcore.Request, error) {
+func (client *ContainerServicesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, containerServiceName string, options *ContainerServicesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{containerServiceName}", url.PathEscape(containerServiceName))
@@ -272,11 +272,11 @@ func (client *ContainerServicesClient) GetHandleError(resp *azcore.Response) err
 }
 
 // List - Gets a list of container services in the specified subscription. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-func (client *ContainerServicesClient) List() ContainerServiceListResultPager {
+func (client *ContainerServicesClient) List(options *ContainerServicesListOptions) ContainerServiceListResultPager {
 	return &containerServiceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -287,7 +287,7 @@ func (client *ContainerServicesClient) List() ContainerServiceListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *ContainerServicesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ContainerServicesClient) ListCreateRequest(ctx context.Context, options *ContainerServicesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -320,11 +320,11 @@ func (client *ContainerServicesClient) ListHandleError(resp *azcore.Response) er
 }
 
 // ListByResourceGroup - Gets a list of container services in the specified subscription and resource group. The operation returns properties of each container service including state, orchestrator, number of masters and agents, and FQDNs of masters and agents.
-func (client *ContainerServicesClient) ListByResourceGroup(resourceGroupName string) ContainerServiceListResultPager {
+func (client *ContainerServicesClient) ListByResourceGroup(resourceGroupName string, options *ContainerServicesListByResourceGroupOptions) ContainerServiceListResultPager {
 	return &containerServiceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -335,7 +335,7 @@ func (client *ContainerServicesClient) ListByResourceGroup(resourceGroupName str
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ContainerServicesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ContainerServicesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ContainerServicesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
@@ -19,17 +19,17 @@ import (
 // DedicatedHostGroupsOperations contains the methods for the DedicatedHostGroups group.
 type DedicatedHostGroupsOperations interface {
 	// CreateOrUpdate - Create or update a dedicated host group. For details of Dedicated Host and Dedicated Host Groups please see [Dedicated Host Documentation] (https://go.microsoft.com/fwlink/?linkid=2082596)
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup) (*DedicatedHostGroupResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup, options *DedicatedHostGroupsCreateOrUpdateOptions) (*DedicatedHostGroupResponse, error)
 	// Delete - Delete a dedicated host group.
-	Delete(ctx context.Context, resourceGroupName string, hostGroupName string) (*http.Response, error)
+	Delete(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsDeleteOptions) (*http.Response, error)
 	// Get - Retrieves information about a dedicated host group.
-	Get(ctx context.Context, resourceGroupName string, hostGroupName string) (*DedicatedHostGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsGetOptions) (*DedicatedHostGroupResponse, error)
 	// ListByResourceGroup - Lists all of the dedicated host groups in the specified resource group. Use the nextLink property in the response to get the next page of dedicated host groups.
-	ListByResourceGroup(resourceGroupName string) DedicatedHostGroupListResultPager
+	ListByResourceGroup(resourceGroupName string, options *DedicatedHostGroupsListByResourceGroupOptions) DedicatedHostGroupListResultPager
 	// ListBySubscription - Lists all of the dedicated host groups in the subscription. Use the nextLink property in the response to get the next page of dedicated host groups.
-	ListBySubscription() DedicatedHostGroupListResultPager
+	ListBySubscription(options *DedicatedHostGroupsListBySubscriptionOptions) DedicatedHostGroupListResultPager
 	// Update - Update an dedicated host group.
-	Update(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate) (*DedicatedHostGroupResponse, error)
+	Update(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate, options *DedicatedHostGroupsUpdateOptions) (*DedicatedHostGroupResponse, error)
 }
 
 // DedicatedHostGroupsClient implements the DedicatedHostGroupsOperations interface.
@@ -50,8 +50,8 @@ func (client *DedicatedHostGroupsClient) Do(req *azcore.Request) (*azcore.Respon
 }
 
 // CreateOrUpdate - Create or update a dedicated host group. For details of Dedicated Host and Dedicated Host Groups please see [Dedicated Host Documentation] (https://go.microsoft.com/fwlink/?linkid=2082596)
-func (client *DedicatedHostGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup) (*DedicatedHostGroupResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, hostGroupName, parameters)
+func (client *DedicatedHostGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup, options *DedicatedHostGroupsCreateOrUpdateOptions) (*DedicatedHostGroupResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, hostGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (client *DedicatedHostGroupsClient) CreateOrUpdate(ctx context.Context, res
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DedicatedHostGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroup, options *DedicatedHostGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -105,8 +105,8 @@ func (client *DedicatedHostGroupsClient) CreateOrUpdateHandleError(resp *azcore.
 }
 
 // Delete - Delete a dedicated host group.
-func (client *DedicatedHostGroupsClient) Delete(ctx context.Context, resourceGroupName string, hostGroupName string) (*http.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, hostGroupName)
+func (client *DedicatedHostGroupsClient) Delete(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsDeleteOptions) (*http.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, hostGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (client *DedicatedHostGroupsClient) Delete(ctx context.Context, resourceGro
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DedicatedHostGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -149,8 +149,8 @@ func (client *DedicatedHostGroupsClient) DeleteHandleError(resp *azcore.Response
 }
 
 // Get - Retrieves information about a dedicated host group.
-func (client *DedicatedHostGroupsClient) Get(ctx context.Context, resourceGroupName string, hostGroupName string) (*DedicatedHostGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, hostGroupName)
+func (client *DedicatedHostGroupsClient) Get(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsGetOptions) (*DedicatedHostGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, hostGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (client *DedicatedHostGroupsClient) Get(ctx context.Context, resourceGroupN
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DedicatedHostGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -204,11 +204,11 @@ func (client *DedicatedHostGroupsClient) GetHandleError(resp *azcore.Response) e
 }
 
 // ListByResourceGroup - Lists all of the dedicated host groups in the specified resource group. Use the nextLink property in the response to get the next page of dedicated host groups.
-func (client *DedicatedHostGroupsClient) ListByResourceGroup(resourceGroupName string) DedicatedHostGroupListResultPager {
+func (client *DedicatedHostGroupsClient) ListByResourceGroup(resourceGroupName string, options *DedicatedHostGroupsListByResourceGroupOptions) DedicatedHostGroupListResultPager {
 	return &dedicatedHostGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -219,7 +219,7 @@ func (client *DedicatedHostGroupsClient) ListByResourceGroup(resourceGroupName s
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *DedicatedHostGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *DedicatedHostGroupsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -253,11 +253,11 @@ func (client *DedicatedHostGroupsClient) ListByResourceGroupHandleError(resp *az
 }
 
 // ListBySubscription - Lists all of the dedicated host groups in the subscription. Use the nextLink property in the response to get the next page of dedicated host groups.
-func (client *DedicatedHostGroupsClient) ListBySubscription() DedicatedHostGroupListResultPager {
+func (client *DedicatedHostGroupsClient) ListBySubscription(options *DedicatedHostGroupsListBySubscriptionOptions) DedicatedHostGroupListResultPager {
 	return &dedicatedHostGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -268,7 +268,7 @@ func (client *DedicatedHostGroupsClient) ListBySubscription() DedicatedHostGroup
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *DedicatedHostGroupsClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) ListBySubscriptionCreateRequest(ctx context.Context, options *DedicatedHostGroupsListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/hostGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -301,8 +301,8 @@ func (client *DedicatedHostGroupsClient) ListBySubscriptionHandleError(resp *azc
 }
 
 // Update - Update an dedicated host group.
-func (client *DedicatedHostGroupsClient) Update(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate) (*DedicatedHostGroupResponse, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, hostGroupName, parameters)
+func (client *DedicatedHostGroupsClient) Update(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate, options *DedicatedHostGroupsUpdateOptions) (*DedicatedHostGroupResponse, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, hostGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (client *DedicatedHostGroupsClient) Update(ctx context.Context, resourceGro
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *DedicatedHostGroupsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate) (*azcore.Request, error) {
+func (client *DedicatedHostGroupsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, parameters DedicatedHostGroupUpdate, options *DedicatedHostGroupsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
@@ -21,19 +21,19 @@ import (
 // DedicatedHostsOperations contains the methods for the DedicatedHosts group.
 type DedicatedHostsOperations interface {
 	// BeginCreateOrUpdate - Create or update a dedicated host .
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost) (*DedicatedHostPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsCreateOrUpdateOptions) (*DedicatedHostPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (DedicatedHostPoller, error)
 	// BeginDelete - Delete a dedicated host.
-	BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a dedicated host.
-	Get(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, dedicatedHostsGetOptions *DedicatedHostsGetOptions) (*DedicatedHostResponse, error)
+	Get(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsGetOptions) (*DedicatedHostResponse, error)
 	// ListByHostGroup - Lists all of the dedicated hosts in the specified dedicated host group. Use the nextLink property in the response to get the next page of dedicated hosts.
-	ListByHostGroup(resourceGroupName string, hostGroupName string) DedicatedHostListResultPager
+	ListByHostGroup(resourceGroupName string, hostGroupName string, options *DedicatedHostsListByHostGroupOptions) DedicatedHostListResultPager
 	// BeginUpdate - Update an dedicated host .
-	BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate) (*DedicatedHostPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsUpdateOptions) (*DedicatedHostPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (DedicatedHostPoller, error)
 }
@@ -55,8 +55,8 @@ func (client *DedicatedHostsClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost) (*DedicatedHostPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, hostGroupName, hostName, parameters)
+func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsCreateOrUpdateOptions) (*DedicatedHostPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func (client *DedicatedHostsClient) ResumeCreateOrUpdate(token string) (Dedicate
 }
 
 // CreateOrUpdate - Create or update a dedicated host .
-func (client *DedicatedHostsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, parameters)
+func (client *DedicatedHostsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (client *DedicatedHostsClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DedicatedHostsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost) (*azcore.Request, error) {
+func (client *DedicatedHostsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHost, options *DedicatedHostsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -141,8 +141,8 @@ func (client *DedicatedHostsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, hostGroupName, hostName)
+func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, hostGroupName, hostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,8 @@ func (client *DedicatedHostsClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Delete a dedicated host.
-func (client *DedicatedHostsClient) Delete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, hostGroupName, hostName)
+func (client *DedicatedHostsClient) Delete(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (client *DedicatedHostsClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DedicatedHostsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string) (*azcore.Request, error) {
+func (client *DedicatedHostsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -221,8 +221,8 @@ func (client *DedicatedHostsClient) DeleteHandleError(resp *azcore.Response) err
 }
 
 // Get - Retrieves information about a dedicated host.
-func (client *DedicatedHostsClient) Get(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, dedicatedHostsGetOptions *DedicatedHostsGetOptions) (*DedicatedHostResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, dedicatedHostsGetOptions)
+func (client *DedicatedHostsClient) Get(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsGetOptions) (*DedicatedHostResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *DedicatedHostsClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DedicatedHostsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, dedicatedHostsGetOptions *DedicatedHostsGetOptions) (*azcore.Request, error) {
+func (client *DedicatedHostsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, options *DedicatedHostsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -252,7 +252,7 @@ func (client *DedicatedHostsClient) GetCreateRequest(ctx context.Context, resour
 		return nil, err
 	}
 	query := req.URL.Query()
-	if dedicatedHostsGetOptions != nil && dedicatedHostsGetOptions.Expand != nil {
+	if options != nil && options.Expand != nil {
 		query.Set("$expand", "instanceView")
 	}
 	query.Set("api-version", "2019-12-01")
@@ -280,11 +280,11 @@ func (client *DedicatedHostsClient) GetHandleError(resp *azcore.Response) error 
 }
 
 // ListByHostGroup - Lists all of the dedicated hosts in the specified dedicated host group. Use the nextLink property in the response to get the next page of dedicated hosts.
-func (client *DedicatedHostsClient) ListByHostGroup(resourceGroupName string, hostGroupName string) DedicatedHostListResultPager {
+func (client *DedicatedHostsClient) ListByHostGroup(resourceGroupName string, hostGroupName string, options *DedicatedHostsListByHostGroupOptions) DedicatedHostListResultPager {
 	return &dedicatedHostListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByHostGroupCreateRequest(ctx, resourceGroupName, hostGroupName)
+			return client.ListByHostGroupCreateRequest(ctx, resourceGroupName, hostGroupName, options)
 		},
 		responder: client.ListByHostGroupHandleResponse,
 		errorer:   client.ListByHostGroupHandleError,
@@ -295,7 +295,7 @@ func (client *DedicatedHostsClient) ListByHostGroup(resourceGroupName string, ho
 }
 
 // ListByHostGroupCreateRequest creates the ListByHostGroup request.
-func (client *DedicatedHostsClient) ListByHostGroupCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string) (*azcore.Request, error) {
+func (client *DedicatedHostsClient) ListByHostGroupCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, options *DedicatedHostsListByHostGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))
@@ -329,8 +329,8 @@ func (client *DedicatedHostsClient) ListByHostGroupHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate) (*DedicatedHostPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, hostGroupName, hostName, parameters)
+func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsUpdateOptions) (*DedicatedHostPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +364,8 @@ func (client *DedicatedHostsClient) ResumeUpdate(token string) (DedicatedHostPol
 }
 
 // Update - Update an dedicated host .
-func (client *DedicatedHostsClient) Update(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, parameters)
+func (client *DedicatedHostsClient) Update(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, hostGroupName, hostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (client *DedicatedHostsClient) Update(ctx context.Context, resourceGroupNam
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *DedicatedHostsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate) (*azcore.Request, error) {
+func (client *DedicatedHostsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, hostGroupName string, hostName string, parameters DedicatedHostUpdate, options *DedicatedHostsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/hostGroups/{hostGroupName}/hosts/{hostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{hostGroupName}", url.PathEscape(hostGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
@@ -18,21 +18,21 @@ import (
 // DiskEncryptionSetsOperations contains the methods for the DiskEncryptionSets group.
 type DiskEncryptionSetsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a disk encryption set
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet) (*DiskEncryptionSetPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsCreateOrUpdateOptions) (*DiskEncryptionSetPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (DiskEncryptionSetPoller, error)
 	// BeginDelete - Deletes a disk encryption set.
-	BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about a disk encryption set.
-	Get(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*DiskEncryptionSetResponse, error)
+	Get(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsGetOptions) (*DiskEncryptionSetResponse, error)
 	// List - Lists all the disk encryption sets under a subscription.
-	List() DiskEncryptionSetListPager
+	List(options *DiskEncryptionSetsListOptions) DiskEncryptionSetListPager
 	// ListByResourceGroup - Lists all the disk encryption sets under a resource group.
-	ListByResourceGroup(resourceGroupName string) DiskEncryptionSetListPager
+	ListByResourceGroup(resourceGroupName string, options *DiskEncryptionSetsListByResourceGroupOptions) DiskEncryptionSetListPager
 	// BeginUpdate - Updates (patches) a disk encryption set.
-	BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate) (*DiskEncryptionSetPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsUpdateOptions) (*DiskEncryptionSetPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (DiskEncryptionSetPoller, error)
 }
@@ -54,8 +54,8 @@ func (client *DiskEncryptionSetsClient) Do(req *azcore.Request) (*azcore.Respons
 	return client.p.Do(req)
 }
 
-func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet) (*DiskEncryptionSetPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet)
+func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsCreateOrUpdateOptions) (*DiskEncryptionSetPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func (client *DiskEncryptionSetsClient) ResumeCreateOrUpdate(token string) (Disk
 }
 
 // CreateOrUpdate - Creates or updates a disk encryption set
-func (client *DiskEncryptionSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet)
+func (client *DiskEncryptionSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (client *DiskEncryptionSetsClient) CreateOrUpdate(ctx context.Context, reso
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DiskEncryptionSetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSet, options *DiskEncryptionSetsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -136,8 +136,8 @@ func (client *DiskEncryptionSetsClient) CreateOrUpdateHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, diskEncryptionSetName)
+func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, diskEncryptionSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *DiskEncryptionSetsClient) ResumeDelete(token string) (HTTPPoller, 
 }
 
 // Delete - Deletes a disk encryption set.
-func (client *DiskEncryptionSetsClient) Delete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, diskEncryptionSetName)
+func (client *DiskEncryptionSetsClient) Delete(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *DiskEncryptionSetsClient) Delete(ctx context.Context, resourceGrou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DiskEncryptionSetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -213,8 +213,8 @@ func (client *DiskEncryptionSetsClient) DeleteHandleError(resp *azcore.Response)
 }
 
 // Get - Gets information about a disk encryption set.
-func (client *DiskEncryptionSetsClient) Get(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*DiskEncryptionSetResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, diskEncryptionSetName)
+func (client *DiskEncryptionSetsClient) Get(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsGetOptions) (*DiskEncryptionSetResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (client *DiskEncryptionSetsClient) Get(ctx context.Context, resourceGroupNa
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DiskEncryptionSetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, options *DiskEncryptionSetsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -265,11 +265,11 @@ func (client *DiskEncryptionSetsClient) GetHandleError(resp *azcore.Response) er
 }
 
 // List - Lists all the disk encryption sets under a subscription.
-func (client *DiskEncryptionSetsClient) List() DiskEncryptionSetListPager {
+func (client *DiskEncryptionSetsClient) List(options *DiskEncryptionSetsListOptions) DiskEncryptionSetListPager {
 	return &diskEncryptionSetListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -280,7 +280,7 @@ func (client *DiskEncryptionSetsClient) List() DiskEncryptionSetListPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *DiskEncryptionSetsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) ListCreateRequest(ctx context.Context, options *DiskEncryptionSetsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/diskEncryptionSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -310,11 +310,11 @@ func (client *DiskEncryptionSetsClient) ListHandleError(resp *azcore.Response) e
 }
 
 // ListByResourceGroup - Lists all the disk encryption sets under a resource group.
-func (client *DiskEncryptionSetsClient) ListByResourceGroup(resourceGroupName string) DiskEncryptionSetListPager {
+func (client *DiskEncryptionSetsClient) ListByResourceGroup(resourceGroupName string, options *DiskEncryptionSetsListByResourceGroupOptions) DiskEncryptionSetListPager {
 	return &diskEncryptionSetListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -325,7 +325,7 @@ func (client *DiskEncryptionSetsClient) ListByResourceGroup(resourceGroupName st
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *DiskEncryptionSetsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *DiskEncryptionSetsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -355,8 +355,8 @@ func (client *DiskEncryptionSetsClient) ListByResourceGroupHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate) (*DiskEncryptionSetPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet)
+func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsUpdateOptions) (*DiskEncryptionSetPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
 		return nil, err
 	}
@@ -390,8 +390,8 @@ func (client *DiskEncryptionSetsClient) ResumeUpdate(token string) (DiskEncrypti
 }
 
 // Update - Updates (patches) a disk encryption set.
-func (client *DiskEncryptionSetsClient) Update(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet)
+func (client *DiskEncryptionSetsClient) Update(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, diskEncryptionSetName, diskEncryptionSet, options)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (client *DiskEncryptionSetsClient) Update(ctx context.Context, resourceGrou
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *DiskEncryptionSetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate) (*azcore.Request, error) {
+func (client *DiskEncryptionSetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, diskEncryptionSetName string, diskEncryptionSet DiskEncryptionSetUpdate, options *DiskEncryptionSetsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskEncryptionSets/{diskEncryptionSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks.go
@@ -21,29 +21,29 @@ import (
 // DisksOperations contains the methods for the Disks group.
 type DisksOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a disk.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk) (*DiskPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksCreateOrUpdateOptions) (*DiskPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (DiskPoller, error)
 	// BeginDelete - Deletes a disk.
-	BeginDelete(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, diskName string, options *DisksDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about a disk.
-	Get(ctx context.Context, resourceGroupName string, diskName string) (*DiskResponse, error)
+	Get(ctx context.Context, resourceGroupName string, diskName string, options *DisksGetOptions) (*DiskResponse, error)
 	// BeginGrantAccess - Grants access to a disk.
-	BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error)
+	BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksGrantAccessOptions) (*AccessURIPollerResponse, error)
 	// ResumeGrantAccess - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGrantAccess(token string) (AccessURIPoller, error)
 	// List - Lists all the disks under a subscription.
-	List() DiskListPager
+	List(options *DisksListOptions) DiskListPager
 	// ListByResourceGroup - Lists all the disks under a resource group.
-	ListByResourceGroup(resourceGroupName string) DiskListPager
+	ListByResourceGroup(resourceGroupName string, options *DisksListByResourceGroupOptions) DiskListPager
 	// BeginRevokeAccess - Revokes access to a disk.
-	BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error)
+	BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string, options *DisksRevokeAccessOptions) (*HTTPPollerResponse, error)
 	// ResumeRevokeAccess - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRevokeAccess(token string) (HTTPPoller, error)
 	// BeginUpdate - Updates (patches) a disk.
-	BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate) (*DiskPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksUpdateOptions) (*DiskPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (DiskPoller, error)
 }
@@ -65,8 +65,8 @@ func (client *DisksClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk) (*DiskPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, diskName, disk)
+func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksCreateOrUpdateOptions) (*DiskPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ func (client *DisksClient) ResumeCreateOrUpdate(token string) (DiskPoller, error
 }
 
 // CreateOrUpdate - Creates or updates a disk.
-func (client *DisksClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, diskName, disk)
+func (client *DisksClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (client *DisksClient) CreateOrUpdate(ctx context.Context, resourceGroupName
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DisksClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, diskName string, disk Disk) (*azcore.Request, error) {
+func (client *DisksClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, diskName string, disk Disk, options *DisksCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -150,8 +150,8 @@ func (client *DisksClient) CreateOrUpdateHandleError(resp *azcore.Response) erro
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, diskName)
+func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName string, diskName string, options *DisksDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, diskName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (client *DisksClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes a disk.
-func (client *DisksClient) Delete(ctx context.Context, resourceGroupName string, diskName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, diskName)
+func (client *DisksClient) Delete(ctx context.Context, resourceGroupName string, diskName string, options *DisksDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, diskName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (client *DisksClient) Delete(ctx context.Context, resourceGroupName string,
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DisksClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, diskName string) (*azcore.Request, error) {
+func (client *DisksClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, diskName string, options *DisksDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -229,8 +229,8 @@ func (client *DisksClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets information about a disk.
-func (client *DisksClient) Get(ctx context.Context, resourceGroupName string, diskName string) (*DiskResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, diskName)
+func (client *DisksClient) Get(ctx context.Context, resourceGroupName string, diskName string, options *DisksGetOptions) (*DiskResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, diskName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (client *DisksClient) Get(ctx context.Context, resourceGroupName string, di
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DisksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, diskName string) (*azcore.Request, error) {
+func (client *DisksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, diskName string, options *DisksGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -283,8 +283,8 @@ func (client *DisksClient) GetHandleError(resp *azcore.Response) error {
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error) {
-	resp, err := client.GrantAccess(ctx, resourceGroupName, diskName, grantAccessData)
+func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksGrantAccessOptions) (*AccessURIPollerResponse, error) {
+	resp, err := client.GrantAccess(ctx, resourceGroupName, diskName, grantAccessData, options)
 	if err != nil {
 		return nil, err
 	}
@@ -318,8 +318,8 @@ func (client *DisksClient) ResumeGrantAccess(token string) (AccessURIPoller, err
 }
 
 // GrantAccess - Grants access to a disk.
-func (client *DisksClient) GrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData) (*azcore.Response, error) {
-	req, err := client.GrantAccessCreateRequest(ctx, resourceGroupName, diskName, grantAccessData)
+func (client *DisksClient) GrantAccess(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksGrantAccessOptions) (*azcore.Response, error) {
+	req, err := client.GrantAccessCreateRequest(ctx, resourceGroupName, diskName, grantAccessData, options)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (client *DisksClient) GrantAccess(ctx context.Context, resourceGroupName st
 }
 
 // GrantAccessCreateRequest creates the GrantAccess request.
-func (client *DisksClient) GrantAccessCreateRequest(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData) (*azcore.Request, error) {
+func (client *DisksClient) GrantAccessCreateRequest(ctx context.Context, resourceGroupName string, diskName string, grantAccessData GrantAccessData, options *DisksGrantAccessOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}/beginGetAccess"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -369,11 +369,11 @@ func (client *DisksClient) GrantAccessHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all the disks under a subscription.
-func (client *DisksClient) List() DiskListPager {
+func (client *DisksClient) List(options *DisksListOptions) DiskListPager {
 	return &diskListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -384,7 +384,7 @@ func (client *DisksClient) List() DiskListPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *DisksClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DisksClient) ListCreateRequest(ctx context.Context, options *DisksListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/disks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -417,11 +417,11 @@ func (client *DisksClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all the disks under a resource group.
-func (client *DisksClient) ListByResourceGroup(resourceGroupName string) DiskListPager {
+func (client *DisksClient) ListByResourceGroup(resourceGroupName string, options *DisksListByResourceGroupOptions) DiskListPager {
 	return &diskListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -432,7 +432,7 @@ func (client *DisksClient) ListByResourceGroup(resourceGroupName string) DiskLis
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *DisksClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *DisksClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *DisksListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -465,8 +465,8 @@ func (client *DisksClient) ListByResourceGroupHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string) (*HTTPPollerResponse, error) {
-	resp, err := client.RevokeAccess(ctx, resourceGroupName, diskName)
+func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, diskName string, options *DisksRevokeAccessOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.RevokeAccess(ctx, resourceGroupName, diskName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -500,8 +500,8 @@ func (client *DisksClient) ResumeRevokeAccess(token string) (HTTPPoller, error) 
 }
 
 // RevokeAccess - Revokes access to a disk.
-func (client *DisksClient) RevokeAccess(ctx context.Context, resourceGroupName string, diskName string) (*azcore.Response, error) {
-	req, err := client.RevokeAccessCreateRequest(ctx, resourceGroupName, diskName)
+func (client *DisksClient) RevokeAccess(ctx context.Context, resourceGroupName string, diskName string, options *DisksRevokeAccessOptions) (*azcore.Response, error) {
+	req, err := client.RevokeAccessCreateRequest(ctx, resourceGroupName, diskName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +516,7 @@ func (client *DisksClient) RevokeAccess(ctx context.Context, resourceGroupName s
 }
 
 // RevokeAccessCreateRequest creates the RevokeAccess request.
-func (client *DisksClient) RevokeAccessCreateRequest(ctx context.Context, resourceGroupName string, diskName string) (*azcore.Request, error) {
+func (client *DisksClient) RevokeAccessCreateRequest(ctx context.Context, resourceGroupName string, diskName string, options *DisksRevokeAccessOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}/endGetAccess"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -543,8 +543,8 @@ func (client *DisksClient) RevokeAccessHandleError(resp *azcore.Response) error 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate) (*DiskPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, diskName, disk)
+func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksUpdateOptions) (*DiskPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
 		return nil, err
 	}
@@ -578,8 +578,8 @@ func (client *DisksClient) ResumeUpdate(token string) (DiskPoller, error) {
 }
 
 // Update - Updates (patches) a disk.
-func (client *DisksClient) Update(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, diskName, disk)
+func (client *DisksClient) Update(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, diskName, disk, options)
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (client *DisksClient) Update(ctx context.Context, resourceGroupName string,
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *DisksClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate) (*azcore.Request, error) {
+func (client *DisksClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, diskName string, disk DiskUpdate, options *DisksUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
@@ -18,21 +18,21 @@ import (
 // GalleriesOperations contains the methods for the Galleries group.
 type GalleriesOperations interface {
 	// BeginCreateOrUpdate - Create or update a Shared Image Gallery.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery) (*GalleryPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesCreateOrUpdateOptions) (*GalleryPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (GalleryPoller, error)
 	// BeginDelete - Delete a Shared Image Gallery.
-	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a Shared Image Gallery.
-	Get(ctx context.Context, resourceGroupName string, galleryName string) (*GalleryResponse, error)
+	Get(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesGetOptions) (*GalleryResponse, error)
 	// List - List galleries under a subscription.
-	List() GalleryListPager
+	List(options *GalleriesListOptions) GalleryListPager
 	// ListByResourceGroup - List galleries under a resource group.
-	ListByResourceGroup(resourceGroupName string) GalleryListPager
+	ListByResourceGroup(resourceGroupName string, options *GalleriesListByResourceGroupOptions) GalleryListPager
 	// BeginUpdate - Update a Shared Image Gallery.
-	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate) (*GalleryPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesUpdateOptions) (*GalleryPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (GalleryPoller, error)
 }
@@ -54,8 +54,8 @@ func (client *GalleriesClient) Do(req *azcore.Request) (*azcore.Response, error)
 	return client.p.Do(req)
 }
 
-func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery) (*GalleryPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, gallery)
+func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesCreateOrUpdateOptions) (*GalleryPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func (client *GalleriesClient) ResumeCreateOrUpdate(token string) (GalleryPoller
 }
 
 // CreateOrUpdate - Create or update a Shared Image Gallery.
-func (client *GalleriesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, gallery)
+func (client *GalleriesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (client *GalleriesClient) CreateOrUpdate(ctx context.Context, resourceGroup
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *GalleriesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery) (*azcore.Request, error) {
+func (client *GalleriesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, gallery Gallery, options *GalleriesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -136,8 +136,8 @@ func (client *GalleriesClient) CreateOrUpdateHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, galleryName)
+func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, galleryName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *GalleriesClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Delete a Shared Image Gallery.
-func (client *GalleriesClient) Delete(ctx context.Context, resourceGroupName string, galleryName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName)
+func (client *GalleriesClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *GalleriesClient) Delete(ctx context.Context, resourceGroupName str
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *GalleriesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string) (*azcore.Request, error) {
+func (client *GalleriesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -213,8 +213,8 @@ func (client *GalleriesClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Retrieves information about a Shared Image Gallery.
-func (client *GalleriesClient) Get(ctx context.Context, resourceGroupName string, galleryName string) (*GalleryResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName)
+func (client *GalleriesClient) Get(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesGetOptions) (*GalleryResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (client *GalleriesClient) Get(ctx context.Context, resourceGroupName string
 }
 
 // GetCreateRequest creates the Get request.
-func (client *GalleriesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string) (*azcore.Request, error) {
+func (client *GalleriesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, options *GalleriesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -265,11 +265,11 @@ func (client *GalleriesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - List galleries under a subscription.
-func (client *GalleriesClient) List() GalleryListPager {
+func (client *GalleriesClient) List(options *GalleriesListOptions) GalleryListPager {
 	return &galleryListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -280,7 +280,7 @@ func (client *GalleriesClient) List() GalleryListPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *GalleriesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *GalleriesClient) ListCreateRequest(ctx context.Context, options *GalleriesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/galleries"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -310,11 +310,11 @@ func (client *GalleriesClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - List galleries under a resource group.
-func (client *GalleriesClient) ListByResourceGroup(resourceGroupName string) GalleryListPager {
+func (client *GalleriesClient) ListByResourceGroup(resourceGroupName string, options *GalleriesListByResourceGroupOptions) GalleryListPager {
 	return &galleryListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -325,7 +325,7 @@ func (client *GalleriesClient) ListByResourceGroup(resourceGroupName string) Gal
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *GalleriesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *GalleriesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *GalleriesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -355,8 +355,8 @@ func (client *GalleriesClient) ListByResourceGroupHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate) (*GalleryPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, galleryName, gallery)
+func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesUpdateOptions) (*GalleryPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -390,8 +390,8 @@ func (client *GalleriesClient) ResumeUpdate(token string) (GalleryPoller, error)
 }
 
 // Update - Update a Shared Image Gallery.
-func (client *GalleriesClient) Update(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, gallery)
+func (client *GalleriesClient) Update(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, gallery, options)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (client *GalleriesClient) Update(ctx context.Context, resourceGroupName str
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *GalleriesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate) (*azcore.Request, error) {
+func (client *GalleriesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, gallery GalleryUpdate, options *GalleriesUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
@@ -18,19 +18,19 @@ import (
 // GalleryApplicationsOperations contains the methods for the GalleryApplications group.
 type GalleryApplicationsOperations interface {
 	// BeginCreateOrUpdate - Create or update a gallery Application Definition.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication) (*GalleryApplicationPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsCreateOrUpdateOptions) (*GalleryApplicationPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (GalleryApplicationPoller, error)
 	// BeginDelete - Delete a gallery Application.
-	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a gallery Application Definition.
-	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*GalleryApplicationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsGetOptions) (*GalleryApplicationResponse, error)
 	// ListByGallery - List gallery Application Definitions in a gallery.
-	ListByGallery(resourceGroupName string, galleryName string) GalleryApplicationListPager
+	ListByGallery(resourceGroupName string, galleryName string, options *GalleryApplicationsListByGalleryOptions) GalleryApplicationListPager
 	// BeginUpdate - Update a gallery Application Definition.
-	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate) (*GalleryApplicationPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsUpdateOptions) (*GalleryApplicationPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (GalleryApplicationPoller, error)
 }
@@ -52,8 +52,8 @@ func (client *GalleryApplicationsClient) Do(req *azcore.Request) (*azcore.Respon
 	return client.p.Do(req)
 }
 
-func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication) (*GalleryApplicationPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication)
+func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsCreateOrUpdateOptions) (*GalleryApplicationPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *GalleryApplicationsClient) ResumeCreateOrUpdate(token string) (Gal
 }
 
 // CreateOrUpdate - Create or update a gallery Application Definition.
-func (client *GalleryApplicationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication)
+func (client *GalleryApplicationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *GalleryApplicationsClient) CreateOrUpdate(ctx context.Context, res
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *GalleryApplicationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication) (*azcore.Request, error) {
+func (client *GalleryApplicationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplication, options *GalleryApplicationsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -135,8 +135,8 @@ func (client *GalleryApplicationsClient) CreateOrUpdateHandleError(resp *azcore.
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryApplicationName)
+func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryApplicationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +170,8 @@ func (client *GalleryApplicationsClient) ResumeDelete(token string) (HTTPPoller,
 }
 
 // Delete - Delete a gallery Application.
-func (client *GalleryApplicationsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName)
+func (client *GalleryApplicationsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (client *GalleryApplicationsClient) Delete(ctx context.Context, resourceGro
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *GalleryApplicationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*azcore.Request, error) {
+func (client *GalleryApplicationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -213,8 +213,8 @@ func (client *GalleryApplicationsClient) DeleteHandleError(resp *azcore.Response
 }
 
 // Get - Retrieves information about a gallery Application Definition.
-func (client *GalleryApplicationsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*GalleryApplicationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName)
+func (client *GalleryApplicationsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsGetOptions) (*GalleryApplicationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (client *GalleryApplicationsClient) Get(ctx context.Context, resourceGroupN
 }
 
 // GetCreateRequest creates the Get request.
-func (client *GalleryApplicationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*azcore.Request, error) {
+func (client *GalleryApplicationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -266,11 +266,11 @@ func (client *GalleryApplicationsClient) GetHandleError(resp *azcore.Response) e
 }
 
 // ListByGallery - List gallery Application Definitions in a gallery.
-func (client *GalleryApplicationsClient) ListByGallery(resourceGroupName string, galleryName string) GalleryApplicationListPager {
+func (client *GalleryApplicationsClient) ListByGallery(resourceGroupName string, galleryName string, options *GalleryApplicationsListByGalleryOptions) GalleryApplicationListPager {
 	return &galleryApplicationListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByGalleryCreateRequest(ctx, resourceGroupName, galleryName)
+			return client.ListByGalleryCreateRequest(ctx, resourceGroupName, galleryName, options)
 		},
 		responder: client.ListByGalleryHandleResponse,
 		errorer:   client.ListByGalleryHandleError,
@@ -281,7 +281,7 @@ func (client *GalleryApplicationsClient) ListByGallery(resourceGroupName string,
 }
 
 // ListByGalleryCreateRequest creates the ListByGallery request.
-func (client *GalleryApplicationsClient) ListByGalleryCreateRequest(ctx context.Context, resourceGroupName string, galleryName string) (*azcore.Request, error) {
+func (client *GalleryApplicationsClient) ListByGalleryCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, options *GalleryApplicationsListByGalleryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -312,8 +312,8 @@ func (client *GalleryApplicationsClient) ListByGalleryHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate) (*GalleryApplicationPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication)
+func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsUpdateOptions) (*GalleryApplicationPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
 		return nil, err
 	}
@@ -347,8 +347,8 @@ func (client *GalleryApplicationsClient) ResumeUpdate(token string) (GalleryAppl
 }
 
 // Update - Update a gallery Application Definition.
-func (client *GalleryApplicationsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication)
+func (client *GalleryApplicationsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplication, options)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (client *GalleryApplicationsClient) Update(ctx context.Context, resourceGro
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *GalleryApplicationsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate) (*azcore.Request, error) {
+func (client *GalleryApplicationsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplication GalleryApplicationUpdate, options *GalleryApplicationsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
@@ -18,19 +18,19 @@ import (
 // GalleryApplicationVersionsOperations contains the methods for the GalleryApplicationVersions group.
 type GalleryApplicationVersionsOperations interface {
 	// BeginCreateOrUpdate - Create or update a gallery Application Version.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion) (*GalleryApplicationVersionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsCreateOrUpdateOptions) (*GalleryApplicationVersionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (GalleryApplicationVersionPoller, error)
 	// BeginDelete - Delete a gallery Application Version.
-	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a gallery Application Version.
-	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersionsGetOptions *GalleryApplicationVersionsGetOptions) (*GalleryApplicationVersionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsGetOptions) (*GalleryApplicationVersionResponse, error)
 	// ListByGalleryApplication - List gallery Application Versions in a gallery Application Definition.
-	ListByGalleryApplication(resourceGroupName string, galleryName string, galleryApplicationName string) GalleryApplicationVersionListPager
+	ListByGalleryApplication(resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationVersionsListByGalleryApplicationOptions) GalleryApplicationVersionListPager
 	// BeginUpdate - Update a gallery Application Version.
-	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate) (*GalleryApplicationVersionPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsUpdateOptions) (*GalleryApplicationVersionPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (GalleryApplicationVersionPoller, error)
 }
@@ -52,8 +52,8 @@ func (client *GalleryApplicationVersionsClient) Do(req *azcore.Request) (*azcore
 	return client.p.Do(req)
 }
 
-func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion) (*GalleryApplicationVersionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion)
+func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsCreateOrUpdateOptions) (*GalleryApplicationVersionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *GalleryApplicationVersionsClient) ResumeCreateOrUpdate(token strin
 }
 
 // CreateOrUpdate - Create or update a gallery Application Version.
-func (client *GalleryApplicationVersionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion)
+func (client *GalleryApplicationVersionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *GalleryApplicationVersionsClient) CreateOrUpdate(ctx context.Conte
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *GalleryApplicationVersionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion) (*azcore.Request, error) {
+func (client *GalleryApplicationVersionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersion, options *GalleryApplicationVersionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}/versions/{galleryApplicationVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -136,8 +136,8 @@ func (client *GalleryApplicationVersionsClient) CreateOrUpdateHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName)
+func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *GalleryApplicationVersionsClient) ResumeDelete(token string) (HTTP
 }
 
 // Delete - Delete a gallery Application Version.
-func (client *GalleryApplicationVersionsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName)
+func (client *GalleryApplicationVersionsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *GalleryApplicationVersionsClient) Delete(ctx context.Context, reso
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *GalleryApplicationVersionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string) (*azcore.Request, error) {
+func (client *GalleryApplicationVersionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}/versions/{galleryApplicationVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -215,8 +215,8 @@ func (client *GalleryApplicationVersionsClient) DeleteHandleError(resp *azcore.R
 }
 
 // Get - Retrieves information about a gallery Application Version.
-func (client *GalleryApplicationVersionsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersionsGetOptions *GalleryApplicationVersionsGetOptions) (*GalleryApplicationVersionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersionsGetOptions)
+func (client *GalleryApplicationVersionsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsGetOptions) (*GalleryApplicationVersionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (client *GalleryApplicationVersionsClient) Get(ctx context.Context, resourc
 }
 
 // GetCreateRequest creates the Get request.
-func (client *GalleryApplicationVersionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersionsGetOptions *GalleryApplicationVersionsGetOptions) (*azcore.Request, error) {
+func (client *GalleryApplicationVersionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, options *GalleryApplicationVersionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}/versions/{galleryApplicationVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -247,8 +247,8 @@ func (client *GalleryApplicationVersionsClient) GetCreateRequest(ctx context.Con
 		return nil, err
 	}
 	query := req.URL.Query()
-	if galleryApplicationVersionsGetOptions != nil && galleryApplicationVersionsGetOptions.Expand != nil {
-		query.Set("$expand", string(*galleryApplicationVersionsGetOptions.Expand))
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", string(*options.Expand))
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -272,11 +272,11 @@ func (client *GalleryApplicationVersionsClient) GetHandleError(resp *azcore.Resp
 }
 
 // ListByGalleryApplication - List gallery Application Versions in a gallery Application Definition.
-func (client *GalleryApplicationVersionsClient) ListByGalleryApplication(resourceGroupName string, galleryName string, galleryApplicationName string) GalleryApplicationVersionListPager {
+func (client *GalleryApplicationVersionsClient) ListByGalleryApplication(resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationVersionsListByGalleryApplicationOptions) GalleryApplicationVersionListPager {
 	return &galleryApplicationVersionListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByGalleryApplicationCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName)
+			return client.ListByGalleryApplicationCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, options)
 		},
 		responder: client.ListByGalleryApplicationHandleResponse,
 		errorer:   client.ListByGalleryApplicationHandleError,
@@ -287,7 +287,7 @@ func (client *GalleryApplicationVersionsClient) ListByGalleryApplication(resourc
 }
 
 // ListByGalleryApplicationCreateRequest creates the ListByGalleryApplication request.
-func (client *GalleryApplicationVersionsClient) ListByGalleryApplicationCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string) (*azcore.Request, error) {
+func (client *GalleryApplicationVersionsClient) ListByGalleryApplicationCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, options *GalleryApplicationVersionsListByGalleryApplicationOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}/versions"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -319,8 +319,8 @@ func (client *GalleryApplicationVersionsClient) ListByGalleryApplicationHandleEr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate) (*GalleryApplicationVersionPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion)
+func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsUpdateOptions) (*GalleryApplicationVersionPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +354,8 @@ func (client *GalleryApplicationVersionsClient) ResumeUpdate(token string) (Gall
 }
 
 // Update - Update a gallery Application Version.
-func (client *GalleryApplicationVersionsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion)
+func (client *GalleryApplicationVersionsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryApplicationName, galleryApplicationVersionName, galleryApplicationVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (client *GalleryApplicationVersionsClient) Update(ctx context.Context, reso
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *GalleryApplicationVersionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate) (*azcore.Request, error) {
+func (client *GalleryApplicationVersionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryApplicationName string, galleryApplicationVersionName string, galleryApplicationVersion GalleryApplicationVersionUpdate, options *GalleryApplicationVersionsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/applications/{galleryApplicationName}/versions/{galleryApplicationVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
@@ -18,19 +18,19 @@ import (
 // GalleryImagesOperations contains the methods for the GalleryImages group.
 type GalleryImagesOperations interface {
 	// BeginCreateOrUpdate - Create or update a gallery Image Definition.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage) (*GalleryImagePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesCreateOrUpdateOptions) (*GalleryImagePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (GalleryImagePoller, error)
 	// BeginDelete - Delete a gallery image.
-	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a gallery Image Definition.
-	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*GalleryImageResponse, error)
+	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesGetOptions) (*GalleryImageResponse, error)
 	// ListByGallery - List gallery Image Definitions in a gallery.
-	ListByGallery(resourceGroupName string, galleryName string) GalleryImageListPager
+	ListByGallery(resourceGroupName string, galleryName string, options *GalleryImagesListByGalleryOptions) GalleryImageListPager
 	// BeginUpdate - Update a gallery Image Definition.
-	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate) (*GalleryImagePollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesUpdateOptions) (*GalleryImagePollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (GalleryImagePoller, error)
 }
@@ -52,8 +52,8 @@ func (client *GalleryImagesClient) Do(req *azcore.Request) (*azcore.Response, er
 	return client.p.Do(req)
 }
 
-func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage) (*GalleryImagePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage)
+func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesCreateOrUpdateOptions) (*GalleryImagePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *GalleryImagesClient) ResumeCreateOrUpdate(token string) (GalleryIm
 }
 
 // CreateOrUpdate - Create or update a gallery Image Definition.
-func (client *GalleryImagesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage)
+func (client *GalleryImagesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *GalleryImagesClient) CreateOrUpdate(ctx context.Context, resourceG
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *GalleryImagesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage) (*azcore.Request, error) {
+func (client *GalleryImagesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImage, options *GalleryImagesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -135,8 +135,8 @@ func (client *GalleryImagesClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryImageName)
+func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryImageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +170,8 @@ func (client *GalleryImagesClient) ResumeDelete(token string) (HTTPPoller, error
 }
 
 // Delete - Delete a gallery image.
-func (client *GalleryImagesClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName)
+func (client *GalleryImagesClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (client *GalleryImagesClient) Delete(ctx context.Context, resourceGroupName
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *GalleryImagesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*azcore.Request, error) {
+func (client *GalleryImagesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -213,8 +213,8 @@ func (client *GalleryImagesClient) DeleteHandleError(resp *azcore.Response) erro
 }
 
 // Get - Retrieves information about a gallery Image Definition.
-func (client *GalleryImagesClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*GalleryImageResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName)
+func (client *GalleryImagesClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesGetOptions) (*GalleryImageResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (client *GalleryImagesClient) Get(ctx context.Context, resourceGroupName st
 }
 
 // GetCreateRequest creates the Get request.
-func (client *GalleryImagesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*azcore.Request, error) {
+func (client *GalleryImagesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImagesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -266,11 +266,11 @@ func (client *GalleryImagesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // ListByGallery - List gallery Image Definitions in a gallery.
-func (client *GalleryImagesClient) ListByGallery(resourceGroupName string, galleryName string) GalleryImageListPager {
+func (client *GalleryImagesClient) ListByGallery(resourceGroupName string, galleryName string, options *GalleryImagesListByGalleryOptions) GalleryImageListPager {
 	return &galleryImageListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByGalleryCreateRequest(ctx, resourceGroupName, galleryName)
+			return client.ListByGalleryCreateRequest(ctx, resourceGroupName, galleryName, options)
 		},
 		responder: client.ListByGalleryHandleResponse,
 		errorer:   client.ListByGalleryHandleError,
@@ -281,7 +281,7 @@ func (client *GalleryImagesClient) ListByGallery(resourceGroupName string, galle
 }
 
 // ListByGalleryCreateRequest creates the ListByGallery request.
-func (client *GalleryImagesClient) ListByGalleryCreateRequest(ctx context.Context, resourceGroupName string, galleryName string) (*azcore.Request, error) {
+func (client *GalleryImagesClient) ListByGalleryCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, options *GalleryImagesListByGalleryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -312,8 +312,8 @@ func (client *GalleryImagesClient) ListByGalleryHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate) (*GalleryImagePollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage)
+func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesUpdateOptions) (*GalleryImagePollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
 		return nil, err
 	}
@@ -347,8 +347,8 @@ func (client *GalleryImagesClient) ResumeUpdate(token string) (GalleryImagePolle
 }
 
 // Update - Update a gallery Image Definition.
-func (client *GalleryImagesClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage)
+func (client *GalleryImagesClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImage, options)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func (client *GalleryImagesClient) Update(ctx context.Context, resourceGroupName
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *GalleryImagesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate) (*azcore.Request, error) {
+func (client *GalleryImagesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImage GalleryImageUpdate, options *GalleryImagesUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
@@ -18,19 +18,19 @@ import (
 // GalleryImageVersionsOperations contains the methods for the GalleryImageVersions group.
 type GalleryImageVersionsOperations interface {
 	// BeginCreateOrUpdate - Create or update a gallery Image Version.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion) (*GalleryImageVersionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsCreateOrUpdateOptions) (*GalleryImageVersionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (GalleryImageVersionPoller, error)
 	// BeginDelete - Delete a gallery Image Version.
-	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves information about a gallery Image Version.
-	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersionsGetOptions *GalleryImageVersionsGetOptions) (*GalleryImageVersionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsGetOptions) (*GalleryImageVersionResponse, error)
 	// ListByGalleryImage - List gallery Image Versions in a gallery Image Definition.
-	ListByGalleryImage(resourceGroupName string, galleryName string, galleryImageName string) GalleryImageVersionListPager
+	ListByGalleryImage(resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImageVersionsListByGalleryImageOptions) GalleryImageVersionListPager
 	// BeginUpdate - Update a gallery Image Version.
-	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate) (*GalleryImageVersionPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsUpdateOptions) (*GalleryImageVersionPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (GalleryImageVersionPoller, error)
 }
@@ -52,8 +52,8 @@ func (client *GalleryImageVersionsClient) Do(req *azcore.Request) (*azcore.Respo
 	return client.p.Do(req)
 }
 
-func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion) (*GalleryImageVersionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion)
+func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsCreateOrUpdateOptions) (*GalleryImageVersionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *GalleryImageVersionsClient) ResumeCreateOrUpdate(token string) (Ga
 }
 
 // CreateOrUpdate - Create or update a gallery Image Version.
-func (client *GalleryImageVersionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion)
+func (client *GalleryImageVersionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *GalleryImageVersionsClient) CreateOrUpdate(ctx context.Context, re
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *GalleryImageVersionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion) (*azcore.Request, error) {
+func (client *GalleryImageVersionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersion, options *GalleryImageVersionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -136,8 +136,8 @@ func (client *GalleryImageVersionsClient) CreateOrUpdateHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName)
+func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *GalleryImageVersionsClient) ResumeDelete(token string) (HTTPPoller
 }
 
 // Delete - Delete a gallery Image Version.
-func (client *GalleryImageVersionsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName)
+func (client *GalleryImageVersionsClient) Delete(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *GalleryImageVersionsClient) Delete(ctx context.Context, resourceGr
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *GalleryImageVersionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string) (*azcore.Request, error) {
+func (client *GalleryImageVersionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -215,8 +215,8 @@ func (client *GalleryImageVersionsClient) DeleteHandleError(resp *azcore.Respons
 }
 
 // Get - Retrieves information about a gallery Image Version.
-func (client *GalleryImageVersionsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersionsGetOptions *GalleryImageVersionsGetOptions) (*GalleryImageVersionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersionsGetOptions)
+func (client *GalleryImageVersionsClient) Get(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsGetOptions) (*GalleryImageVersionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (client *GalleryImageVersionsClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *GalleryImageVersionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersionsGetOptions *GalleryImageVersionsGetOptions) (*azcore.Request, error) {
+func (client *GalleryImageVersionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, options *GalleryImageVersionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -247,8 +247,8 @@ func (client *GalleryImageVersionsClient) GetCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	query := req.URL.Query()
-	if galleryImageVersionsGetOptions != nil && galleryImageVersionsGetOptions.Expand != nil {
-		query.Set("$expand", string(*galleryImageVersionsGetOptions.Expand))
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", string(*options.Expand))
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -272,11 +272,11 @@ func (client *GalleryImageVersionsClient) GetHandleError(resp *azcore.Response) 
 }
 
 // ListByGalleryImage - List gallery Image Versions in a gallery Image Definition.
-func (client *GalleryImageVersionsClient) ListByGalleryImage(resourceGroupName string, galleryName string, galleryImageName string) GalleryImageVersionListPager {
+func (client *GalleryImageVersionsClient) ListByGalleryImage(resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImageVersionsListByGalleryImageOptions) GalleryImageVersionListPager {
 	return &galleryImageVersionListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByGalleryImageCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName)
+			return client.ListByGalleryImageCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, options)
 		},
 		responder: client.ListByGalleryImageHandleResponse,
 		errorer:   client.ListByGalleryImageHandleError,
@@ -287,7 +287,7 @@ func (client *GalleryImageVersionsClient) ListByGalleryImage(resourceGroupName s
 }
 
 // ListByGalleryImageCreateRequest creates the ListByGalleryImage request.
-func (client *GalleryImageVersionsClient) ListByGalleryImageCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string) (*azcore.Request, error) {
+func (client *GalleryImageVersionsClient) ListByGalleryImageCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, options *GalleryImageVersionsListByGalleryImageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -319,8 +319,8 @@ func (client *GalleryImageVersionsClient) ListByGalleryImageHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate) (*GalleryImageVersionPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion)
+func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsUpdateOptions) (*GalleryImageVersionPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +354,8 @@ func (client *GalleryImageVersionsClient) ResumeUpdate(token string) (GalleryIma
 }
 
 // Update - Update a gallery Image Version.
-func (client *GalleryImageVersionsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion)
+func (client *GalleryImageVersionsClient) Update(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, galleryName, galleryImageName, galleryImageVersionName, galleryImageVersion, options)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (client *GalleryImageVersionsClient) Update(ctx context.Context, resourceGr
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *GalleryImageVersionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate) (*azcore.Request, error) {
+func (client *GalleryImageVersionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, galleryName string, galleryImageName string, galleryImageVersionName string, galleryImageVersion GalleryImageVersionUpdate, options *GalleryImageVersionsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_images.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images.go
@@ -21,21 +21,21 @@ import (
 // ImagesOperations contains the methods for the Images group.
 type ImagesOperations interface {
 	// BeginCreateOrUpdate - Create or update an image.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image) (*ImagePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesCreateOrUpdateOptions) (*ImagePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ImagePoller, error)
 	// BeginDelete - Deletes an Image.
-	BeginDelete(ctx context.Context, resourceGroupName string, imageName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, imageName string, options *ImagesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets an image.
-	Get(ctx context.Context, resourceGroupName string, imageName string, imagesGetOptions *ImagesGetOptions) (*ImageResponse, error)
+	Get(ctx context.Context, resourceGroupName string, imageName string, options *ImagesGetOptions) (*ImageResponse, error)
 	// List - Gets the list of Images in the subscription. Use nextLink property in the response to get the next page of Images. Do this till nextLink is null to fetch all the Images.
-	List() ImageListResultPager
+	List(options *ImagesListOptions) ImageListResultPager
 	// ListByResourceGroup - Gets the list of images under a resource group.
-	ListByResourceGroup(resourceGroupName string) ImageListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ImagesListByResourceGroupOptions) ImageListResultPager
 	// BeginUpdate - Update an image.
-	BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate) (*ImagePollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesUpdateOptions) (*ImagePollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (ImagePoller, error)
 }
@@ -57,8 +57,8 @@ func (client *ImagesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image) (*ImagePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, imageName, parameters)
+func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesCreateOrUpdateOptions) (*ImagePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ func (client *ImagesClient) ResumeCreateOrUpdate(token string) (ImagePoller, err
 }
 
 // CreateOrUpdate - Create or update an image.
-func (client *ImagesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, imageName, parameters)
+func (client *ImagesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (client *ImagesClient) CreateOrUpdate(ctx context.Context, resourceGroupNam
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ImagesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, imageName string, parameters Image) (*azcore.Request, error) {
+func (client *ImagesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, imageName string, parameters Image, options *ImagesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{imageName}", url.PathEscape(imageName))
@@ -142,8 +142,8 @@ func (client *ImagesClient) CreateOrUpdateHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, imageName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, imageName)
+func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName string, imageName string, options *ImagesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, imageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +177,8 @@ func (client *ImagesClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes an Image.
-func (client *ImagesClient) Delete(ctx context.Context, resourceGroupName string, imageName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, imageName)
+func (client *ImagesClient) Delete(ctx context.Context, resourceGroupName string, imageName string, options *ImagesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, imageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (client *ImagesClient) Delete(ctx context.Context, resourceGroupName string
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ImagesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, imageName string) (*azcore.Request, error) {
+func (client *ImagesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, imageName string, options *ImagesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{imageName}", url.PathEscape(imageName))
@@ -221,8 +221,8 @@ func (client *ImagesClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets an image.
-func (client *ImagesClient) Get(ctx context.Context, resourceGroupName string, imageName string, imagesGetOptions *ImagesGetOptions) (*ImageResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, imageName, imagesGetOptions)
+func (client *ImagesClient) Get(ctx context.Context, resourceGroupName string, imageName string, options *ImagesGetOptions) (*ImageResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, imageName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *ImagesClient) Get(ctx context.Context, resourceGroupName string, i
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ImagesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, imageName string, imagesGetOptions *ImagesGetOptions) (*azcore.Request, error) {
+func (client *ImagesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, imageName string, options *ImagesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{imageName}", url.PathEscape(imageName))
@@ -251,8 +251,8 @@ func (client *ImagesClient) GetCreateRequest(ctx context.Context, resourceGroupN
 		return nil, err
 	}
 	query := req.URL.Query()
-	if imagesGetOptions != nil && imagesGetOptions.Expand != nil {
-		query.Set("$expand", *imagesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -279,11 +279,11 @@ func (client *ImagesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets the list of Images in the subscription. Use nextLink property in the response to get the next page of Images. Do this till nextLink is null to fetch all the Images.
-func (client *ImagesClient) List() ImageListResultPager {
+func (client *ImagesClient) List(options *ImagesListOptions) ImageListResultPager {
 	return &imageListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -294,7 +294,7 @@ func (client *ImagesClient) List() ImageListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *ImagesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ImagesClient) ListCreateRequest(ctx context.Context, options *ImagesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/images"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -327,11 +327,11 @@ func (client *ImagesClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Gets the list of images under a resource group.
-func (client *ImagesClient) ListByResourceGroup(resourceGroupName string) ImageListResultPager {
+func (client *ImagesClient) ListByResourceGroup(resourceGroupName string, options *ImagesListByResourceGroupOptions) ImageListResultPager {
 	return &imageListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -342,7 +342,7 @@ func (client *ImagesClient) ListByResourceGroup(resourceGroupName string) ImageL
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ImagesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ImagesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ImagesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -375,8 +375,8 @@ func (client *ImagesClient) ListByResourceGroupHandleError(resp *azcore.Response
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate) (*ImagePollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, imageName, parameters)
+func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesUpdateOptions) (*ImagePollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -410,8 +410,8 @@ func (client *ImagesClient) ResumeUpdate(token string) (ImagePoller, error) {
 }
 
 // Update - Update an image.
-func (client *ImagesClient) Update(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, imageName, parameters)
+func (client *ImagesClient) Update(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, imageName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +426,7 @@ func (client *ImagesClient) Update(ctx context.Context, resourceGroupName string
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *ImagesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate) (*azcore.Request, error) {
+func (client *ImagesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, imageName string, parameters ImageUpdate, options *ImagesUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{imageName}", url.PathEscape(imageName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
@@ -21,11 +21,11 @@ import (
 // LogAnalyticsOperations contains the methods for the LogAnalytics group.
 type LogAnalyticsOperations interface {
 	// BeginExportRequestRateByInterval - Export logs that show Api requests made by this subscription in the given time window to show throttling activities.
-	BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput) (*LogAnalyticsOperationResultPollerResponse, error)
+	BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsExportRequestRateByIntervalOptions) (*LogAnalyticsOperationResultPollerResponse, error)
 	// ResumeExportRequestRateByInterval - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeExportRequestRateByInterval(token string) (LogAnalyticsOperationResultPoller, error)
 	// BeginExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.
-	BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase) (*LogAnalyticsOperationResultPollerResponse, error)
+	BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsExportThrottledRequestsOptions) (*LogAnalyticsOperationResultPollerResponse, error)
 	// ResumeExportThrottledRequests - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeExportThrottledRequests(token string) (LogAnalyticsOperationResultPoller, error)
 }
@@ -47,8 +47,8 @@ func (client *LogAnalyticsClient) Do(req *azcore.Request) (*azcore.Response, err
 	return client.p.Do(req)
 }
 
-func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput) (*LogAnalyticsOperationResultPollerResponse, error) {
-	resp, err := client.ExportRequestRateByInterval(ctx, location, parameters)
+func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsExportRequestRateByIntervalOptions) (*LogAnalyticsOperationResultPollerResponse, error) {
+	resp, err := client.ExportRequestRateByInterval(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func (client *LogAnalyticsClient) ResumeExportRequestRateByInterval(token string
 }
 
 // ExportRequestRateByInterval - Export logs that show Api requests made by this subscription in the given time window to show throttling activities.
-func (client *LogAnalyticsClient) ExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput) (*azcore.Response, error) {
-	req, err := client.ExportRequestRateByIntervalCreateRequest(ctx, location, parameters)
+func (client *LogAnalyticsClient) ExportRequestRateByInterval(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsExportRequestRateByIntervalOptions) (*azcore.Response, error) {
+	req, err := client.ExportRequestRateByIntervalCreateRequest(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (client *LogAnalyticsClient) ExportRequestRateByInterval(ctx context.Contex
 }
 
 // ExportRequestRateByIntervalCreateRequest creates the ExportRequestRateByInterval request.
-func (client *LogAnalyticsClient) ExportRequestRateByIntervalCreateRequest(ctx context.Context, location string, parameters RequestRateByIntervalInput) (*azcore.Request, error) {
+func (client *LogAnalyticsClient) ExportRequestRateByIntervalCreateRequest(ctx context.Context, location string, parameters RequestRateByIntervalInput, options *LogAnalyticsExportRequestRateByIntervalOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getRequestRateByInterval"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -131,8 +131,8 @@ func (client *LogAnalyticsClient) ExportRequestRateByIntervalHandleError(resp *a
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase) (*LogAnalyticsOperationResultPollerResponse, error) {
-	resp, err := client.ExportThrottledRequests(ctx, location, parameters)
+func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsExportThrottledRequestsOptions) (*LogAnalyticsOperationResultPollerResponse, error) {
+	resp, err := client.ExportThrottledRequests(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *LogAnalyticsClient) ResumeExportThrottledRequests(token string) (L
 }
 
 // ExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.
-func (client *LogAnalyticsClient) ExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase) (*azcore.Response, error) {
-	req, err := client.ExportThrottledRequestsCreateRequest(ctx, location, parameters)
+func (client *LogAnalyticsClient) ExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsExportThrottledRequestsOptions) (*azcore.Response, error) {
+	req, err := client.ExportThrottledRequestsCreateRequest(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *LogAnalyticsClient) ExportThrottledRequests(ctx context.Context, l
 }
 
 // ExportThrottledRequestsCreateRequest creates the ExportThrottledRequests request.
-func (client *LogAnalyticsClient) ExportThrottledRequestsCreateRequest(ctx context.Context, location string, parameters LogAnalyticsInputBase) (*azcore.Request, error) {
+func (client *LogAnalyticsClient) ExportThrottledRequestsCreateRequest(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsExportThrottledRequestsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getThrottledRequests"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -209,11 +209,42 @@ type AvailabilitySetUpdate struct {
 	SKU *SKU `json:"sku,omitempty"`
 }
 
+// AvailabilitySetsCreateOrUpdateOptions contains the optional parameters for the AvailabilitySets.CreateOrUpdate method.
+type AvailabilitySetsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailabilitySetsDeleteOptions contains the optional parameters for the AvailabilitySets.Delete method.
+type AvailabilitySetsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailabilitySetsGetOptions contains the optional parameters for the AvailabilitySets.Get method.
+type AvailabilitySetsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailabilitySetsListAvailableSizesOptions contains the optional parameters for the AvailabilitySets.ListAvailableSizes
+// method.
+type AvailabilitySetsListAvailableSizesOptions struct {
+	// placeholder for future optional parameters
+}
+
 // AvailabilitySetsListBySubscriptionOptions contains the optional parameters for the AvailabilitySets.ListBySubscription
 // method.
 type AvailabilitySetsListBySubscriptionOptions struct {
 	// The expand expression to apply to the operation. Allowed values are 'instanceView'.
 	Expand *string
+}
+
+// AvailabilitySetsListOptions contains the optional parameters for the AvailabilitySets.List method.
+type AvailabilitySetsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailabilitySetsUpdateOptions contains the optional parameters for the AvailabilitySets.Update method.
+type AvailabilitySetsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Specifies the billing related details of a Azure Spot VM or VMSS. <br><br>Minimum api-version: 2019-03-01.
@@ -502,6 +533,32 @@ type ContainerServiceWindowsProfile struct {
 	AdminUsername *string `json:"adminUsername,omitempty"`
 }
 
+// ContainerServicesCreateOrUpdateOptions contains the optional parameters for the ContainerServices.CreateOrUpdate method.
+type ContainerServicesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ContainerServicesDeleteOptions contains the optional parameters for the ContainerServices.Delete method.
+type ContainerServicesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ContainerServicesGetOptions contains the optional parameters for the ContainerServices.Get method.
+type ContainerServicesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ContainerServicesListByResourceGroupOptions contains the optional parameters for the ContainerServices.ListByResourceGroup
+// method.
+type ContainerServicesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ContainerServicesListOptions contains the optional parameters for the ContainerServices.List method.
+type ContainerServicesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Data used when creating a disk.
 type CreationData struct {
 	// This enumerates the possible sources of a disk's creation.
@@ -688,6 +745,38 @@ type DedicatedHostGroupUpdate struct {
 	Zones *[]string `json:"zones,omitempty"`
 }
 
+// DedicatedHostGroupsCreateOrUpdateOptions contains the optional parameters for the DedicatedHostGroups.CreateOrUpdate method.
+type DedicatedHostGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostGroupsDeleteOptions contains the optional parameters for the DedicatedHostGroups.Delete method.
+type DedicatedHostGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostGroupsGetOptions contains the optional parameters for the DedicatedHostGroups.Get method.
+type DedicatedHostGroupsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostGroupsListByResourceGroupOptions contains the optional parameters for the DedicatedHostGroups.ListByResourceGroup
+// method.
+type DedicatedHostGroupsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostGroupsListBySubscriptionOptions contains the optional parameters for the DedicatedHostGroups.ListBySubscription
+// method.
+type DedicatedHostGroupsListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostGroupsUpdateOptions contains the optional parameters for the DedicatedHostGroups.Update method.
+type DedicatedHostGroupsUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The instance view of a dedicated host.
 type DedicatedHostInstanceView struct {
 	// Specifies the unique id of the dedicated physical machine on which the dedicated host resides.
@@ -865,10 +954,30 @@ type DedicatedHostUpdate struct {
 	Properties *DedicatedHostProperties `json:"properties,omitempty"`
 }
 
+// DedicatedHostsCreateOrUpdateOptions contains the optional parameters for the DedicatedHosts.CreateOrUpdate method.
+type DedicatedHostsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostsDeleteOptions contains the optional parameters for the DedicatedHosts.Delete method.
+type DedicatedHostsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // DedicatedHostsGetOptions contains the optional parameters for the DedicatedHosts.Get method.
 type DedicatedHostsGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+}
+
+// DedicatedHostsListByHostGroupOptions contains the optional parameters for the DedicatedHosts.ListByHostGroup method.
+type DedicatedHostsListByHostGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DedicatedHostsUpdateOptions contains the optional parameters for the DedicatedHosts.Update method.
+type DedicatedHostsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Specifies the boot diagnostic settings state. <br><br>Minimum api-version: 2015-06-15.
@@ -989,6 +1098,37 @@ type DiskEncryptionSetUpdate struct {
 type DiskEncryptionSetUpdateProperties struct {
 	// Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
 	ActiveKey *KeyVaultAndKeyReference `json:"activeKey,omitempty"`
+}
+
+// DiskEncryptionSetsCreateOrUpdateOptions contains the optional parameters for the DiskEncryptionSets.CreateOrUpdate method.
+type DiskEncryptionSetsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DiskEncryptionSetsDeleteOptions contains the optional parameters for the DiskEncryptionSets.Delete method.
+type DiskEncryptionSetsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DiskEncryptionSetsGetOptions contains the optional parameters for the DiskEncryptionSets.Get method.
+type DiskEncryptionSetsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DiskEncryptionSetsListByResourceGroupOptions contains the optional parameters for the DiskEncryptionSets.ListByResourceGroup
+// method.
+type DiskEncryptionSetsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DiskEncryptionSetsListOptions contains the optional parameters for the DiskEncryptionSets.List method.
+type DiskEncryptionSetsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DiskEncryptionSetsUpdateOptions contains the optional parameters for the DiskEncryptionSets.Update method.
+type DiskEncryptionSetsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Describes a Encryption Settings for a Disk
@@ -1341,6 +1481,46 @@ type DiskUpdateProperties struct {
 	OSType *OperatingSystemTypes `json:"osType,omitempty"`
 }
 
+// DisksCreateOrUpdateOptions contains the optional parameters for the Disks.CreateOrUpdate method.
+type DisksCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksDeleteOptions contains the optional parameters for the Disks.Delete method.
+type DisksDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksGetOptions contains the optional parameters for the Disks.Get method.
+type DisksGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksGrantAccessOptions contains the optional parameters for the Disks.GrantAccess method.
+type DisksGrantAccessOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksListByResourceGroupOptions contains the optional parameters for the Disks.ListByResourceGroup method.
+type DisksListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksListOptions contains the optional parameters for the Disks.List method.
+type DisksListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksRevokeAccessOptions contains the optional parameters for the Disks.RevokeAccess method.
+type DisksRevokeAccessOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DisksUpdateOptions contains the optional parameters for the Disks.Update method.
+type DisksUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Encryption at rest settings for disk or snapshot
 type Encryption struct {
 	// ResourceId of the disk encryption set to use for enabling encryption at rest.
@@ -1409,6 +1589,36 @@ type EncryptionSettingsElement struct {
 	// Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap
 	// the disk encryption key.
 	KeyEncryptionKey *KeyVaultAndKeyReference `json:"keyEncryptionKey,omitempty"`
+}
+
+// GalleriesCreateOrUpdateOptions contains the optional parameters for the Galleries.CreateOrUpdate method.
+type GalleriesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleriesDeleteOptions contains the optional parameters for the Galleries.Delete method.
+type GalleriesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleriesGetOptions contains the optional parameters for the Galleries.Get method.
+type GalleriesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleriesListByResourceGroupOptions contains the optional parameters for the Galleries.ListByResourceGroup method.
+type GalleriesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleriesListOptions contains the optional parameters for the Galleries.List method.
+type GalleriesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleriesUpdateOptions contains the optional parameters for the Galleries.Update method.
+type GalleriesUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Specifies information about the Shared Image Gallery that you want to create or update.
@@ -1697,10 +1907,57 @@ type GalleryApplicationVersionUpdate struct {
 	Properties *GalleryApplicationVersionProperties `json:"properties,omitempty"`
 }
 
+// GalleryApplicationVersionsCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationVersions.CreateOrUpdate
+// method.
+type GalleryApplicationVersionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationVersionsDeleteOptions contains the optional parameters for the GalleryApplicationVersions.Delete method.
+type GalleryApplicationVersionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // GalleryApplicationVersionsGetOptions contains the optional parameters for the GalleryApplicationVersions.Get method.
 type GalleryApplicationVersionsGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *ReplicationStatusTypes
+}
+
+// GalleryApplicationVersionsListByGalleryApplicationOptions contains the optional parameters for the GalleryApplicationVersions.ListByGalleryApplication
+// method.
+type GalleryApplicationVersionsListByGalleryApplicationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationVersionsUpdateOptions contains the optional parameters for the GalleryApplicationVersions.Update method.
+type GalleryApplicationVersionsUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationsCreateOrUpdateOptions contains the optional parameters for the GalleryApplications.CreateOrUpdate method.
+type GalleryApplicationsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationsDeleteOptions contains the optional parameters for the GalleryApplications.Delete method.
+type GalleryApplicationsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationsGetOptions contains the optional parameters for the GalleryApplications.Get method.
+type GalleryApplicationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationsListByGalleryOptions contains the optional parameters for the GalleryApplications.ListByGallery method.
+type GalleryApplicationsListByGalleryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryApplicationsUpdateOptions contains the optional parameters for the GalleryApplications.Update method.
+type GalleryApplicationsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Describes the basic gallery artifact publishing profile.
@@ -2174,10 +2431,57 @@ type GalleryImageVersionUpdate struct {
 	Properties *GalleryImageVersionProperties `json:"properties,omitempty"`
 }
 
+// GalleryImageVersionsCreateOrUpdateOptions contains the optional parameters for the GalleryImageVersions.CreateOrUpdate
+// method.
+type GalleryImageVersionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImageVersionsDeleteOptions contains the optional parameters for the GalleryImageVersions.Delete method.
+type GalleryImageVersionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // GalleryImageVersionsGetOptions contains the optional parameters for the GalleryImageVersions.Get method.
 type GalleryImageVersionsGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *ReplicationStatusTypes
+}
+
+// GalleryImageVersionsListByGalleryImageOptions contains the optional parameters for the GalleryImageVersions.ListByGalleryImage
+// method.
+type GalleryImageVersionsListByGalleryImageOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImageVersionsUpdateOptions contains the optional parameters for the GalleryImageVersions.Update method.
+type GalleryImageVersionsUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImagesCreateOrUpdateOptions contains the optional parameters for the GalleryImages.CreateOrUpdate method.
+type GalleryImagesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImagesDeleteOptions contains the optional parameters for the GalleryImages.Delete method.
+type GalleryImagesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImagesGetOptions contains the optional parameters for the GalleryImages.Get method.
+type GalleryImagesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImagesListByGalleryOptions contains the optional parameters for the GalleryImages.ListByGallery method.
+type GalleryImagesListByGalleryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// GalleryImagesUpdateOptions contains the optional parameters for the GalleryImages.Update method.
+type GalleryImagesUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // The List Galleries operation response.
@@ -2452,10 +2756,35 @@ type ImageUpdate struct {
 	Properties *ImageProperties `json:"properties,omitempty"`
 }
 
+// ImagesCreateOrUpdateOptions contains the optional parameters for the Images.CreateOrUpdate method.
+type ImagesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ImagesDeleteOptions contains the optional parameters for the Images.Delete method.
+type ImagesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ImagesGetOptions contains the optional parameters for the Images.Get method.
 type ImagesGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+}
+
+// ImagesListByResourceGroupOptions contains the optional parameters for the Images.ListByResourceGroup method.
+type ImagesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ImagesListOptions contains the optional parameters for the Images.List method.
+type ImagesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ImagesUpdateOptions contains the optional parameters for the Images.Update method.
+type ImagesUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Inner error details.
@@ -2619,6 +2948,18 @@ type ListUsagesResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// LogAnalyticsExportRequestRateByIntervalOptions contains the optional parameters for the LogAnalytics.ExportRequestRateByInterval
+// method.
+type LogAnalyticsExportRequestRateByIntervalOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LogAnalyticsExportThrottledRequestsOptions contains the optional parameters for the LogAnalytics.ExportThrottledRequests
+// method.
+type LogAnalyticsExportThrottledRequestsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Api input base class for LogAnalytics Api.
@@ -3016,6 +3357,11 @@ type OSProfile struct {
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
 }
 
+// OperationsListOptions contains the optional parameters for the Operations.List method.
+type OperationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The input for OrchestrationServiceState
 type OrchestrationServiceStateInput struct {
 	// The action to be performed.
@@ -3111,10 +3457,38 @@ type ProximityPlacementGroupUpdate struct {
 	UpdateResource
 }
 
+// ProximityPlacementGroupsCreateOrUpdateOptions contains the optional parameters for the ProximityPlacementGroups.CreateOrUpdate
+// method.
+type ProximityPlacementGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ProximityPlacementGroupsDeleteOptions contains the optional parameters for the ProximityPlacementGroups.Delete method.
+type ProximityPlacementGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ProximityPlacementGroupsGetOptions contains the optional parameters for the ProximityPlacementGroups.Get method.
 type ProximityPlacementGroupsGetOptions struct {
 	// includeColocationStatus=true enables fetching the colocation status of all the resources in the proximity placement group.
 	IncludeColocationStatus *string
+}
+
+// ProximityPlacementGroupsListByResourceGroupOptions contains the optional parameters for the ProximityPlacementGroups.ListByResourceGroup
+// method.
+type ProximityPlacementGroupsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ProximityPlacementGroupsListBySubscriptionOptions contains the optional parameters for the ProximityPlacementGroups.ListBySubscription
+// method.
+type ProximityPlacementGroupsListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ProximityPlacementGroupsUpdateOptions contains the optional parameters for the ProximityPlacementGroups.Update method.
+type ProximityPlacementGroupsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
@@ -3749,6 +4123,26 @@ type SSHPublicKeyUpdateResource struct {
 	Properties *SSHPublicKeyResourceProperties `json:"properties,omitempty"`
 }
 
+// SSHPublicKeysCreateOptions contains the optional parameters for the SSHPublicKeys.Create method.
+type SSHPublicKeysCreateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SSHPublicKeysDeleteOptions contains the optional parameters for the SSHPublicKeys.Delete method.
+type SSHPublicKeysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SSHPublicKeysGenerateKeyPairOptions contains the optional parameters for the SSHPublicKeys.GenerateKeyPair method.
+type SSHPublicKeysGenerateKeyPairOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SSHPublicKeysGetOptions contains the optional parameters for the SSHPublicKeys.Get method.
+type SSHPublicKeysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The list SSH public keys operation response.
 type SSHPublicKeysGroupListResult struct {
 	// The URI to fetch the next page of SSH public keys. Call ListNext() with this URI to fetch the next page of SSH public keys.
@@ -3766,6 +4160,21 @@ type SSHPublicKeysGroupListResultResponse struct {
 
 	// The list SSH public keys operation response.
 	SSHPublicKeysGroupListResult *SSHPublicKeysGroupListResult
+}
+
+// SSHPublicKeysListByResourceGroupOptions contains the optional parameters for the SSHPublicKeys.ListByResourceGroup method.
+type SSHPublicKeysListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SSHPublicKeysListBySubscriptionOptions contains the optional parameters for the SSHPublicKeys.ListBySubscription method.
+type SSHPublicKeysListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SSHPublicKeysUpdateOptions contains the optional parameters for the SSHPublicKeys.Update method.
+type SSHPublicKeysUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Describes a scale-in policy for a virtual machine scale set.
@@ -4035,6 +4444,46 @@ type SnapshotUpdateProperties struct {
 	OSType *OperatingSystemTypes `json:"osType,omitempty"`
 }
 
+// SnapshotsCreateOrUpdateOptions contains the optional parameters for the Snapshots.CreateOrUpdate method.
+type SnapshotsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsDeleteOptions contains the optional parameters for the Snapshots.Delete method.
+type SnapshotsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsGetOptions contains the optional parameters for the Snapshots.Get method.
+type SnapshotsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsGrantAccessOptions contains the optional parameters for the Snapshots.GrantAccess method.
+type SnapshotsGrantAccessOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsListByResourceGroupOptions contains the optional parameters for the Snapshots.ListByResourceGroup method.
+type SnapshotsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsListOptions contains the optional parameters for the Snapshots.List method.
+type SnapshotsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsRevokeAccessOptions contains the optional parameters for the Snapshots.RevokeAccess method.
+type SnapshotsRevokeAccessOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SnapshotsUpdateOptions contains the optional parameters for the Snapshots.Update method.
+type SnapshotsUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The vault id is an Azure Resource Manager Resource id in the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}
 type SourceVault struct {
 	// Resource Id
@@ -4249,6 +4698,11 @@ type Usage struct {
 	Unit *string `json:"unit,omitempty"`
 }
 
+// UsageListOptions contains the optional parameters for the Usage.List method.
+type UsageListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The Usage Names.
 type UsageName struct {
 	// The localized name of the resource.
@@ -4453,6 +4907,17 @@ type VirtualMachineExtensionImageResponse struct {
 	VirtualMachineExtensionImage *VirtualMachineExtensionImage
 }
 
+// VirtualMachineExtensionImagesGetOptions contains the optional parameters for the VirtualMachineExtensionImages.Get method.
+type VirtualMachineExtensionImagesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineExtensionImagesListTypesOptions contains the optional parameters for the VirtualMachineExtensionImages.ListTypes
+// method.
+type VirtualMachineExtensionImagesListTypesOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineExtensionImagesListVersionsOptions contains the optional parameters for the VirtualMachineExtensionImages.ListVersions
 // method.
 type VirtualMachineExtensionImagesListVersionsOptions struct {
@@ -4565,6 +5030,17 @@ type VirtualMachineExtensionUpdateProperties struct {
 	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
 }
 
+// VirtualMachineExtensionsCreateOrUpdateOptions contains the optional parameters for the VirtualMachineExtensions.CreateOrUpdate
+// method.
+type VirtualMachineExtensionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineExtensionsDeleteOptions contains the optional parameters for the VirtualMachineExtensions.Delete method.
+type VirtualMachineExtensionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineExtensionsGetOptions contains the optional parameters for the VirtualMachineExtensions.Get method.
 type VirtualMachineExtensionsGetOptions struct {
 	// The expand expression to apply on the operation.
@@ -4591,6 +5067,11 @@ type VirtualMachineExtensionsListResultResponse struct {
 
 	// The List Extension operation response
 	VirtualMachineExtensionsListResult *VirtualMachineExtensionsListResult
+}
+
+// VirtualMachineExtensionsUpdateOptions contains the optional parameters for the VirtualMachineExtensions.Update method.
+type VirtualMachineExtensionsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // The health status of the VM.
@@ -4672,12 +5153,33 @@ type VirtualMachineImageResponse struct {
 	VirtualMachineImage *VirtualMachineImage
 }
 
+// VirtualMachineImagesGetOptions contains the optional parameters for the VirtualMachineImages.Get method.
+type VirtualMachineImagesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineImagesListOffersOptions contains the optional parameters for the VirtualMachineImages.ListOffers method.
+type VirtualMachineImagesListOffersOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineImagesListOptions contains the optional parameters for the VirtualMachineImages.List method.
 type VirtualMachineImagesListOptions struct {
 	// The expand expression to apply on the operation.
 	Expand  *string
 	Orderby *string
 	Top     *int32
+}
+
+// VirtualMachineImagesListPublishersOptions contains the optional parameters for the VirtualMachineImages.ListPublishers
+// method.
+type VirtualMachineImagesListPublishersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineImagesListSKUsOptions contains the optional parameters for the VirtualMachineImages.ListSKUs method.
+type VirtualMachineImagesListSKUsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // The instance view of a virtual machine.
@@ -4852,6 +5354,16 @@ type VirtualMachineResponse struct {
 	VirtualMachine *VirtualMachine
 }
 
+// VirtualMachineRunCommandsGetOptions contains the optional parameters for the VirtualMachineRunCommands.Get method.
+type VirtualMachineRunCommandsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineRunCommandsListOptions contains the optional parameters for the VirtualMachineRunCommands.List method.
+type VirtualMachineRunCommandsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Describes a Virtual Machine Scale Set.
 type VirtualMachineScaleSet struct {
 	Resource
@@ -5016,11 +5528,35 @@ type VirtualMachineScaleSetExtensionUpdate struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// VirtualMachineScaleSetExtensionsCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensions.CreateOrUpdate
+// method.
+type VirtualMachineScaleSetExtensionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetExtensionsDeleteOptions contains the optional parameters for the VirtualMachineScaleSetExtensions.Delete
+// method.
+type VirtualMachineScaleSetExtensionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetExtensionsGetOptions contains the optional parameters for the VirtualMachineScaleSetExtensions.Get
 // method.
 type VirtualMachineScaleSetExtensionsGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+}
+
+// VirtualMachineScaleSetExtensionsListOptions contains the optional parameters for the VirtualMachineScaleSetExtensions.List
+// method.
+type VirtualMachineScaleSetExtensionsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetExtensionsUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensions.Update
+// method.
+type VirtualMachineScaleSetExtensionsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Identity for the virtual machine scale set.
@@ -5453,6 +5989,30 @@ type VirtualMachineScaleSetResponse struct {
 	VirtualMachineScaleSet *VirtualMachineScaleSet
 }
 
+// VirtualMachineScaleSetRollingUpgradesCancelOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgrades.Cancel
+// method.
+type VirtualMachineScaleSetRollingUpgradesCancelOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetRollingUpgradesGetLatestOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgrades.GetLatest
+// method.
+type VirtualMachineScaleSetRollingUpgradesGetLatestOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgrades.StartExtensionUpgrade
+// method.
+type VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgrades.StartOSUpgrade
+// method.
+type VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Describes an available virtual machine scale set sku.
 type VirtualMachineScaleSetSKU struct {
 	// Specifies the number of virtual machines in the scale set.
@@ -5750,6 +6310,18 @@ type VirtualMachineScaleSetVM struct {
 	Zones *[]string `json:"zones,omitempty" azure:"ro"`
 }
 
+// VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.CreateOrUpdate
+// method.
+type VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMExtensionsDeleteOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.Delete
+// method.
+type VirtualMachineScaleSetVMExtensionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetVMExtensionsGetOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.Get
 // method.
 type VirtualMachineScaleSetVMExtensionsGetOptions struct {
@@ -5771,6 +6343,12 @@ type VirtualMachineScaleSetVMExtensionsSummary struct {
 
 	// The extensions information.
 	StatusesSummary *[]VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+}
+
+// VirtualMachineScaleSetVMExtensionsUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.Update
+// method.
+type VirtualMachineScaleSetVMExtensionsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Specifies a list of virtual machine instance IDs from the VM scale set.
@@ -5995,6 +6573,23 @@ type VirtualMachineScaleSetVMResponse struct {
 	VirtualMachineScaleSetVM *VirtualMachineScaleSetVM
 }
 
+// VirtualMachineScaleSetVMSDeallocateOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Deallocate
+// method.
+type VirtualMachineScaleSetVMSDeallocateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSDeleteOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Delete method.
+type VirtualMachineScaleSetVMSDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSGetInstanceViewOptions contains the optional parameters for the VirtualMachineScaleSetVMS.GetInstanceView
+// method.
+type VirtualMachineScaleSetVMSGetInstanceViewOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetVMSGetOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Get method.
 type VirtualMachineScaleSetVMSGetOptions struct {
 	// The expand expression to apply on the operation.
@@ -6012,11 +6607,28 @@ type VirtualMachineScaleSetVMSListOptions struct {
 	SelectParameter *string
 }
 
+// VirtualMachineScaleSetVMSPerformMaintenanceOptions contains the optional parameters for the VirtualMachineScaleSetVMS.PerformMaintenance
+// method.
+type VirtualMachineScaleSetVMSPerformMaintenanceOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetVMSPowerOffOptions contains the optional parameters for the VirtualMachineScaleSetVMS.PowerOff method.
 type VirtualMachineScaleSetVMSPowerOffOptions struct {
 	// The parameter to request non-graceful VM shutdown. True value for this flag indicates non-graceful shutdown whereas false
 	// indicates otherwise. Default value for this flag is false if not specified
 	SkipShutdown *bool
+}
+
+// VirtualMachineScaleSetVMSRedeployOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Redeploy method.
+type VirtualMachineScaleSetVMSRedeployOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSReimageAllOptions contains the optional parameters for the VirtualMachineScaleSetVMS.ReimageAll
+// method.
+type VirtualMachineScaleSetVMSReimageAllOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualMachineScaleSetVMSReimageOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Reimage method.
@@ -6025,10 +6637,98 @@ type VirtualMachineScaleSetVMSReimageOptions struct {
 	VMScaleSetVMReimageInput *VirtualMachineReimageParameters
 }
 
+// VirtualMachineScaleSetVMSRestartOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Restart method.
+type VirtualMachineScaleSetVMSRestartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSRunCommandOptions contains the optional parameters for the VirtualMachineScaleSetVMS.RunCommand
+// method.
+type VirtualMachineScaleSetVMSRunCommandOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSSimulateEvictionOptions contains the optional parameters for the VirtualMachineScaleSetVMS.SimulateEviction
+// method.
+type VirtualMachineScaleSetVMSSimulateEvictionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSStartOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Start method.
+type VirtualMachineScaleSetVMSStartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetVMSUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMS.Update method.
+type VirtualMachineScaleSetVMSUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsConvertToSinglePlacementGroupOptions contains the optional parameters for the VirtualMachineScaleSets.ConvertToSinglePlacementGroup
+// method.
+type VirtualMachineScaleSetsConvertToSinglePlacementGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSets.CreateOrUpdate
+// method.
+type VirtualMachineScaleSetsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetsDeallocateOptions contains the optional parameters for the VirtualMachineScaleSets.Deallocate method.
 type VirtualMachineScaleSetsDeallocateOptions struct {
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
+}
+
+// VirtualMachineScaleSetsDeleteInstancesOptions contains the optional parameters for the VirtualMachineScaleSets.DeleteInstances
+// method.
+type VirtualMachineScaleSetsDeleteInstancesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsDeleteOptions contains the optional parameters for the VirtualMachineScaleSets.Delete method.
+type VirtualMachineScaleSetsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions contains the optional parameters for the
+// VirtualMachineScaleSets.ForceRecoveryServiceFabricPlatformUpdateDomainWalk method.
+type VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsGetInstanceViewOptions contains the optional parameters for the VirtualMachineScaleSets.GetInstanceView
+// method.
+type VirtualMachineScaleSetsGetInstanceViewOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsGetOSUpgradeHistoryOptions contains the optional parameters for the VirtualMachineScaleSets.GetOSUpgradeHistory
+// method.
+type VirtualMachineScaleSetsGetOSUpgradeHistoryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsGetOptions contains the optional parameters for the VirtualMachineScaleSets.Get method.
+type VirtualMachineScaleSetsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsListAllOptions contains the optional parameters for the VirtualMachineScaleSets.ListAll method.
+type VirtualMachineScaleSetsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsListOptions contains the optional parameters for the VirtualMachineScaleSets.List method.
+type VirtualMachineScaleSetsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsListSKUsOptions contains the optional parameters for the VirtualMachineScaleSets.ListSKUs method.
+type VirtualMachineScaleSetsListSKUsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualMachineScaleSetsPerformMaintenanceOptions contains the optional parameters for the VirtualMachineScaleSets.PerformMaintenance
@@ -6071,10 +6771,27 @@ type VirtualMachineScaleSetsRestartOptions struct {
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
 
+// VirtualMachineScaleSetsSetOrchestrationServiceStateOptions contains the optional parameters for the VirtualMachineScaleSets.SetOrchestrationServiceState
+// method.
+type VirtualMachineScaleSetsSetOrchestrationServiceStateOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachineScaleSetsStartOptions contains the optional parameters for the VirtualMachineScaleSets.Start method.
 type VirtualMachineScaleSetsStartOptions struct {
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
+}
+
+// VirtualMachineScaleSetsUpdateInstancesOptions contains the optional parameters for the VirtualMachineScaleSets.UpdateInstances
+// method.
+type VirtualMachineScaleSetsUpdateInstancesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachineScaleSetsUpdateOptions contains the optional parameters for the VirtualMachineScaleSets.Update method.
+type VirtualMachineScaleSetsUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Describes the properties of a VM size.
@@ -6114,6 +6831,11 @@ type VirtualMachineSizeListResultResponse struct {
 	VirtualMachineSizeListResult *VirtualMachineSizeListResult
 }
 
+// VirtualMachineSizesListOptions contains the optional parameters for the VirtualMachineSizes.List method.
+type VirtualMachineSizesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The status code and count of the virtual machine scale set instance view status summary.
 type VirtualMachineStatusCodeCount struct {
 	// The instance view status code.
@@ -6142,16 +6864,72 @@ type VirtualMachineUpdate struct {
 	Zones *[]string `json:"zones,omitempty"`
 }
 
+// VirtualMachinesCaptureOptions contains the optional parameters for the VirtualMachines.Capture method.
+type VirtualMachinesCaptureOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesConvertToManagedDisksOptions contains the optional parameters for the VirtualMachines.ConvertToManagedDisks
+// method.
+type VirtualMachinesConvertToManagedDisksOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesCreateOrUpdateOptions contains the optional parameters for the VirtualMachines.CreateOrUpdate method.
+type VirtualMachinesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesDeallocateOptions contains the optional parameters for the VirtualMachines.Deallocate method.
+type VirtualMachinesDeallocateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesDeleteOptions contains the optional parameters for the VirtualMachines.Delete method.
+type VirtualMachinesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesGeneralizeOptions contains the optional parameters for the VirtualMachines.Generalize method.
+type VirtualMachinesGeneralizeOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachinesGetOptions contains the optional parameters for the VirtualMachines.Get method.
 type VirtualMachinesGetOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
 }
 
+// VirtualMachinesInstanceViewOptions contains the optional parameters for the VirtualMachines.InstanceView method.
+type VirtualMachinesInstanceViewOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachinesListAllOptions contains the optional parameters for the VirtualMachines.ListAll method.
 type VirtualMachinesListAllOptions struct {
 	// statusOnly=true enables fetching run time status of all Virtual Machines in the subscription.
 	StatusOnly *string
+}
+
+// VirtualMachinesListAvailableSizesOptions contains the optional parameters for the VirtualMachines.ListAvailableSizes method.
+type VirtualMachinesListAvailableSizesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesListByLocationOptions contains the optional parameters for the VirtualMachines.ListByLocation method.
+type VirtualMachinesListByLocationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesListOptions contains the optional parameters for the VirtualMachines.List method.
+type VirtualMachinesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesPerformMaintenanceOptions contains the optional parameters for the VirtualMachines.PerformMaintenance method.
+type VirtualMachinesPerformMaintenanceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualMachinesPowerOffOptions contains the optional parameters for the VirtualMachines.PowerOff method.
@@ -6161,10 +6939,45 @@ type VirtualMachinesPowerOffOptions struct {
 	SkipShutdown *bool
 }
 
+// VirtualMachinesReapplyOptions contains the optional parameters for the VirtualMachines.Reapply method.
+type VirtualMachinesReapplyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesRedeployOptions contains the optional parameters for the VirtualMachines.Redeploy method.
+type VirtualMachinesRedeployOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualMachinesReimageOptions contains the optional parameters for the VirtualMachines.Reimage method.
 type VirtualMachinesReimageOptions struct {
 	// Parameters supplied to the Reimage Virtual Machine operation.
 	Parameters *VirtualMachineReimageParameters
+}
+
+// VirtualMachinesRestartOptions contains the optional parameters for the VirtualMachines.Restart method.
+type VirtualMachinesRestartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesRunCommandOptions contains the optional parameters for the VirtualMachines.RunCommand method.
+type VirtualMachinesRunCommandOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesSimulateEvictionOptions contains the optional parameters for the VirtualMachines.SimulateEviction method.
+type VirtualMachinesSimulateEvictionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesStartOptions contains the optional parameters for the VirtualMachines.Start method.
+type VirtualMachinesStartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualMachinesUpdateOptions contains the optional parameters for the VirtualMachines.Update method.
+type VirtualMachinesUpdateOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Describes Windows Remote Management configuration of the VM

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations.go
@@ -17,7 +17,7 @@ import (
 // Operations contains the methods for the Operations group.
 type Operations interface {
 	// List - Gets a list of compute operations.
-	List(ctx context.Context) (*ComputeOperationListResultResponse, error)
+	List(ctx context.Context, options *OperationsListOptions) (*ComputeOperationListResultResponse, error)
 }
 
 // OperationsClient implements the Operations interface.
@@ -37,8 +37,8 @@ func (client *OperationsClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // List - Gets a list of compute operations.
-func (client *OperationsClient) List(ctx context.Context) (*ComputeOperationListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx)
+func (client *OperationsClient) List(ctx context.Context, options *OperationsListOptions) (*ComputeOperationListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (client *OperationsClient) List(ctx context.Context) (*ComputeOperationList
 }
 
 // ListCreateRequest creates the List request.
-func (client *OperationsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *OperationsClient) ListCreateRequest(ctx context.Context, options *OperationsListOptions) (*azcore.Request, error) {
 	urlPath := "/providers/Microsoft.Compute/operations"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
@@ -19,17 +19,17 @@ import (
 // ProximityPlacementGroupsOperations contains the methods for the ProximityPlacementGroups group.
 type ProximityPlacementGroupsOperations interface {
 	// CreateOrUpdate - Create or update a proximity placement group.
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup) (*ProximityPlacementGroupResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup, options *ProximityPlacementGroupsCreateOrUpdateOptions) (*ProximityPlacementGroupResponse, error)
 	// Delete - Delete a proximity placement group.
-	Delete(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string) (*http.Response, error)
+	Delete(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsDeleteOptions) (*http.Response, error)
 	// Get - Retrieves information about a proximity placement group .
-	Get(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, proximityPlacementGroupsGetOptions *ProximityPlacementGroupsGetOptions) (*ProximityPlacementGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsGetOptions) (*ProximityPlacementGroupResponse, error)
 	// ListByResourceGroup - Lists all proximity placement groups in a resource group.
-	ListByResourceGroup(resourceGroupName string) ProximityPlacementGroupListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ProximityPlacementGroupsListByResourceGroupOptions) ProximityPlacementGroupListResultPager
 	// ListBySubscription - Lists all proximity placement groups in a subscription.
-	ListBySubscription() ProximityPlacementGroupListResultPager
+	ListBySubscription(options *ProximityPlacementGroupsListBySubscriptionOptions) ProximityPlacementGroupListResultPager
 	// Update - Update a proximity placement group.
-	Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource) (*ProximityPlacementGroupResponse, error)
+	Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource, options *ProximityPlacementGroupsUpdateOptions) (*ProximityPlacementGroupResponse, error)
 }
 
 // ProximityPlacementGroupsClient implements the ProximityPlacementGroupsOperations interface.
@@ -50,8 +50,8 @@ func (client *ProximityPlacementGroupsClient) Do(req *azcore.Request) (*azcore.R
 }
 
 // CreateOrUpdate - Create or update a proximity placement group.
-func (client *ProximityPlacementGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup) (*ProximityPlacementGroupResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, parameters)
+func (client *ProximityPlacementGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup, options *ProximityPlacementGroupsCreateOrUpdateOptions) (*ProximityPlacementGroupResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (client *ProximityPlacementGroupsClient) CreateOrUpdate(ctx context.Context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ProximityPlacementGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroup, options *ProximityPlacementGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{proximityPlacementGroupName}", url.PathEscape(proximityPlacementGroupName))
@@ -105,8 +105,8 @@ func (client *ProximityPlacementGroupsClient) CreateOrUpdateHandleError(resp *az
 }
 
 // Delete - Delete a proximity placement group.
-func (client *ProximityPlacementGroupsClient) Delete(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string) (*http.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName)
+func (client *ProximityPlacementGroupsClient) Delete(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsDeleteOptions) (*http.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (client *ProximityPlacementGroupsClient) Delete(ctx context.Context, resour
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ProximityPlacementGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{proximityPlacementGroupName}", url.PathEscape(proximityPlacementGroupName))
@@ -149,8 +149,8 @@ func (client *ProximityPlacementGroupsClient) DeleteHandleError(resp *azcore.Res
 }
 
 // Get - Retrieves information about a proximity placement group .
-func (client *ProximityPlacementGroupsClient) Get(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, proximityPlacementGroupsGetOptions *ProximityPlacementGroupsGetOptions) (*ProximityPlacementGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, proximityPlacementGroupsGetOptions)
+func (client *ProximityPlacementGroupsClient) Get(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsGetOptions) (*ProximityPlacementGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (client *ProximityPlacementGroupsClient) Get(ctx context.Context, resourceG
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ProximityPlacementGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, proximityPlacementGroupsGetOptions *ProximityPlacementGroupsGetOptions) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, options *ProximityPlacementGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{proximityPlacementGroupName}", url.PathEscape(proximityPlacementGroupName))
@@ -179,8 +179,8 @@ func (client *ProximityPlacementGroupsClient) GetCreateRequest(ctx context.Conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if proximityPlacementGroupsGetOptions != nil && proximityPlacementGroupsGetOptions.IncludeColocationStatus != nil {
-		query.Set("includeColocationStatus", *proximityPlacementGroupsGetOptions.IncludeColocationStatus)
+	if options != nil && options.IncludeColocationStatus != nil {
+		query.Set("includeColocationStatus", *options.IncludeColocationStatus)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -207,11 +207,11 @@ func (client *ProximityPlacementGroupsClient) GetHandleError(resp *azcore.Respon
 }
 
 // ListByResourceGroup - Lists all proximity placement groups in a resource group.
-func (client *ProximityPlacementGroupsClient) ListByResourceGroup(resourceGroupName string) ProximityPlacementGroupListResultPager {
+func (client *ProximityPlacementGroupsClient) ListByResourceGroup(resourceGroupName string, options *ProximityPlacementGroupsListByResourceGroupOptions) ProximityPlacementGroupListResultPager {
 	return &proximityPlacementGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -222,7 +222,7 @@ func (client *ProximityPlacementGroupsClient) ListByResourceGroup(resourceGroupN
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ProximityPlacementGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ProximityPlacementGroupsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -256,11 +256,11 @@ func (client *ProximityPlacementGroupsClient) ListByResourceGroupHandleError(res
 }
 
 // ListBySubscription - Lists all proximity placement groups in a subscription.
-func (client *ProximityPlacementGroupsClient) ListBySubscription() ProximityPlacementGroupListResultPager {
+func (client *ProximityPlacementGroupsClient) ListBySubscription(options *ProximityPlacementGroupsListBySubscriptionOptions) ProximityPlacementGroupListResultPager {
 	return &proximityPlacementGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -271,7 +271,7 @@ func (client *ProximityPlacementGroupsClient) ListBySubscription() ProximityPlac
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *ProximityPlacementGroupsClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) ListBySubscriptionCreateRequest(ctx context.Context, options *ProximityPlacementGroupsListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/proximityPlacementGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -304,8 +304,8 @@ func (client *ProximityPlacementGroupsClient) ListBySubscriptionHandleError(resp
 }
 
 // Update - Update a proximity placement group.
-func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource) (*ProximityPlacementGroupResponse, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, parameters)
+func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource, options *ProximityPlacementGroupsUpdateOptions) (*ProximityPlacementGroupResponse, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +324,7 @@ func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resour
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *ProximityPlacementGroupsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource, options *ProximityPlacementGroupsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{proximityPlacementGroupName}", url.PathEscape(proximityPlacementGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
@@ -19,7 +19,7 @@ import (
 // ResourceSKUsOperations contains the methods for the ResourceSKUs group.
 type ResourceSKUsOperations interface {
 	// List - Gets the list of Microsoft.Compute SKUs available for your Subscription.
-	List(resourceSkUsListOptions *ResourceSKUsListOptions) ResourceSKUsResultPager
+	List(options *ResourceSKUsListOptions) ResourceSKUsResultPager
 }
 
 // ResourceSKUsClient implements the ResourceSKUsOperations interface.
@@ -40,11 +40,11 @@ func (client *ResourceSKUsClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // List - Gets the list of Microsoft.Compute SKUs available for your Subscription.
-func (client *ResourceSKUsClient) List(resourceSkUsListOptions *ResourceSKUsListOptions) ResourceSKUsResultPager {
+func (client *ResourceSKUsClient) List(options *ResourceSKUsListOptions) ResourceSKUsResultPager {
 	return &resourceSkUsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceSkUsListOptions)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -55,7 +55,7 @@ func (client *ResourceSKUsClient) List(resourceSkUsListOptions *ResourceSKUsList
 }
 
 // ListCreateRequest creates the List request.
-func (client *ResourceSKUsClient) ListCreateRequest(ctx context.Context, resourceSkUsListOptions *ResourceSKUsListOptions) (*azcore.Request, error) {
+func (client *ResourceSKUsClient) ListCreateRequest(ctx context.Context, options *ResourceSKUsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/skus"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -64,8 +64,8 @@ func (client *ResourceSKUsClient) ListCreateRequest(ctx context.Context, resourc
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2019-04-01")
-	if resourceSkUsListOptions != nil && resourceSkUsListOptions.Filter != nil {
-		query.Set("$filter", *resourceSkUsListOptions.Filter)
+	if options != nil && options.Filter != nil {
+		query.Set("$filter", *options.Filter)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
@@ -21,29 +21,29 @@ import (
 // SnapshotsOperations contains the methods for the Snapshots group.
 type SnapshotsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a snapshot.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot) (*SnapshotPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsCreateOrUpdateOptions) (*SnapshotPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (SnapshotPoller, error)
 	// BeginDelete - Deletes a snapshot.
-	BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about a snapshot.
-	Get(ctx context.Context, resourceGroupName string, snapshotName string) (*SnapshotResponse, error)
+	Get(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsGetOptions) (*SnapshotResponse, error)
 	// BeginGrantAccess - Grants access to a snapshot.
-	BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error)
+	BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsGrantAccessOptions) (*AccessURIPollerResponse, error)
 	// ResumeGrantAccess - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGrantAccess(token string) (AccessURIPoller, error)
 	// List - Lists snapshots under a subscription.
-	List() SnapshotListPager
+	List(options *SnapshotsListOptions) SnapshotListPager
 	// ListByResourceGroup - Lists snapshots under a resource group.
-	ListByResourceGroup(resourceGroupName string) SnapshotListPager
+	ListByResourceGroup(resourceGroupName string, options *SnapshotsListByResourceGroupOptions) SnapshotListPager
 	// BeginRevokeAccess - Revokes access to a snapshot.
-	BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error)
+	BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsRevokeAccessOptions) (*HTTPPollerResponse, error)
 	// ResumeRevokeAccess - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRevokeAccess(token string) (HTTPPoller, error)
 	// BeginUpdate - Updates (patches) a snapshot.
-	BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate) (*SnapshotPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsUpdateOptions) (*SnapshotPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (SnapshotPoller, error)
 }
@@ -65,8 +65,8 @@ func (client *SnapshotsClient) Do(req *azcore.Request) (*azcore.Response, error)
 	return client.p.Do(req)
 }
 
-func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot) (*SnapshotPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, snapshotName, snapshot)
+func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsCreateOrUpdateOptions) (*SnapshotPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
 		return nil, err
 	}
@@ -100,8 +100,8 @@ func (client *SnapshotsClient) ResumeCreateOrUpdate(token string) (SnapshotPolle
 }
 
 // CreateOrUpdate - Creates or updates a snapshot.
-func (client *SnapshotsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, snapshotName, snapshot)
+func (client *SnapshotsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (client *SnapshotsClient) CreateOrUpdate(ctx context.Context, resourceGroup
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *SnapshotsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot) (*azcore.Request, error) {
+func (client *SnapshotsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, snapshot Snapshot, options *SnapshotsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -150,8 +150,8 @@ func (client *SnapshotsClient) CreateOrUpdateHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, snapshotName)
+func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (client *SnapshotsClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes a snapshot.
-func (client *SnapshotsClient) Delete(ctx context.Context, resourceGroupName string, snapshotName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, snapshotName)
+func (client *SnapshotsClient) Delete(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (client *SnapshotsClient) Delete(ctx context.Context, resourceGroupName str
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *SnapshotsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string) (*azcore.Request, error) {
+func (client *SnapshotsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -229,8 +229,8 @@ func (client *SnapshotsClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets information about a snapshot.
-func (client *SnapshotsClient) Get(ctx context.Context, resourceGroupName string, snapshotName string) (*SnapshotResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, snapshotName)
+func (client *SnapshotsClient) Get(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsGetOptions) (*SnapshotResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (client *SnapshotsClient) Get(ctx context.Context, resourceGroupName string
 }
 
 // GetCreateRequest creates the Get request.
-func (client *SnapshotsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string) (*azcore.Request, error) {
+func (client *SnapshotsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -283,8 +283,8 @@ func (client *SnapshotsClient) GetHandleError(resp *azcore.Response) error {
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData) (*AccessURIPollerResponse, error) {
-	resp, err := client.GrantAccess(ctx, resourceGroupName, snapshotName, grantAccessData)
+func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsGrantAccessOptions) (*AccessURIPollerResponse, error) {
+	resp, err := client.GrantAccess(ctx, resourceGroupName, snapshotName, grantAccessData, options)
 	if err != nil {
 		return nil, err
 	}
@@ -318,8 +318,8 @@ func (client *SnapshotsClient) ResumeGrantAccess(token string) (AccessURIPoller,
 }
 
 // GrantAccess - Grants access to a snapshot.
-func (client *SnapshotsClient) GrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData) (*azcore.Response, error) {
-	req, err := client.GrantAccessCreateRequest(ctx, resourceGroupName, snapshotName, grantAccessData)
+func (client *SnapshotsClient) GrantAccess(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsGrantAccessOptions) (*azcore.Response, error) {
+	req, err := client.GrantAccessCreateRequest(ctx, resourceGroupName, snapshotName, grantAccessData, options)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (client *SnapshotsClient) GrantAccess(ctx context.Context, resourceGroupNam
 }
 
 // GrantAccessCreateRequest creates the GrantAccess request.
-func (client *SnapshotsClient) GrantAccessCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData) (*azcore.Request, error) {
+func (client *SnapshotsClient) GrantAccessCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, grantAccessData GrantAccessData, options *SnapshotsGrantAccessOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}/beginGetAccess"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -369,11 +369,11 @@ func (client *SnapshotsClient) GrantAccessHandleError(resp *azcore.Response) err
 }
 
 // List - Lists snapshots under a subscription.
-func (client *SnapshotsClient) List() SnapshotListPager {
+func (client *SnapshotsClient) List(options *SnapshotsListOptions) SnapshotListPager {
 	return &snapshotListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -384,7 +384,7 @@ func (client *SnapshotsClient) List() SnapshotListPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *SnapshotsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SnapshotsClient) ListCreateRequest(ctx context.Context, options *SnapshotsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/snapshots"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -417,11 +417,11 @@ func (client *SnapshotsClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists snapshots under a resource group.
-func (client *SnapshotsClient) ListByResourceGroup(resourceGroupName string) SnapshotListPager {
+func (client *SnapshotsClient) ListByResourceGroup(resourceGroupName string, options *SnapshotsListByResourceGroupOptions) SnapshotListPager {
 	return &snapshotListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -432,7 +432,7 @@ func (client *SnapshotsClient) ListByResourceGroup(resourceGroupName string) Sna
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *SnapshotsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *SnapshotsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *SnapshotsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -465,8 +465,8 @@ func (client *SnapshotsClient) ListByResourceGroupHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string) (*HTTPPollerResponse, error) {
-	resp, err := client.RevokeAccess(ctx, resourceGroupName, snapshotName)
+func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsRevokeAccessOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.RevokeAccess(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -500,8 +500,8 @@ func (client *SnapshotsClient) ResumeRevokeAccess(token string) (HTTPPoller, err
 }
 
 // RevokeAccess - Revokes access to a snapshot.
-func (client *SnapshotsClient) RevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string) (*azcore.Response, error) {
-	req, err := client.RevokeAccessCreateRequest(ctx, resourceGroupName, snapshotName)
+func (client *SnapshotsClient) RevokeAccess(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsRevokeAccessOptions) (*azcore.Response, error) {
+	req, err := client.RevokeAccessCreateRequest(ctx, resourceGroupName, snapshotName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +516,7 @@ func (client *SnapshotsClient) RevokeAccess(ctx context.Context, resourceGroupNa
 }
 
 // RevokeAccessCreateRequest creates the RevokeAccess request.
-func (client *SnapshotsClient) RevokeAccessCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string) (*azcore.Request, error) {
+func (client *SnapshotsClient) RevokeAccessCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, options *SnapshotsRevokeAccessOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}/endGetAccess"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -543,8 +543,8 @@ func (client *SnapshotsClient) RevokeAccessHandleError(resp *azcore.Response) er
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate) (*SnapshotPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, snapshotName, snapshot)
+func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsUpdateOptions) (*SnapshotPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
 		return nil, err
 	}
@@ -578,8 +578,8 @@ func (client *SnapshotsClient) ResumeUpdate(token string) (SnapshotPoller, error
 }
 
 // Update - Updates (patches) a snapshot.
-func (client *SnapshotsClient) Update(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, snapshotName, snapshot)
+func (client *SnapshotsClient) Update(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, snapshotName, snapshot, options)
 	if err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (client *SnapshotsClient) Update(ctx context.Context, resourceGroupName str
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *SnapshotsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate) (*azcore.Request, error) {
+func (client *SnapshotsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, snapshotName string, snapshot SnapshotUpdate, options *SnapshotsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
@@ -19,19 +19,19 @@ import (
 // SSHPublicKeysOperations contains the methods for the SSHPublicKeys group.
 type SSHPublicKeysOperations interface {
 	// Create - Creates a new SSH public key resource.
-	Create(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource) (*SSHPublicKeyResourceResponse, error)
+	Create(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource, options *SSHPublicKeysCreateOptions) (*SSHPublicKeyResourceResponse, error)
 	// Delete - Delete an SSH public key.
-	Delete(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*http.Response, error)
+	Delete(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysDeleteOptions) (*http.Response, error)
 	// GenerateKeyPair - Generates and returns a public/private key pair and populates the SSH public key resource with the public key. The length of the key will be 3072 bits. This operation can only be performed once per SSH public key resource.
-	GenerateKeyPair(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*SSHPublicKeyGenerateKeyPairResultResponse, error)
+	GenerateKeyPair(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGenerateKeyPairOptions) (*SSHPublicKeyGenerateKeyPairResultResponse, error)
 	// Get - Retrieves information about an SSH public key.
-	Get(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*SSHPublicKeyResourceResponse, error)
+	Get(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGetOptions) (*SSHPublicKeyResourceResponse, error)
 	// ListByResourceGroup - Lists all of the SSH public keys in the specified resource group. Use the nextLink property in the response to get the next page of SSH public keys.
-	ListByResourceGroup(resourceGroupName string) SSHPublicKeysGroupListResultPager
+	ListByResourceGroup(resourceGroupName string, options *SSHPublicKeysListByResourceGroupOptions) SSHPublicKeysGroupListResultPager
 	// ListBySubscription - Lists all of the SSH public keys in the subscription. Use the nextLink property in the response to get the next page of SSH public keys.
-	ListBySubscription() SSHPublicKeysGroupListResultPager
+	ListBySubscription(options *SSHPublicKeysListBySubscriptionOptions) SSHPublicKeysGroupListResultPager
 	// Update - Updates a new SSH public key resource.
-	Update(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource) (*SSHPublicKeyResourceResponse, error)
+	Update(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource, options *SSHPublicKeysUpdateOptions) (*SSHPublicKeyResourceResponse, error)
 }
 
 // SSHPublicKeysClient implements the SSHPublicKeysOperations interface.
@@ -52,8 +52,8 @@ func (client *SSHPublicKeysClient) Do(req *azcore.Request) (*azcore.Response, er
 }
 
 // Create - Creates a new SSH public key resource.
-func (client *SSHPublicKeysClient) Create(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource) (*SSHPublicKeyResourceResponse, error) {
-	req, err := client.CreateCreateRequest(ctx, resourceGroupName, sshPublicKeyName, parameters)
+func (client *SSHPublicKeysClient) Create(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource, options *SSHPublicKeysCreateOptions) (*SSHPublicKeyResourceResponse, error) {
+	req, err := client.CreateCreateRequest(ctx, resourceGroupName, sshPublicKeyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (client *SSHPublicKeysClient) Create(ctx context.Context, resourceGroupName
 }
 
 // CreateCreateRequest creates the Create request.
-func (client *SSHPublicKeysClient) CreateCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) CreateCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyResource, options *SSHPublicKeysCreateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{sshPublicKeyName}", url.PathEscape(sshPublicKeyName))
@@ -107,8 +107,8 @@ func (client *SSHPublicKeysClient) CreateHandleError(resp *azcore.Response) erro
 }
 
 // Delete - Delete an SSH public key.
-func (client *SSHPublicKeysClient) Delete(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*http.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, sshPublicKeyName)
+func (client *SSHPublicKeysClient) Delete(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysDeleteOptions) (*http.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, sshPublicKeyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (client *SSHPublicKeysClient) Delete(ctx context.Context, resourceGroupName
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *SSHPublicKeysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{sshPublicKeyName}", url.PathEscape(sshPublicKeyName))
@@ -151,8 +151,8 @@ func (client *SSHPublicKeysClient) DeleteHandleError(resp *azcore.Response) erro
 }
 
 // GenerateKeyPair - Generates and returns a public/private key pair and populates the SSH public key resource with the public key. The length of the key will be 3072 bits. This operation can only be performed once per SSH public key resource.
-func (client *SSHPublicKeysClient) GenerateKeyPair(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*SSHPublicKeyGenerateKeyPairResultResponse, error) {
-	req, err := client.GenerateKeyPairCreateRequest(ctx, resourceGroupName, sshPublicKeyName)
+func (client *SSHPublicKeysClient) GenerateKeyPair(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGenerateKeyPairOptions) (*SSHPublicKeyGenerateKeyPairResultResponse, error) {
+	req, err := client.GenerateKeyPairCreateRequest(ctx, resourceGroupName, sshPublicKeyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (client *SSHPublicKeysClient) GenerateKeyPair(ctx context.Context, resource
 }
 
 // GenerateKeyPairCreateRequest creates the GenerateKeyPair request.
-func (client *SSHPublicKeysClient) GenerateKeyPairCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) GenerateKeyPairCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGenerateKeyPairOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}/generateKeyPair"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{sshPublicKeyName}", url.PathEscape(sshPublicKeyName))
@@ -206,8 +206,8 @@ func (client *SSHPublicKeysClient) GenerateKeyPairHandleError(resp *azcore.Respo
 }
 
 // Get - Retrieves information about an SSH public key.
-func (client *SSHPublicKeysClient) Get(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*SSHPublicKeyResourceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, sshPublicKeyName)
+func (client *SSHPublicKeysClient) Get(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGetOptions) (*SSHPublicKeyResourceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, sshPublicKeyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (client *SSHPublicKeysClient) Get(ctx context.Context, resourceGroupName st
 }
 
 // GetCreateRequest creates the Get request.
-func (client *SSHPublicKeysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, options *SSHPublicKeysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{sshPublicKeyName}", url.PathEscape(sshPublicKeyName))
@@ -261,11 +261,11 @@ func (client *SSHPublicKeysClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all of the SSH public keys in the specified resource group. Use the nextLink property in the response to get the next page of SSH public keys.
-func (client *SSHPublicKeysClient) ListByResourceGroup(resourceGroupName string) SSHPublicKeysGroupListResultPager {
+func (client *SSHPublicKeysClient) ListByResourceGroup(resourceGroupName string, options *SSHPublicKeysListByResourceGroupOptions) SSHPublicKeysGroupListResultPager {
 	return &sshPublicKeysGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -276,7 +276,7 @@ func (client *SSHPublicKeysClient) ListByResourceGroup(resourceGroupName string)
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *SSHPublicKeysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *SSHPublicKeysListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -310,11 +310,11 @@ func (client *SSHPublicKeysClient) ListByResourceGroupHandleError(resp *azcore.R
 }
 
 // ListBySubscription - Lists all of the SSH public keys in the subscription. Use the nextLink property in the response to get the next page of SSH public keys.
-func (client *SSHPublicKeysClient) ListBySubscription() SSHPublicKeysGroupListResultPager {
+func (client *SSHPublicKeysClient) ListBySubscription(options *SSHPublicKeysListBySubscriptionOptions) SSHPublicKeysGroupListResultPager {
 	return &sshPublicKeysGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -325,7 +325,7 @@ func (client *SSHPublicKeysClient) ListBySubscription() SSHPublicKeysGroupListRe
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *SSHPublicKeysClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) ListBySubscriptionCreateRequest(ctx context.Context, options *SSHPublicKeysListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/sshPublicKeys"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -358,8 +358,8 @@ func (client *SSHPublicKeysClient) ListBySubscriptionHandleError(resp *azcore.Re
 }
 
 // Update - Updates a new SSH public key resource.
-func (client *SSHPublicKeysClient) Update(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource) (*SSHPublicKeyResourceResponse, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, sshPublicKeyName, parameters)
+func (client *SSHPublicKeysClient) Update(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource, options *SSHPublicKeysUpdateOptions) (*SSHPublicKeyResourceResponse, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, sshPublicKeyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (client *SSHPublicKeysClient) Update(ctx context.Context, resourceGroupName
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *SSHPublicKeysClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource) (*azcore.Request, error) {
+func (client *SSHPublicKeysClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, sshPublicKeyName string, parameters SSHPublicKeyUpdateResource, options *SSHPublicKeysUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{sshPublicKeyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{sshPublicKeyName}", url.PathEscape(sshPublicKeyName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage.go
@@ -19,7 +19,7 @@ import (
 // UsageOperations contains the methods for the Usage group.
 type UsageOperations interface {
 	// List - Gets, for the specified location, the current compute resource usage information as well as the limits for compute resources under the subscription.
-	List(location string) ListUsagesResultPager
+	List(location string, options *UsageListOptions) ListUsagesResultPager
 }
 
 // UsageClient implements the UsageOperations interface.
@@ -40,11 +40,11 @@ func (client *UsageClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // List - Gets, for the specified location, the current compute resource usage information as well as the limits for compute resources under the subscription.
-func (client *UsageClient) List(location string) ListUsagesResultPager {
+func (client *UsageClient) List(location string, options *UsageListOptions) ListUsagesResultPager {
 	return &listUsagesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -55,7 +55,7 @@ func (client *UsageClient) List(location string) ListUsagesResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *UsageClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *UsageClient) ListCreateRequest(ctx context.Context, location string, options *UsageListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
@@ -20,11 +20,11 @@ import (
 // VirtualMachineExtensionImagesOperations contains the methods for the VirtualMachineExtensionImages group.
 type VirtualMachineExtensionImagesOperations interface {
 	// Get - Gets a virtual machine extension image.
-	Get(ctx context.Context, location string, publisherName string, typeParameter string, version string) (*VirtualMachineExtensionImageResponse, error)
+	Get(ctx context.Context, location string, publisherName string, typeParameter string, version string, options *VirtualMachineExtensionImagesGetOptions) (*VirtualMachineExtensionImageResponse, error)
 	// ListTypes - Gets a list of virtual machine extension image types.
-	ListTypes(ctx context.Context, location string, publisherName string) (*VirtualMachineExtensionImageArrayResponse, error)
+	ListTypes(ctx context.Context, location string, publisherName string, options *VirtualMachineExtensionImagesListTypesOptions) (*VirtualMachineExtensionImageArrayResponse, error)
 	// ListVersions - Gets a list of virtual machine extension image versions.
-	ListVersions(ctx context.Context, location string, publisherName string, typeParameter string, virtualMachineExtensionImagesListVersionsOptions *VirtualMachineExtensionImagesListVersionsOptions) (*VirtualMachineExtensionImageArrayResponse, error)
+	ListVersions(ctx context.Context, location string, publisherName string, typeParameter string, options *VirtualMachineExtensionImagesListVersionsOptions) (*VirtualMachineExtensionImageArrayResponse, error)
 }
 
 // VirtualMachineExtensionImagesClient implements the VirtualMachineExtensionImagesOperations interface.
@@ -45,8 +45,8 @@ func (client *VirtualMachineExtensionImagesClient) Do(req *azcore.Request) (*azc
 }
 
 // Get - Gets a virtual machine extension image.
-func (client *VirtualMachineExtensionImagesClient) Get(ctx context.Context, location string, publisherName string, typeParameter string, version string) (*VirtualMachineExtensionImageResponse, error) {
-	req, err := client.GetCreateRequest(ctx, location, publisherName, typeParameter, version)
+func (client *VirtualMachineExtensionImagesClient) Get(ctx context.Context, location string, publisherName string, typeParameter string, version string, options *VirtualMachineExtensionImagesGetOptions) (*VirtualMachineExtensionImageResponse, error) {
+	req, err := client.GetCreateRequest(ctx, location, publisherName, typeParameter, version, options)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (client *VirtualMachineExtensionImagesClient) Get(ctx context.Context, loca
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineExtensionImagesClient) GetCreateRequest(ctx context.Context, location string, publisherName string, typeParameter string, version string) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionImagesClient) GetCreateRequest(ctx context.Context, location string, publisherName string, typeParameter string, version string, options *VirtualMachineExtensionImagesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -102,8 +102,8 @@ func (client *VirtualMachineExtensionImagesClient) GetHandleError(resp *azcore.R
 }
 
 // ListTypes - Gets a list of virtual machine extension image types.
-func (client *VirtualMachineExtensionImagesClient) ListTypes(ctx context.Context, location string, publisherName string) (*VirtualMachineExtensionImageArrayResponse, error) {
-	req, err := client.ListTypesCreateRequest(ctx, location, publisherName)
+func (client *VirtualMachineExtensionImagesClient) ListTypes(ctx context.Context, location string, publisherName string, options *VirtualMachineExtensionImagesListTypesOptions) (*VirtualMachineExtensionImageArrayResponse, error) {
+	req, err := client.ListTypesCreateRequest(ctx, location, publisherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (client *VirtualMachineExtensionImagesClient) ListTypes(ctx context.Context
 }
 
 // ListTypesCreateRequest creates the ListTypes request.
-func (client *VirtualMachineExtensionImagesClient) ListTypesCreateRequest(ctx context.Context, location string, publisherName string) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionImagesClient) ListTypesCreateRequest(ctx context.Context, location string, publisherName string, options *VirtualMachineExtensionImagesListTypesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -157,8 +157,8 @@ func (client *VirtualMachineExtensionImagesClient) ListTypesHandleError(resp *az
 }
 
 // ListVersions - Gets a list of virtual machine extension image versions.
-func (client *VirtualMachineExtensionImagesClient) ListVersions(ctx context.Context, location string, publisherName string, typeParameter string, virtualMachineExtensionImagesListVersionsOptions *VirtualMachineExtensionImagesListVersionsOptions) (*VirtualMachineExtensionImageArrayResponse, error) {
-	req, err := client.ListVersionsCreateRequest(ctx, location, publisherName, typeParameter, virtualMachineExtensionImagesListVersionsOptions)
+func (client *VirtualMachineExtensionImagesClient) ListVersions(ctx context.Context, location string, publisherName string, typeParameter string, options *VirtualMachineExtensionImagesListVersionsOptions) (*VirtualMachineExtensionImageArrayResponse, error) {
+	req, err := client.ListVersionsCreateRequest(ctx, location, publisherName, typeParameter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (client *VirtualMachineExtensionImagesClient) ListVersions(ctx context.Cont
 }
 
 // ListVersionsCreateRequest creates the ListVersions request.
-func (client *VirtualMachineExtensionImagesClient) ListVersionsCreateRequest(ctx context.Context, location string, publisherName string, typeParameter string, virtualMachineExtensionImagesListVersionsOptions *VirtualMachineExtensionImagesListVersionsOptions) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionImagesClient) ListVersionsCreateRequest(ctx context.Context, location string, publisherName string, typeParameter string, options *VirtualMachineExtensionImagesListVersionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -188,14 +188,14 @@ func (client *VirtualMachineExtensionImagesClient) ListVersionsCreateRequest(ctx
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineExtensionImagesListVersionsOptions != nil && virtualMachineExtensionImagesListVersionsOptions.Filter != nil {
-		query.Set("$filter", *virtualMachineExtensionImagesListVersionsOptions.Filter)
+	if options != nil && options.Filter != nil {
+		query.Set("$filter", *options.Filter)
 	}
-	if virtualMachineExtensionImagesListVersionsOptions != nil && virtualMachineExtensionImagesListVersionsOptions.Top != nil {
-		query.Set("$top", strconv.FormatInt(int64(*virtualMachineExtensionImagesListVersionsOptions.Top), 10))
+	if options != nil && options.Top != nil {
+		query.Set("$top", strconv.FormatInt(int64(*options.Top), 10))
 	}
-	if virtualMachineExtensionImagesListVersionsOptions != nil && virtualMachineExtensionImagesListVersionsOptions.Orderby != nil {
-		query.Set("$orderby", *virtualMachineExtensionImagesListVersionsOptions.Orderby)
+	if options != nil && options.Orderby != nil {
+		query.Set("$orderby", *options.Orderby)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
@@ -21,19 +21,19 @@ import (
 // VirtualMachineExtensionsOperations contains the methods for the VirtualMachineExtensions group.
 type VirtualMachineExtensionsOperations interface {
 	// BeginCreateOrUpdate - The operation to create or update the extension.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*VirtualMachineExtensionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsCreateOrUpdateOptions) (*VirtualMachineExtensionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualMachineExtensionPoller, error)
 	// BeginDelete - The operation to delete the extension.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - The operation to get the extension.
-	Get(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, virtualMachineExtensionsGetOptions *VirtualMachineExtensionsGetOptions) (*VirtualMachineExtensionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsGetOptions) (*VirtualMachineExtensionResponse, error)
 	// List - The operation to get all extensions of a Virtual Machine.
-	List(ctx context.Context, resourceGroupName string, vmName string, virtualMachineExtensionsListOptions *VirtualMachineExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachineExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error)
 	// BeginUpdate - The operation to update the extension.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsUpdateOptions) (*VirtualMachineExtensionPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachineExtensionPoller, error)
 }
@@ -55,8 +55,8 @@ func (client *VirtualMachineExtensionsClient) Do(req *azcore.Request) (*azcore.R
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*VirtualMachineExtensionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsCreateOrUpdateOptions) (*VirtualMachineExtensionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func (client *VirtualMachineExtensionsClient) ResumeCreateOrUpdate(token string)
 }
 
 // CreateOrUpdate - The operation to create or update the extension.
-func (client *VirtualMachineExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client *VirtualMachineExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (client *VirtualMachineExtensionsClient) CreateOrUpdate(ctx context.Context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualMachineExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineExtensionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -141,8 +141,8 @@ func (client *VirtualMachineExtensionsClient) CreateOrUpdateHandleError(resp *az
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmName, vmExtensionName)
+func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmName, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,8 @@ func (client *VirtualMachineExtensionsClient) ResumeDelete(token string) (HTTPPo
 }
 
 // Delete - The operation to delete the extension.
-func (client *VirtualMachineExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName)
+func (client *VirtualMachineExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (client *VirtualMachineExtensionsClient) Delete(ctx context.Context, resour
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachineExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -221,8 +221,8 @@ func (client *VirtualMachineExtensionsClient) DeleteHandleError(resp *azcore.Res
 }
 
 // Get - The operation to get the extension.
-func (client *VirtualMachineExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, virtualMachineExtensionsGetOptions *VirtualMachineExtensionsGetOptions) (*VirtualMachineExtensionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, virtualMachineExtensionsGetOptions)
+func (client *VirtualMachineExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsGetOptions) (*VirtualMachineExtensionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *VirtualMachineExtensionsClient) Get(ctx context.Context, resourceG
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, virtualMachineExtensionsGetOptions *VirtualMachineExtensionsGetOptions) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, options *VirtualMachineExtensionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -252,8 +252,8 @@ func (client *VirtualMachineExtensionsClient) GetCreateRequest(ctx context.Conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineExtensionsGetOptions != nil && virtualMachineExtensionsGetOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineExtensionsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -280,8 +280,8 @@ func (client *VirtualMachineExtensionsClient) GetHandleError(resp *azcore.Respon
 }
 
 // List - The operation to get all extensions of a Virtual Machine.
-func (client *VirtualMachineExtensionsClient) List(ctx context.Context, resourceGroupName string, vmName string, virtualMachineExtensionsListOptions *VirtualMachineExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, vmName, virtualMachineExtensionsListOptions)
+func (client *VirtualMachineExtensionsClient) List(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachineExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (client *VirtualMachineExtensionsClient) List(ctx context.Context, resource
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmName string, virtualMachineExtensionsListOptions *VirtualMachineExtensionsListOptions) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachineExtensionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -310,8 +310,8 @@ func (client *VirtualMachineExtensionsClient) ListCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineExtensionsListOptions != nil && virtualMachineExtensionsListOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineExtensionsListOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -337,8 +337,8 @@ func (client *VirtualMachineExtensionsClient) ListHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsUpdateOptions) (*VirtualMachineExtensionPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -372,8 +372,8 @@ func (client *VirtualMachineExtensionsClient) ResumeUpdate(token string) (Virtua
 }
 
 // Update - The operation to update the extension.
-func (client *VirtualMachineExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters)
+func (client *VirtualMachineExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmName, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (client *VirtualMachineExtensionsClient) Update(ctx context.Context, resour
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachineExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*azcore.Request, error) {
+func (client *VirtualMachineExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineExtensionsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
@@ -20,15 +20,15 @@ import (
 // VirtualMachineImagesOperations contains the methods for the VirtualMachineImages group.
 type VirtualMachineImagesOperations interface {
 	// Get - Gets a virtual machine image.
-	Get(ctx context.Context, location string, publisherName string, offer string, skus string, version string) (*VirtualMachineImageResponse, error)
+	Get(ctx context.Context, location string, publisherName string, offer string, skus string, version string, options *VirtualMachineImagesGetOptions) (*VirtualMachineImageResponse, error)
 	// List - Gets a list of all virtual machine image versions for the specified location, publisher, offer, and SKU.
-	List(ctx context.Context, location string, publisherName string, offer string, skus string, virtualMachineImagesListOptions *VirtualMachineImagesListOptions) (*VirtualMachineImageResourceArrayResponse, error)
+	List(ctx context.Context, location string, publisherName string, offer string, skus string, options *VirtualMachineImagesListOptions) (*VirtualMachineImageResourceArrayResponse, error)
 	// ListOffers - Gets a list of virtual machine image offers for the specified location and publisher.
-	ListOffers(ctx context.Context, location string, publisherName string) (*VirtualMachineImageResourceArrayResponse, error)
+	ListOffers(ctx context.Context, location string, publisherName string, options *VirtualMachineImagesListOffersOptions) (*VirtualMachineImageResourceArrayResponse, error)
 	// ListPublishers - Gets a list of virtual machine image publishers for the specified Azure location.
-	ListPublishers(ctx context.Context, location string) (*VirtualMachineImageResourceArrayResponse, error)
+	ListPublishers(ctx context.Context, location string, options *VirtualMachineImagesListPublishersOptions) (*VirtualMachineImageResourceArrayResponse, error)
 	// ListSKUs - Gets a list of virtual machine image SKUs for the specified location, publisher, and offer.
-	ListSKUs(ctx context.Context, location string, publisherName string, offer string) (*VirtualMachineImageResourceArrayResponse, error)
+	ListSKUs(ctx context.Context, location string, publisherName string, offer string, options *VirtualMachineImagesListSKUsOptions) (*VirtualMachineImageResourceArrayResponse, error)
 }
 
 // VirtualMachineImagesClient implements the VirtualMachineImagesOperations interface.
@@ -49,8 +49,8 @@ func (client *VirtualMachineImagesClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // Get - Gets a virtual machine image.
-func (client *VirtualMachineImagesClient) Get(ctx context.Context, location string, publisherName string, offer string, skus string, version string) (*VirtualMachineImageResponse, error) {
-	req, err := client.GetCreateRequest(ctx, location, publisherName, offer, skus, version)
+func (client *VirtualMachineImagesClient) Get(ctx context.Context, location string, publisherName string, offer string, skus string, version string, options *VirtualMachineImagesGetOptions) (*VirtualMachineImageResponse, error) {
+	req, err := client.GetCreateRequest(ctx, location, publisherName, offer, skus, version, options)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (client *VirtualMachineImagesClient) Get(ctx context.Context, location stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineImagesClient) GetCreateRequest(ctx context.Context, location string, publisherName string, offer string, skus string, version string) (*azcore.Request, error) {
+func (client *VirtualMachineImagesClient) GetCreateRequest(ctx context.Context, location string, publisherName string, offer string, skus string, version string, options *VirtualMachineImagesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus/{skus}/versions/{version}"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -107,8 +107,8 @@ func (client *VirtualMachineImagesClient) GetHandleError(resp *azcore.Response) 
 }
 
 // List - Gets a list of all virtual machine image versions for the specified location, publisher, offer, and SKU.
-func (client *VirtualMachineImagesClient) List(ctx context.Context, location string, publisherName string, offer string, skus string, virtualMachineImagesListOptions *VirtualMachineImagesListOptions) (*VirtualMachineImageResourceArrayResponse, error) {
-	req, err := client.ListCreateRequest(ctx, location, publisherName, offer, skus, virtualMachineImagesListOptions)
+func (client *VirtualMachineImagesClient) List(ctx context.Context, location string, publisherName string, offer string, skus string, options *VirtualMachineImagesListOptions) (*VirtualMachineImageResourceArrayResponse, error) {
+	req, err := client.ListCreateRequest(ctx, location, publisherName, offer, skus, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (client *VirtualMachineImagesClient) List(ctx context.Context, location str
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineImagesClient) ListCreateRequest(ctx context.Context, location string, publisherName string, offer string, skus string, virtualMachineImagesListOptions *VirtualMachineImagesListOptions) (*azcore.Request, error) {
+func (client *VirtualMachineImagesClient) ListCreateRequest(ctx context.Context, location string, publisherName string, offer string, skus string, options *VirtualMachineImagesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus/{skus}/versions"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -139,14 +139,14 @@ func (client *VirtualMachineImagesClient) ListCreateRequest(ctx context.Context,
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineImagesListOptions != nil && virtualMachineImagesListOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineImagesListOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
-	if virtualMachineImagesListOptions != nil && virtualMachineImagesListOptions.Top != nil {
-		query.Set("$top", strconv.FormatInt(int64(*virtualMachineImagesListOptions.Top), 10))
+	if options != nil && options.Top != nil {
+		query.Set("$top", strconv.FormatInt(int64(*options.Top), 10))
 	}
-	if virtualMachineImagesListOptions != nil && virtualMachineImagesListOptions.Orderby != nil {
-		query.Set("$orderby", *virtualMachineImagesListOptions.Orderby)
+	if options != nil && options.Orderby != nil {
+		query.Set("$orderby", *options.Orderby)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -173,8 +173,8 @@ func (client *VirtualMachineImagesClient) ListHandleError(resp *azcore.Response)
 }
 
 // ListOffers - Gets a list of virtual machine image offers for the specified location and publisher.
-func (client *VirtualMachineImagesClient) ListOffers(ctx context.Context, location string, publisherName string) (*VirtualMachineImageResourceArrayResponse, error) {
-	req, err := client.ListOffersCreateRequest(ctx, location, publisherName)
+func (client *VirtualMachineImagesClient) ListOffers(ctx context.Context, location string, publisherName string, options *VirtualMachineImagesListOffersOptions) (*VirtualMachineImageResourceArrayResponse, error) {
+	req, err := client.ListOffersCreateRequest(ctx, location, publisherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (client *VirtualMachineImagesClient) ListOffers(ctx context.Context, locati
 }
 
 // ListOffersCreateRequest creates the ListOffers request.
-func (client *VirtualMachineImagesClient) ListOffersCreateRequest(ctx context.Context, location string, publisherName string) (*azcore.Request, error) {
+func (client *VirtualMachineImagesClient) ListOffersCreateRequest(ctx context.Context, location string, publisherName string, options *VirtualMachineImagesListOffersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))
@@ -228,8 +228,8 @@ func (client *VirtualMachineImagesClient) ListOffersHandleError(resp *azcore.Res
 }
 
 // ListPublishers - Gets a list of virtual machine image publishers for the specified Azure location.
-func (client *VirtualMachineImagesClient) ListPublishers(ctx context.Context, location string) (*VirtualMachineImageResourceArrayResponse, error) {
-	req, err := client.ListPublishersCreateRequest(ctx, location)
+func (client *VirtualMachineImagesClient) ListPublishers(ctx context.Context, location string, options *VirtualMachineImagesListPublishersOptions) (*VirtualMachineImageResourceArrayResponse, error) {
+	req, err := client.ListPublishersCreateRequest(ctx, location, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (client *VirtualMachineImagesClient) ListPublishers(ctx context.Context, lo
 }
 
 // ListPublishersCreateRequest creates the ListPublishers request.
-func (client *VirtualMachineImagesClient) ListPublishersCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *VirtualMachineImagesClient) ListPublishersCreateRequest(ctx context.Context, location string, options *VirtualMachineImagesListPublishersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -282,8 +282,8 @@ func (client *VirtualMachineImagesClient) ListPublishersHandleError(resp *azcore
 }
 
 // ListSKUs - Gets a list of virtual machine image SKUs for the specified location, publisher, and offer.
-func (client *VirtualMachineImagesClient) ListSKUs(ctx context.Context, location string, publisherName string, offer string) (*VirtualMachineImageResourceArrayResponse, error) {
-	req, err := client.ListSKUsCreateRequest(ctx, location, publisherName, offer)
+func (client *VirtualMachineImagesClient) ListSKUs(ctx context.Context, location string, publisherName string, offer string, options *VirtualMachineImagesListSKUsOptions) (*VirtualMachineImageResourceArrayResponse, error) {
+	req, err := client.ListSKUsCreateRequest(ctx, location, publisherName, offer, options)
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +302,7 @@ func (client *VirtualMachineImagesClient) ListSKUs(ctx context.Context, location
 }
 
 // ListSKUsCreateRequest creates the ListSKUs request.
-func (client *VirtualMachineImagesClient) ListSKUsCreateRequest(ctx context.Context, location string, publisherName string, offer string) (*azcore.Request, error) {
+func (client *VirtualMachineImagesClient) ListSKUsCreateRequest(ctx context.Context, location string, publisherName string, offer string, options *VirtualMachineImagesListSKUsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{publisherName}", url.PathEscape(publisherName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
@@ -19,9 +19,9 @@ import (
 // VirtualMachineRunCommandsOperations contains the methods for the VirtualMachineRunCommands group.
 type VirtualMachineRunCommandsOperations interface {
 	// Get - Gets specific run command for a subscription in a location.
-	Get(ctx context.Context, location string, commandId string) (*RunCommandDocumentResponse, error)
+	Get(ctx context.Context, location string, commandId string, options *VirtualMachineRunCommandsGetOptions) (*RunCommandDocumentResponse, error)
 	// List - Lists all available run commands for a subscription in a location.
-	List(location string) RunCommandListResultPager
+	List(location string, options *VirtualMachineRunCommandsListOptions) RunCommandListResultPager
 }
 
 // VirtualMachineRunCommandsClient implements the VirtualMachineRunCommandsOperations interface.
@@ -42,8 +42,8 @@ func (client *VirtualMachineRunCommandsClient) Do(req *azcore.Request) (*azcore.
 }
 
 // Get - Gets specific run command for a subscription in a location.
-func (client *VirtualMachineRunCommandsClient) Get(ctx context.Context, location string, commandId string) (*RunCommandDocumentResponse, error) {
-	req, err := client.GetCreateRequest(ctx, location, commandId)
+func (client *VirtualMachineRunCommandsClient) Get(ctx context.Context, location string, commandId string, options *VirtualMachineRunCommandsGetOptions) (*RunCommandDocumentResponse, error) {
+	req, err := client.GetCreateRequest(ctx, location, commandId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (client *VirtualMachineRunCommandsClient) Get(ctx context.Context, location
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineRunCommandsClient) GetCreateRequest(ctx context.Context, location string, commandId string) (*azcore.Request, error) {
+func (client *VirtualMachineRunCommandsClient) GetCreateRequest(ctx context.Context, location string, commandId string, options *VirtualMachineRunCommandsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands/{commandId}"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{commandId}", url.PathEscape(commandId))
@@ -97,11 +97,11 @@ func (client *VirtualMachineRunCommandsClient) GetHandleError(resp *azcore.Respo
 }
 
 // List - Lists all available run commands for a subscription in a location.
-func (client *VirtualMachineRunCommandsClient) List(location string) RunCommandListResultPager {
+func (client *VirtualMachineRunCommandsClient) List(location string, options *VirtualMachineRunCommandsListOptions) RunCommandListResultPager {
 	return &runCommandListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -112,7 +112,7 @@ func (client *VirtualMachineRunCommandsClient) List(location string) RunCommandL
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineRunCommandsClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *VirtualMachineRunCommandsClient) ListCreateRequest(ctx context.Context, location string, options *VirtualMachineRunCommandsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -22,75 +22,75 @@ import (
 // VirtualMachinesOperations contains the methods for the VirtualMachines group.
 type VirtualMachinesOperations interface {
 	// BeginCapture - Captures the VM by copying virtual hard disks of the VM and outputs a template that can be used to create similar VMs.
-	BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*VirtualMachineCaptureResultPollerResponse, error)
+	BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesCaptureOptions) (*VirtualMachineCaptureResultPollerResponse, error)
 	// ResumeCapture - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCapture(token string) (VirtualMachineCaptureResultPoller, error)
 	// BeginConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated before invoking this operation.
-	BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesConvertToManagedDisksOptions) (*HTTPPollerResponse, error)
 	// ResumeConvertToManagedDisks - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeConvertToManagedDisks(token string) (HTTPPoller, error)
 	// BeginCreateOrUpdate - The operation to create or update a virtual machine. Please note some properties can be set only during virtual machine creation.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine) (*VirtualMachinePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesCreateOrUpdateOptions) (*VirtualMachinePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualMachinePoller, error)
 	// BeginDeallocate - Shuts down the virtual machine and releases the compute resources. You are not billed for the compute resources that this virtual machine uses.
-	BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeallocateOptions) (*HTTPPollerResponse, error)
 	// ResumeDeallocate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeallocate(token string) (HTTPPoller, error)
 	// BeginDelete - The operation to delete a virtual machine.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Generalize - Sets the OS state of the virtual machine to generalized. It is recommended to sysprep the virtual machine before performing this operation. <br>For Windows, please refer to [Create a managed image of a generalized VM in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource).<br>For Linux, please refer to [How to create an image of a virtual machine or VHD](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/capture-image).
-	Generalize(ctx context.Context, resourceGroupName string, vmName string) (*http.Response, error)
+	Generalize(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGeneralizeOptions) (*http.Response, error)
 	// Get - Retrieves information about the model view or the instance view of a virtual machine.
-	Get(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesGetOptions *VirtualMachinesGetOptions) (*VirtualMachineResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGetOptions) (*VirtualMachineResponse, error)
 	// InstanceView - Retrieves information about the run-time state of a virtual machine.
-	InstanceView(ctx context.Context, resourceGroupName string, vmName string) (*VirtualMachineInstanceViewResponse, error)
+	InstanceView(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesInstanceViewOptions) (*VirtualMachineInstanceViewResponse, error)
 	// List - Lists all of the virtual machines in the specified resource group. Use the nextLink property in the response to get the next page of virtual machines.
-	List(resourceGroupName string) VirtualMachineListResultPager
+	List(resourceGroupName string, options *VirtualMachinesListOptions) VirtualMachineListResultPager
 	// ListAll - Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines.
-	ListAll(virtualMachinesListAllOptions *VirtualMachinesListAllOptions) VirtualMachineListResultPager
+	ListAll(options *VirtualMachinesListAllOptions) VirtualMachineListResultPager
 	// ListAvailableSizes - Lists all available virtual machine sizes to which the specified virtual machine can be resized.
-	ListAvailableSizes(ctx context.Context, resourceGroupName string, vmName string) (*VirtualMachineSizeListResultResponse, error)
+	ListAvailableSizes(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesListAvailableSizesOptions) (*VirtualMachineSizeListResultResponse, error)
 	// ListByLocation - Gets all the virtual machines under the specified subscription for the specified location.
-	ListByLocation(location string) VirtualMachineListResultPager
+	ListByLocation(location string, options *VirtualMachinesListByLocationOptions) VirtualMachineListResultPager
 	// BeginPerformMaintenance - The operation to perform maintenance on a virtual machine.
-	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPerformMaintenanceOptions) (*HTTPPollerResponse, error)
 	// ResumePerformMaintenance - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePerformMaintenance(token string) (HTTPPoller, error)
 	// BeginPowerOff - The operation to power off (stop) a virtual machine. The virtual machine can be restarted with the same provisioned resources. You are still charged for this virtual machine.
-	BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesPowerOffOptions *VirtualMachinesPowerOffOptions) (*HTTPPollerResponse, error)
+	BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPowerOffOptions) (*HTTPPollerResponse, error)
 	// ResumePowerOff - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePowerOff(token string) (HTTPPoller, error)
 	// BeginReapply - The operation to reapply a virtual machine's state.
-	BeginReapply(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginReapply(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReapplyOptions) (*HTTPPollerResponse, error)
 	// ResumeReapply - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReapply(token string) (HTTPPoller, error)
 	// BeginRedeploy - Shuts down the virtual machine, moves it to a new node, and powers it back on.
-	BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRedeployOptions) (*HTTPPollerResponse, error)
 	// ResumeRedeploy - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRedeploy(token string) (HTTPPoller, error)
 	// BeginReimage - Reimages the virtual machine which has an ephemeral OS disk back to its initial state.
-	BeginReimage(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesReimageOptions *VirtualMachinesReimageOptions) (*HTTPPollerResponse, error)
+	BeginReimage(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReimageOptions) (*HTTPPollerResponse, error)
 	// ResumeReimage - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReimage(token string) (HTTPPoller, error)
 	// BeginRestart - The operation to restart a virtual machine.
-	BeginRestart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginRestart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRestartOptions) (*HTTPPollerResponse, error)
 	// ResumeRestart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRestart(token string) (HTTPPoller, error)
 	// BeginRunCommand - Run command on the VM.
-	BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error)
+	BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesRunCommandOptions) (*RunCommandResultPollerResponse, error)
 	// ResumeRunCommand - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRunCommand(token string) (RunCommandResultPoller, error)
 	// SimulateEviction - The operation to simulate the eviction of spot virtual machine. The eviction will occur within 30 minutes of calling the API
-	SimulateEviction(ctx context.Context, resourceGroupName string, vmName string) (*http.Response, error)
+	SimulateEviction(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesSimulateEvictionOptions) (*http.Response, error)
 	// BeginStart - The operation to start a virtual machine.
-	BeginStart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error)
+	BeginStart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesStartOptions) (*HTTPPollerResponse, error)
 	// ResumeStart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStart(token string) (HTTPPoller, error)
 	// BeginUpdate - The operation to update a virtual machine.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate) (*VirtualMachinePollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesUpdateOptions) (*VirtualMachinePollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachinePoller, error)
 }
@@ -112,8 +112,8 @@ func (client *VirtualMachinesClient) Do(req *azcore.Request) (*azcore.Response, 
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*VirtualMachineCaptureResultPollerResponse, error) {
-	resp, err := client.Capture(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesCaptureOptions) (*VirtualMachineCaptureResultPollerResponse, error) {
+	resp, err := client.Capture(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +147,8 @@ func (client *VirtualMachinesClient) ResumeCapture(token string) (VirtualMachine
 }
 
 // Capture - Captures the VM by copying virtual hard disks of the VM and outputs a template that can be used to create similar VMs.
-func (client *VirtualMachinesClient) Capture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*azcore.Response, error) {
-	req, err := client.CaptureCreateRequest(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) Capture(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesCaptureOptions) (*azcore.Response, error) {
+	req, err := client.CaptureCreateRequest(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (client *VirtualMachinesClient) Capture(ctx context.Context, resourceGroupN
 }
 
 // CaptureCreateRequest creates the Capture request.
-func (client *VirtualMachinesClient) CaptureCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) CaptureCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineCaptureParameters, options *VirtualMachinesCaptureOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/capture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -197,8 +197,8 @@ func (client *VirtualMachinesClient) CaptureHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.ConvertToManagedDisks(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesConvertToManagedDisksOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.ConvertToManagedDisks(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -232,8 +232,8 @@ func (client *VirtualMachinesClient) ResumeConvertToManagedDisks(token string) (
 }
 
 // ConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated before invoking this operation.
-func (client *VirtualMachinesClient) ConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.ConvertToManagedDisksCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) ConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesConvertToManagedDisksOptions) (*azcore.Response, error) {
+	req, err := client.ConvertToManagedDisksCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +248,7 @@ func (client *VirtualMachinesClient) ConvertToManagedDisks(ctx context.Context, 
 }
 
 // ConvertToManagedDisksCreateRequest creates the ConvertToManagedDisks request.
-func (client *VirtualMachinesClient) ConvertToManagedDisksCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ConvertToManagedDisksCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesConvertToManagedDisksOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/convertToManagedDisks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -275,8 +275,8 @@ func (client *VirtualMachinesClient) ConvertToManagedDisksHandleError(resp *azco
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine) (*VirtualMachinePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesCreateOrUpdateOptions) (*VirtualMachinePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -310,8 +310,8 @@ func (client *VirtualMachinesClient) ResumeCreateOrUpdate(token string) (Virtual
 }
 
 // CreateOrUpdate - The operation to create or update a virtual machine. Please note some properties can be set only during virtual machine creation.
-func (client *VirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func (client *VirtualMachinesClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualMachinesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachine, options *VirtualMachinesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -360,8 +360,8 @@ func (client *VirtualMachinesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Deallocate(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeallocateOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Deallocate(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -395,8 +395,8 @@ func (client *VirtualMachinesClient) ResumeDeallocate(token string) (HTTPPoller,
 }
 
 // Deallocate - Shuts down the virtual machine and releases the compute resources. You are not billed for the compute resources that this virtual machine uses.
-func (client *VirtualMachinesClient) Deallocate(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Deallocate(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeallocateOptions) (*azcore.Response, error) {
+	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (client *VirtualMachinesClient) Deallocate(ctx context.Context, resourceGro
 }
 
 // DeallocateCreateRequest creates the Deallocate request.
-func (client *VirtualMachinesClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeallocateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/deallocate"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -438,8 +438,8 @@ func (client *VirtualMachinesClient) DeallocateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -473,8 +473,8 @@ func (client *VirtualMachinesClient) ResumeDelete(token string) (HTTPPoller, err
 }
 
 // Delete - The operation to delete a virtual machine.
-func (client *VirtualMachinesClient) Delete(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Delete(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +489,7 @@ func (client *VirtualMachinesClient) Delete(ctx context.Context, resourceGroupNa
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachinesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -517,8 +517,8 @@ func (client *VirtualMachinesClient) DeleteHandleError(resp *azcore.Response) er
 }
 
 // Generalize - Sets the OS state of the virtual machine to generalized. It is recommended to sysprep the virtual machine before performing this operation. <br>For Windows, please refer to [Create a managed image of a generalized VM in Azure](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource).<br>For Linux, please refer to [How to create an image of a virtual machine or VHD](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/capture-image).
-func (client *VirtualMachinesClient) Generalize(ctx context.Context, resourceGroupName string, vmName string) (*http.Response, error) {
-	req, err := client.GeneralizeCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Generalize(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGeneralizeOptions) (*http.Response, error) {
+	req, err := client.GeneralizeCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (client *VirtualMachinesClient) Generalize(ctx context.Context, resourceGro
 }
 
 // GeneralizeCreateRequest creates the Generalize request.
-func (client *VirtualMachinesClient) GeneralizeCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) GeneralizeCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGeneralizeOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/generalize"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -561,8 +561,8 @@ func (client *VirtualMachinesClient) GeneralizeHandleError(resp *azcore.Response
 }
 
 // Get - Retrieves information about the model view or the instance view of a virtual machine.
-func (client *VirtualMachinesClient) Get(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesGetOptions *VirtualMachinesGetOptions) (*VirtualMachineResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmName, virtualMachinesGetOptions)
+func (client *VirtualMachinesClient) Get(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGetOptions) (*VirtualMachineResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -581,7 +581,7 @@ func (client *VirtualMachinesClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachinesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesGetOptions *VirtualMachinesGetOptions) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -591,7 +591,7 @@ func (client *VirtualMachinesClient) GetCreateRequest(ctx context.Context, resou
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachinesGetOptions != nil && virtualMachinesGetOptions.Expand != nil {
+	if options != nil && options.Expand != nil {
 		query.Set("$expand", "instanceView")
 	}
 	query.Set("api-version", "2019-12-01")
@@ -619,8 +619,8 @@ func (client *VirtualMachinesClient) GetHandleError(resp *azcore.Response) error
 }
 
 // InstanceView - Retrieves information about the run-time state of a virtual machine.
-func (client *VirtualMachinesClient) InstanceView(ctx context.Context, resourceGroupName string, vmName string) (*VirtualMachineInstanceViewResponse, error) {
-	req, err := client.InstanceViewCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) InstanceView(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesInstanceViewOptions) (*VirtualMachineInstanceViewResponse, error) {
+	req, err := client.InstanceViewCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +639,7 @@ func (client *VirtualMachinesClient) InstanceView(ctx context.Context, resourceG
 }
 
 // InstanceViewCreateRequest creates the InstanceView request.
-func (client *VirtualMachinesClient) InstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) InstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesInstanceViewOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/instanceView"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -674,11 +674,11 @@ func (client *VirtualMachinesClient) InstanceViewHandleError(resp *azcore.Respon
 }
 
 // List - Lists all of the virtual machines in the specified resource group. Use the nextLink property in the response to get the next page of virtual machines.
-func (client *VirtualMachinesClient) List(resourceGroupName string) VirtualMachineListResultPager {
+func (client *VirtualMachinesClient) List(resourceGroupName string, options *VirtualMachinesListOptions) VirtualMachineListResultPager {
 	return &virtualMachineListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -689,7 +689,7 @@ func (client *VirtualMachinesClient) List(resourceGroupName string) VirtualMachi
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachinesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualMachinesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -723,11 +723,11 @@ func (client *VirtualMachinesClient) ListHandleError(resp *azcore.Response) erro
 }
 
 // ListAll - Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response to get the next page of virtual machines.
-func (client *VirtualMachinesClient) ListAll(virtualMachinesListAllOptions *VirtualMachinesListAllOptions) VirtualMachineListResultPager {
+func (client *VirtualMachinesClient) ListAll(options *VirtualMachinesListAllOptions) VirtualMachineListResultPager {
 	return &virtualMachineListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx, virtualMachinesListAllOptions)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -738,7 +738,7 @@ func (client *VirtualMachinesClient) ListAll(virtualMachinesListAllOptions *Virt
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *VirtualMachinesClient) ListAllCreateRequest(ctx context.Context, virtualMachinesListAllOptions *VirtualMachinesListAllOptions) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ListAllCreateRequest(ctx context.Context, options *VirtualMachinesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -747,8 +747,8 @@ func (client *VirtualMachinesClient) ListAllCreateRequest(ctx context.Context, v
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
-	if virtualMachinesListAllOptions != nil && virtualMachinesListAllOptions.StatusOnly != nil {
-		query.Set("statusOnly", *virtualMachinesListAllOptions.StatusOnly)
+	if options != nil && options.StatusOnly != nil {
+		query.Set("statusOnly", *options.StatusOnly)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -774,8 +774,8 @@ func (client *VirtualMachinesClient) ListAllHandleError(resp *azcore.Response) e
 }
 
 // ListAvailableSizes - Lists all available virtual machine sizes to which the specified virtual machine can be resized.
-func (client *VirtualMachinesClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, vmName string) (*VirtualMachineSizeListResultResponse, error) {
-	req, err := client.ListAvailableSizesCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) ListAvailableSizes(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesListAvailableSizesOptions) (*VirtualMachineSizeListResultResponse, error) {
+	req, err := client.ListAvailableSizesCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +794,7 @@ func (client *VirtualMachinesClient) ListAvailableSizes(ctx context.Context, res
 }
 
 // ListAvailableSizesCreateRequest creates the ListAvailableSizes request.
-func (client *VirtualMachinesClient) ListAvailableSizesCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ListAvailableSizesCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesListAvailableSizesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/vmSizes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -829,11 +829,11 @@ func (client *VirtualMachinesClient) ListAvailableSizesHandleError(resp *azcore.
 }
 
 // ListByLocation - Gets all the virtual machines under the specified subscription for the specified location.
-func (client *VirtualMachinesClient) ListByLocation(location string) VirtualMachineListResultPager {
+func (client *VirtualMachinesClient) ListByLocation(location string, options *VirtualMachinesListByLocationOptions) VirtualMachineListResultPager {
 	return &virtualMachineListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByLocationCreateRequest(ctx, location)
+			return client.ListByLocationCreateRequest(ctx, location, options)
 		},
 		responder: client.ListByLocationHandleResponse,
 		errorer:   client.ListByLocationHandleError,
@@ -844,7 +844,7 @@ func (client *VirtualMachinesClient) ListByLocation(location string) VirtualMach
 }
 
 // ListByLocationCreateRequest creates the ListByLocation request.
-func (client *VirtualMachinesClient) ListByLocationCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ListByLocationCreateRequest(ctx context.Context, location string, options *VirtualMachinesListByLocationOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/virtualMachines"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -877,8 +877,8 @@ func (client *VirtualMachinesClient) ListByLocationHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPerformMaintenanceOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -912,8 +912,8 @@ func (client *VirtualMachinesClient) ResumePerformMaintenance(token string) (HTT
 }
 
 // PerformMaintenance - The operation to perform maintenance on a virtual machine.
-func (client *VirtualMachinesClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPerformMaintenanceOptions) (*azcore.Response, error) {
+	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -928,7 +928,7 @@ func (client *VirtualMachinesClient) PerformMaintenance(ctx context.Context, res
 }
 
 // PerformMaintenanceCreateRequest creates the PerformMaintenance request.
-func (client *VirtualMachinesClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPerformMaintenanceOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/performMaintenance"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -955,8 +955,8 @@ func (client *VirtualMachinesClient) PerformMaintenanceHandleError(resp *azcore.
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesPowerOffOptions *VirtualMachinesPowerOffOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PowerOff(ctx, resourceGroupName, vmName, virtualMachinesPowerOffOptions)
+func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPowerOffOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PowerOff(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -990,8 +990,8 @@ func (client *VirtualMachinesClient) ResumePowerOff(token string) (HTTPPoller, e
 }
 
 // PowerOff - The operation to power off (stop) a virtual machine. The virtual machine can be restarted with the same provisioned resources. You are still charged for this virtual machine.
-func (client *VirtualMachinesClient) PowerOff(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesPowerOffOptions *VirtualMachinesPowerOffOptions) (*azcore.Response, error) {
-	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmName, virtualMachinesPowerOffOptions)
+func (client *VirtualMachinesClient) PowerOff(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPowerOffOptions) (*azcore.Response, error) {
+	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1006,7 +1006,7 @@ func (client *VirtualMachinesClient) PowerOff(ctx context.Context, resourceGroup
 }
 
 // PowerOffCreateRequest creates the PowerOff request.
-func (client *VirtualMachinesClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesPowerOffOptions *VirtualMachinesPowerOffOptions) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesPowerOffOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/powerOff"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1016,8 +1016,8 @@ func (client *VirtualMachinesClient) PowerOffCreateRequest(ctx context.Context, 
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachinesPowerOffOptions != nil && virtualMachinesPowerOffOptions.SkipShutdown != nil {
-		query.Set("skipShutdown", strconv.FormatBool(*virtualMachinesPowerOffOptions.SkipShutdown))
+	if options != nil && options.SkipShutdown != nil {
+		query.Set("skipShutdown", strconv.FormatBool(*options.SkipShutdown))
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -1036,8 +1036,8 @@ func (client *VirtualMachinesClient) PowerOffHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Reapply(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReapplyOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Reapply(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1071,8 +1071,8 @@ func (client *VirtualMachinesClient) ResumeReapply(token string) (HTTPPoller, er
 }
 
 // Reapply - The operation to reapply a virtual machine's state.
-func (client *VirtualMachinesClient) Reapply(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.ReapplyCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Reapply(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReapplyOptions) (*azcore.Response, error) {
+	req, err := client.ReapplyCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1087,7 +1087,7 @@ func (client *VirtualMachinesClient) Reapply(ctx context.Context, resourceGroupN
 }
 
 // ReapplyCreateRequest creates the Reapply request.
-func (client *VirtualMachinesClient) ReapplyCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ReapplyCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReapplyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/reapply"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1112,8 +1112,8 @@ func (client *VirtualMachinesClient) ReapplyHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Redeploy(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRedeployOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Redeploy(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1147,8 +1147,8 @@ func (client *VirtualMachinesClient) ResumeRedeploy(token string) (HTTPPoller, e
 }
 
 // Redeploy - Shuts down the virtual machine, moves it to a new node, and powers it back on.
-func (client *VirtualMachinesClient) Redeploy(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Redeploy(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRedeployOptions) (*azcore.Response, error) {
+	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1163,7 +1163,7 @@ func (client *VirtualMachinesClient) Redeploy(ctx context.Context, resourceGroup
 }
 
 // RedeployCreateRequest creates the Redeploy request.
-func (client *VirtualMachinesClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRedeployOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/redeploy"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1190,8 +1190,8 @@ func (client *VirtualMachinesClient) RedeployHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesReimageOptions *VirtualMachinesReimageOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Reimage(ctx, resourceGroupName, vmName, virtualMachinesReimageOptions)
+func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReimageOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Reimage(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1225,8 +1225,8 @@ func (client *VirtualMachinesClient) ResumeReimage(token string) (HTTPPoller, er
 }
 
 // Reimage - Reimages the virtual machine which has an ephemeral OS disk back to its initial state.
-func (client *VirtualMachinesClient) Reimage(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesReimageOptions *VirtualMachinesReimageOptions) (*azcore.Response, error) {
-	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmName, virtualMachinesReimageOptions)
+func (client *VirtualMachinesClient) Reimage(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReimageOptions) (*azcore.Response, error) {
+	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1241,7 +1241,7 @@ func (client *VirtualMachinesClient) Reimage(ctx context.Context, resourceGroupN
 }
 
 // ReimageCreateRequest creates the Reimage request.
-func (client *VirtualMachinesClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmName string, virtualMachinesReimageOptions *VirtualMachinesReimageOptions) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesReimageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/reimage"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1253,8 +1253,8 @@ func (client *VirtualMachinesClient) ReimageCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachinesReimageOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachinesReimageOptions.Parameters)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil
 }
@@ -1271,8 +1271,8 @@ func (client *VirtualMachinesClient) ReimageHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Restart(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRestartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Restart(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1306,8 +1306,8 @@ func (client *VirtualMachinesClient) ResumeRestart(token string) (HTTPPoller, er
 }
 
 // Restart - The operation to restart a virtual machine.
-func (client *VirtualMachinesClient) Restart(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Restart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRestartOptions) (*azcore.Response, error) {
+	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1322,7 +1322,7 @@ func (client *VirtualMachinesClient) Restart(ctx context.Context, resourceGroupN
 }
 
 // RestartCreateRequest creates the Restart request.
-func (client *VirtualMachinesClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesRestartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1349,8 +1349,8 @@ func (client *VirtualMachinesClient) RestartHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error) {
-	resp, err := client.RunCommand(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesRunCommandOptions) (*RunCommandResultPollerResponse, error) {
+	resp, err := client.RunCommand(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1384,8 +1384,8 @@ func (client *VirtualMachinesClient) ResumeRunCommand(token string) (RunCommandR
 }
 
 // RunCommand - Run command on the VM.
-func (client *VirtualMachinesClient) RunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput) (*azcore.Response, error) {
-	req, err := client.RunCommandCreateRequest(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) RunCommand(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesRunCommandOptions) (*azcore.Response, error) {
+	req, err := client.RunCommandCreateRequest(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1400,7 +1400,7 @@ func (client *VirtualMachinesClient) RunCommand(ctx context.Context, resourceGro
 }
 
 // RunCommandCreateRequest creates the RunCommand request.
-func (client *VirtualMachinesClient) RunCommandCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) RunCommandCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters RunCommandInput, options *VirtualMachinesRunCommandOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommand"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1435,8 +1435,8 @@ func (client *VirtualMachinesClient) RunCommandHandleError(resp *azcore.Response
 }
 
 // SimulateEviction - The operation to simulate the eviction of spot virtual machine. The eviction will occur within 30 minutes of calling the API
-func (client *VirtualMachinesClient) SimulateEviction(ctx context.Context, resourceGroupName string, vmName string) (*http.Response, error) {
-	req, err := client.SimulateEvictionCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) SimulateEviction(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesSimulateEvictionOptions) (*http.Response, error) {
+	req, err := client.SimulateEvictionCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1451,7 +1451,7 @@ func (client *VirtualMachinesClient) SimulateEviction(ctx context.Context, resou
 }
 
 // SimulateEvictionCreateRequest creates the SimulateEviction request.
-func (client *VirtualMachinesClient) SimulateEvictionCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) SimulateEvictionCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesSimulateEvictionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/simulateEviction"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1478,8 +1478,8 @@ func (client *VirtualMachinesClient) SimulateEvictionHandleError(resp *azcore.Re
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGroupName string, vmName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Start(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesStartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Start(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1513,8 +1513,8 @@ func (client *VirtualMachinesClient) ResumeStart(token string) (HTTPPoller, erro
 }
 
 // Start - The operation to start a virtual machine.
-func (client *VirtualMachinesClient) Start(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Response, error) {
-	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmName)
+func (client *VirtualMachinesClient) Start(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesStartOptions) (*azcore.Response, error) {
+	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1529,7 +1529,7 @@ func (client *VirtualMachinesClient) Start(ctx context.Context, resourceGroupNam
 }
 
 // StartCreateRequest creates the Start request.
-func (client *VirtualMachinesClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmName string) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesStartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))
@@ -1556,8 +1556,8 @@ func (client *VirtualMachinesClient) StartHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate) (*VirtualMachinePollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesUpdateOptions) (*VirtualMachinePollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1591,8 +1591,8 @@ func (client *VirtualMachinesClient) ResumeUpdate(token string) (VirtualMachineP
 }
 
 // Update - The operation to update a virtual machine.
-func (client *VirtualMachinesClient) Update(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmName, parameters)
+func (client *VirtualMachinesClient) Update(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1607,7 +1607,7 @@ func (client *VirtualMachinesClient) Update(ctx context.Context, resourceGroupNa
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachinesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate) (*azcore.Request, error) {
+func (client *VirtualMachinesClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmName string, parameters VirtualMachineUpdate, options *VirtualMachinesUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmName}", url.PathEscape(vmName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
@@ -21,19 +21,19 @@ import (
 // VirtualMachineScaleSetExtensionsOperations contains the methods for the VirtualMachineScaleSetExtensions group.
 type VirtualMachineScaleSetExtensionsOperations interface {
 	// BeginCreateOrUpdate - The operation to create or update an extension.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension) (*VirtualMachineScaleSetExtensionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsCreateOrUpdateOptions) (*VirtualMachineScaleSetExtensionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualMachineScaleSetExtensionPoller, error)
 	// BeginDelete - The operation to delete the extension.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - The operation to get the extension.
-	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, virtualMachineScaleSetExtensionsGetOptions *VirtualMachineScaleSetExtensionsGetOptions) (*VirtualMachineScaleSetExtensionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsGetOptions) (*VirtualMachineScaleSetExtensionResponse, error)
 	// List - Gets a list of all extensions in a VM scale set.
-	List(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetExtensionListResultPager
+	List(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetExtensionsListOptions) VirtualMachineScaleSetExtensionListResultPager
 	// BeginUpdate - The operation to update an extension.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate) (*VirtualMachineScaleSetExtensionPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsUpdateOptions) (*VirtualMachineScaleSetExtensionPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachineScaleSetExtensionPoller, error)
 }
@@ -55,8 +55,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) Do(req *azcore.Request) (*
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension) (*VirtualMachineScaleSetExtensionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsCreateOrUpdateOptions) (*VirtualMachineScaleSetExtensionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +90,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) ResumeCreateOrUpdate(token
 }
 
 // CreateOrUpdate - The operation to create or update an extension.
-func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdate(ctx context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtension, options *VirtualMachineScaleSetExtensionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -141,8 +141,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) CreateOrUpdateHandleError(
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName)
+func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) ResumeDelete(token string)
 }
 
 // Delete - The operation to delete the extension.
-func (client *VirtualMachineScaleSetExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName)
+func (client *VirtualMachineScaleSetExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) Delete(ctx context.Context
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachineScaleSetExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -221,8 +221,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) DeleteHandleError(resp *az
 }
 
 // Get - The operation to get the extension.
-func (client *VirtualMachineScaleSetExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, virtualMachineScaleSetExtensionsGetOptions *VirtualMachineScaleSetExtensionsGetOptions) (*VirtualMachineScaleSetExtensionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, virtualMachineScaleSetExtensionsGetOptions)
+func (client *VirtualMachineScaleSetExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsGetOptions) (*VirtualMachineScaleSetExtensionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) Get(ctx context.Context, r
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineScaleSetExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, virtualMachineScaleSetExtensionsGetOptions *VirtualMachineScaleSetExtensionsGetOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, options *VirtualMachineScaleSetExtensionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -252,8 +252,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) GetCreateRequest(ctx conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetExtensionsGetOptions != nil && virtualMachineScaleSetExtensionsGetOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineScaleSetExtensionsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -280,11 +280,11 @@ func (client *VirtualMachineScaleSetExtensionsClient) GetHandleError(resp *azcor
 }
 
 // List - Gets a list of all extensions in a VM scale set.
-func (client *VirtualMachineScaleSetExtensionsClient) List(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetExtensionListResultPager {
+func (client *VirtualMachineScaleSetExtensionsClient) List(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetExtensionsListOptions) VirtualMachineScaleSetExtensionListResultPager {
 	return &virtualMachineScaleSetExtensionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+			return client.ListCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -295,7 +295,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) List(resourceGroupName str
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineScaleSetExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetExtensionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -329,8 +329,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) ListHandleError(resp *azco
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate) (*VirtualMachineScaleSetExtensionPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsUpdateOptions) (*VirtualMachineScaleSetExtensionPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +364,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) ResumeUpdate(token string)
 }
 
 // Update - The operation to update an extension.
-func (client *VirtualMachineScaleSetExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmssExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) Update(ctx context.Context
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachineScaleSetExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmssExtensionName string, extensionParameters VirtualMachineScaleSetExtensionUpdate, options *VirtualMachineScaleSetExtensionsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
@@ -21,17 +21,17 @@ import (
 // VirtualMachineScaleSetRollingUpgradesOperations contains the methods for the VirtualMachineScaleSetRollingUpgrades group.
 type VirtualMachineScaleSetRollingUpgradesOperations interface {
 	// BeginCancel - Cancels the current virtual machine scale set rolling upgrade.
-	BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error)
+	BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesCancelOptions) (*HTTPPollerResponse, error)
 	// ResumeCancel - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCancel(token string) (HTTPPoller, error)
 	// GetLatest - Gets the status of the latest virtual machine scale set rolling upgrade.
-	GetLatest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*RollingUpgradeStatusInfoResponse, error)
+	GetLatest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesGetLatestOptions) (*RollingUpgradeStatusInfoResponse, error)
 	// BeginStartExtensionUpgrade - Starts a rolling upgrade to move all extensions for all virtual machine scale set instances to the latest available extension version. Instances which are already running the latest extension versions are not affected.
-	BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error)
+	BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions) (*HTTPPollerResponse, error)
 	// ResumeStartExtensionUpgrade - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStartExtensionUpgrade(token string) (HTTPPoller, error)
 	// BeginStartOSUpgrade - Starts a rolling upgrade to move all virtual machine scale set instances to the latest available Platform Image OS version. Instances which are already running the latest available OS version are not affected.
-	BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error)
+	BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions) (*HTTPPollerResponse, error)
 	// ResumeStartOSUpgrade - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStartOSUpgrade(token string) (HTTPPoller, error)
 }
@@ -53,8 +53,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) Do(req *azcore.Reques
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Cancel(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesCancelOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Cancel(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +88,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeCancel(token st
 }
 
 // Cancel - Cancels the current virtual machine scale set rolling upgrade.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) Cancel(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Response, error) {
-	req, err := client.CancelCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) Cancel(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesCancelOptions) (*azcore.Response, error) {
+	req, err := client.CancelCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) Cancel(ctx context.Co
 }
 
 // CancelCreateRequest creates the Cancel request.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) CancelCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) CancelCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesCancelOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -132,8 +132,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) CancelHandleError(res
 }
 
 // GetLatest - Gets the status of the latest virtual machine scale set rolling upgrade.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*RollingUpgradeStatusInfoResponse, error) {
-	req, err := client.GetLatestCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesGetLatestOptions) (*RollingUpgradeStatusInfoResponse, error) {
+	req, err := client.GetLatestCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context
 }
 
 // GetLatestCreateRequest creates the GetLatest request.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatestCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatestCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesGetLatestOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/latest"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -186,8 +186,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatestHandleError(
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.StartExtensionUpgrade(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.StartExtensionUpgrade(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -221,8 +221,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartExtensionU
 }
 
 // StartExtensionUpgrade - Starts a rolling upgrade to move all extensions for all virtual machine scale set instances to the latest available extension version. Instances which are already running the latest extension versions are not affected.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Response, error) {
-	req, err := client.StartExtensionUpgradeCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions) (*azcore.Response, error) {
+	req, err := client.StartExtensionUpgradeCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade
 }
 
 // StartExtensionUpgradeCreateRequest creates the StartExtensionUpgrade request.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgradeCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgradeCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartExtensionUpgradeOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensionRollingUpgrade"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -264,8 +264,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) StartExtensionUpgrade
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.StartOSUpgrade(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.StartOSUpgrade(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -299,8 +299,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartOSUpgrade(
 }
 
 // StartOSUpgrade - Starts a rolling upgrade to move all virtual machine scale set instances to the latest available Platform Image OS version. Instances which are already running the latest available OS version are not affected.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Response, error) {
-	req, err := client.StartOSUpgradeCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgrade(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions) (*azcore.Response, error) {
+	req, err := client.StartOSUpgradeCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgrade(ctx co
 }
 
 // StartOSUpgradeCreateRequest creates the StartOSUpgrade request.
-func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgradeCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) StartOSUpgradeCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetRollingUpgradesStartOSUpgradeOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/osRollingUpgrade"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
@@ -22,75 +22,75 @@ import (
 // VirtualMachineScaleSetsOperations contains the methods for the VirtualMachineScaleSets group.
 type VirtualMachineScaleSetsOperations interface {
 	// ConvertToSinglePlacementGroup - Converts SinglePlacementGroup property to false for a existing virtual machine scale set.
-	ConvertToSinglePlacementGroup(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput) (*http.Response, error)
+	ConvertToSinglePlacementGroup(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput, options *VirtualMachineScaleSetsConvertToSinglePlacementGroupOptions) (*http.Response, error)
 	// BeginCreateOrUpdate - Create or update a VM scale set.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet) (*VirtualMachineScaleSetPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsCreateOrUpdateOptions) (*VirtualMachineScaleSetPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualMachineScaleSetPoller, error)
 	// BeginDeallocate - Deallocates specific virtual machines in a VM scale set. Shuts down the virtual machines and releases the compute resources. You are not billed for the compute resources that this virtual machine scale set deallocates.
-	BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsDeallocateOptions *VirtualMachineScaleSetsDeallocateOptions) (*HTTPPollerResponse, error)
+	BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeallocateOptions) (*HTTPPollerResponse, error)
 	// ResumeDeallocate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeallocate(token string) (HTTPPoller, error)
 	// BeginDelete - Deletes a VM scale set.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// BeginDeleteInstances - Deletes virtual machines in a VM scale set.
-	BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error)
+	BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsDeleteInstancesOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteInstances - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteInstances(token string) (HTTPPoller, error)
 	// ForceRecoveryServiceFabricPlatformUpdateDomainWalk - Manual platform update domain walk to update virtual machines in a service fabric virtual machine scale set.
-	ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32) (*RecoveryWalkResponseResponse, error)
+	ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32, options *VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions) (*RecoveryWalkResponseResponse, error)
 	// Get - Display information about a virtual machine scale set.
-	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*VirtualMachineScaleSetResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOptions) (*VirtualMachineScaleSetResponse, error)
 	// GetInstanceView - Gets the status of a VM scale set instance.
-	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*VirtualMachineScaleSetInstanceViewResponse, error)
+	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetInstanceViewOptions) (*VirtualMachineScaleSetInstanceViewResponse, error)
 	// GetOSUpgradeHistory - Gets list of OS upgrades on a VM scale set instance.
-	GetOSUpgradeHistory(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetListOSUpgradeHistoryPager
+	GetOSUpgradeHistory(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOSUpgradeHistoryOptions) VirtualMachineScaleSetListOSUpgradeHistoryPager
 	// List - Gets a list of all VM scale sets under a resource group.
-	List(resourceGroupName string) VirtualMachineScaleSetListResultPager
+	List(resourceGroupName string, options *VirtualMachineScaleSetsListOptions) VirtualMachineScaleSetListResultPager
 	// ListAll - Gets a list of all VM Scale Sets in the subscription, regardless of the associated resource group. Use nextLink property in the response to get the next page of VM Scale Sets. Do this till nextLink is null to fetch all the VM Scale Sets.
-	ListAll() VirtualMachineScaleSetListWithLinkResultPager
+	ListAll(options *VirtualMachineScaleSetsListAllOptions) VirtualMachineScaleSetListWithLinkResultPager
 	// ListSKUs - Gets a list of SKUs available for your VM scale set, including the minimum and maximum VM instances allowed for each SKU.
-	ListSKUs(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetListSKUsResultPager
+	ListSKUs(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsListSKUsOptions) VirtualMachineScaleSetListSKUsResultPager
 	// BeginPerformMaintenance - Perform maintenance on one or more virtual machines in a VM scale set. Operation on instances which are not eligible for perform maintenance will be failed. Please refer to best practices for more details: https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-maintenance-notifications
-	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPerformMaintenanceOptions *VirtualMachineScaleSetsPerformMaintenanceOptions) (*HTTPPollerResponse, error)
+	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPerformMaintenanceOptions) (*HTTPPollerResponse, error)
 	// ResumePerformMaintenance - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePerformMaintenance(token string) (HTTPPoller, error)
 	// BeginPowerOff - Power off (stop) one or more virtual machines in a VM scale set. Note that resources are still attached and you are getting charged for the resources. Instead, use deallocate to release resources and avoid charges.
-	BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPowerOffOptions *VirtualMachineScaleSetsPowerOffOptions) (*HTTPPollerResponse, error)
+	BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPowerOffOptions) (*HTTPPollerResponse, error)
 	// ResumePowerOff - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePowerOff(token string) (HTTPPoller, error)
 	// BeginRedeploy - Shuts down all the virtual machines in the virtual machine scale set, moves them to a new node, and powers them back on.
-	BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRedeployOptions *VirtualMachineScaleSetsRedeployOptions) (*HTTPPollerResponse, error)
+	BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRedeployOptions) (*HTTPPollerResponse, error)
 	// ResumeRedeploy - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRedeploy(token string) (HTTPPoller, error)
 	// BeginReimage - Reimages (upgrade the operating system) one or more virtual machines in a VM scale set which don't have a ephemeral OS disk, for virtual machines who have a ephemeral OS disk the virtual machine is reset to initial state.
-	BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageOptions *VirtualMachineScaleSetsReimageOptions) (*HTTPPollerResponse, error)
+	BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageOptions) (*HTTPPollerResponse, error)
 	// ResumeReimage - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReimage(token string) (HTTPPoller, error)
 	// BeginReimageAll - Reimages all the disks ( including data disks ) in the virtual machines in a VM scale set. This operation is only supported for managed disks.
-	BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageAllOptions *VirtualMachineScaleSetsReimageAllOptions) (*HTTPPollerResponse, error)
+	BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageAllOptions) (*HTTPPollerResponse, error)
 	// ResumeReimageAll - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReimageAll(token string) (HTTPPoller, error)
 	// BeginRestart - Restarts one or more virtual machines in a VM scale set.
-	BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRestartOptions *VirtualMachineScaleSetsRestartOptions) (*HTTPPollerResponse, error)
+	BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRestartOptions) (*HTTPPollerResponse, error)
 	// ResumeRestart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRestart(token string) (HTTPPoller, error)
 	// BeginSetOrchestrationServiceState - Changes ServiceState property for a given service
-	BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput) (*HTTPPollerResponse, error)
+	BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsSetOrchestrationServiceStateOptions) (*HTTPPollerResponse, error)
 	// ResumeSetOrchestrationServiceState - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeSetOrchestrationServiceState(token string) (HTTPPoller, error)
 	// BeginStart - Starts one or more virtual machines in a VM scale set.
-	BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsStartOptions *VirtualMachineScaleSetsStartOptions) (*HTTPPollerResponse, error)
+	BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsStartOptions) (*HTTPPollerResponse, error)
 	// ResumeStart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStart(token string) (HTTPPoller, error)
 	// BeginUpdate - Update a VM scale set.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate) (*VirtualMachineScaleSetPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsUpdateOptions) (*VirtualMachineScaleSetPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachineScaleSetPoller, error)
 	// BeginUpdateInstances - Upgrades one or more virtual machines to the latest SKU set in the VM scale set model.
-	BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error)
+	BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsUpdateInstancesOptions) (*HTTPPollerResponse, error)
 	// ResumeUpdateInstances - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdateInstances(token string) (HTTPPoller, error)
 }
@@ -113,8 +113,8 @@ func (client *VirtualMachineScaleSetsClient) Do(req *azcore.Request) (*azcore.Re
 }
 
 // ConvertToSinglePlacementGroup - Converts SinglePlacementGroup property to false for a existing virtual machine scale set.
-func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroup(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput) (*http.Response, error) {
-	req, err := client.ConvertToSinglePlacementGroupCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroup(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput, options *VirtualMachineScaleSetsConvertToSinglePlacementGroupOptions) (*http.Response, error) {
+	req, err := client.ConvertToSinglePlacementGroupCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroup(ctx c
 }
 
 // ConvertToSinglePlacementGroupCreateRequest creates the ConvertToSinglePlacementGroup request.
-func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroupCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroupCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VMScaleSetConvertToSinglePlacementGroupInput, options *VirtualMachineScaleSetsConvertToSinglePlacementGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/convertToSinglePlacementGroup"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -156,8 +156,8 @@ func (client *VirtualMachineScaleSetsClient) ConvertToSinglePlacementGroupHandle
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet) (*VirtualMachineScaleSetPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsCreateOrUpdateOptions) (*VirtualMachineScaleSetPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +191,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeCreateOrUpdate(token string) 
 }
 
 // CreateOrUpdate - Create or update a VM scale set.
-func (client *VirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (client *VirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context,
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualMachineScaleSetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSet, options *VirtualMachineScaleSetsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -241,8 +241,8 @@ func (client *VirtualMachineScaleSetsClient) CreateOrUpdateHandleError(resp *azc
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsDeallocateOptions *VirtualMachineScaleSetsDeallocateOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Deallocate(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsDeallocateOptions)
+func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeallocateOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Deallocate(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -276,8 +276,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeDeallocate(token string) (HTT
 }
 
 // Deallocate - Deallocates specific virtual machines in a VM scale set. Shuts down the virtual machines and releases the compute resources. You are not billed for the compute resources that this virtual machine scale set deallocates.
-func (client *VirtualMachineScaleSetsClient) Deallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsDeallocateOptions *VirtualMachineScaleSetsDeallocateOptions) (*azcore.Response, error) {
-	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsDeallocateOptions)
+func (client *VirtualMachineScaleSetsClient) Deallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeallocateOptions) (*azcore.Response, error) {
+	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (client *VirtualMachineScaleSetsClient) Deallocate(ctx context.Context, res
 }
 
 // DeallocateCreateRequest creates the Deallocate request.
-func (client *VirtualMachineScaleSetsClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsDeallocateOptions *VirtualMachineScaleSetsDeallocateOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeallocateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/deallocate"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -304,8 +304,8 @@ func (client *VirtualMachineScaleSetsClient) DeallocateCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsDeallocateOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsDeallocateOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -322,8 +322,8 @@ func (client *VirtualMachineScaleSetsClient) DeallocateHandleError(resp *azcore.
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -357,8 +357,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeDelete(token string) (HTTPPol
 }
 
 // Delete - Deletes a VM scale set.
-func (client *VirtualMachineScaleSetsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (client *VirtualMachineScaleSetsClient) Delete(ctx context.Context, resourc
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachineScaleSetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -400,8 +400,8 @@ func (client *VirtualMachineScaleSetsClient) DeleteHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsDeleteInstancesOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
 		return nil, err
 	}
@@ -435,8 +435,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeDeleteInstances(token string)
 }
 
 // DeleteInstances - Deletes virtual machines in a VM scale set.
-func (client *VirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*azcore.Response, error) {
-	req, err := client.DeleteInstancesCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client *VirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsDeleteInstancesOptions) (*azcore.Response, error) {
+	req, err := client.DeleteInstancesCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
 		return nil, err
 	}
@@ -451,7 +451,7 @@ func (client *VirtualMachineScaleSetsClient) DeleteInstances(ctx context.Context
 }
 
 // DeleteInstancesCreateRequest creates the DeleteInstances request.
-func (client *VirtualMachineScaleSetsClient) DeleteInstancesCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) DeleteInstancesCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsDeleteInstancesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/delete"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -479,8 +479,8 @@ func (client *VirtualMachineScaleSetsClient) DeleteInstancesHandleError(resp *az
 }
 
 // ForceRecoveryServiceFabricPlatformUpdateDomainWalk - Manual platform update domain walk to update virtual machines in a service fabric virtual machine scale set.
-func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32) (*RecoveryWalkResponseResponse, error) {
-	req, err := client.ForceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest(ctx, resourceGroupName, vmScaleSetName, platformUpdateDomain)
+func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUpdateDomainWalk(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32, options *VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions) (*RecoveryWalkResponseResponse, error) {
+	req, err := client.ForceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest(ctx, resourceGroupName, vmScaleSetName, platformUpdateDomain, options)
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +499,7 @@ func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformU
 }
 
 // ForceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest creates the ForceRecoveryServiceFabricPlatformUpdateDomainWalk request.
-func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, platformUpdateDomain int32, options *VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/forceRecoveryServiceFabricPlatformUpdateDomainWalk"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -535,8 +535,8 @@ func (client *VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformU
 }
 
 // Get - Display information about a virtual machine scale set.
-func (client *VirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*VirtualMachineScaleSetResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOptions) (*VirtualMachineScaleSetResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +555,7 @@ func (client *VirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGr
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineScaleSetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -590,8 +590,8 @@ func (client *VirtualMachineScaleSetsClient) GetHandleError(resp *azcore.Respons
 }
 
 // GetInstanceView - Gets the status of a VM scale set instance.
-func (client *VirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*VirtualMachineScaleSetInstanceViewResponse, error) {
-	req, err := client.GetInstanceViewCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+func (client *VirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetInstanceViewOptions) (*VirtualMachineScaleSetInstanceViewResponse, error) {
+	req, err := client.GetInstanceViewCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -610,7 +610,7 @@ func (client *VirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context
 }
 
 // GetInstanceViewCreateRequest creates the GetInstanceView request.
-func (client *VirtualMachineScaleSetsClient) GetInstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) GetInstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetInstanceViewOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/instanceView"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -645,11 +645,11 @@ func (client *VirtualMachineScaleSetsClient) GetInstanceViewHandleError(resp *az
 }
 
 // GetOSUpgradeHistory - Gets list of OS upgrades on a VM scale set instance.
-func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistory(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetListOSUpgradeHistoryPager {
+func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistory(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOSUpgradeHistoryOptions) VirtualMachineScaleSetListOSUpgradeHistoryPager {
 	return &virtualMachineScaleSetListOSUpgradeHistoryPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetOSUpgradeHistoryCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+			return client.GetOSUpgradeHistoryCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 		},
 		responder: client.GetOSUpgradeHistoryHandleResponse,
 		errorer:   client.GetOSUpgradeHistoryHandleError,
@@ -660,7 +660,7 @@ func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistory(resourceGroupNa
 }
 
 // GetOSUpgradeHistoryCreateRequest creates the GetOSUpgradeHistory request.
-func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistoryCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistoryCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsGetOSUpgradeHistoryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/osUpgradeHistory"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -695,11 +695,11 @@ func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistoryHandleError(resp
 }
 
 // List - Gets a list of all VM scale sets under a resource group.
-func (client *VirtualMachineScaleSetsClient) List(resourceGroupName string) VirtualMachineScaleSetListResultPager {
+func (client *VirtualMachineScaleSetsClient) List(resourceGroupName string, options *VirtualMachineScaleSetsListOptions) VirtualMachineScaleSetListResultPager {
 	return &virtualMachineScaleSetListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -710,7 +710,7 @@ func (client *VirtualMachineScaleSetsClient) List(resourceGroupName string) Virt
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineScaleSetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualMachineScaleSetsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -744,11 +744,11 @@ func (client *VirtualMachineScaleSetsClient) ListHandleError(resp *azcore.Respon
 }
 
 // ListAll - Gets a list of all VM Scale Sets in the subscription, regardless of the associated resource group. Use nextLink property in the response to get the next page of VM Scale Sets. Do this till nextLink is null to fetch all the VM Scale Sets.
-func (client *VirtualMachineScaleSetsClient) ListAll() VirtualMachineScaleSetListWithLinkResultPager {
+func (client *VirtualMachineScaleSetsClient) ListAll(options *VirtualMachineScaleSetsListAllOptions) VirtualMachineScaleSetListWithLinkResultPager {
 	return &virtualMachineScaleSetListWithLinkResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -759,7 +759,7 @@ func (client *VirtualMachineScaleSetsClient) ListAll() VirtualMachineScaleSetLis
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *VirtualMachineScaleSetsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ListAllCreateRequest(ctx context.Context, options *VirtualMachineScaleSetsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachineScaleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -792,11 +792,11 @@ func (client *VirtualMachineScaleSetsClient) ListAllHandleError(resp *azcore.Res
 }
 
 // ListSKUs - Gets a list of SKUs available for your VM scale set, including the minimum and maximum VM instances allowed for each SKU.
-func (client *VirtualMachineScaleSetsClient) ListSKUs(resourceGroupName string, vmScaleSetName string) VirtualMachineScaleSetListSKUsResultPager {
+func (client *VirtualMachineScaleSetsClient) ListSKUs(resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsListSKUsOptions) VirtualMachineScaleSetListSKUsResultPager {
 	return &virtualMachineScaleSetListSkUsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListSKUsCreateRequest(ctx, resourceGroupName, vmScaleSetName)
+			return client.ListSKUsCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 		},
 		responder: client.ListSKUsHandleResponse,
 		errorer:   client.ListSKUsHandleError,
@@ -807,7 +807,7 @@ func (client *VirtualMachineScaleSetsClient) ListSKUs(resourceGroupName string, 
 }
 
 // ListSKUsCreateRequest creates the ListSKUs request.
-func (client *VirtualMachineScaleSetsClient) ListSKUsCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ListSKUsCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsListSKUsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/skus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -841,8 +841,8 @@ func (client *VirtualMachineScaleSetsClient) ListSKUsHandleError(resp *azcore.Re
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPerformMaintenanceOptions *VirtualMachineScaleSetsPerformMaintenanceOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsPerformMaintenanceOptions)
+func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPerformMaintenanceOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -876,8 +876,8 @@ func (client *VirtualMachineScaleSetsClient) ResumePerformMaintenance(token stri
 }
 
 // PerformMaintenance - Perform maintenance on one or more virtual machines in a VM scale set. Operation on instances which are not eligible for perform maintenance will be failed. Please refer to best practices for more details: https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-maintenance-notifications
-func (client *VirtualMachineScaleSetsClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPerformMaintenanceOptions *VirtualMachineScaleSetsPerformMaintenanceOptions) (*azcore.Response, error) {
-	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsPerformMaintenanceOptions)
+func (client *VirtualMachineScaleSetsClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPerformMaintenanceOptions) (*azcore.Response, error) {
+	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +892,7 @@ func (client *VirtualMachineScaleSetsClient) PerformMaintenance(ctx context.Cont
 }
 
 // PerformMaintenanceCreateRequest creates the PerformMaintenance request.
-func (client *VirtualMachineScaleSetsClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPerformMaintenanceOptions *VirtualMachineScaleSetsPerformMaintenanceOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPerformMaintenanceOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/performMaintenance"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -904,8 +904,8 @@ func (client *VirtualMachineScaleSetsClient) PerformMaintenanceCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsPerformMaintenanceOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsPerformMaintenanceOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -922,8 +922,8 @@ func (client *VirtualMachineScaleSetsClient) PerformMaintenanceHandleError(resp 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPowerOffOptions *VirtualMachineScaleSetsPowerOffOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PowerOff(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsPowerOffOptions)
+func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPowerOffOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PowerOff(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -957,8 +957,8 @@ func (client *VirtualMachineScaleSetsClient) ResumePowerOff(token string) (HTTPP
 }
 
 // PowerOff - Power off (stop) one or more virtual machines in a VM scale set. Note that resources are still attached and you are getting charged for the resources. Instead, use deallocate to release resources and avoid charges.
-func (client *VirtualMachineScaleSetsClient) PowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPowerOffOptions *VirtualMachineScaleSetsPowerOffOptions) (*azcore.Response, error) {
-	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsPowerOffOptions)
+func (client *VirtualMachineScaleSetsClient) PowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPowerOffOptions) (*azcore.Response, error) {
+	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +973,7 @@ func (client *VirtualMachineScaleSetsClient) PowerOff(ctx context.Context, resou
 }
 
 // PowerOffCreateRequest creates the PowerOff request.
-func (client *VirtualMachineScaleSetsClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsPowerOffOptions *VirtualMachineScaleSetsPowerOffOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsPowerOffOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/poweroff"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -983,13 +983,13 @@ func (client *VirtualMachineScaleSetsClient) PowerOffCreateRequest(ctx context.C
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetsPowerOffOptions != nil && virtualMachineScaleSetsPowerOffOptions.SkipShutdown != nil {
-		query.Set("skipShutdown", strconv.FormatBool(*virtualMachineScaleSetsPowerOffOptions.SkipShutdown))
+	if options != nil && options.SkipShutdown != nil {
+		query.Set("skipShutdown", strconv.FormatBool(*options.SkipShutdown))
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsPowerOffOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsPowerOffOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -1006,8 +1006,8 @@ func (client *VirtualMachineScaleSetsClient) PowerOffHandleError(resp *azcore.Re
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRedeployOptions *VirtualMachineScaleSetsRedeployOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Redeploy(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsRedeployOptions)
+func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRedeployOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Redeploy(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1041,8 +1041,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeRedeploy(token string) (HTTPP
 }
 
 // Redeploy - Shuts down all the virtual machines in the virtual machine scale set, moves them to a new node, and powers them back on.
-func (client *VirtualMachineScaleSetsClient) Redeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRedeployOptions *VirtualMachineScaleSetsRedeployOptions) (*azcore.Response, error) {
-	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsRedeployOptions)
+func (client *VirtualMachineScaleSetsClient) Redeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRedeployOptions) (*azcore.Response, error) {
+	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1057,7 +1057,7 @@ func (client *VirtualMachineScaleSetsClient) Redeploy(ctx context.Context, resou
 }
 
 // RedeployCreateRequest creates the Redeploy request.
-func (client *VirtualMachineScaleSetsClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRedeployOptions *VirtualMachineScaleSetsRedeployOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRedeployOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/redeploy"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1069,8 +1069,8 @@ func (client *VirtualMachineScaleSetsClient) RedeployCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsRedeployOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsRedeployOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -1087,8 +1087,8 @@ func (client *VirtualMachineScaleSetsClient) RedeployHandleError(resp *azcore.Re
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageOptions *VirtualMachineScaleSetsReimageOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Reimage(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsReimageOptions)
+func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Reimage(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1122,8 +1122,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeReimage(token string) (HTTPPo
 }
 
 // Reimage - Reimages (upgrade the operating system) one or more virtual machines in a VM scale set which don't have a ephemeral OS disk, for virtual machines who have a ephemeral OS disk the virtual machine is reset to initial state.
-func (client *VirtualMachineScaleSetsClient) Reimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageOptions *VirtualMachineScaleSetsReimageOptions) (*azcore.Response, error) {
-	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsReimageOptions)
+func (client *VirtualMachineScaleSetsClient) Reimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageOptions) (*azcore.Response, error) {
+	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1138,7 +1138,7 @@ func (client *VirtualMachineScaleSetsClient) Reimage(ctx context.Context, resour
 }
 
 // ReimageCreateRequest creates the Reimage request.
-func (client *VirtualMachineScaleSetsClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageOptions *VirtualMachineScaleSetsReimageOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimage"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1150,8 +1150,8 @@ func (client *VirtualMachineScaleSetsClient) ReimageCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsReimageOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsReimageOptions.VMScaleSetReimageInput)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMScaleSetReimageInput)
 	}
 	return req, nil
 }
@@ -1168,8 +1168,8 @@ func (client *VirtualMachineScaleSetsClient) ReimageHandleError(resp *azcore.Res
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageAllOptions *VirtualMachineScaleSetsReimageAllOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.ReimageAll(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsReimageAllOptions)
+func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageAllOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.ReimageAll(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1203,8 +1203,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeReimageAll(token string) (HTT
 }
 
 // ReimageAll - Reimages all the disks ( including data disks ) in the virtual machines in a VM scale set. This operation is only supported for managed disks.
-func (client *VirtualMachineScaleSetsClient) ReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageAllOptions *VirtualMachineScaleSetsReimageAllOptions) (*azcore.Response, error) {
-	req, err := client.ReimageAllCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsReimageAllOptions)
+func (client *VirtualMachineScaleSetsClient) ReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageAllOptions) (*azcore.Response, error) {
+	req, err := client.ReimageAllCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1219,7 +1219,7 @@ func (client *VirtualMachineScaleSetsClient) ReimageAll(ctx context.Context, res
 }
 
 // ReimageAllCreateRequest creates the ReimageAll request.
-func (client *VirtualMachineScaleSetsClient) ReimageAllCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsReimageAllOptions *VirtualMachineScaleSetsReimageAllOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) ReimageAllCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsReimageAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimageall"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1231,8 +1231,8 @@ func (client *VirtualMachineScaleSetsClient) ReimageAllCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsReimageAllOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsReimageAllOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -1249,8 +1249,8 @@ func (client *VirtualMachineScaleSetsClient) ReimageAllHandleError(resp *azcore.
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRestartOptions *VirtualMachineScaleSetsRestartOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Restart(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsRestartOptions)
+func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRestartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Restart(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1284,8 +1284,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeRestart(token string) (HTTPPo
 }
 
 // Restart - Restarts one or more virtual machines in a VM scale set.
-func (client *VirtualMachineScaleSetsClient) Restart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRestartOptions *VirtualMachineScaleSetsRestartOptions) (*azcore.Response, error) {
-	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsRestartOptions)
+func (client *VirtualMachineScaleSetsClient) Restart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRestartOptions) (*azcore.Response, error) {
+	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1300,7 +1300,7 @@ func (client *VirtualMachineScaleSetsClient) Restart(ctx context.Context, resour
 }
 
 // RestartCreateRequest creates the Restart request.
-func (client *VirtualMachineScaleSetsClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsRestartOptions *VirtualMachineScaleSetsRestartOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsRestartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/restart"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1312,8 +1312,8 @@ func (client *VirtualMachineScaleSetsClient) RestartCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsRestartOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsRestartOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -1330,8 +1330,8 @@ func (client *VirtualMachineScaleSetsClient) RestartHandleError(resp *azcore.Res
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput) (*HTTPPollerResponse, error) {
-	resp, err := client.SetOrchestrationServiceState(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsSetOrchestrationServiceStateOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.SetOrchestrationServiceState(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1365,8 +1365,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeSetOrchestrationServiceState(
 }
 
 // SetOrchestrationServiceState - Changes ServiceState property for a given service
-func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput) (*azcore.Response, error) {
-	req, err := client.SetOrchestrationServiceStateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceState(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsSetOrchestrationServiceStateOptions) (*azcore.Response, error) {
+	req, err := client.SetOrchestrationServiceStateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1381,7 +1381,7 @@ func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceState(ctx co
 }
 
 // SetOrchestrationServiceStateCreateRequest creates the SetOrchestrationServiceState request.
-func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceStateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceStateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters OrchestrationServiceStateInput, options *VirtualMachineScaleSetsSetOrchestrationServiceStateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/setOrchestrationServiceState"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1408,8 +1408,8 @@ func (client *VirtualMachineScaleSetsClient) SetOrchestrationServiceStateHandleE
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsStartOptions *VirtualMachineScaleSetsStartOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Start(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsStartOptions)
+func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsStartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Start(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1443,8 +1443,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeStart(token string) (HTTPPoll
 }
 
 // Start - Starts one or more virtual machines in a VM scale set.
-func (client *VirtualMachineScaleSetsClient) Start(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsStartOptions *VirtualMachineScaleSetsStartOptions) (*azcore.Response, error) {
-	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmScaleSetName, virtualMachineScaleSetsStartOptions)
+func (client *VirtualMachineScaleSetsClient) Start(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsStartOptions) (*azcore.Response, error) {
+	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmScaleSetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1459,7 +1459,7 @@ func (client *VirtualMachineScaleSetsClient) Start(ctx context.Context, resource
 }
 
 // StartCreateRequest creates the Start request.
-func (client *VirtualMachineScaleSetsClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, virtualMachineScaleSetsStartOptions *VirtualMachineScaleSetsStartOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, options *VirtualMachineScaleSetsStartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1471,8 +1471,8 @@ func (client *VirtualMachineScaleSetsClient) StartCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetsStartOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetsStartOptions.VMInstanceIDs)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
 }
@@ -1489,8 +1489,8 @@ func (client *VirtualMachineScaleSetsClient) StartHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate) (*VirtualMachineScaleSetPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsUpdateOptions) (*VirtualMachineScaleSetPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1524,8 +1524,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeUpdate(token string) (Virtual
 }
 
 // Update - Update a VM scale set.
-func (client *VirtualMachineScaleSetsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters)
+func (client *VirtualMachineScaleSetsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1540,7 +1540,7 @@ func (client *VirtualMachineScaleSetsClient) Update(ctx context.Context, resourc
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachineScaleSetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, parameters VirtualMachineScaleSetUpdate, options *VirtualMachineScaleSetsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1574,8 +1574,8 @@ func (client *VirtualMachineScaleSetsClient) UpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*HTTPPollerResponse, error) {
-	resp, err := client.UpdateInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsUpdateInstancesOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.UpdateInstances(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1609,8 +1609,8 @@ func (client *VirtualMachineScaleSetsClient) ResumeUpdateInstances(token string)
 }
 
 // UpdateInstances - Upgrades one or more virtual machines to the latest SKU set in the VM scale set model.
-func (client *VirtualMachineScaleSetsClient) UpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*azcore.Response, error) {
-	req, err := client.UpdateInstancesCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs)
+func (client *VirtualMachineScaleSetsClient) UpdateInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsUpdateInstancesOptions) (*azcore.Response, error) {
+	req, err := client.UpdateInstancesCreateRequest(ctx, resourceGroupName, vmScaleSetName, vmInstanceIDs, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1625,7 +1625,7 @@ func (client *VirtualMachineScaleSetsClient) UpdateInstances(ctx context.Context
 }
 
 // UpdateInstancesCreateRequest creates the UpdateInstances request.
-func (client *VirtualMachineScaleSetsClient) UpdateInstancesCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetsClient) UpdateInstancesCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs VirtualMachineScaleSetVMInstanceRequiredIDs, options *VirtualMachineScaleSetsUpdateInstancesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/manualupgrade"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
@@ -18,19 +18,19 @@ import (
 // VirtualMachineScaleSetVMExtensionsOperations contains the methods for the VirtualMachineScaleSetVMExtensions group.
 type VirtualMachineScaleSetVMExtensionsOperations interface {
 	// BeginCreateOrUpdate - The operation to create or update the VMSS VM extension.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*VirtualMachineExtensionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions) (*VirtualMachineExtensionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualMachineExtensionPoller, error)
 	// BeginDelete - The operation to delete the VMSS VM extension.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - The operation to get the VMSS VM extension.
-	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, virtualMachineScaleSetVMExtensionsGetOptions *VirtualMachineScaleSetVMExtensionsGetOptions) (*VirtualMachineExtensionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsGetOptions) (*VirtualMachineExtensionResponse, error)
 	// List - The operation to get all extensions of an instance in Virtual Machine Scaleset.
-	List(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVMExtensionsListOptions *VirtualMachineScaleSetVMExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error)
 	// BeginUpdate - The operation to update the VMSS VM extension.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsUpdateOptions) (*VirtualMachineExtensionPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachineExtensionPoller, error)
 }
@@ -52,8 +52,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) Do(req *azcore.Request) 
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*VirtualMachineExtensionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions) (*VirtualMachineExtensionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeCreateOrUpdate(tok
 }
 
 // CreateOrUpdate - The operation to create or update the VMSS VM extension.
-func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdate(ctx conte
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtension, options *VirtualMachineScaleSetVMExtensionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -136,8 +136,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) CreateOrUpdateHandleErro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName)
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeDelete(token strin
 }
 
 // Delete - The operation to delete the VMSS VM extension.
-func (client *VirtualMachineScaleSetVMExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName)
+func (client *VirtualMachineScaleSetVMExtensionsClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) Delete(ctx context.Conte
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachineScaleSetVMExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -215,8 +215,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) DeleteHandleError(resp *
 }
 
 // Get - The operation to get the VMSS VM extension.
-func (client *VirtualMachineScaleSetVMExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, virtualMachineScaleSetVMExtensionsGetOptions *VirtualMachineScaleSetVMExtensionsGetOptions) (*VirtualMachineExtensionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, virtualMachineScaleSetVMExtensionsGetOptions)
+func (client *VirtualMachineScaleSetVMExtensionsClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsGetOptions) (*VirtualMachineExtensionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) Get(ctx context.Context,
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineScaleSetVMExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, virtualMachineScaleSetVMExtensionsGetOptions *VirtualMachineScaleSetVMExtensionsGetOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, options *VirtualMachineScaleSetVMExtensionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -247,8 +247,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) GetCreateRequest(ctx con
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetVMExtensionsGetOptions != nil && virtualMachineScaleSetVMExtensionsGetOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineScaleSetVMExtensionsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -272,8 +272,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) GetHandleError(resp *azc
 }
 
 // List - The operation to get all extensions of an instance in Virtual Machine Scaleset.
-func (client *VirtualMachineScaleSetVMExtensionsClient) List(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVMExtensionsListOptions *VirtualMachineScaleSetVMExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVMExtensionsListOptions)
+func (client *VirtualMachineScaleSetVMExtensionsClient) List(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMExtensionsListOptions) (*VirtualMachineExtensionsListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) List(ctx context.Context
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineScaleSetVMExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVMExtensionsListOptions *VirtualMachineScaleSetVMExtensionsListOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMExtensionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -303,8 +303,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ListCreateRequest(ctx co
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetVMExtensionsListOptions != nil && virtualMachineScaleSetVMExtensionsListOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineScaleSetVMExtensionsListOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -327,8 +327,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ListHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*VirtualMachineExtensionPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsUpdateOptions) (*VirtualMachineExtensionPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +362,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeUpdate(token strin
 }
 
 // Update - The operation to update the VMSS VM extension.
-func (client *VirtualMachineScaleSetVMExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters)
+func (client *VirtualMachineScaleSetVMExtensionsClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, vmExtensionName, extensionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) Update(ctx context.Conte
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachineScaleSetVMExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, vmExtensionName string, extensionParameters VirtualMachineExtensionUpdate, options *VirtualMachineScaleSetVMExtensionsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/extensions/{vmExtensionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
@@ -22,55 +22,55 @@ import (
 // VirtualMachineScaleSetVMSOperations contains the methods for the VirtualMachineScaleSetVMS group.
 type VirtualMachineScaleSetVMSOperations interface {
 	// BeginDeallocate - Deallocates a specific virtual machine in a VM scale set. Shuts down the virtual machine and releases the compute resources it uses. You are not billed for the compute resources of this virtual machine once it is deallocated.
-	BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeallocateOptions) (*HTTPPollerResponse, error)
 	// ResumeDeallocate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeallocate(token string) (HTTPPoller, error)
 	// BeginDelete - Deletes a virtual machine from a VM scale set.
-	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets a virtual machine from a VM scale set.
-	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsGetOptions *VirtualMachineScaleSetVMSGetOptions) (*VirtualMachineScaleSetVMResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetOptions) (*VirtualMachineScaleSetVMResponse, error)
 	// GetInstanceView - Gets the status of a virtual machine from a VM scale set.
-	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*VirtualMachineScaleSetVMInstanceViewResponse, error)
+	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetInstanceViewOptions) (*VirtualMachineScaleSetVMInstanceViewResponse, error)
 	// List - Gets a list of all virtual machines in a VM scale sets.
-	List(resourceGroupName string, virtualMachineScaleSetName string, virtualMachineScaleSetVmsListOptions *VirtualMachineScaleSetVMSListOptions) VirtualMachineScaleSetVMListResultPager
+	List(resourceGroupName string, virtualMachineScaleSetName string, options *VirtualMachineScaleSetVMSListOptions) VirtualMachineScaleSetVMListResultPager
 	// BeginPerformMaintenance - Performs maintenance on a virtual machine in a VM scale set.
-	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPerformMaintenanceOptions) (*HTTPPollerResponse, error)
 	// ResumePerformMaintenance - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePerformMaintenance(token string) (HTTPPoller, error)
 	// BeginPowerOff - Power off (stop) a virtual machine in a VM scale set. Note that resources are still attached and you are getting charged for the resources. Instead, use deallocate to release resources and avoid charges.
-	BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsPowerOffOptions *VirtualMachineScaleSetVMSPowerOffOptions) (*HTTPPollerResponse, error)
+	BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPowerOffOptions) (*HTTPPollerResponse, error)
 	// ResumePowerOff - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePowerOff(token string) (HTTPPoller, error)
 	// BeginRedeploy - Shuts down the virtual machine in the virtual machine scale set, moves it to a new node, and powers it back on.
-	BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRedeployOptions) (*HTTPPollerResponse, error)
 	// ResumeRedeploy - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRedeploy(token string) (HTTPPoller, error)
 	// BeginReimage - Reimages (upgrade the operating system) a specific virtual machine in a VM scale set.
-	BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsReimageOptions *VirtualMachineScaleSetVMSReimageOptions) (*HTTPPollerResponse, error)
+	BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageOptions) (*HTTPPollerResponse, error)
 	// ResumeReimage - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReimage(token string) (HTTPPoller, error)
 	// BeginReimageAll - Allows you to re-image all the disks ( including data disks ) in the a VM scale set instance. This operation is only supported for managed disks.
-	BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageAllOptions) (*HTTPPollerResponse, error)
 	// ResumeReimageAll - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReimageAll(token string) (HTTPPoller, error)
 	// BeginRestart - Restarts a virtual machine in a VM scale set.
-	BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRestartOptions) (*HTTPPollerResponse, error)
 	// ResumeRestart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRestart(token string) (HTTPPoller, error)
 	// BeginRunCommand - Run command on a virtual machine in a VM scale set.
-	BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error)
+	BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput, options *VirtualMachineScaleSetVMSRunCommandOptions) (*RunCommandResultPollerResponse, error)
 	// ResumeRunCommand - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeRunCommand(token string) (RunCommandResultPoller, error)
 	// SimulateEviction - The operation to simulate the eviction of spot virtual machine in a VM scale set. The eviction will occur within 30 minutes of calling the API
-	SimulateEviction(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*http.Response, error)
+	SimulateEviction(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSSimulateEvictionOptions) (*http.Response, error)
 	// BeginStart - Starts a virtual machine in a VM scale set.
-	BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error)
+	BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSStartOptions) (*HTTPPollerResponse, error)
 	// ResumeStart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStart(token string) (HTTPPoller, error)
 	// BeginUpdate - Updates a virtual machine of a VM scale set.
-	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM) (*VirtualMachineScaleSetVMPollerResponse, error)
+	BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMSUpdateOptions) (*VirtualMachineScaleSetVMPollerResponse, error)
 	// ResumeUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdate(token string) (VirtualMachineScaleSetVMPoller, error)
 }
@@ -92,8 +92,8 @@ func (client *VirtualMachineScaleSetVMSClient) Do(req *azcore.Request) (*azcore.
 	return client.p.Do(req)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.Deallocate(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginDeallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeallocateOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Deallocate(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +127,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeDeallocate(token string) (H
 }
 
 // Deallocate - Deallocates a specific virtual machine in a VM scale set. Shuts down the virtual machine and releases the compute resources it uses. You are not billed for the compute resources of this virtual machine once it is deallocated.
-func (client *VirtualMachineScaleSetVMSClient) Deallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) Deallocate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeallocateOptions) (*azcore.Response, error) {
+	req, err := client.DeallocateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (client *VirtualMachineScaleSetVMSClient) Deallocate(ctx context.Context, r
 }
 
 // DeallocateCreateRequest creates the Deallocate request.
-func (client *VirtualMachineScaleSetVMSClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) DeallocateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeallocateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/deallocate"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -171,8 +171,8 @@ func (client *VirtualMachineScaleSetVMSClient) DeallocateHandleError(resp *azcor
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginDelete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -206,8 +206,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeDelete(token string) (HTTPP
 }
 
 // Delete - Deletes a virtual machine from a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) Delete(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (client *VirtualMachineScaleSetVMSClient) Delete(ctx context.Context, resou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualMachineScaleSetVMSClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -251,8 +251,8 @@ func (client *VirtualMachineScaleSetVMSClient) DeleteHandleError(resp *azcore.Re
 }
 
 // Get - Gets a virtual machine from a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsGetOptions *VirtualMachineScaleSetVMSGetOptions) (*VirtualMachineScaleSetVMResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVmsGetOptions)
+func (client *VirtualMachineScaleSetVMSClient) Get(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetOptions) (*VirtualMachineScaleSetVMResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +271,7 @@ func (client *VirtualMachineScaleSetVMSClient) Get(ctx context.Context, resource
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualMachineScaleSetVMSClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsGetOptions *VirtualMachineScaleSetVMSGetOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -282,7 +282,7 @@ func (client *VirtualMachineScaleSetVMSClient) GetCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetVmsGetOptions != nil && virtualMachineScaleSetVmsGetOptions.Expand != nil {
+	if options != nil && options.Expand != nil {
 		query.Set("$expand", "instanceView")
 	}
 	query.Set("api-version", "2019-12-01")
@@ -310,8 +310,8 @@ func (client *VirtualMachineScaleSetVMSClient) GetHandleError(resp *azcore.Respo
 }
 
 // GetInstanceView - Gets the status of a virtual machine from a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*VirtualMachineScaleSetVMInstanceViewResponse, error) {
-	req, err := client.GetInstanceViewCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetInstanceViewOptions) (*VirtualMachineScaleSetVMInstanceViewResponse, error) {
+	req, err := client.GetInstanceViewCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func (client *VirtualMachineScaleSetVMSClient) GetInstanceView(ctx context.Conte
 }
 
 // GetInstanceViewCreateRequest creates the GetInstanceView request.
-func (client *VirtualMachineScaleSetVMSClient) GetInstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) GetInstanceViewCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSGetInstanceViewOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/instanceView"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -366,11 +366,11 @@ func (client *VirtualMachineScaleSetVMSClient) GetInstanceViewHandleError(resp *
 }
 
 // List - Gets a list of all virtual machines in a VM scale sets.
-func (client *VirtualMachineScaleSetVMSClient) List(resourceGroupName string, virtualMachineScaleSetName string, virtualMachineScaleSetVmsListOptions *VirtualMachineScaleSetVMSListOptions) VirtualMachineScaleSetVMListResultPager {
+func (client *VirtualMachineScaleSetVMSClient) List(resourceGroupName string, virtualMachineScaleSetName string, options *VirtualMachineScaleSetVMSListOptions) VirtualMachineScaleSetVMListResultPager {
 	return &virtualMachineScaleSetVMListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualMachineScaleSetVmsListOptions)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -381,7 +381,7 @@ func (client *VirtualMachineScaleSetVMSClient) List(resourceGroupName string, vi
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineScaleSetVMSClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualMachineScaleSetVmsListOptions *VirtualMachineScaleSetVMSListOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, options *VirtualMachineScaleSetVMSListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -391,14 +391,14 @@ func (client *VirtualMachineScaleSetVMSClient) ListCreateRequest(ctx context.Con
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetVmsListOptions != nil && virtualMachineScaleSetVmsListOptions.Filter != nil {
-		query.Set("$filter", *virtualMachineScaleSetVmsListOptions.Filter)
+	if options != nil && options.Filter != nil {
+		query.Set("$filter", *options.Filter)
 	}
-	if virtualMachineScaleSetVmsListOptions != nil && virtualMachineScaleSetVmsListOptions.SelectParameter != nil {
-		query.Set("$select", *virtualMachineScaleSetVmsListOptions.SelectParameter)
+	if options != nil && options.SelectParameter != nil {
+		query.Set("$select", *options.SelectParameter)
 	}
-	if virtualMachineScaleSetVmsListOptions != nil && virtualMachineScaleSetVmsListOptions.Expand != nil {
-		query.Set("$expand", *virtualMachineScaleSetVmsListOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -424,8 +424,8 @@ func (client *VirtualMachineScaleSetVMSClient) ListHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginPerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPerformMaintenanceOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PerformMaintenance(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -459,8 +459,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumePerformMaintenance(token st
 }
 
 // PerformMaintenance - Performs maintenance on a virtual machine in a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) PerformMaintenance(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPerformMaintenanceOptions) (*azcore.Response, error) {
+	req, err := client.PerformMaintenanceCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +475,7 @@ func (client *VirtualMachineScaleSetVMSClient) PerformMaintenance(ctx context.Co
 }
 
 // PerformMaintenanceCreateRequest creates the PerformMaintenance request.
-func (client *VirtualMachineScaleSetVMSClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) PerformMaintenanceCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPerformMaintenanceOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/performMaintenance"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -503,8 +503,8 @@ func (client *VirtualMachineScaleSetVMSClient) PerformMaintenanceHandleError(res
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsPowerOffOptions *VirtualMachineScaleSetVMSPowerOffOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.PowerOff(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVmsPowerOffOptions)
+func (client *VirtualMachineScaleSetVMSClient) BeginPowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPowerOffOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PowerOff(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -538,8 +538,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumePowerOff(token string) (HTT
 }
 
 // PowerOff - Power off (stop) a virtual machine in a VM scale set. Note that resources are still attached and you are getting charged for the resources. Instead, use deallocate to release resources and avoid charges.
-func (client *VirtualMachineScaleSetVMSClient) PowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsPowerOffOptions *VirtualMachineScaleSetVMSPowerOffOptions) (*azcore.Response, error) {
-	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVmsPowerOffOptions)
+func (client *VirtualMachineScaleSetVMSClient) PowerOff(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPowerOffOptions) (*azcore.Response, error) {
+	req, err := client.PowerOffCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -554,7 +554,7 @@ func (client *VirtualMachineScaleSetVMSClient) PowerOff(ctx context.Context, res
 }
 
 // PowerOffCreateRequest creates the PowerOff request.
-func (client *VirtualMachineScaleSetVMSClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsPowerOffOptions *VirtualMachineScaleSetVMSPowerOffOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) PowerOffCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSPowerOffOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/poweroff"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -565,8 +565,8 @@ func (client *VirtualMachineScaleSetVMSClient) PowerOffCreateRequest(ctx context
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualMachineScaleSetVmsPowerOffOptions != nil && virtualMachineScaleSetVmsPowerOffOptions.SkipShutdown != nil {
-		query.Set("skipShutdown", strconv.FormatBool(*virtualMachineScaleSetVmsPowerOffOptions.SkipShutdown))
+	if options != nil && options.SkipShutdown != nil {
+		query.Set("skipShutdown", strconv.FormatBool(*options.SkipShutdown))
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
@@ -585,8 +585,8 @@ func (client *VirtualMachineScaleSetVMSClient) PowerOffHandleError(resp *azcore.
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.Redeploy(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginRedeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRedeployOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Redeploy(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -620,8 +620,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeRedeploy(token string) (HTT
 }
 
 // Redeploy - Shuts down the virtual machine in the virtual machine scale set, moves it to a new node, and powers it back on.
-func (client *VirtualMachineScaleSetVMSClient) Redeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) Redeploy(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRedeployOptions) (*azcore.Response, error) {
+	req, err := client.RedeployCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -636,7 +636,7 @@ func (client *VirtualMachineScaleSetVMSClient) Redeploy(ctx context.Context, res
 }
 
 // RedeployCreateRequest creates the Redeploy request.
-func (client *VirtualMachineScaleSetVMSClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) RedeployCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRedeployOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/redeploy"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -664,8 +664,8 @@ func (client *VirtualMachineScaleSetVMSClient) RedeployHandleError(resp *azcore.
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsReimageOptions *VirtualMachineScaleSetVMSReimageOptions) (*HTTPPollerResponse, error) {
-	resp, err := client.Reimage(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVmsReimageOptions)
+func (client *VirtualMachineScaleSetVMSClient) BeginReimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Reimage(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -699,8 +699,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeReimage(token string) (HTTP
 }
 
 // Reimage - Reimages (upgrade the operating system) a specific virtual machine in a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Reimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsReimageOptions *VirtualMachineScaleSetVMSReimageOptions) (*azcore.Response, error) {
-	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, virtualMachineScaleSetVmsReimageOptions)
+func (client *VirtualMachineScaleSetVMSClient) Reimage(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageOptions) (*azcore.Response, error) {
+	req, err := client.ReimageCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +715,7 @@ func (client *VirtualMachineScaleSetVMSClient) Reimage(ctx context.Context, reso
 }
 
 // ReimageCreateRequest creates the Reimage request.
-func (client *VirtualMachineScaleSetVMSClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, virtualMachineScaleSetVmsReimageOptions *VirtualMachineScaleSetVMSReimageOptions) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) ReimageCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/reimage"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -728,8 +728,8 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if virtualMachineScaleSetVmsReimageOptions != nil {
-		return req, req.MarshalAsJSON(virtualMachineScaleSetVmsReimageOptions.VMScaleSetVMReimageInput)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.VMScaleSetVMReimageInput)
 	}
 	return req, nil
 }
@@ -746,8 +746,8 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageHandleError(resp *azcore.R
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.ReimageAll(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageAllOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.ReimageAll(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -781,8 +781,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeReimageAll(token string) (H
 }
 
 // ReimageAll - Allows you to re-image all the disks ( including data disks ) in the a VM scale set instance. This operation is only supported for managed disks.
-func (client *VirtualMachineScaleSetVMSClient) ReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.ReimageAllCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) ReimageAll(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageAllOptions) (*azcore.Response, error) {
+	req, err := client.ReimageAllCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -797,7 +797,7 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageAll(ctx context.Context, r
 }
 
 // ReimageAllCreateRequest creates the ReimageAll request.
-func (client *VirtualMachineScaleSetVMSClient) ReimageAllCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) ReimageAllCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSReimageAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/reimageall"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -825,8 +825,8 @@ func (client *VirtualMachineScaleSetVMSClient) ReimageAllHandleError(resp *azcor
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.Restart(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginRestart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRestartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Restart(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -860,8 +860,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeRestart(token string) (HTTP
 }
 
 // Restart - Restarts a virtual machine in a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Restart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) Restart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRestartOptions) (*azcore.Response, error) {
+	req, err := client.RestartCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -876,7 +876,7 @@ func (client *VirtualMachineScaleSetVMSClient) Restart(ctx context.Context, reso
 }
 
 // RestartCreateRequest creates the Restart request.
-func (client *VirtualMachineScaleSetVMSClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) RestartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSRestartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/restart"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -904,8 +904,8 @@ func (client *VirtualMachineScaleSetVMSClient) RestartHandleError(resp *azcore.R
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput) (*RunCommandResultPollerResponse, error) {
-	resp, err := client.RunCommand(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters)
+func (client *VirtualMachineScaleSetVMSClient) BeginRunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput, options *VirtualMachineScaleSetVMSRunCommandOptions) (*RunCommandResultPollerResponse, error) {
+	resp, err := client.RunCommand(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -939,8 +939,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeRunCommand(token string) (R
 }
 
 // RunCommand - Run command on a virtual machine in a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) RunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput) (*azcore.Response, error) {
-	req, err := client.RunCommandCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters)
+func (client *VirtualMachineScaleSetVMSClient) RunCommand(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput, options *VirtualMachineScaleSetVMSRunCommandOptions) (*azcore.Response, error) {
+	req, err := client.RunCommandCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -955,7 +955,7 @@ func (client *VirtualMachineScaleSetVMSClient) RunCommand(ctx context.Context, r
 }
 
 // RunCommandCreateRequest creates the RunCommand request.
-func (client *VirtualMachineScaleSetVMSClient) RunCommandCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) RunCommandCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters RunCommandInput, options *VirtualMachineScaleSetVMSRunCommandOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/runCommand"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -991,8 +991,8 @@ func (client *VirtualMachineScaleSetVMSClient) RunCommandHandleError(resp *azcor
 }
 
 // SimulateEviction - The operation to simulate the eviction of spot virtual machine in a VM scale set. The eviction will occur within 30 minutes of calling the API
-func (client *VirtualMachineScaleSetVMSClient) SimulateEviction(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*http.Response, error) {
-	req, err := client.SimulateEvictionCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) SimulateEviction(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSSimulateEvictionOptions) (*http.Response, error) {
+	req, err := client.SimulateEvictionCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1007,7 +1007,7 @@ func (client *VirtualMachineScaleSetVMSClient) SimulateEviction(ctx context.Cont
 }
 
 // SimulateEvictionCreateRequest creates the SimulateEviction request.
-func (client *VirtualMachineScaleSetVMSClient) SimulateEvictionCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) SimulateEvictionCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSSimulateEvictionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualMachines/{instanceId}/simulateEviction"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1035,8 +1035,8 @@ func (client *VirtualMachineScaleSetVMSClient) SimulateEvictionHandleError(resp 
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*HTTPPollerResponse, error) {
-	resp, err := client.Start(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) BeginStart(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSStartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Start(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1070,8 +1070,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeStart(token string) (HTTPPo
 }
 
 // Start - Starts a virtual machine in a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Start(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Response, error) {
-	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId)
+func (client *VirtualMachineScaleSetVMSClient) Start(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSStartOptions) (*azcore.Response, error) {
+	req, err := client.StartCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1086,7 +1086,7 @@ func (client *VirtualMachineScaleSetVMSClient) Start(ctx context.Context, resour
 }
 
 // StartCreateRequest creates the Start request.
-func (client *VirtualMachineScaleSetVMSClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) StartCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, options *VirtualMachineScaleSetVMSStartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))
@@ -1114,8 +1114,8 @@ func (client *VirtualMachineScaleSetVMSClient) StartHandleError(resp *azcore.Res
 	return azcore.NewResponseError(errors.New(string(body)), resp.Response)
 }
 
-func (client *VirtualMachineScaleSetVMSClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM) (*VirtualMachineScaleSetVMPollerResponse, error) {
-	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters)
+func (client *VirtualMachineScaleSetVMSClient) BeginUpdate(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMSUpdateOptions) (*VirtualMachineScaleSetVMPollerResponse, error) {
+	resp, err := client.Update(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1149,8 +1149,8 @@ func (client *VirtualMachineScaleSetVMSClient) ResumeUpdate(token string) (Virtu
 }
 
 // Update - Updates a virtual machine of a VM scale set.
-func (client *VirtualMachineScaleSetVMSClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM) (*azcore.Response, error) {
-	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters)
+func (client *VirtualMachineScaleSetVMSClient) Update(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMSUpdateOptions) (*azcore.Response, error) {
+	req, err := client.UpdateCreateRequest(ctx, resourceGroupName, vmScaleSetName, instanceId, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1165,7 +1165,7 @@ func (client *VirtualMachineScaleSetVMSClient) Update(ctx context.Context, resou
 }
 
 // UpdateCreateRequest creates the Update request.
-func (client *VirtualMachineScaleSetVMSClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM) (*azcore.Request, error) {
+func (client *VirtualMachineScaleSetVMSClient) UpdateCreateRequest(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceId string, parameters VirtualMachineScaleSetVM, options *VirtualMachineScaleSetVMSUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{vmScaleSetName}", url.PathEscape(vmScaleSetName))

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
@@ -19,7 +19,7 @@ import (
 // VirtualMachineSizesOperations contains the methods for the VirtualMachineSizes group.
 type VirtualMachineSizesOperations interface {
 	// List - This API is deprecated. Use [Resources Skus](https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list)
-	List(ctx context.Context, location string) (*VirtualMachineSizeListResultResponse, error)
+	List(ctx context.Context, location string, options *VirtualMachineSizesListOptions) (*VirtualMachineSizeListResultResponse, error)
 }
 
 // VirtualMachineSizesClient implements the VirtualMachineSizesOperations interface.
@@ -40,8 +40,8 @@ func (client *VirtualMachineSizesClient) Do(req *azcore.Request) (*azcore.Respon
 }
 
 // List - This API is deprecated. Use [Resources Skus](https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list)
-func (client *VirtualMachineSizesClient) List(ctx context.Context, location string) (*VirtualMachineSizeListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, location)
+func (client *VirtualMachineSizesClient) List(ctx context.Context, location string, options *VirtualMachineSizesListOptions) (*VirtualMachineSizeListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, location, options)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (client *VirtualMachineSizesClient) List(ctx context.Context, location stri
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualMachineSizesClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *VirtualMachineSizesClient) ListCreateRequest(ctx context.Context, location string, options *VirtualMachineSizesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/vmSizes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -18,51 +18,51 @@ import (
 // ApplicationGatewaysOperations contains the methods for the ApplicationGateways group.
 type ApplicationGatewaysOperations interface {
 	// BeginBackendHealth - Gets the backend health of the specified application gateway in a resource group.
-	BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, applicationGatewaysBackendHealthOptions *ApplicationGatewaysBackendHealthOptions) (*ApplicationGatewayBackendHealthPollerResponse, error)
+	BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysBackendHealthOptions) (*ApplicationGatewayBackendHealthPollerResponse, error)
 	// ResumeBackendHealth - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeBackendHealth(token string) (ApplicationGatewayBackendHealthPoller, error)
 	// BeginBackendHealthOnDemand - Gets the backend health for given combination of backend pool and http setting of the specified application gateway in a resource group.
-	BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error)
+	BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysBackendHealthOnDemandOptions) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error)
 	// ResumeBackendHealthOnDemand - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeBackendHealthOnDemand(token string) (ApplicationGatewayBackendHealthOnDemandPoller, error)
 	// BeginCreateOrUpdate - Creates or updates the specified application gateway.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*ApplicationGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysCreateOrUpdateOptions) (*ApplicationGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ApplicationGatewayPoller, error)
 	// BeginDelete - Deletes the specified application gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified application gateway.
-	Get(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*ApplicationGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysGetOptions) (*ApplicationGatewayResponse, error)
 	// GetSslPredefinedPolicy - Gets Ssl predefined policy with the specified policy name.
-	GetSslPredefinedPolicy(ctx context.Context, predefinedPolicyName string) (*ApplicationGatewaySslPredefinedPolicyResponse, error)
+	GetSslPredefinedPolicy(ctx context.Context, predefinedPolicyName string, options *ApplicationGatewaysGetSslPredefinedPolicyOptions) (*ApplicationGatewaySslPredefinedPolicyResponse, error)
 	// List - Lists all application gateways in a resource group.
-	List(resourceGroupName string) ApplicationGatewayListResultPager
+	List(resourceGroupName string, options *ApplicationGatewaysListOptions) ApplicationGatewayListResultPager
 	// ListAll - Gets all the application gateways in a subscription.
-	ListAll() ApplicationGatewayListResultPager
+	ListAll(options *ApplicationGatewaysListAllOptions) ApplicationGatewayListResultPager
 	// ListAvailableRequestHeaders - Lists all available request headers.
-	ListAvailableRequestHeaders(ctx context.Context) (*StringArrayResponse, error)
+	ListAvailableRequestHeaders(ctx context.Context, options *ApplicationGatewaysListAvailableRequestHeadersOptions) (*StringArrayResponse, error)
 	// ListAvailableResponseHeaders - Lists all available response headers.
-	ListAvailableResponseHeaders(ctx context.Context) (*StringArrayResponse, error)
+	ListAvailableResponseHeaders(ctx context.Context, options *ApplicationGatewaysListAvailableResponseHeadersOptions) (*StringArrayResponse, error)
 	// ListAvailableServerVariables - Lists all available server variables.
-	ListAvailableServerVariables(ctx context.Context) (*StringArrayResponse, error)
+	ListAvailableServerVariables(ctx context.Context, options *ApplicationGatewaysListAvailableServerVariablesOptions) (*StringArrayResponse, error)
 	// ListAvailableSslOptions - Lists available Ssl options for configuring Ssl policy.
-	ListAvailableSslOptions(ctx context.Context) (*ApplicationGatewayAvailableSslOptionsResponse, error)
+	ListAvailableSslOptions(ctx context.Context, options *ApplicationGatewaysListAvailableSslOptionsOptions) (*ApplicationGatewayAvailableSslOptionsResponse, error)
 	// ListAvailableSslPredefinedPolicies - Lists all SSL predefined policies for configuring Ssl policy.
-	ListAvailableSslPredefinedPolicies() ApplicationGatewayAvailableSslPredefinedPoliciesPager
+	ListAvailableSslPredefinedPolicies(options *ApplicationGatewaysListAvailableSslPredefinedPoliciesOptions) ApplicationGatewayAvailableSslPredefinedPoliciesPager
 	// ListAvailableWafRuleSets - Lists all available web application firewall rule sets.
-	ListAvailableWafRuleSets(ctx context.Context) (*ApplicationGatewayAvailableWafRuleSetsResultResponse, error)
+	ListAvailableWafRuleSets(ctx context.Context, options *ApplicationGatewaysListAvailableWafRuleSetsOptions) (*ApplicationGatewayAvailableWafRuleSetsResultResponse, error)
 	// BeginStart - Starts the specified application gateway.
-	BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error)
+	BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStartOptions) (*HTTPPollerResponse, error)
 	// ResumeStart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStart(token string) (HTTPPoller, error)
 	// BeginStop - Stops the specified application gateway in a resource group.
-	BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error)
+	BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStopOptions) (*HTTPPollerResponse, error)
 	// ResumeStop - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStop(token string) (HTTPPoller, error)
 	// UpdateTags - Updates the specified application gateway tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject) (*ApplicationGatewayResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject, options *ApplicationGatewaysUpdateTagsOptions) (*ApplicationGatewayResponse, error)
 }
 
 // ApplicationGatewaysClient implements the ApplicationGatewaysOperations interface.
@@ -82,8 +82,8 @@ func (client *ApplicationGatewaysClient) Do(req *azcore.Request) (*azcore.Respon
 	return client.p.Do(req)
 }
 
-func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, applicationGatewaysBackendHealthOptions *ApplicationGatewaysBackendHealthOptions) (*ApplicationGatewayBackendHealthPollerResponse, error) {
-	resp, err := client.BackendHealth(ctx, resourceGroupName, applicationGatewayName, applicationGatewaysBackendHealthOptions)
+func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysBackendHealthOptions) (*ApplicationGatewayBackendHealthPollerResponse, error) {
+	resp, err := client.BackendHealth(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -117,8 +117,8 @@ func (client *ApplicationGatewaysClient) ResumeBackendHealth(token string) (Appl
 }
 
 // BackendHealth - Gets the backend health of the specified application gateway in a resource group.
-func (client *ApplicationGatewaysClient) BackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, applicationGatewaysBackendHealthOptions *ApplicationGatewaysBackendHealthOptions) (*azcore.Response, error) {
-	req, err := client.BackendHealthCreateRequest(ctx, resourceGroupName, applicationGatewayName, applicationGatewaysBackendHealthOptions)
+func (client *ApplicationGatewaysClient) BackendHealth(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysBackendHealthOptions) (*azcore.Response, error) {
+	req, err := client.BackendHealthCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (client *ApplicationGatewaysClient) BackendHealth(ctx context.Context, reso
 }
 
 // BackendHealthCreateRequest creates the BackendHealth request.
-func (client *ApplicationGatewaysClient) BackendHealthCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, applicationGatewaysBackendHealthOptions *ApplicationGatewaysBackendHealthOptions) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) BackendHealthCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysBackendHealthOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendhealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -144,8 +144,8 @@ func (client *ApplicationGatewaysClient) BackendHealthCreateRequest(ctx context.
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if applicationGatewaysBackendHealthOptions != nil && applicationGatewaysBackendHealthOptions.Expand != nil {
-		query.Set("$expand", *applicationGatewaysBackendHealthOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -167,8 +167,8 @@ func (client *ApplicationGatewaysClient) BackendHealthHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error) {
-	resp, err := client.BackendHealthOnDemand(ctx, resourceGroupName, applicationGatewayName, probeRequest, applicationGatewaysBackendHealthOnDemandOptions)
+func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysBackendHealthOnDemandOptions) (*ApplicationGatewayBackendHealthOnDemandPollerResponse, error) {
+	resp, err := client.BackendHealthOnDemand(ctx, resourceGroupName, applicationGatewayName, probeRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +202,8 @@ func (client *ApplicationGatewaysClient) ResumeBackendHealthOnDemand(token strin
 }
 
 // BackendHealthOnDemand - Gets the backend health for given combination of backend pool and http setting of the specified application gateway in a resource group.
-func (client *ApplicationGatewaysClient) BackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*azcore.Response, error) {
-	req, err := client.BackendHealthOnDemandCreateRequest(ctx, resourceGroupName, applicationGatewayName, probeRequest, applicationGatewaysBackendHealthOnDemandOptions)
+func (client *ApplicationGatewaysClient) BackendHealthOnDemand(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysBackendHealthOnDemandOptions) (*azcore.Response, error) {
+	req, err := client.BackendHealthOnDemandCreateRequest(ctx, resourceGroupName, applicationGatewayName, probeRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemand(ctx context.Conte
 }
 
 // BackendHealthOnDemandCreateRequest creates the BackendHealthOnDemand request.
-func (client *ApplicationGatewaysClient) BackendHealthOnDemandCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, applicationGatewaysBackendHealthOnDemandOptions *ApplicationGatewaysBackendHealthOnDemandOptions) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) BackendHealthOnDemandCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, probeRequest ApplicationGatewayOnDemandProbe, options *ApplicationGatewaysBackendHealthOnDemandOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/getBackendHealthOnDemand"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -229,8 +229,8 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandCreateRequest(ctx 
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if applicationGatewaysBackendHealthOnDemandOptions != nil && applicationGatewaysBackendHealthOnDemandOptions.Expand != nil {
-		query.Set("$expand", *applicationGatewaysBackendHealthOnDemandOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -252,8 +252,8 @@ func (client *ApplicationGatewaysClient) BackendHealthOnDemandHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*ApplicationGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, applicationGatewayName, parameters)
+func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysCreateOrUpdateOptions) (*ApplicationGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, applicationGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -287,8 +287,8 @@ func (client *ApplicationGatewaysClient) ResumeCreateOrUpdate(token string) (App
 }
 
 // CreateOrUpdate - Creates or updates the specified application gateway.
-func (client *ApplicationGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, applicationGatewayName, parameters)
+func (client *ApplicationGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, applicationGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +303,7 @@ func (client *ApplicationGatewaysClient) CreateOrUpdate(ctx context.Context, res
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ApplicationGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters ApplicationGateway, options *ApplicationGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -334,8 +334,8 @@ func (client *ApplicationGatewaysClient) CreateOrUpdateHandleError(resp *azcore.
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -369,8 +369,8 @@ func (client *ApplicationGatewaysClient) ResumeDelete(token string) (HTTPPoller,
 }
 
 // Delete - Deletes the specified application gateway.
-func (client *ApplicationGatewaysClient) Delete(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) Delete(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +385,7 @@ func (client *ApplicationGatewaysClient) Delete(ctx context.Context, resourceGro
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ApplicationGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -411,8 +411,8 @@ func (client *ApplicationGatewaysClient) DeleteHandleError(resp *azcore.Response
 }
 
 // Get - Gets the specified application gateway.
-func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*ApplicationGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysGetOptions) (*ApplicationGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupN
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ApplicationGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -463,8 +463,8 @@ func (client *ApplicationGatewaysClient) GetHandleError(resp *azcore.Response) e
 }
 
 // GetSslPredefinedPolicy - Gets Ssl predefined policy with the specified policy name.
-func (client *ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Context, predefinedPolicyName string) (*ApplicationGatewaySslPredefinedPolicyResponse, error) {
-	req, err := client.GetSslPredefinedPolicyCreateRequest(ctx, predefinedPolicyName)
+func (client *ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Context, predefinedPolicyName string, options *ApplicationGatewaysGetSslPredefinedPolicyOptions) (*ApplicationGatewaySslPredefinedPolicyResponse, error) {
+	req, err := client.GetSslPredefinedPolicyCreateRequest(ctx, predefinedPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Cont
 }
 
 // GetSslPredefinedPolicyCreateRequest creates the GetSslPredefinedPolicy request.
-func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyCreateRequest(ctx context.Context, predefinedPolicyName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyCreateRequest(ctx context.Context, predefinedPolicyName string, options *ApplicationGatewaysGetSslPredefinedPolicyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{predefinedPolicyName}", url.PathEscape(predefinedPolicyName))
@@ -514,11 +514,11 @@ func (client *ApplicationGatewaysClient) GetSslPredefinedPolicyHandleError(resp 
 }
 
 // List - Lists all application gateways in a resource group.
-func (client *ApplicationGatewaysClient) List(resourceGroupName string) ApplicationGatewayListResultPager {
+func (client *ApplicationGatewaysClient) List(resourceGroupName string, options *ApplicationGatewaysListOptions) ApplicationGatewayListResultPager {
 	return &applicationGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -529,7 +529,7 @@ func (client *ApplicationGatewaysClient) List(resourceGroupName string) Applicat
 }
 
 // ListCreateRequest creates the List request.
-func (client *ApplicationGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *ApplicationGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -560,11 +560,11 @@ func (client *ApplicationGatewaysClient) ListHandleError(resp *azcore.Response) 
 }
 
 // ListAll - Gets all the application gateways in a subscription.
-func (client *ApplicationGatewaysClient) ListAll() ApplicationGatewayListResultPager {
+func (client *ApplicationGatewaysClient) ListAll(options *ApplicationGatewaysListAllOptions) ApplicationGatewayListResultPager {
 	return &applicationGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -575,7 +575,7 @@ func (client *ApplicationGatewaysClient) ListAll() ApplicationGatewayListResultP
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *ApplicationGatewaysClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAllCreateRequest(ctx context.Context, options *ApplicationGatewaysListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -605,8 +605,8 @@ func (client *ApplicationGatewaysClient) ListAllHandleError(resp *azcore.Respons
 }
 
 // ListAvailableRequestHeaders - Lists all available request headers.
-func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.ListAvailableRequestHeadersCreateRequest(ctx)
+func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context.Context, options *ApplicationGatewaysListAvailableRequestHeadersOptions) (*StringArrayResponse, error) {
+	req, err := client.ListAvailableRequestHeadersCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context
 }
 
 // ListAvailableRequestHeadersCreateRequest creates the ListAvailableRequestHeaders request.
-func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableRequestHeadersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -655,8 +655,8 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeadersHandleError(
 }
 
 // ListAvailableResponseHeaders - Lists all available response headers.
-func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.ListAvailableResponseHeadersCreateRequest(ctx)
+func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx context.Context, options *ApplicationGatewaysListAvailableResponseHeadersOptions) (*StringArrayResponse, error) {
+	req, err := client.ListAvailableResponseHeadersCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -675,7 +675,7 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx contex
 }
 
 // ListAvailableResponseHeadersCreateRequest creates the ListAvailableResponseHeaders request.
-func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableResponseHeadersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -705,8 +705,8 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeadersHandleError
 }
 
 // ListAvailableServerVariables - Lists all available server variables.
-func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx context.Context) (*StringArrayResponse, error) {
-	req, err := client.ListAvailableServerVariablesCreateRequest(ctx)
+func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx context.Context, options *ApplicationGatewaysListAvailableServerVariablesOptions) (*StringArrayResponse, error) {
+	req, err := client.ListAvailableServerVariablesCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +725,7 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx contex
 }
 
 // ListAvailableServerVariablesCreateRequest creates the ListAvailableServerVariables request.
-func (client *ApplicationGatewaysClient) ListAvailableServerVariablesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableServerVariablesCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableServerVariablesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -755,8 +755,8 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariablesHandleError
 }
 
 // ListAvailableSslOptions - Lists available Ssl options for configuring Ssl policy.
-func (client *ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Context) (*ApplicationGatewayAvailableSslOptionsResponse, error) {
-	req, err := client.ListAvailableSslOptionsCreateRequest(ctx)
+func (client *ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Context, options *ApplicationGatewaysListAvailableSslOptionsOptions) (*ApplicationGatewayAvailableSslOptionsResponse, error) {
+	req, err := client.ListAvailableSslOptionsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -775,7 +775,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Con
 }
 
 // ListAvailableSslOptionsCreateRequest creates the ListAvailableSslOptions request.
-func (client *ApplicationGatewaysClient) ListAvailableSslOptionsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableSslOptionsCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableSslOptionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -805,11 +805,11 @@ func (client *ApplicationGatewaysClient) ListAvailableSslOptionsHandleError(resp
 }
 
 // ListAvailableSslPredefinedPolicies - Lists all SSL predefined policies for configuring Ssl policy.
-func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPolicies() ApplicationGatewayAvailableSslPredefinedPoliciesPager {
+func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPolicies(options *ApplicationGatewaysListAvailableSslPredefinedPoliciesOptions) ApplicationGatewayAvailableSslPredefinedPoliciesPager {
 	return &applicationGatewayAvailableSslPredefinedPoliciesPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAvailableSslPredefinedPoliciesCreateRequest(ctx)
+			return client.ListAvailableSslPredefinedPoliciesCreateRequest(ctx, options)
 		},
 		responder: client.ListAvailableSslPredefinedPoliciesHandleResponse,
 		errorer:   client.ListAvailableSslPredefinedPoliciesHandleError,
@@ -820,7 +820,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPolicies() Ap
 }
 
 // ListAvailableSslPredefinedPoliciesCreateRequest creates the ListAvailableSslPredefinedPolicies request.
-func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableSslPredefinedPoliciesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -850,8 +850,8 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPoliciesHandl
 }
 
 // ListAvailableWafRuleSets - Lists all available web application firewall rule sets.
-func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Context) (*ApplicationGatewayAvailableWafRuleSetsResultResponse, error) {
-	req, err := client.ListAvailableWafRuleSetsCreateRequest(ctx)
+func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Context, options *ApplicationGatewaysListAvailableWafRuleSetsOptions) (*ApplicationGatewayAvailableWafRuleSetsResultResponse, error) {
+	req, err := client.ListAvailableWafRuleSetsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -870,7 +870,7 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Co
 }
 
 // ListAvailableWafRuleSetsCreateRequest creates the ListAvailableWafRuleSets request.
-func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsCreateRequest(ctx context.Context, options *ApplicationGatewaysListAvailableWafRuleSetsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -899,8 +899,8 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSetsHandleError(res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Start(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Start(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -934,8 +934,8 @@ func (client *ApplicationGatewaysClient) ResumeStart(token string) (HTTPPoller, 
 }
 
 // Start - Starts the specified application gateway.
-func (client *ApplicationGatewaysClient) Start(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Response, error) {
-	req, err := client.StartCreateRequest(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) Start(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStartOptions) (*azcore.Response, error) {
+	req, err := client.StartCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -950,7 +950,7 @@ func (client *ApplicationGatewaysClient) Start(ctx context.Context, resourceGrou
 }
 
 // StartCreateRequest creates the Start request.
-func (client *ApplicationGatewaysClient) StartCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) StartCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -975,8 +975,8 @@ func (client *ApplicationGatewaysClient) StartHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Stop(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStopOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Stop(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,8 +1010,8 @@ func (client *ApplicationGatewaysClient) ResumeStop(token string) (HTTPPoller, e
 }
 
 // Stop - Stops the specified application gateway in a resource group.
-func (client *ApplicationGatewaysClient) Stop(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Response, error) {
-	req, err := client.StopCreateRequest(ctx, resourceGroupName, applicationGatewayName)
+func (client *ApplicationGatewaysClient) Stop(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStopOptions) (*azcore.Response, error) {
+	req, err := client.StopCreateRequest(ctx, resourceGroupName, applicationGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,7 +1026,7 @@ func (client *ApplicationGatewaysClient) Stop(ctx context.Context, resourceGroup
 }
 
 // StopCreateRequest creates the Stop request.
-func (client *ApplicationGatewaysClient) StopCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) StopCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, options *ApplicationGatewaysStopOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))
@@ -1052,8 +1052,8 @@ func (client *ApplicationGatewaysClient) StopHandleError(resp *azcore.Response) 
 }
 
 // UpdateTags - Updates the specified application gateway tags.
-func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject) (*ApplicationGatewayResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, applicationGatewayName, parameters)
+func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject, options *ApplicationGatewaysUpdateTagsOptions) (*ApplicationGatewayResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, applicationGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,7 +1072,7 @@ func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourc
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ApplicationGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ApplicationGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, applicationGatewayName string, parameters TagsObject, options *ApplicationGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationGatewayName}", url.PathEscape(applicationGatewayName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -18,21 +18,21 @@ import (
 // ApplicationSecurityGroupsOperations contains the methods for the ApplicationSecurityGroups group.
 type ApplicationSecurityGroupsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an application security group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup) (*ApplicationSecurityGroupPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsCreateOrUpdateOptions) (*ApplicationSecurityGroupPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ApplicationSecurityGroupPoller, error)
 	// BeginDelete - Deletes the specified application security group.
-	BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified application security group.
-	Get(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*ApplicationSecurityGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsGetOptions) (*ApplicationSecurityGroupResponse, error)
 	// List - Gets all the application security groups in a resource group.
-	List(resourceGroupName string) ApplicationSecurityGroupListResultPager
+	List(resourceGroupName string, options *ApplicationSecurityGroupsListOptions) ApplicationSecurityGroupListResultPager
 	// ListAll - Gets all application security groups in a subscription.
-	ListAll() ApplicationSecurityGroupListResultPager
+	ListAll(options *ApplicationSecurityGroupsListAllOptions) ApplicationSecurityGroupListResultPager
 	// UpdateTags - Updates an application security group's tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject) (*ApplicationSecurityGroupResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject, options *ApplicationSecurityGroupsUpdateTagsOptions) (*ApplicationSecurityGroupResponse, error)
 }
 
 // ApplicationSecurityGroupsClient implements the ApplicationSecurityGroupsOperations interface.
@@ -52,8 +52,8 @@ func (client *ApplicationSecurityGroupsClient) Do(req *azcore.Request) (*azcore.
 	return client.p.Do(req)
 }
 
-func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup) (*ApplicationSecurityGroupPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, applicationSecurityGroupName, parameters)
+func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsCreateOrUpdateOptions) (*ApplicationSecurityGroupPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, applicationSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *ApplicationSecurityGroupsClient) ResumeCreateOrUpdate(token string
 }
 
 // CreateOrUpdate - Creates or updates an application security group.
-func (client *ApplicationSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, parameters)
+func (client *ApplicationSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdate(ctx context.Contex
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ApplicationSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters ApplicationSecurityGroup, options *ApplicationSecurityGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
@@ -134,8 +134,8 @@ func (client *ApplicationSecurityGroupsClient) CreateOrUpdateHandleError(resp *a
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, applicationSecurityGroupName)
+func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, applicationSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *ApplicationSecurityGroupsClient) ResumeDelete(token string) (HTTPP
 }
 
 // Delete - Deletes the specified application security group.
-func (client *ApplicationSecurityGroupsClient) Delete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName)
+func (client *ApplicationSecurityGroupsClient) Delete(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *ApplicationSecurityGroupsClient) Delete(ctx context.Context, resou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ApplicationSecurityGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
@@ -211,8 +211,8 @@ func (client *ApplicationSecurityGroupsClient) DeleteHandleError(resp *azcore.Re
 }
 
 // Get - Gets information about the specified application security group.
-func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*ApplicationSecurityGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName)
+func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsGetOptions) (*ApplicationSecurityGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resource
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ApplicationSecurityGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, options *ApplicationSecurityGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))
@@ -263,11 +263,11 @@ func (client *ApplicationSecurityGroupsClient) GetHandleError(resp *azcore.Respo
 }
 
 // List - Gets all the application security groups in a resource group.
-func (client *ApplicationSecurityGroupsClient) List(resourceGroupName string) ApplicationSecurityGroupListResultPager {
+func (client *ApplicationSecurityGroupsClient) List(resourceGroupName string, options *ApplicationSecurityGroupsListOptions) ApplicationSecurityGroupListResultPager {
 	return &applicationSecurityGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *ApplicationSecurityGroupsClient) List(resourceGroupName string) Ap
 }
 
 // ListCreateRequest creates the List request.
-func (client *ApplicationSecurityGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *ApplicationSecurityGroupsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -309,11 +309,11 @@ func (client *ApplicationSecurityGroupsClient) ListHandleError(resp *azcore.Resp
 }
 
 // ListAll - Gets all application security groups in a subscription.
-func (client *ApplicationSecurityGroupsClient) ListAll() ApplicationSecurityGroupListResultPager {
+func (client *ApplicationSecurityGroupsClient) ListAll(options *ApplicationSecurityGroupsListAllOptions) ApplicationSecurityGroupListResultPager {
 	return &applicationSecurityGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -324,7 +324,7 @@ func (client *ApplicationSecurityGroupsClient) ListAll() ApplicationSecurityGrou
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *ApplicationSecurityGroupsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) ListAllCreateRequest(ctx context.Context, options *ApplicationSecurityGroupsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -354,8 +354,8 @@ func (client *ApplicationSecurityGroupsClient) ListAllHandleError(resp *azcore.R
 }
 
 // UpdateTags - Updates an application security group's tags.
-func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject) (*ApplicationSecurityGroupResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, parameters)
+func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject, options *ApplicationSecurityGroupsUpdateTagsOptions) (*ApplicationSecurityGroupResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, applicationSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, r
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ApplicationSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ApplicationSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, applicationSecurityGroupName string, parameters TagsObject, options *ApplicationSecurityGroupsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{applicationSecurityGroupName}", url.PathEscape(applicationSecurityGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -16,7 +16,7 @@ import (
 // AvailableDelegationsOperations contains the methods for the AvailableDelegations group.
 type AvailableDelegationsOperations interface {
 	// List - Gets all of the available subnet delegations for this subscription in this region.
-	List(location string) AvailableDelegationsResultPager
+	List(location string, options *AvailableDelegationsListOptions) AvailableDelegationsResultPager
 }
 
 // AvailableDelegationsClient implements the AvailableDelegationsOperations interface.
@@ -37,11 +37,11 @@ func (client *AvailableDelegationsClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // List - Gets all of the available subnet delegations for this subscription in this region.
-func (client *AvailableDelegationsClient) List(location string) AvailableDelegationsResultPager {
+func (client *AvailableDelegationsClient) List(location string, options *AvailableDelegationsListOptions) AvailableDelegationsResultPager {
 	return &availableDelegationsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *AvailableDelegationsClient) List(location string) AvailableDelegat
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailableDelegationsClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *AvailableDelegationsClient) ListCreateRequest(ctx context.Context, location string, options *AvailableDelegationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -16,7 +16,7 @@ import (
 // AvailableEndpointServicesOperations contains the methods for the AvailableEndpointServices group.
 type AvailableEndpointServicesOperations interface {
 	// List - List what values of endpoint services are available for use.
-	List(location string) EndpointServicesListResultPager
+	List(location string, options *AvailableEndpointServicesListOptions) EndpointServicesListResultPager
 }
 
 // AvailableEndpointServicesClient implements the AvailableEndpointServicesOperations interface.
@@ -37,11 +37,11 @@ func (client *AvailableEndpointServicesClient) Do(req *azcore.Request) (*azcore.
 }
 
 // List - List what values of endpoint services are available for use.
-func (client *AvailableEndpointServicesClient) List(location string) EndpointServicesListResultPager {
+func (client *AvailableEndpointServicesClient) List(location string, options *AvailableEndpointServicesListOptions) EndpointServicesListResultPager {
 	return &endpointServicesListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *AvailableEndpointServicesClient) List(location string) EndpointSer
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailableEndpointServicesClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *AvailableEndpointServicesClient) ListCreateRequest(ctx context.Context, location string, options *AvailableEndpointServicesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -16,9 +16,9 @@ import (
 // AvailablePrivateEndpointTypesOperations contains the methods for the AvailablePrivateEndpointTypes group.
 type AvailablePrivateEndpointTypesOperations interface {
 	// List - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.
-	List(location string) AvailablePrivateEndpointTypesResultPager
+	List(location string, options *AvailablePrivateEndpointTypesListOptions) AvailablePrivateEndpointTypesResultPager
 	// ListByResourceGroup - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.
-	ListByResourceGroup(location string, resourceGroupName string) AvailablePrivateEndpointTypesResultPager
+	ListByResourceGroup(location string, resourceGroupName string, options *AvailablePrivateEndpointTypesListByResourceGroupOptions) AvailablePrivateEndpointTypesResultPager
 }
 
 // AvailablePrivateEndpointTypesClient implements the AvailablePrivateEndpointTypesOperations interface.
@@ -39,11 +39,11 @@ func (client *AvailablePrivateEndpointTypesClient) Do(req *azcore.Request) (*azc
 }
 
 // List - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.
-func (client *AvailablePrivateEndpointTypesClient) List(location string) AvailablePrivateEndpointTypesResultPager {
+func (client *AvailablePrivateEndpointTypesClient) List(location string, options *AvailablePrivateEndpointTypesListOptions) AvailablePrivateEndpointTypesResultPager {
 	return &availablePrivateEndpointTypesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -54,7 +54,7 @@ func (client *AvailablePrivateEndpointTypesClient) List(location string) Availab
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailablePrivateEndpointTypesClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *AvailablePrivateEndpointTypesClient) ListCreateRequest(ctx context.Context, location string, options *AvailablePrivateEndpointTypesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -85,11 +85,11 @@ func (client *AvailablePrivateEndpointTypesClient) ListHandleError(resp *azcore.
 }
 
 // ListByResourceGroup - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.
-func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroup(location string, resourceGroupName string) AvailablePrivateEndpointTypesResultPager {
+func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroup(location string, resourceGroupName string, options *AvailablePrivateEndpointTypesListByResourceGroupOptions) AvailablePrivateEndpointTypesResultPager {
 	return &availablePrivateEndpointTypesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, location, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, location, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -100,7 +100,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroup(location 
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string) (*azcore.Request, error) {
+func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string, options *AvailablePrivateEndpointTypesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -16,7 +16,7 @@ import (
 // AvailableResourceGroupDelegationsOperations contains the methods for the AvailableResourceGroupDelegations group.
 type AvailableResourceGroupDelegationsOperations interface {
 	// List - Gets all of the available subnet delegations for this resource group in this region.
-	List(location string, resourceGroupName string) AvailableDelegationsResultPager
+	List(location string, resourceGroupName string, options *AvailableResourceGroupDelegationsListOptions) AvailableDelegationsResultPager
 }
 
 // AvailableResourceGroupDelegationsClient implements the AvailableResourceGroupDelegationsOperations interface.
@@ -37,11 +37,11 @@ func (client *AvailableResourceGroupDelegationsClient) Do(req *azcore.Request) (
 }
 
 // List - Gets all of the available subnet delegations for this resource group in this region.
-func (client *AvailableResourceGroupDelegationsClient) List(location string, resourceGroupName string) AvailableDelegationsResultPager {
+func (client *AvailableResourceGroupDelegationsClient) List(location string, resourceGroupName string, options *AvailableResourceGroupDelegationsListOptions) AvailableDelegationsResultPager {
 	return &availableDelegationsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location, resourceGroupName)
+			return client.ListCreateRequest(ctx, location, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *AvailableResourceGroupDelegationsClient) List(location string, res
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailableResourceGroupDelegationsClient) ListCreateRequest(ctx context.Context, location string, resourceGroupName string) (*azcore.Request, error) {
+func (client *AvailableResourceGroupDelegationsClient) ListCreateRequest(ctx context.Context, location string, resourceGroupName string, options *AvailableResourceGroupDelegationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableDelegations"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -16,9 +16,9 @@ import (
 // AvailableServiceAliasesOperations contains the methods for the AvailableServiceAliases group.
 type AvailableServiceAliasesOperations interface {
 	// List - Gets all available service aliases for this subscription in this region.
-	List(location string) AvailableServiceAliasesResultPager
+	List(location string, options *AvailableServiceAliasesListOptions) AvailableServiceAliasesResultPager
 	// ListByResourceGroup - Gets all available service aliases for this resource group in this region.
-	ListByResourceGroup(resourceGroupName string, location string) AvailableServiceAliasesResultPager
+	ListByResourceGroup(resourceGroupName string, location string, options *AvailableServiceAliasesListByResourceGroupOptions) AvailableServiceAliasesResultPager
 }
 
 // AvailableServiceAliasesClient implements the AvailableServiceAliasesOperations interface.
@@ -39,11 +39,11 @@ func (client *AvailableServiceAliasesClient) Do(req *azcore.Request) (*azcore.Re
 }
 
 // List - Gets all available service aliases for this subscription in this region.
-func (client *AvailableServiceAliasesClient) List(location string) AvailableServiceAliasesResultPager {
+func (client *AvailableServiceAliasesClient) List(location string, options *AvailableServiceAliasesListOptions) AvailableServiceAliasesResultPager {
 	return &availableServiceAliasesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -54,7 +54,7 @@ func (client *AvailableServiceAliasesClient) List(location string) AvailableServ
 }
 
 // ListCreateRequest creates the List request.
-func (client *AvailableServiceAliasesClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *AvailableServiceAliasesClient) ListCreateRequest(ctx context.Context, location string, options *AvailableServiceAliasesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -85,11 +85,11 @@ func (client *AvailableServiceAliasesClient) ListHandleError(resp *azcore.Respon
 }
 
 // ListByResourceGroup - Gets all available service aliases for this resource group in this region.
-func (client *AvailableServiceAliasesClient) ListByResourceGroup(resourceGroupName string, location string) AvailableServiceAliasesResultPager {
+func (client *AvailableServiceAliasesClient) ListByResourceGroup(resourceGroupName string, location string, options *AvailableServiceAliasesListByResourceGroupOptions) AvailableServiceAliasesResultPager {
 	return &availableServiceAliasesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, location)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, location, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -100,7 +100,7 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroup(resourceGroupNa
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *AvailableServiceAliasesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, location string) (*azcore.Request, error) {
+func (client *AvailableServiceAliasesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, location string, options *AvailableServiceAliasesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableServiceAliases"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -16,7 +16,7 @@ import (
 // AzureFirewallFqdnTagsOperations contains the methods for the AzureFirewallFqdnTags group.
 type AzureFirewallFqdnTagsOperations interface {
 	// ListAll - Gets all the Azure Firewall FQDN Tags in a subscription.
-	ListAll() AzureFirewallFqdnTagListResultPager
+	ListAll(options *AzureFirewallFqdnTagsListAllOptions) AzureFirewallFqdnTagListResultPager
 }
 
 // AzureFirewallFqdnTagsClient implements the AzureFirewallFqdnTagsOperations interface.
@@ -37,11 +37,11 @@ func (client *AzureFirewallFqdnTagsClient) Do(req *azcore.Request) (*azcore.Resp
 }
 
 // ListAll - Gets all the Azure Firewall FQDN Tags in a subscription.
-func (client *AzureFirewallFqdnTagsClient) ListAll() AzureFirewallFqdnTagListResultPager {
+func (client *AzureFirewallFqdnTagsClient) ListAll(options *AzureFirewallFqdnTagsListAllOptions) AzureFirewallFqdnTagListResultPager {
 	return &azureFirewallFqdnTagListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -52,7 +52,7 @@ func (client *AzureFirewallFqdnTagsClient) ListAll() AzureFirewallFqdnTagListRes
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *AzureFirewallFqdnTagsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *AzureFirewallFqdnTagsClient) ListAllCreateRequest(ctx context.Context, options *AzureFirewallFqdnTagsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewallFqdnTags"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -18,21 +18,21 @@ import (
 // AzureFirewallsOperations contains the methods for the AzureFirewalls group.
 type AzureFirewallsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Azure Firewall.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall) (*AzureFirewallPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsCreateOrUpdateOptions) (*AzureFirewallPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (AzureFirewallPoller, error)
 	// BeginDelete - Deletes the specified Azure Firewall.
-	BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Azure Firewall.
-	Get(ctx context.Context, resourceGroupName string, azureFirewallName string) (*AzureFirewallResponse, error)
+	Get(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsGetOptions) (*AzureFirewallResponse, error)
 	// List - Lists all Azure Firewalls in a resource group.
-	List(resourceGroupName string) AzureFirewallListResultPager
+	List(resourceGroupName string, options *AzureFirewallsListOptions) AzureFirewallListResultPager
 	// ListAll - Gets all the Azure Firewalls in a subscription.
-	ListAll() AzureFirewallListResultPager
+	ListAll(options *AzureFirewallsListAllOptions) AzureFirewallListResultPager
 	// BeginUpdateTags - Updates tags of an Azure Firewall resource.
-	BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject) (*AzureFirewallPollerResponse, error)
+	BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsUpdateTagsOptions) (*AzureFirewallPollerResponse, error)
 	// ResumeUpdateTags - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdateTags(token string) (AzureFirewallPoller, error)
 }
@@ -54,8 +54,8 @@ func (client *AzureFirewallsClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall) (*AzureFirewallPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, azureFirewallName, parameters)
+func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsCreateOrUpdateOptions) (*AzureFirewallPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func (client *AzureFirewallsClient) ResumeCreateOrUpdate(token string) (AzureFir
 }
 
 // CreateOrUpdate - Creates or updates the specified Azure Firewall.
-func (client *AzureFirewallsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, azureFirewallName, parameters)
+func (client *AzureFirewallsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (client *AzureFirewallsClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *AzureFirewallsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters AzureFirewall, options *AzureFirewallsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
@@ -136,8 +136,8 @@ func (client *AzureFirewallsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, azureFirewallName)
+func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, azureFirewallName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,8 @@ func (client *AzureFirewallsClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Deletes the specified Azure Firewall.
-func (client *AzureFirewallsClient) Delete(ctx context.Context, resourceGroupName string, azureFirewallName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, azureFirewallName)
+func (client *AzureFirewallsClient) Delete(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, azureFirewallName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func (client *AzureFirewallsClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *AzureFirewallsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
@@ -213,8 +213,8 @@ func (client *AzureFirewallsClient) DeleteHandleError(resp *azcore.Response) err
 }
 
 // Get - Gets the specified Azure Firewall.
-func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName string, azureFirewallName string) (*AzureFirewallResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, azureFirewallName)
+func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsGetOptions) (*AzureFirewallResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, azureFirewallName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *AzureFirewallsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, options *AzureFirewallsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))
@@ -265,11 +265,11 @@ func (client *AzureFirewallsClient) GetHandleError(resp *azcore.Response) error 
 }
 
 // List - Lists all Azure Firewalls in a resource group.
-func (client *AzureFirewallsClient) List(resourceGroupName string) AzureFirewallListResultPager {
+func (client *AzureFirewallsClient) List(resourceGroupName string, options *AzureFirewallsListOptions) AzureFirewallListResultPager {
 	return &azureFirewallListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -280,7 +280,7 @@ func (client *AzureFirewallsClient) List(resourceGroupName string) AzureFirewall
 }
 
 // ListCreateRequest creates the List request.
-func (client *AzureFirewallsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *AzureFirewallsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -311,11 +311,11 @@ func (client *AzureFirewallsClient) ListHandleError(resp *azcore.Response) error
 }
 
 // ListAll - Gets all the Azure Firewalls in a subscription.
-func (client *AzureFirewallsClient) ListAll() AzureFirewallListResultPager {
+func (client *AzureFirewallsClient) ListAll(options *AzureFirewallsListAllOptions) AzureFirewallListResultPager {
 	return &azureFirewallListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -326,7 +326,7 @@ func (client *AzureFirewallsClient) ListAll() AzureFirewallListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *AzureFirewallsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) ListAllCreateRequest(ctx context.Context, options *AzureFirewallsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -355,8 +355,8 @@ func (client *AzureFirewallsClient) ListAllHandleError(resp *azcore.Response) er
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject) (*AzureFirewallPollerResponse, error) {
-	resp, err := client.UpdateTags(ctx, resourceGroupName, azureFirewallName, parameters)
+func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsUpdateTagsOptions) (*AzureFirewallPollerResponse, error) {
+	resp, err := client.UpdateTags(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -390,8 +390,8 @@ func (client *AzureFirewallsClient) ResumeUpdateTags(token string) (AzureFirewal
 }
 
 // UpdateTags - Updates tags of an Azure Firewall resource.
-func (client *AzureFirewallsClient) UpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject) (*azcore.Response, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, azureFirewallName, parameters)
+func (client *AzureFirewallsClient) UpdateTags(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsUpdateTagsOptions) (*azcore.Response, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, azureFirewallName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +406,7 @@ func (client *AzureFirewallsClient) UpdateTags(ctx context.Context, resourceGrou
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *AzureFirewallsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *AzureFirewallsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, azureFirewallName string, parameters TagsObject, options *AzureFirewallsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{azureFirewallName}", url.PathEscape(azureFirewallName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -18,19 +18,19 @@ import (
 // BastionHostsOperations contains the methods for the BastionHosts group.
 type BastionHostsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Bastion Host.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost) (*BastionHostPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsCreateOrUpdateOptions) (*BastionHostPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (BastionHostPoller, error)
 	// BeginDelete - Deletes the specified Bastion Host.
-	BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Bastion Host.
-	Get(ctx context.Context, resourceGroupName string, bastionHostName string) (*BastionHostResponse, error)
+	Get(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsGetOptions) (*BastionHostResponse, error)
 	// List - Lists all Bastion Hosts in a subscription.
-	List() BastionHostListResultPager
+	List(options *BastionHostsListOptions) BastionHostListResultPager
 	// ListByResourceGroup - Lists all Bastion Hosts in a resource group.
-	ListByResourceGroup(resourceGroupName string) BastionHostListResultPager
+	ListByResourceGroup(resourceGroupName string, options *BastionHostsListByResourceGroupOptions) BastionHostListResultPager
 }
 
 // BastionHostsClient implements the BastionHostsOperations interface.
@@ -50,8 +50,8 @@ func (client *BastionHostsClient) Do(req *azcore.Request) (*azcore.Response, err
 	return client.p.Do(req)
 }
 
-func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost) (*BastionHostPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, bastionHostName, parameters)
+func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsCreateOrUpdateOptions) (*BastionHostPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, bastionHostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *BastionHostsClient) ResumeCreateOrUpdate(token string) (BastionHos
 }
 
 // CreateOrUpdate - Creates or updates the specified Bastion Host.
-func (client *BastionHostsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, bastionHostName, parameters)
+func (client *BastionHostsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, bastionHostName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *BastionHostsClient) CreateOrUpdate(ctx context.Context, resourceGr
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *BastionHostsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost) (*azcore.Request, error) {
+func (client *BastionHostsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, parameters BastionHost, options *BastionHostsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -132,8 +132,8 @@ func (client *BastionHostsClient) CreateOrUpdateHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, bastionHostName)
+func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *BastionHostsClient) ResumeDelete(token string) (HTTPPoller, error)
 }
 
 // Delete - Deletes the specified Bastion Host.
-func (client *BastionHostsClient) Delete(ctx context.Context, resourceGroupName string, bastionHostName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, bastionHostName)
+func (client *BastionHostsClient) Delete(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *BastionHostsClient) Delete(ctx context.Context, resourceGroupName 
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *BastionHostsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+func (client *BastionHostsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -209,8 +209,8 @@ func (client *BastionHostsClient) DeleteHandleError(resp *azcore.Response) error
 }
 
 // Get - Gets the specified Bastion Host.
-func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName string, bastionHostName string) (*BastionHostResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, bastionHostName)
+func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsGetOptions) (*BastionHostResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName str
 }
 
 // GetCreateRequest creates the Get request.
-func (client *BastionHostsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+func (client *BastionHostsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, options *BastionHostsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -261,11 +261,11 @@ func (client *BastionHostsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all Bastion Hosts in a subscription.
-func (client *BastionHostsClient) List() BastionHostListResultPager {
+func (client *BastionHostsClient) List(options *BastionHostsListOptions) BastionHostListResultPager {
 	return &bastionHostListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -276,7 +276,7 @@ func (client *BastionHostsClient) List() BastionHostListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *BastionHostsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BastionHostsClient) ListCreateRequest(ctx context.Context, options *BastionHostsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -306,11 +306,11 @@ func (client *BastionHostsClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all Bastion Hosts in a resource group.
-func (client *BastionHostsClient) ListByResourceGroup(resourceGroupName string) BastionHostListResultPager {
+func (client *BastionHostsClient) ListByResourceGroup(resourceGroupName string, options *BastionHostsListByResourceGroupOptions) BastionHostListResultPager {
 	return &bastionHostListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -321,7 +321,7 @@ func (client *BastionHostsClient) ListByResourceGroup(resourceGroupName string) 
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *BastionHostsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *BastionHostsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *BastionHostsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -16,7 +16,7 @@ import (
 // BgpServiceCommunitiesOperations contains the methods for the BgpServiceCommunities group.
 type BgpServiceCommunitiesOperations interface {
 	// List - Gets all the available bgp service communities.
-	List() BgpServiceCommunityListResultPager
+	List(options *BgpServiceCommunitiesListOptions) BgpServiceCommunityListResultPager
 }
 
 // BgpServiceCommunitiesClient implements the BgpServiceCommunitiesOperations interface.
@@ -37,11 +37,11 @@ func (client *BgpServiceCommunitiesClient) Do(req *azcore.Request) (*azcore.Resp
 }
 
 // List - Gets all the available bgp service communities.
-func (client *BgpServiceCommunitiesClient) List() BgpServiceCommunityListResultPager {
+func (client *BgpServiceCommunitiesClient) List(options *BgpServiceCommunitiesListOptions) BgpServiceCommunityListResultPager {
 	return &bgpServiceCommunityListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *BgpServiceCommunitiesClient) List() BgpServiceCommunityListResultP
 }
 
 // ListCreateRequest creates the List request.
-func (client *BgpServiceCommunitiesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *BgpServiceCommunitiesClient) ListCreateRequest(ctx context.Context, options *BgpServiceCommunitiesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -18,31 +18,31 @@ import (
 // ConnectionMonitorsOperations contains the methods for the ConnectionMonitors group.
 type ConnectionMonitorsOperations interface {
 	// BeginCreateOrUpdate - Create or update a connection monitor.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor) (*ConnectionMonitorResultPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsCreateOrUpdateOptions) (*ConnectionMonitorResultPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ConnectionMonitorResultPoller, error)
 	// BeginDelete - Deletes the specified connection monitor.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets a connection monitor by name.
-	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*ConnectionMonitorResultResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsGetOptions) (*ConnectionMonitorResultResponse, error)
 	// List - Lists all connection monitors for the specified Network Watcher.
-	List(ctx context.Context, resourceGroupName string, networkWatcherName string) (*ConnectionMonitorListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *ConnectionMonitorsListOptions) (*ConnectionMonitorListResultResponse, error)
 	// BeginQuery - Query a snapshot of the most recent connection states.
-	BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*ConnectionMonitorQueryResultPollerResponse, error)
+	BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsQueryOptions) (*ConnectionMonitorQueryResultPollerResponse, error)
 	// ResumeQuery - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeQuery(token string) (ConnectionMonitorQueryResultPoller, error)
 	// BeginStart - Starts the specified connection monitor.
-	BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error)
+	BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStartOptions) (*HTTPPollerResponse, error)
 	// ResumeStart - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStart(token string) (HTTPPoller, error)
 	// BeginStop - Stops the specified connection monitor.
-	BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error)
+	BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStopOptions) (*HTTPPollerResponse, error)
 	// ResumeStop - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStop(token string) (HTTPPoller, error)
 	// UpdateTags - Update tags of the specified connection monitor.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject) (*ConnectionMonitorResultResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject, options *ConnectionMonitorsUpdateTagsOptions) (*ConnectionMonitorResultResponse, error)
 }
 
 // ConnectionMonitorsClient implements the ConnectionMonitorsOperations interface.
@@ -62,8 +62,8 @@ func (client *ConnectionMonitorsClient) Do(req *azcore.Request) (*azcore.Respons
 	return client.p.Do(req)
 }
 
-func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor) (*ConnectionMonitorResultPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters)
+func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsCreateOrUpdateOptions) (*ConnectionMonitorResultPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ func (client *ConnectionMonitorsClient) ResumeCreateOrUpdate(token string) (Conn
 }
 
 // CreateOrUpdate - Create or update a connection monitor.
-func (client *ConnectionMonitorsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters)
+func (client *ConnectionMonitorsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (client *ConnectionMonitorsClient) CreateOrUpdate(ctx context.Context, reso
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ConnectionMonitorsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters ConnectionMonitor, options *ConnectionMonitorsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -145,8 +145,8 @@ func (client *ConnectionMonitorsClient) CreateOrUpdateHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +180,8 @@ func (client *ConnectionMonitorsClient) ResumeDelete(token string) (HTTPPoller, 
 }
 
 // Delete - Deletes the specified connection monitor.
-func (client *ConnectionMonitorsClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (client *ConnectionMonitorsClient) Delete(ctx context.Context, resourceGrou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ConnectionMonitorsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -223,8 +223,8 @@ func (client *ConnectionMonitorsClient) DeleteHandleError(resp *azcore.Response)
 }
 
 // Get - Gets a connection monitor by name.
-func (client *ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*ConnectionMonitorResultResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsGetOptions) (*ConnectionMonitorResultResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (client *ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupNa
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ConnectionMonitorsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -276,8 +276,8 @@ func (client *ConnectionMonitorsClient) GetHandleError(resp *azcore.Response) er
 }
 
 // List - Lists all connection monitors for the specified Network Watcher.
-func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string) (*ConnectionMonitorListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName)
+func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *ConnectionMonitorsListOptions) (*ConnectionMonitorListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (client *ConnectionMonitorsClient) List(ctx context.Context, resourceGroupN
 }
 
 // ListCreateRequest creates the List request.
-func (client *ConnectionMonitorsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *ConnectionMonitorsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -327,8 +327,8 @@ func (client *ConnectionMonitorsClient) ListHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*ConnectionMonitorQueryResultPollerResponse, error) {
-	resp, err := client.Query(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsQueryOptions) (*ConnectionMonitorQueryResultPollerResponse, error) {
+	resp, err := client.Query(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +362,8 @@ func (client *ConnectionMonitorsClient) ResumeQuery(token string) (ConnectionMon
 }
 
 // Query - Query a snapshot of the most recent connection states.
-func (client *ConnectionMonitorsClient) Query(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Response, error) {
-	req, err := client.QueryCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) Query(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsQueryOptions) (*azcore.Response, error) {
+	req, err := client.QueryCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (client *ConnectionMonitorsClient) Query(ctx context.Context, resourceGroup
 }
 
 // QueryCreateRequest creates the Query request.
-func (client *ConnectionMonitorsClient) QueryCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) QueryCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsQueryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/query"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -410,8 +410,8 @@ func (client *ConnectionMonitorsClient) QueryHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Start(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStartOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Start(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -445,8 +445,8 @@ func (client *ConnectionMonitorsClient) ResumeStart(token string) (HTTPPoller, e
 }
 
 // Start - Starts the specified connection monitor.
-func (client *ConnectionMonitorsClient) Start(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Response, error) {
-	req, err := client.StartCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) Start(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStartOptions) (*azcore.Response, error) {
+	req, err := client.StartCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func (client *ConnectionMonitorsClient) Start(ctx context.Context, resourceGroup
 }
 
 // StartCreateRequest creates the Start request.
-func (client *ConnectionMonitorsClient) StartCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) StartCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStartOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -487,8 +487,8 @@ func (client *ConnectionMonitorsClient) StartHandleError(resp *azcore.Response) 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Stop(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStopOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Stop(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -522,8 +522,8 @@ func (client *ConnectionMonitorsClient) ResumeStop(token string) (HTTPPoller, er
 }
 
 // Stop - Stops the specified connection monitor.
-func (client *ConnectionMonitorsClient) Stop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Response, error) {
-	req, err := client.StopCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName)
+func (client *ConnectionMonitorsClient) Stop(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStopOptions) (*azcore.Response, error) {
+	req, err := client.StopCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -538,7 +538,7 @@ func (client *ConnectionMonitorsClient) Stop(ctx context.Context, resourceGroupN
 }
 
 // StopCreateRequest creates the Stop request.
-func (client *ConnectionMonitorsClient) StopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) StopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, options *ConnectionMonitorsStopOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -565,8 +565,8 @@ func (client *ConnectionMonitorsClient) StopHandleError(resp *azcore.Response) e
 }
 
 // UpdateTags - Update tags of the specified connection monitor.
-func (client *ConnectionMonitorsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject) (*ConnectionMonitorResultResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters)
+func (client *ConnectionMonitorsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject, options *ConnectionMonitorsUpdateTagsOptions) (*ConnectionMonitorResultResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkWatcherName, connectionMonitorName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +585,7 @@ func (client *ConnectionMonitorsClient) UpdateTags(ctx context.Context, resource
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ConnectionMonitorsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ConnectionMonitorsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, connectionMonitorName string, parameters TagsObject, options *ConnectionMonitorsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -18,17 +18,17 @@ import (
 // DdosCustomPoliciesOperations contains the methods for the DdosCustomPolicies group.
 type DdosCustomPoliciesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a DDoS custom policy.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy) (*DdosCustomPolicyPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesCreateOrUpdateOptions) (*DdosCustomPolicyPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (DdosCustomPolicyPoller, error)
 	// BeginDelete - Deletes the specified DDoS custom policy.
-	BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified DDoS custom policy.
-	Get(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*DdosCustomPolicyResponse, error)
+	Get(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesGetOptions) (*DdosCustomPolicyResponse, error)
 	// UpdateTags - Update a DDoS custom policy tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject) (*DdosCustomPolicyResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject, options *DdosCustomPoliciesUpdateTagsOptions) (*DdosCustomPolicyResponse, error)
 }
 
 // DdosCustomPoliciesClient implements the DdosCustomPoliciesOperations interface.
@@ -48,8 +48,8 @@ func (client *DdosCustomPoliciesClient) Do(req *azcore.Request) (*azcore.Respons
 	return client.p.Do(req)
 }
 
-func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy) (*DdosCustomPolicyPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ddosCustomPolicyName, parameters)
+func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesCreateOrUpdateOptions) (*DdosCustomPolicyPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ddosCustomPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *DdosCustomPoliciesClient) ResumeCreateOrUpdate(token string) (Ddos
 }
 
 // CreateOrUpdate - Creates or updates a DDoS custom policy.
-func (client *DdosCustomPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, parameters)
+func (client *DdosCustomPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdate(ctx context.Context, reso
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DdosCustomPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy) (*azcore.Request, error) {
+func (client *DdosCustomPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters DdosCustomPolicy, options *DdosCustomPoliciesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
@@ -130,8 +130,8 @@ func (client *DdosCustomPoliciesClient) CreateOrUpdateHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, ddosCustomPolicyName)
+func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, ddosCustomPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -165,8 +165,8 @@ func (client *DdosCustomPoliciesClient) ResumeDelete(token string) (HTTPPoller, 
 }
 
 // Delete - Deletes the specified DDoS custom policy.
-func (client *DdosCustomPoliciesClient) Delete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName)
+func (client *DdosCustomPoliciesClient) Delete(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (client *DdosCustomPoliciesClient) Delete(ctx context.Context, resourceGrou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DdosCustomPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*azcore.Request, error) {
+func (client *DdosCustomPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
@@ -207,8 +207,8 @@ func (client *DdosCustomPoliciesClient) DeleteHandleError(resp *azcore.Response)
 }
 
 // Get - Gets information about the specified DDoS custom policy.
-func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*DdosCustomPolicyResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName)
+func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesGetOptions) (*DdosCustomPolicyResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupNa
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DdosCustomPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string) (*azcore.Request, error) {
+func (client *DdosCustomPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, options *DdosCustomPoliciesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))
@@ -259,8 +259,8 @@ func (client *DdosCustomPoliciesClient) GetHandleError(resp *azcore.Response) er
 }
 
 // UpdateTags - Update a DDoS custom policy tags.
-func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject) (*DdosCustomPolicyResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, parameters)
+func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject, options *DdosCustomPoliciesUpdateTagsOptions) (*DdosCustomPolicyResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ddosCustomPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resource
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *DdosCustomPoliciesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *DdosCustomPoliciesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ddosCustomPolicyName string, parameters TagsObject, options *DdosCustomPoliciesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosCustomPolicyName}", url.PathEscape(ddosCustomPolicyName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -18,21 +18,21 @@ import (
 // DdosProtectionPlansOperations contains the methods for the DdosProtectionPlans group.
 type DdosProtectionPlansOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a DDoS protection plan.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan) (*DdosProtectionPlanPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansCreateOrUpdateOptions) (*DdosProtectionPlanPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (DdosProtectionPlanPoller, error)
 	// BeginDelete - Deletes the specified DDoS protection plan.
-	BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified DDoS protection plan.
-	Get(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*DdosProtectionPlanResponse, error)
+	Get(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansGetOptions) (*DdosProtectionPlanResponse, error)
 	// List - Gets all DDoS protection plans in a subscription.
-	List() DdosProtectionPlanListResultPager
+	List(options *DdosProtectionPlansListOptions) DdosProtectionPlanListResultPager
 	// ListByResourceGroup - Gets all the DDoS protection plans in a resource group.
-	ListByResourceGroup(resourceGroupName string) DdosProtectionPlanListResultPager
+	ListByResourceGroup(resourceGroupName string, options *DdosProtectionPlansListByResourceGroupOptions) DdosProtectionPlanListResultPager
 	// UpdateTags - Update a DDoS protection plan tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject) (*DdosProtectionPlanResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject, options *DdosProtectionPlansUpdateTagsOptions) (*DdosProtectionPlanResponse, error)
 }
 
 // DdosProtectionPlansClient implements the DdosProtectionPlansOperations interface.
@@ -52,8 +52,8 @@ func (client *DdosProtectionPlansClient) Do(req *azcore.Request) (*azcore.Respon
 	return client.p.Do(req)
 }
 
-func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan) (*DdosProtectionPlanPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ddosProtectionPlanName, parameters)
+func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansCreateOrUpdateOptions) (*DdosProtectionPlanPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ddosProtectionPlanName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *DdosProtectionPlansClient) ResumeCreateOrUpdate(token string) (Ddo
 }
 
 // CreateOrUpdate - Creates or updates a DDoS protection plan.
-func (client *DdosProtectionPlansClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, parameters)
+func (client *DdosProtectionPlansClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *DdosProtectionPlansClient) CreateOrUpdate(ctx context.Context, res
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *DdosProtectionPlansClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters DdosProtectionPlan, options *DdosProtectionPlansCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
@@ -134,8 +134,8 @@ func (client *DdosProtectionPlansClient) CreateOrUpdateHandleError(resp *azcore.
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, ddosProtectionPlanName)
+func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, ddosProtectionPlanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *DdosProtectionPlansClient) ResumeDelete(token string) (HTTPPoller,
 }
 
 // Delete - Deletes the specified DDoS protection plan.
-func (client *DdosProtectionPlansClient) Delete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName)
+func (client *DdosProtectionPlansClient) Delete(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *DdosProtectionPlansClient) Delete(ctx context.Context, resourceGro
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *DdosProtectionPlansClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
@@ -211,8 +211,8 @@ func (client *DdosProtectionPlansClient) DeleteHandleError(resp *azcore.Response
 }
 
 // Get - Gets information about the specified DDoS protection plan.
-func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*DdosProtectionPlanResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName)
+func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansGetOptions) (*DdosProtectionPlanResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupN
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DdosProtectionPlansClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, options *DdosProtectionPlansGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))
@@ -263,11 +263,11 @@ func (client *DdosProtectionPlansClient) GetHandleError(resp *azcore.Response) e
 }
 
 // List - Gets all DDoS protection plans in a subscription.
-func (client *DdosProtectionPlansClient) List() DdosProtectionPlanListResultPager {
+func (client *DdosProtectionPlansClient) List(options *DdosProtectionPlansListOptions) DdosProtectionPlanListResultPager {
 	return &ddosProtectionPlanListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *DdosProtectionPlansClient) List() DdosProtectionPlanListResultPage
 }
 
 // ListCreateRequest creates the List request.
-func (client *DdosProtectionPlansClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) ListCreateRequest(ctx context.Context, options *DdosProtectionPlansListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *DdosProtectionPlansClient) ListHandleError(resp *azcore.Response) 
 }
 
 // ListByResourceGroup - Gets all the DDoS protection plans in a resource group.
-func (client *DdosProtectionPlansClient) ListByResourceGroup(resourceGroupName string) DdosProtectionPlanListResultPager {
+func (client *DdosProtectionPlansClient) ListByResourceGroup(resourceGroupName string, options *DdosProtectionPlansListByResourceGroupOptions) DdosProtectionPlanListResultPager {
 	return &ddosProtectionPlanListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *DdosProtectionPlansClient) ListByResourceGroup(resourceGroupName s
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *DdosProtectionPlansClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *DdosProtectionPlansListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -354,8 +354,8 @@ func (client *DdosProtectionPlansClient) ListByResourceGroupHandleError(resp *az
 }
 
 // UpdateTags - Update a DDoS protection plan tags.
-func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject) (*DdosProtectionPlanResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, parameters)
+func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject, options *DdosProtectionPlansUpdateTagsOptions) (*DdosProtectionPlanResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ddosProtectionPlanName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourc
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *DdosProtectionPlansClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *DdosProtectionPlansClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ddosProtectionPlanName string, parameters TagsObject, options *DdosProtectionPlansUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ddosProtectionPlanName}", url.PathEscape(ddosProtectionPlanName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -16,9 +16,9 @@ import (
 // DefaultSecurityRulesOperations contains the methods for the DefaultSecurityRules group.
 type DefaultSecurityRulesOperations interface {
 	// Get - Get the specified default network security rule.
-	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string) (*SecurityRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string, options *DefaultSecurityRulesGetOptions) (*SecurityRuleResponse, error)
 	// List - Gets all default security rules in a network security group.
-	List(resourceGroupName string, networkSecurityGroupName string) SecurityRuleListResultPager
+	List(resourceGroupName string, networkSecurityGroupName string, options *DefaultSecurityRulesListOptions) SecurityRuleListResultPager
 }
 
 // DefaultSecurityRulesClient implements the DefaultSecurityRulesOperations interface.
@@ -39,8 +39,8 @@ func (client *DefaultSecurityRulesClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // Get - Get the specified default network security rule.
-func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string) (*SecurityRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, defaultSecurityRuleName)
+func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string, options *DefaultSecurityRulesGetOptions) (*SecurityRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, defaultSecurityRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *DefaultSecurityRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string) (*azcore.Request, error) {
+func (client *DefaultSecurityRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, defaultSecurityRuleName string, options *DefaultSecurityRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules/{defaultSecurityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -92,11 +92,11 @@ func (client *DefaultSecurityRulesClient) GetHandleError(resp *azcore.Response) 
 }
 
 // List - Gets all default security rules in a network security group.
-func (client *DefaultSecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string) SecurityRuleListResultPager {
+func (client *DefaultSecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string, options *DefaultSecurityRulesListOptions) SecurityRuleListResultPager {
 	return &securityRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *DefaultSecurityRulesClient) List(resourceGroupName string, network
 }
 
 // ListCreateRequest creates the List request.
-func (client *DefaultSecurityRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+func (client *DefaultSecurityRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *DefaultSecurityRulesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -18,17 +18,17 @@ import (
 // ExpressRouteCircuitAuthorizationsOperations contains the methods for the ExpressRouteCircuitAuthorizations group.
 type ExpressRouteCircuitAuthorizationsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an authorization in the specified express route circuit.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*ExpressRouteCircuitAuthorizationPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions) (*ExpressRouteCircuitAuthorizationPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCircuitAuthorizationPoller, error)
 	// BeginDelete - Deletes the specified authorization from the specified express route circuit.
-	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified authorization from the specified express route circuit.
-	Get(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*ExpressRouteCircuitAuthorizationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsGetOptions) (*ExpressRouteCircuitAuthorizationResponse, error)
 	// List - Gets all authorizations in an express route circuit.
-	List(resourceGroupName string, circuitName string) AuthorizationListResultPager
+	List(resourceGroupName string, circuitName string, options *ExpressRouteCircuitAuthorizationsListOptions) AuthorizationListResultPager
 }
 
 // ExpressRouteCircuitAuthorizationsClient implements the ExpressRouteCircuitAuthorizationsOperations interface.
@@ -48,8 +48,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Do(req *azcore.Request) (
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*ExpressRouteCircuitAuthorizationPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, authorizationName, authorizationParameters)
+func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions) (*ExpressRouteCircuitAuthorizationPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, authorizationName, authorizationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ResumeCreateOrUpdate(toke
 }
 
 // CreateOrUpdate - Creates or updates an authorization in the specified express route circuit.
-func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, authorizationName, authorizationParameters)
+func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, authorizationName, authorizationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdate(ctx contex
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, authorizationParameters ExpressRouteCircuitAuthorization, options *ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -131,8 +131,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) CreateOrUpdateHandleError
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, circuitName, authorizationName)
+func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, circuitName, authorizationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) ResumeDelete(token string
 }
 
 // Delete - Deletes the specified authorization from the specified express route circuit.
-func (client *ExpressRouteCircuitAuthorizationsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, authorizationName)
+func (client *ExpressRouteCircuitAuthorizationsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, authorizationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Delete(ctx context.Contex
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteCircuitAuthorizationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -209,8 +209,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) DeleteHandleError(resp *a
 }
 
 // Get - Gets the specified authorization from the specified express route circuit.
-func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*ExpressRouteCircuitAuthorizationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, authorizationName)
+func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsGetOptions) (*ExpressRouteCircuitAuthorizationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, authorizationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCircuitAuthorizationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, authorizationName string, options *ExpressRouteCircuitAuthorizationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -262,11 +262,11 @@ func (client *ExpressRouteCircuitAuthorizationsClient) GetHandleError(resp *azco
 }
 
 // List - Gets all authorizations in an express route circuit.
-func (client *ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName string, circuitName string) AuthorizationListResultPager {
+func (client *ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName string, circuitName string, options *ExpressRouteCircuitAuthorizationsListOptions) AuthorizationListResultPager {
 	return &authorizationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, circuitName)
+			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName st
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCircuitAuthorizationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitAuthorizationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -18,17 +18,17 @@ import (
 // ExpressRouteCircuitConnectionsOperations contains the methods for the ExpressRouteCircuitConnections group.
 type ExpressRouteCircuitConnectionsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a Express Route Circuit Connection in the specified express route circuits.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection) (*ExpressRouteCircuitConnectionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsCreateOrUpdateOptions) (*ExpressRouteCircuitConnectionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCircuitConnectionPoller, error)
 	// BeginDelete - Deletes the specified Express Route Circuit Connection from the specified express route circuit.
-	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Express Route Circuit Connection from the specified express route circuit.
-	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*ExpressRouteCircuitConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsGetOptions) (*ExpressRouteCircuitConnectionResponse, error)
 	// List - Gets all global reach connections associated with a private peering in an express route circuit.
-	List(resourceGroupName string, circuitName string, peeringName string) ExpressRouteCircuitConnectionListResultPager
+	List(resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitConnectionsListOptions) ExpressRouteCircuitConnectionListResultPager
 }
 
 // ExpressRouteCircuitConnectionsClient implements the ExpressRouteCircuitConnectionsOperations interface.
@@ -48,8 +48,8 @@ func (client *ExpressRouteCircuitConnectionsClient) Do(req *azcore.Request) (*az
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection) (*ExpressRouteCircuitConnectionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, peeringName, connectionName, expressRouteCircuitConnectionParameters)
+func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsCreateOrUpdateOptions) (*ExpressRouteCircuitConnectionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, peeringName, connectionName, expressRouteCircuitConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ExpressRouteCircuitConnectionsClient) ResumeCreateOrUpdate(token s
 }
 
 // CreateOrUpdate - Creates or updates a Express Route Circuit Connection in the specified express route circuits.
-func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName, expressRouteCircuitConnectionParameters)
+func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName, expressRouteCircuitConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdate(ctx context.C
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, expressRouteCircuitConnectionParameters ExpressRouteCircuitConnection, options *ExpressRouteCircuitConnectionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -132,8 +132,8 @@ func (client *ExpressRouteCircuitConnectionsClient) CreateOrUpdateHandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, circuitName, peeringName, connectionName)
+func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, circuitName, peeringName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *ExpressRouteCircuitConnectionsClient) ResumeDelete(token string) (
 }
 
 // Delete - Deletes the specified Express Route Circuit Connection from the specified express route circuit.
-func (client *ExpressRouteCircuitConnectionsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName)
+func (client *ExpressRouteCircuitConnectionsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *ExpressRouteCircuitConnectionsClient) Delete(ctx context.Context, 
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteCircuitConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -211,8 +211,8 @@ func (client *ExpressRouteCircuitConnectionsClient) DeleteHandleError(resp *azco
 }
 
 // Get - Gets the specified Express Route Circuit Connection from the specified express route circuit.
-func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*ExpressRouteCircuitConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName)
+func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsGetOptions) (*ExpressRouteCircuitConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, res
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *ExpressRouteCircuitConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -265,11 +265,11 @@ func (client *ExpressRouteCircuitConnectionsClient) GetHandleError(resp *azcore.
 }
 
 // List - Gets all global reach connections associated with a private peering in an express route circuit.
-func (client *ExpressRouteCircuitConnectionsClient) List(resourceGroupName string, circuitName string, peeringName string) ExpressRouteCircuitConnectionListResultPager {
+func (client *ExpressRouteCircuitConnectionsClient) List(resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitConnectionsListOptions) ExpressRouteCircuitConnectionListResultPager {
 	return &expressRouteCircuitConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
+			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -280,7 +280,7 @@ func (client *ExpressRouteCircuitConnectionsClient) List(resourceGroupName strin
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -18,17 +18,17 @@ import (
 // ExpressRouteCircuitPeeringsOperations contains the methods for the ExpressRouteCircuitPeerings group.
 type ExpressRouteCircuitPeeringsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a peering in the specified express route circuits.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*ExpressRouteCircuitPeeringPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsCreateOrUpdateOptions) (*ExpressRouteCircuitPeeringPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCircuitPeeringPoller, error)
 	// BeginDelete - Deletes the specified peering from the specified express route circuit.
-	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified peering for the express route circuit.
-	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*ExpressRouteCircuitPeeringResponse, error)
+	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsGetOptions) (*ExpressRouteCircuitPeeringResponse, error)
 	// List - Gets all peerings in a specified express route circuit.
-	List(resourceGroupName string, circuitName string) ExpressRouteCircuitPeeringListResultPager
+	List(resourceGroupName string, circuitName string, options *ExpressRouteCircuitPeeringsListOptions) ExpressRouteCircuitPeeringListResultPager
 }
 
 // ExpressRouteCircuitPeeringsClient implements the ExpressRouteCircuitPeeringsOperations interface.
@@ -48,8 +48,8 @@ func (client *ExpressRouteCircuitPeeringsClient) Do(req *azcore.Request) (*azcor
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*ExpressRouteCircuitPeeringPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, peeringName, peeringParameters)
+func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsCreateOrUpdateOptions) (*ExpressRouteCircuitPeeringPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, peeringName, peeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ExpressRouteCircuitPeeringsClient) ResumeCreateOrUpdate(token stri
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified express route circuits.
-func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, peeringName, peeringParameters)
+func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, peeringName, peeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdate(ctx context.Cont
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, peeringParameters ExpressRouteCircuitPeering, options *ExpressRouteCircuitPeeringsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -131,8 +131,8 @@ func (client *ExpressRouteCircuitPeeringsClient) CreateOrUpdateHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, circuitName, peeringName)
+func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, circuitName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *ExpressRouteCircuitPeeringsClient) ResumeDelete(token string) (HTT
 }
 
 // Delete - Deletes the specified peering from the specified express route circuit.
-func (client *ExpressRouteCircuitPeeringsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
+func (client *ExpressRouteCircuitPeeringsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *ExpressRouteCircuitPeeringsClient) Delete(ctx context.Context, res
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteCircuitPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -209,8 +209,8 @@ func (client *ExpressRouteCircuitPeeringsClient) DeleteHandleError(resp *azcore.
 }
 
 // Get - Gets the specified peering for the express route circuit.
-func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*ExpressRouteCircuitPeeringResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
+func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsGetOptions) (*ExpressRouteCircuitPeeringResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resour
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCircuitPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitPeeringsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -262,11 +262,11 @@ func (client *ExpressRouteCircuitPeeringsClient) GetHandleError(resp *azcore.Res
 }
 
 // List - Gets all peerings in a specified express route circuit.
-func (client *ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, circuitName string) ExpressRouteCircuitPeeringListResultPager {
+func (client *ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, circuitName string, options *ExpressRouteCircuitPeeringsListOptions) ExpressRouteCircuitPeeringListResultPager {
 	return &expressRouteCircuitPeeringListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, circuitName)
+			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, 
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCircuitPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitPeeringsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -18,37 +18,37 @@ import (
 // ExpressRouteCircuitsOperations contains the methods for the ExpressRouteCircuits group.
 type ExpressRouteCircuitsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an express route circuit.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*ExpressRouteCircuitPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsCreateOrUpdateOptions) (*ExpressRouteCircuitPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCircuitPoller, error)
 	// BeginDelete - Deletes the specified express route circuit.
-	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified express route circuit.
-	Get(ctx context.Context, resourceGroupName string, circuitName string) (*ExpressRouteCircuitResponse, error)
+	Get(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetOptions) (*ExpressRouteCircuitResponse, error)
 	// GetPeeringStats - Gets all stats from an express route circuit in a resource group.
-	GetPeeringStats(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*ExpressRouteCircuitStatsResponse, error)
+	GetPeeringStats(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitsGetPeeringStatsOptions) (*ExpressRouteCircuitStatsResponse, error)
 	// GetStats - Gets all the stats from an express route circuit in a resource group.
-	GetStats(ctx context.Context, resourceGroupName string, circuitName string) (*ExpressRouteCircuitStatsResponse, error)
+	GetStats(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetStatsOptions) (*ExpressRouteCircuitStatsResponse, error)
 	// List - Gets all the express route circuits in a resource group.
-	List(resourceGroupName string) ExpressRouteCircuitListResultPager
+	List(resourceGroupName string, options *ExpressRouteCircuitsListOptions) ExpressRouteCircuitListResultPager
 	// ListAll - Gets all the express route circuits in a subscription.
-	ListAll() ExpressRouteCircuitListResultPager
+	ListAll(options *ExpressRouteCircuitsListAllOptions) ExpressRouteCircuitListResultPager
 	// BeginListArpTable - Gets the currently advertised ARP table associated with the express route circuit in a resource group.
-	BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error)
+	BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListArpTableOptions) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error)
 	// ResumeListArpTable - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListArpTable(token string) (ExpressRouteCircuitsArpTableListResultPoller, error)
 	// BeginListRoutesTable - Gets the currently advertised routes table associated with the express route circuit in a resource group.
-	BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error)
+	BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableOptions) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error)
 	// ResumeListRoutesTable - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListRoutesTable(token string) (ExpressRouteCircuitsRoutesTableListResultPoller, error)
 	// BeginListRoutesTableSummary - Gets the currently advertised routes table summary associated with the express route circuit in a resource group.
-	BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error)
+	BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableSummaryOptions) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error)
 	// ResumeListRoutesTableSummary - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListRoutesTableSummary(token string) (ExpressRouteCircuitsRoutesTableSummaryListResultPoller, error)
 	// UpdateTags - Updates an express route circuit tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject) (*ExpressRouteCircuitResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject, options *ExpressRouteCircuitsUpdateTagsOptions) (*ExpressRouteCircuitResponse, error)
 }
 
 // ExpressRouteCircuitsClient implements the ExpressRouteCircuitsOperations interface.
@@ -68,8 +68,8 @@ func (client *ExpressRouteCircuitsClient) Do(req *azcore.Request) (*azcore.Respo
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*ExpressRouteCircuitPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, parameters)
+func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsCreateOrUpdateOptions) (*ExpressRouteCircuitPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, circuitName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +103,8 @@ func (client *ExpressRouteCircuitsClient) ResumeCreateOrUpdate(token string) (Ex
 }
 
 // CreateOrUpdate - Creates or updates an express route circuit.
-func (client *ExpressRouteCircuitsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, parameters)
+func (client *ExpressRouteCircuitsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, circuitName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdate(ctx context.Context, re
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCircuitsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, parameters ExpressRouteCircuit, options *ExpressRouteCircuitsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -150,8 +150,8 @@ func (client *ExpressRouteCircuitsClient) CreateOrUpdateHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, circuitName)
+func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, circuitName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (client *ExpressRouteCircuitsClient) ResumeDelete(token string) (HTTPPoller
 }
 
 // Delete - Deletes the specified express route circuit.
-func (client *ExpressRouteCircuitsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName)
+func (client *ExpressRouteCircuitsClient) Delete(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, circuitName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (client *ExpressRouteCircuitsClient) Delete(ctx context.Context, resourceGr
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteCircuitsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -227,8 +227,8 @@ func (client *ExpressRouteCircuitsClient) DeleteHandleError(resp *azcore.Respons
 }
 
 // Get - Gets information about the specified express route circuit.
-func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroupName string, circuitName string) (*ExpressRouteCircuitResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName)
+func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetOptions) (*ExpressRouteCircuitResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCircuitsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -279,8 +279,8 @@ func (client *ExpressRouteCircuitsClient) GetHandleError(resp *azcore.Response) 
 }
 
 // GetPeeringStats - Gets all stats from an express route circuit in a resource group.
-func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*ExpressRouteCircuitStatsResponse, error) {
-	req, err := client.GetPeeringStatsCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
+func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitsGetPeeringStatsOptions) (*ExpressRouteCircuitStatsResponse, error) {
+	req, err := client.GetPeeringStatsCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, r
 }
 
 // GetPeeringStatsCreateRequest creates the GetPeeringStats request.
-func (client *ExpressRouteCircuitsClient) GetPeeringStatsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) GetPeeringStatsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *ExpressRouteCircuitsGetPeeringStatsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/stats"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -332,8 +332,8 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStatsHandleError(resp *azcor
 }
 
 // GetStats - Gets all the stats from an express route circuit in a resource group.
-func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resourceGroupName string, circuitName string) (*ExpressRouteCircuitStatsResponse, error) {
-	req, err := client.GetStatsCreateRequest(ctx, resourceGroupName, circuitName)
+func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetStatsOptions) (*ExpressRouteCircuitStatsResponse, error) {
+	req, err := client.GetStatsCreateRequest(ctx, resourceGroupName, circuitName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resource
 }
 
 // GetStatsCreateRequest creates the GetStats request.
-func (client *ExpressRouteCircuitsClient) GetStatsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) GetStatsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, options *ExpressRouteCircuitsGetStatsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stats"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -384,11 +384,11 @@ func (client *ExpressRouteCircuitsClient) GetStatsHandleError(resp *azcore.Respo
 }
 
 // List - Gets all the express route circuits in a resource group.
-func (client *ExpressRouteCircuitsClient) List(resourceGroupName string) ExpressRouteCircuitListResultPager {
+func (client *ExpressRouteCircuitsClient) List(resourceGroupName string, options *ExpressRouteCircuitsListOptions) ExpressRouteCircuitListResultPager {
 	return &expressRouteCircuitListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -399,7 +399,7 @@ func (client *ExpressRouteCircuitsClient) List(resourceGroupName string) Express
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCircuitsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *ExpressRouteCircuitsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -430,11 +430,11 @@ func (client *ExpressRouteCircuitsClient) ListHandleError(resp *azcore.Response)
 }
 
 // ListAll - Gets all the express route circuits in a subscription.
-func (client *ExpressRouteCircuitsClient) ListAll() ExpressRouteCircuitListResultPager {
+func (client *ExpressRouteCircuitsClient) ListAll(options *ExpressRouteCircuitsListAllOptions) ExpressRouteCircuitListResultPager {
 	return &expressRouteCircuitListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -445,7 +445,7 @@ func (client *ExpressRouteCircuitsClient) ListAll() ExpressRouteCircuitListResul
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *ExpressRouteCircuitsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) ListAllCreateRequest(ctx context.Context, options *ExpressRouteCircuitsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -474,8 +474,8 @@ func (client *ExpressRouteCircuitsClient) ListAllHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
-	resp, err := client.ListArpTable(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListArpTableOptions) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
+	resp, err := client.ListArpTable(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -509,8 +509,8 @@ func (client *ExpressRouteCircuitsClient) ResumeListArpTable(token string) (Expr
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route circuit in a resource group.
-func (client *ExpressRouteCircuitsClient) ListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListArpTableCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) ListArpTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListArpTableOptions) (*azcore.Response, error) {
+	req, err := client.ListArpTableCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (client *ExpressRouteCircuitsClient) ListArpTable(ctx context.Context, reso
 }
 
 // ListArpTableCreateRequest creates the ListArpTable request.
-func (client *ExpressRouteCircuitsClient) ListArpTableCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) ListArpTableCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListArpTableOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/arpTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -558,8 +558,8 @@ func (client *ExpressRouteCircuitsClient) ListArpTableHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
-	resp, err := client.ListRoutesTable(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableOptions) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
+	resp, err := client.ListRoutesTable(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -593,8 +593,8 @@ func (client *ExpressRouteCircuitsClient) ResumeListRoutesTable(token string) (E
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route circuit in a resource group.
-func (client *ExpressRouteCircuitsClient) ListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListRoutesTableCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) ListRoutesTable(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableOptions) (*azcore.Response, error) {
+	req, err := client.ListRoutesTableCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTable(ctx context.Context, r
 }
 
 // ListRoutesTableCreateRequest creates the ListRoutesTable request.
-func (client *ExpressRouteCircuitsClient) ListRoutesTableCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) ListRoutesTableCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -642,8 +642,8 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableHandleError(resp *azcor
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error) {
-	resp, err := client.ListRoutesTableSummary(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableSummaryOptions) (*ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error) {
+	resp, err := client.ListRoutesTableSummary(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -677,8 +677,8 @@ func (client *ExpressRouteCircuitsClient) ResumeListRoutesTableSummary(token str
 }
 
 // ListRoutesTableSummary - Gets the currently advertised routes table summary associated with the express route circuit in a resource group.
-func (client *ExpressRouteCircuitsClient) ListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListRoutesTableSummaryCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath)
+func (client *ExpressRouteCircuitsClient) ListRoutesTableSummary(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableSummaryOptions) (*azcore.Response, error) {
+	req, err := client.ListRoutesTableSummaryCreateRequest(ctx, resourceGroupName, circuitName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -693,7 +693,7 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummary(ctx context.Con
 }
 
 // ListRoutesTableSummaryCreateRequest creates the ListRoutesTableSummary request.
-func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, devicePath string, options *ExpressRouteCircuitsListRoutesTableSummaryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTablesSummary/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -727,8 +727,8 @@ func (client *ExpressRouteCircuitsClient) ListRoutesTableSummaryHandleError(resp
 }
 
 // UpdateTags - Updates an express route circuit tags.
-func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject) (*ExpressRouteCircuitResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, circuitName, parameters)
+func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject, options *ExpressRouteCircuitsUpdateTagsOptions) (*ExpressRouteCircuitResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, circuitName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -747,7 +747,7 @@ func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resour
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ExpressRouteCircuitsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ExpressRouteCircuitsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, parameters TagsObject, options *ExpressRouteCircuitsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -18,17 +18,17 @@ import (
 // ExpressRouteConnectionsOperations contains the methods for the ExpressRouteConnections group.
 type ExpressRouteConnectionsOperations interface {
 	// BeginCreateOrUpdate - Creates a connection between an ExpressRoute gateway and an ExpressRoute circuit.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection) (*ExpressRouteConnectionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsCreateOrUpdateOptions) (*ExpressRouteConnectionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteConnectionPoller, error)
 	// BeginDelete - Deletes a connection to a ExpressRoute circuit.
-	BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified ExpressRouteConnection.
-	Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*ExpressRouteConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsGetOptions) (*ExpressRouteConnectionResponse, error)
 	// List - Lists ExpressRouteConnections.
-	List(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*ExpressRouteConnectionListResponse, error)
+	List(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteConnectionsListOptions) (*ExpressRouteConnectionListResponse, error)
 }
 
 // ExpressRouteConnectionsClient implements the ExpressRouteConnectionsOperations interface.
@@ -48,8 +48,8 @@ func (client *ExpressRouteConnectionsClient) Do(req *azcore.Request) (*azcore.Re
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection) (*ExpressRouteConnectionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, connectionName, putExpressRouteConnectionParameters)
+func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsCreateOrUpdateOptions) (*ExpressRouteConnectionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, connectionName, putExpressRouteConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ExpressRouteConnectionsClient) ResumeCreateOrUpdate(token string) 
 }
 
 // CreateOrUpdate - Creates a connection between an ExpressRoute gateway and an ExpressRoute circuit.
-func (client *ExpressRouteConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName, putExpressRouteConnectionParameters)
+func (client *ExpressRouteConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName, putExpressRouteConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdate(ctx context.Context,
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection) (*azcore.Request, error) {
+func (client *ExpressRouteConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, putExpressRouteConnectionParameters ExpressRouteConnection, options *ExpressRouteConnectionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -131,8 +131,8 @@ func (client *ExpressRouteConnectionsClient) CreateOrUpdateHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, expressRouteGatewayName, connectionName)
+func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, expressRouteGatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *ExpressRouteConnectionsClient) ResumeDelete(token string) (HTTPPol
 }
 
 // Delete - Deletes a connection to a ExpressRoute circuit.
-func (client *ExpressRouteConnectionsClient) Delete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName)
+func (client *ExpressRouteConnectionsClient) Delete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *ExpressRouteConnectionsClient) Delete(ctx context.Context, resourc
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -209,8 +209,8 @@ func (client *ExpressRouteConnectionsClient) DeleteHandleError(resp *azcore.Resp
 }
 
 // Get - Gets the specified ExpressRouteConnection.
-func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*ExpressRouteConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName)
+func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsGetOptions) (*ExpressRouteConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGr
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, connectionName string, options *ExpressRouteConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -262,8 +262,8 @@ func (client *ExpressRouteConnectionsClient) GetHandleError(resp *azcore.Respons
 }
 
 // List - Lists ExpressRouteConnections.
-func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*ExpressRouteConnectionListResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, expressRouteGatewayName)
+func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteConnectionsListOptions) (*ExpressRouteConnectionListResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceG
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+func (client *ExpressRouteConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -18,17 +18,17 @@ import (
 // ExpressRouteCrossConnectionPeeringsOperations contains the methods for the ExpressRouteCrossConnectionPeerings group.
 type ExpressRouteCrossConnectionPeeringsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a peering in the specified ExpressRouteCrossConnection.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering) (*ExpressRouteCrossConnectionPeeringPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions) (*ExpressRouteCrossConnectionPeeringPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCrossConnectionPeeringPoller, error)
 	// BeginDelete - Deletes the specified peering from the ExpressRouteCrossConnection.
-	BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified peering for the ExpressRouteCrossConnection.
-	Get(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*ExpressRouteCrossConnectionPeeringResponse, error)
+	Get(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsGetOptions) (*ExpressRouteCrossConnectionPeeringResponse, error)
 	// List - Gets all peerings in a specified ExpressRouteCrossConnection.
-	List(resourceGroupName string, crossConnectionName string) ExpressRouteCrossConnectionPeeringListPager
+	List(resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionPeeringsListOptions) ExpressRouteCrossConnectionPeeringListPager
 }
 
 // ExpressRouteCrossConnectionPeeringsClient implements the ExpressRouteCrossConnectionPeeringsOperations interface.
@@ -48,8 +48,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Do(req *azcore.Request)
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering) (*ExpressRouteCrossConnectionPeeringPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, crossConnectionName, peeringName, peeringParameters)
+func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions) (*ExpressRouteCrossConnectionPeeringPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, crossConnectionName, peeringName, peeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeCreateOrUpdate(to
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, peeringParameters)
+func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, peeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdate(ctx cont
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, peeringParameters ExpressRouteCrossConnectionPeering, options *ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -131,8 +131,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) CreateOrUpdateHandleErr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, crossConnectionName, peeringName)
+func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, crossConnectionName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeDelete(token stri
 }
 
 // Delete - Deletes the specified peering from the ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionPeeringsClient) Delete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName)
+func (client *ExpressRouteCrossConnectionPeeringsClient) Delete(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Delete(ctx context.Cont
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -209,8 +209,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) DeleteHandleError(resp 
 }
 
 // Get - Gets the specified peering for the ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*ExpressRouteCrossConnectionPeeringResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName)
+func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsGetOptions) (*ExpressRouteCrossConnectionPeeringResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCrossConnectionPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, options *ExpressRouteCrossConnectionPeeringsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -262,11 +262,11 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) GetHandleError(resp *az
 }
 
 // List - Gets all peerings in a specified ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionPeeringsClient) List(resourceGroupName string, crossConnectionName string) ExpressRouteCrossConnectionPeeringListPager {
+func (client *ExpressRouteCrossConnectionPeeringsClient) List(resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionPeeringsListOptions) ExpressRouteCrossConnectionPeeringListPager {
 	return &expressRouteCrossConnectionPeeringListPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, crossConnectionName)
+			return client.ListCreateRequest(ctx, resourceGroupName, crossConnectionName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) List(resourceGroupName 
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCrossConnectionPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionPeeringsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -18,29 +18,29 @@ import (
 // ExpressRouteCrossConnectionsOperations contains the methods for the ExpressRouteCrossConnections group.
 type ExpressRouteCrossConnectionsOperations interface {
 	// BeginCreateOrUpdate - Update the specified ExpressRouteCrossConnection.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection) (*ExpressRouteCrossConnectionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsCreateOrUpdateOptions) (*ExpressRouteCrossConnectionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteCrossConnectionPoller, error)
 	// Get - Gets details about the specified ExpressRouteCrossConnection.
-	Get(ctx context.Context, resourceGroupName string, crossConnectionName string) (*ExpressRouteCrossConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionsGetOptions) (*ExpressRouteCrossConnectionResponse, error)
 	// List - Retrieves all the ExpressRouteCrossConnections in a subscription.
-	List() ExpressRouteCrossConnectionListResultPager
+	List(options *ExpressRouteCrossConnectionsListOptions) ExpressRouteCrossConnectionListResultPager
 	// BeginListArpTable - Gets the currently advertised ARP table associated with the express route cross connection in a resource group.
-	BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error)
+	BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListArpTableOptions) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error)
 	// ResumeListArpTable - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListArpTable(token string) (ExpressRouteCircuitsArpTableListResultPoller, error)
 	// ListByResourceGroup - Retrieves all the ExpressRouteCrossConnections in a resource group.
-	ListByResourceGroup(resourceGroupName string) ExpressRouteCrossConnectionListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ExpressRouteCrossConnectionsListByResourceGroupOptions) ExpressRouteCrossConnectionListResultPager
 	// BeginListRoutesTable - Gets the currently advertised routes table associated with the express route cross connection in a resource group.
-	BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error)
+	BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableOptions) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error)
 	// ResumeListRoutesTable - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListRoutesTable(token string) (ExpressRouteCircuitsRoutesTableListResultPoller, error)
 	// BeginListRoutesTableSummary - Gets the route table summary associated with the express route cross connection in a resource group.
-	BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error)
+	BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableSummaryOptions) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error)
 	// ResumeListRoutesTableSummary - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListRoutesTableSummary(token string) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultPoller, error)
 	// UpdateTags - Updates an express route cross connection tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject) (*ExpressRouteCrossConnectionResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject, options *ExpressRouteCrossConnectionsUpdateTagsOptions) (*ExpressRouteCrossConnectionResponse, error)
 }
 
 // ExpressRouteCrossConnectionsClient implements the ExpressRouteCrossConnectionsOperations interface.
@@ -60,8 +60,8 @@ func (client *ExpressRouteCrossConnectionsClient) Do(req *azcore.Request) (*azco
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection) (*ExpressRouteCrossConnectionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, crossConnectionName, parameters)
+func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsCreateOrUpdateOptions) (*ExpressRouteCrossConnectionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, crossConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -95,8 +95,8 @@ func (client *ExpressRouteCrossConnectionsClient) ResumeCreateOrUpdate(token str
 }
 
 // CreateOrUpdate - Update the specified ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, crossConnectionName, parameters)
+func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, crossConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdate(ctx context.Con
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, parameters ExpressRouteCrossConnection, options *ExpressRouteCrossConnectionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -143,8 +143,8 @@ func (client *ExpressRouteCrossConnectionsClient) CreateOrUpdateHandleError(resp
 }
 
 // Get - Gets details about the specified ExpressRouteCrossConnection.
-func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resourceGroupName string, crossConnectionName string) (*ExpressRouteCrossConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, crossConnectionName)
+func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionsGetOptions) (*ExpressRouteCrossConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, crossConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resou
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteCrossConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, options *ExpressRouteCrossConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -195,11 +195,11 @@ func (client *ExpressRouteCrossConnectionsClient) GetHandleError(resp *azcore.Re
 }
 
 // List - Retrieves all the ExpressRouteCrossConnections in a subscription.
-func (client *ExpressRouteCrossConnectionsClient) List() ExpressRouteCrossConnectionListResultPager {
+func (client *ExpressRouteCrossConnectionsClient) List(options *ExpressRouteCrossConnectionsListOptions) ExpressRouteCrossConnectionListResultPager {
 	return &expressRouteCrossConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -210,7 +210,7 @@ func (client *ExpressRouteCrossConnectionsClient) List() ExpressRouteCrossConnec
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteCrossConnectionsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) ListCreateRequest(ctx context.Context, options *ExpressRouteCrossConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -239,8 +239,8 @@ func (client *ExpressRouteCrossConnectionsClient) ListHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
-	resp, err := client.ListArpTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListArpTableOptions) (*ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
+	resp, err := client.ListArpTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +274,8 @@ func (client *ExpressRouteCrossConnectionsClient) ResumeListArpTable(token strin
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route cross connection in a resource group.
-func (client *ExpressRouteCrossConnectionsClient) ListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListArpTableCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) ListArpTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListArpTableOptions) (*azcore.Response, error) {
+	req, err := client.ListArpTableCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +290,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTable(ctx context.Conte
 }
 
 // ListArpTableCreateRequest creates the ListArpTable request.
-func (client *ExpressRouteCrossConnectionsClient) ListArpTableCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) ListArpTableCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListArpTableOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/arpTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -324,11 +324,11 @@ func (client *ExpressRouteCrossConnectionsClient) ListArpTableHandleError(resp *
 }
 
 // ListByResourceGroup - Retrieves all the ExpressRouteCrossConnections in a resource group.
-func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroup(resourceGroupName string) ExpressRouteCrossConnectionListResultPager {
+func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroup(resourceGroupName string, options *ExpressRouteCrossConnectionsListByResourceGroupOptions) ExpressRouteCrossConnectionListResultPager {
 	return &expressRouteCrossConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -339,7 +339,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroup(resourceGr
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ExpressRouteCrossConnectionsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -369,8 +369,8 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroupHandleError
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
-	resp, err := client.ListRoutesTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableOptions) (*ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
+	resp, err := client.ListRoutesTable(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -404,8 +404,8 @@ func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTable(token st
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route cross connection in a resource group.
-func (client *ExpressRouteCrossConnectionsClient) ListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListRoutesTableCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) ListRoutesTable(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableOptions) (*azcore.Response, error) {
+	req, err := client.ListRoutesTableCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTable(ctx context.Co
 }
 
 // ListRoutesTableCreateRequest creates the ListRoutesTable request.
-func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTables/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -453,8 +453,8 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableHandleError(res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error) {
-	resp, err := client.ListRoutesTableSummary(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableSummaryOptions) (*ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error) {
+	resp, err := client.ListRoutesTableSummary(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -488,8 +488,8 @@ func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTableSummary(t
 }
 
 // ListRoutesTableSummary - Gets the route table summary associated with the express route cross connection in a resource group.
-func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Response, error) {
-	req, err := client.ListRoutesTableSummaryCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath)
+func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummary(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableSummaryOptions) (*azcore.Response, error) {
+	req, err := client.ListRoutesTableSummaryCreateRequest(ctx, resourceGroupName, crossConnectionName, peeringName, devicePath, options)
 	if err != nil {
 		return nil, err
 	}
@@ -504,7 +504,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummary(ctx con
 }
 
 // ListRoutesTableSummaryCreateRequest creates the ListRoutesTableSummary request.
-func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, peeringName string, devicePath string, options *ExpressRouteCrossConnectionsListRoutesTableSummaryOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTablesSummary/{devicePath}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))
@@ -538,8 +538,8 @@ func (client *ExpressRouteCrossConnectionsClient) ListRoutesTableSummaryHandleEr
 }
 
 // UpdateTags - Updates an express route cross connection tags.
-func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject) (*ExpressRouteCrossConnectionResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, crossConnectionName, crossConnectionParameters)
+func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject, options *ExpressRouteCrossConnectionsUpdateTagsOptions) (*ExpressRouteCrossConnectionResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, crossConnectionName, crossConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +558,7 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ExpressRouteCrossConnectionsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject) (*azcore.Request, error) {
+func (client *ExpressRouteCrossConnectionsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, crossConnectionName string, crossConnectionParameters TagsObject, options *ExpressRouteCrossConnectionsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{crossConnectionName}", url.PathEscape(crossConnectionName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -18,19 +18,19 @@ import (
 // ExpressRouteGatewaysOperations contains the methods for the ExpressRouteGateways group.
 type ExpressRouteGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a ExpressRoute gateway in a specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway) (*ExpressRouteGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysCreateOrUpdateOptions) (*ExpressRouteGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRouteGatewayPoller, error)
 	// BeginDelete - Deletes the specified ExpressRoute gateway in a resource group. An ExpressRoute gateway resource can only be deleted when there are no connection subresources.
-	BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Fetches the details of a ExpressRoute gateway in a resource group.
-	Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*ExpressRouteGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysGetOptions) (*ExpressRouteGatewayResponse, error)
 	// ListByResourceGroup - Lists ExpressRoute gateways in a given resource group.
-	ListByResourceGroup(ctx context.Context, resourceGroupName string) (*ExpressRouteGatewayListResponse, error)
+	ListByResourceGroup(ctx context.Context, resourceGroupName string, options *ExpressRouteGatewaysListByResourceGroupOptions) (*ExpressRouteGatewayListResponse, error)
 	// ListBySubscription - Lists ExpressRoute gateways under a given subscription.
-	ListBySubscription(ctx context.Context) (*ExpressRouteGatewayListResponse, error)
+	ListBySubscription(ctx context.Context, options *ExpressRouteGatewaysListBySubscriptionOptions) (*ExpressRouteGatewayListResponse, error)
 }
 
 // ExpressRouteGatewaysClient implements the ExpressRouteGatewaysOperations interface.
@@ -50,8 +50,8 @@ func (client *ExpressRouteGatewaysClient) Do(req *azcore.Request) (*azcore.Respo
 	return client.p.Do(req)
 }
 
-func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway) (*ExpressRouteGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, putExpressRouteGatewayParameters)
+func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysCreateOrUpdateOptions) (*ExpressRouteGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRouteGatewayName, putExpressRouteGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *ExpressRouteGatewaysClient) ResumeCreateOrUpdate(token string) (Ex
 }
 
 // CreateOrUpdate - Creates or updates a ExpressRoute gateway in a specified resource group.
-func (client *ExpressRouteGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, putExpressRouteGatewayParameters)
+func (client *ExpressRouteGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, putExpressRouteGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdate(ctx context.Context, re
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRouteGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway) (*azcore.Request, error) {
+func (client *ExpressRouteGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, putExpressRouteGatewayParameters ExpressRouteGateway, options *ExpressRouteGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -132,8 +132,8 @@ func (client *ExpressRouteGatewaysClient) CreateOrUpdateHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, expressRouteGatewayName)
+func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, expressRouteGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *ExpressRouteGatewaysClient) ResumeDelete(token string) (HTTPPoller
 }
 
 // Delete - Deletes the specified ExpressRoute gateway in a resource group. An ExpressRoute gateway resource can only be deleted when there are no connection subresources.
-func (client *ExpressRouteGatewaysClient) Delete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRouteGatewayName)
+func (client *ExpressRouteGatewaysClient) Delete(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *ExpressRouteGatewaysClient) Delete(ctx context.Context, resourceGr
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRouteGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+func (client *ExpressRouteGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -209,8 +209,8 @@ func (client *ExpressRouteGatewaysClient) DeleteHandleError(resp *azcore.Respons
 }
 
 // Get - Fetches the details of a ExpressRoute gateway in a resource group.
-func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*ExpressRouteGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRouteGatewayName)
+func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysGetOptions) (*ExpressRouteGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRouteGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string) (*azcore.Request, error) {
+func (client *ExpressRouteGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRouteGatewayName string, options *ExpressRouteGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{expressRouteGatewayName}", url.PathEscape(expressRouteGatewayName))
@@ -261,8 +261,8 @@ func (client *ExpressRouteGatewaysClient) GetHandleError(resp *azcore.Response) 
 }
 
 // ListByResourceGroup - Lists ExpressRoute gateways in a given resource group.
-func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Context, resourceGroupName string) (*ExpressRouteGatewayListResponse, error) {
-	req, err := client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Context, resourceGroupName string, options *ExpressRouteGatewaysListByResourceGroupOptions) (*ExpressRouteGatewayListResponse, error) {
+	req, err := client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Contex
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ExpressRouteGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ExpressRouteGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ExpressRouteGatewaysListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,8 +312,8 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroupHandleError(resp *a
 }
 
 // ListBySubscription - Lists ExpressRoute gateways under a given subscription.
-func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context) (*ExpressRouteGatewayListResponse, error) {
-	req, err := client.ListBySubscriptionCreateRequest(ctx)
+func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context, options *ExpressRouteGatewaysListBySubscriptionOptions) (*ExpressRouteGatewayListResponse, error) {
+	req, err := client.ListBySubscriptionCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *ExpressRouteGatewaysClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRouteGatewaysClient) ListBySubscriptionCreateRequest(ctx context.Context, options *ExpressRouteGatewaysListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -16,9 +16,9 @@ import (
 // ExpressRouteLinksOperations contains the methods for the ExpressRouteLinks group.
 type ExpressRouteLinksOperations interface {
 	// Get - Retrieves the specified ExpressRouteLink resource.
-	Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string) (*ExpressRouteLinkResponse, error)
+	Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string, options *ExpressRouteLinksGetOptions) (*ExpressRouteLinkResponse, error)
 	// List - Retrieve the ExpressRouteLink sub-resources of the specified ExpressRoutePort resource.
-	List(resourceGroupName string, expressRoutePortName string) ExpressRouteLinkListResultPager
+	List(resourceGroupName string, expressRoutePortName string, options *ExpressRouteLinksListOptions) ExpressRouteLinkListResultPager
 }
 
 // ExpressRouteLinksClient implements the ExpressRouteLinksOperations interface.
@@ -39,8 +39,8 @@ func (client *ExpressRouteLinksClient) Do(req *azcore.Request) (*azcore.Response
 }
 
 // Get - Retrieves the specified ExpressRouteLink resource.
-func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string) (*ExpressRouteLinkResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRoutePortName, linkName)
+func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string, options *ExpressRouteLinksGetOptions) (*ExpressRouteLinkResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRoutePortName, linkName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRouteLinksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string) (*azcore.Request, error) {
+func (client *ExpressRouteLinksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, linkName string, options *ExpressRouteLinksGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links/{linkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -92,11 +92,11 @@ func (client *ExpressRouteLinksClient) GetHandleError(resp *azcore.Response) err
 }
 
 // List - Retrieve the ExpressRouteLink sub-resources of the specified ExpressRoutePort resource.
-func (client *ExpressRouteLinksClient) List(resourceGroupName string, expressRoutePortName string) ExpressRouteLinkListResultPager {
+func (client *ExpressRouteLinksClient) List(resourceGroupName string, expressRoutePortName string, options *ExpressRouteLinksListOptions) ExpressRouteLinkListResultPager {
 	return &expressRouteLinkListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, expressRoutePortName)
+			return client.ListCreateRequest(ctx, resourceGroupName, expressRoutePortName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *ExpressRouteLinksClient) List(resourceGroupName string, expressRou
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+func (client *ExpressRouteLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRouteLinksListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -18,21 +18,21 @@ import (
 // ExpressRoutePortsOperations contains the methods for the ExpressRoutePorts group.
 type ExpressRoutePortsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified ExpressRoutePort resource.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort) (*ExpressRoutePortPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsCreateOrUpdateOptions) (*ExpressRoutePortPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ExpressRoutePortPoller, error)
 	// BeginDelete - Deletes the specified ExpressRoutePort resource.
-	BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the requested ExpressRoutePort resource.
-	Get(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*ExpressRoutePortResponse, error)
+	Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsGetOptions) (*ExpressRoutePortResponse, error)
 	// List - List all the ExpressRoutePort resources in the specified subscription.
-	List() ExpressRoutePortListResultPager
+	List(options *ExpressRoutePortsListOptions) ExpressRoutePortListResultPager
 	// ListByResourceGroup - List all the ExpressRoutePort resources in the specified resource group.
-	ListByResourceGroup(resourceGroupName string) ExpressRoutePortListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ExpressRoutePortsListByResourceGroupOptions) ExpressRoutePortListResultPager
 	// UpdateTags - Update ExpressRoutePort tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject) (*ExpressRoutePortResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject, options *ExpressRoutePortsUpdateTagsOptions) (*ExpressRoutePortResponse, error)
 }
 
 // ExpressRoutePortsClient implements the ExpressRoutePortsOperations interface.
@@ -52,8 +52,8 @@ func (client *ExpressRoutePortsClient) Do(req *azcore.Request) (*azcore.Response
 	return client.p.Do(req)
 }
 
-func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort) (*ExpressRoutePortPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRoutePortName, parameters)
+func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsCreateOrUpdateOptions) (*ExpressRoutePortPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, expressRoutePortName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *ExpressRoutePortsClient) ResumeCreateOrUpdate(token string) (Expre
 }
 
 // CreateOrUpdate - Creates or updates the specified ExpressRoutePort resource.
-func (client *ExpressRoutePortsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRoutePortName, parameters)
+func (client *ExpressRoutePortsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, expressRoutePortName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *ExpressRoutePortsClient) CreateOrUpdate(ctx context.Context, resou
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ExpressRoutePortsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters ExpressRoutePort, options *ExpressRoutePortsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -134,8 +134,8 @@ func (client *ExpressRoutePortsClient) CreateOrUpdateHandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, expressRoutePortName)
+func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, expressRoutePortName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *ExpressRoutePortsClient) ResumeDelete(token string) (HTTPPoller, e
 }
 
 // Delete - Deletes the specified ExpressRoutePort resource.
-func (client *ExpressRoutePortsClient) Delete(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRoutePortName)
+func (client *ExpressRoutePortsClient) Delete(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, expressRoutePortName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *ExpressRoutePortsClient) Delete(ctx context.Context, resourceGroup
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ExpressRoutePortsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -211,8 +211,8 @@ func (client *ExpressRoutePortsClient) DeleteHandleError(resp *azcore.Response) 
 }
 
 // Get - Retrieves the requested ExpressRoutePort resource.
-func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*ExpressRoutePortResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRoutePortName)
+func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsGetOptions) (*ExpressRoutePortResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, expressRoutePortName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRoutePortsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, options *ExpressRoutePortsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -263,11 +263,11 @@ func (client *ExpressRoutePortsClient) GetHandleError(resp *azcore.Response) err
 }
 
 // List - List all the ExpressRoutePort resources in the specified subscription.
-func (client *ExpressRoutePortsClient) List() ExpressRoutePortListResultPager {
+func (client *ExpressRoutePortsClient) List(options *ExpressRoutePortsListOptions) ExpressRoutePortListResultPager {
 	return &expressRoutePortListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *ExpressRoutePortsClient) List() ExpressRoutePortListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRoutePortsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) ListCreateRequest(ctx context.Context, options *ExpressRoutePortsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *ExpressRoutePortsClient) ListHandleError(resp *azcore.Response) er
 }
 
 // ListByResourceGroup - List all the ExpressRoutePort resources in the specified resource group.
-func (client *ExpressRoutePortsClient) ListByResourceGroup(resourceGroupName string) ExpressRoutePortListResultPager {
+func (client *ExpressRoutePortsClient) ListByResourceGroup(resourceGroupName string, options *ExpressRoutePortsListByResourceGroupOptions) ExpressRoutePortListResultPager {
 	return &expressRoutePortListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *ExpressRoutePortsClient) ListByResourceGroup(resourceGroupName str
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ExpressRoutePortsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ExpressRoutePortsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -354,8 +354,8 @@ func (client *ExpressRoutePortsClient) ListByResourceGroupHandleError(resp *azco
 }
 
 // UpdateTags - Update ExpressRoutePort tags.
-func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject) (*ExpressRoutePortResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, expressRoutePortName, parameters)
+func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject, options *ExpressRoutePortsUpdateTagsOptions) (*ExpressRoutePortResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, expressRoutePortName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceG
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ExpressRoutePortsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ExpressRoutePortsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, expressRoutePortName string, parameters TagsObject, options *ExpressRoutePortsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -16,9 +16,9 @@ import (
 // ExpressRoutePortsLocationsOperations contains the methods for the ExpressRoutePortsLocations group.
 type ExpressRoutePortsLocationsOperations interface {
 	// Get - Retrieves a single ExpressRoutePort peering location, including the list of available bandwidths available at said peering location.
-	Get(ctx context.Context, locationName string) (*ExpressRoutePortsLocationResponse, error)
+	Get(ctx context.Context, locationName string, options *ExpressRoutePortsLocationsGetOptions) (*ExpressRoutePortsLocationResponse, error)
 	// List - Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.
-	List() ExpressRoutePortsLocationListResultPager
+	List(options *ExpressRoutePortsLocationsListOptions) ExpressRoutePortsLocationListResultPager
 }
 
 // ExpressRoutePortsLocationsClient implements the ExpressRoutePortsLocationsOperations interface.
@@ -39,8 +39,8 @@ func (client *ExpressRoutePortsLocationsClient) Do(req *azcore.Request) (*azcore
 }
 
 // Get - Retrieves a single ExpressRoutePort peering location, including the list of available bandwidths available at said peering location.
-func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locationName string) (*ExpressRoutePortsLocationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, locationName)
+func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locationName string, options *ExpressRoutePortsLocationsGetOptions) (*ExpressRoutePortsLocationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, locationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locatio
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ExpressRoutePortsLocationsClient) GetCreateRequest(ctx context.Context, locationName string) (*azcore.Request, error) {
+func (client *ExpressRoutePortsLocationsClient) GetCreateRequest(ctx context.Context, locationName string, options *ExpressRoutePortsLocationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations/{locationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{locationName}", url.PathEscape(locationName))
@@ -90,11 +90,11 @@ func (client *ExpressRoutePortsLocationsClient) GetHandleError(resp *azcore.Resp
 }
 
 // List - Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.
-func (client *ExpressRoutePortsLocationsClient) List() ExpressRoutePortsLocationListResultPager {
+func (client *ExpressRoutePortsLocationsClient) List(options *ExpressRoutePortsLocationsListOptions) ExpressRoutePortsLocationListResultPager {
 	return &expressRoutePortsLocationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -105,7 +105,7 @@ func (client *ExpressRoutePortsLocationsClient) List() ExpressRoutePortsLocation
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRoutePortsLocationsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRoutePortsLocationsClient) ListCreateRequest(ctx context.Context, options *ExpressRoutePortsLocationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -16,7 +16,7 @@ import (
 // ExpressRouteServiceProvidersOperations contains the methods for the ExpressRouteServiceProviders group.
 type ExpressRouteServiceProvidersOperations interface {
 	// List - Gets all the available express route service providers.
-	List() ExpressRouteServiceProviderListResultPager
+	List(options *ExpressRouteServiceProvidersListOptions) ExpressRouteServiceProviderListResultPager
 }
 
 // ExpressRouteServiceProvidersClient implements the ExpressRouteServiceProvidersOperations interface.
@@ -37,11 +37,11 @@ func (client *ExpressRouteServiceProvidersClient) Do(req *azcore.Request) (*azco
 }
 
 // List - Gets all the available express route service providers.
-func (client *ExpressRouteServiceProvidersClient) List() ExpressRouteServiceProviderListResultPager {
+func (client *ExpressRouteServiceProvidersClient) List(options *ExpressRouteServiceProvidersListOptions) ExpressRouteServiceProviderListResultPager {
 	return &expressRouteServiceProviderListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *ExpressRouteServiceProvidersClient) List() ExpressRouteServiceProv
 }
 
 // ListCreateRequest creates the List request.
-func (client *ExpressRouteServiceProvidersClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ExpressRouteServiceProvidersClient) ListCreateRequest(ctx context.Context, options *ExpressRouteServiceProvidersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -18,19 +18,19 @@ import (
 // FirewallPoliciesOperations contains the methods for the FirewallPolicies group.
 type FirewallPoliciesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Firewall Policy.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy) (*FirewallPolicyPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesCreateOrUpdateOptions) (*FirewallPolicyPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (FirewallPolicyPoller, error)
 	// BeginDelete - Deletes the specified Firewall Policy.
-	BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Firewall Policy.
-	Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, firewallPoliciesGetOptions *FirewallPoliciesGetOptions) (*FirewallPolicyResponse, error)
+	Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesGetOptions) (*FirewallPolicyResponse, error)
 	// List - Lists all Firewall Policies in a resource group.
-	List(resourceGroupName string) FirewallPolicyListResultPager
+	List(resourceGroupName string, options *FirewallPoliciesListOptions) FirewallPolicyListResultPager
 	// ListAll - Gets all the Firewall Policies in a subscription.
-	ListAll() FirewallPolicyListResultPager
+	ListAll(options *FirewallPoliciesListAllOptions) FirewallPolicyListResultPager
 }
 
 // FirewallPoliciesClient implements the FirewallPoliciesOperations interface.
@@ -50,8 +50,8 @@ func (client *FirewallPoliciesClient) Do(req *azcore.Request) (*azcore.Response,
 	return client.p.Do(req)
 }
 
-func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy) (*FirewallPolicyPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, firewallPolicyName, parameters)
+func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesCreateOrUpdateOptions) (*FirewallPolicyPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, firewallPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *FirewallPoliciesClient) ResumeCreateOrUpdate(token string) (Firewa
 }
 
 // CreateOrUpdate - Creates or updates the specified Firewall Policy.
-func (client *FirewallPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, firewallPolicyName, parameters)
+func (client *FirewallPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, firewallPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *FirewallPoliciesClient) CreateOrUpdate(ctx context.Context, resour
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *FirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy) (*azcore.Request, error) {
+func (client *FirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, parameters FirewallPolicy, options *FirewallPoliciesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -132,8 +132,8 @@ func (client *FirewallPoliciesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, firewallPolicyName)
+func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, firewallPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *FirewallPoliciesClient) ResumeDelete(token string) (HTTPPoller, er
 }
 
 // Delete - Deletes the specified Firewall Policy.
-func (client *FirewallPoliciesClient) Delete(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, firewallPolicyName)
+func (client *FirewallPoliciesClient) Delete(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, firewallPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *FirewallPoliciesClient) Delete(ctx context.Context, resourceGroupN
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *FirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*azcore.Request, error) {
+func (client *FirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -209,8 +209,8 @@ func (client *FirewallPoliciesClient) DeleteHandleError(resp *azcore.Response) e
 }
 
 // Get - Gets the specified Firewall Policy.
-func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, firewallPoliciesGetOptions *FirewallPoliciesGetOptions) (*FirewallPolicyResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, firewallPolicyName, firewallPoliciesGetOptions)
+func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesGetOptions) (*FirewallPolicyResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, firewallPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName
 }
 
 // GetCreateRequest creates the Get request.
-func (client *FirewallPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, firewallPoliciesGetOptions *FirewallPoliciesGetOptions) (*azcore.Request, error) {
+func (client *FirewallPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPoliciesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -240,8 +240,8 @@ func (client *FirewallPoliciesClient) GetCreateRequest(ctx context.Context, reso
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if firewallPoliciesGetOptions != nil && firewallPoliciesGetOptions.Expand != nil {
-		query.Set("$expand", *firewallPoliciesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -264,11 +264,11 @@ func (client *FirewallPoliciesClient) GetHandleError(resp *azcore.Response) erro
 }
 
 // List - Lists all Firewall Policies in a resource group.
-func (client *FirewallPoliciesClient) List(resourceGroupName string) FirewallPolicyListResultPager {
+func (client *FirewallPoliciesClient) List(resourceGroupName string, options *FirewallPoliciesListOptions) FirewallPolicyListResultPager {
 	return &firewallPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -279,7 +279,7 @@ func (client *FirewallPoliciesClient) List(resourceGroupName string) FirewallPol
 }
 
 // ListCreateRequest creates the List request.
-func (client *FirewallPoliciesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *FirewallPoliciesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *FirewallPoliciesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -310,11 +310,11 @@ func (client *FirewallPoliciesClient) ListHandleError(resp *azcore.Response) err
 }
 
 // ListAll - Gets all the Firewall Policies in a subscription.
-func (client *FirewallPoliciesClient) ListAll() FirewallPolicyListResultPager {
+func (client *FirewallPoliciesClient) ListAll(options *FirewallPoliciesListAllOptions) FirewallPolicyListResultPager {
 	return &firewallPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -325,7 +325,7 @@ func (client *FirewallPoliciesClient) ListAll() FirewallPolicyListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *FirewallPoliciesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *FirewallPoliciesClient) ListAllCreateRequest(ctx context.Context, options *FirewallPoliciesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -18,17 +18,17 @@ import (
 // FirewallPolicyRuleGroupsOperations contains the methods for the FirewallPolicyRuleGroups group.
 type FirewallPolicyRuleGroupsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified FirewallPolicyRuleGroup.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup) (*FirewallPolicyRuleGroupPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsCreateOrUpdateOptions) (*FirewallPolicyRuleGroupPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (FirewallPolicyRuleGroupPoller, error)
 	// BeginDelete - Deletes the specified FirewallPolicyRuleGroup.
-	BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified FirewallPolicyRuleGroup.
-	Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*FirewallPolicyRuleGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsGetOptions) (*FirewallPolicyRuleGroupResponse, error)
 	// List - Lists all FirewallPolicyRuleGroups in a FirewallPolicy resource.
-	List(resourceGroupName string, firewallPolicyName string) FirewallPolicyRuleGroupListResultPager
+	List(resourceGroupName string, firewallPolicyName string, options *FirewallPolicyRuleGroupsListOptions) FirewallPolicyRuleGroupListResultPager
 }
 
 // FirewallPolicyRuleGroupsClient implements the FirewallPolicyRuleGroupsOperations interface.
@@ -48,8 +48,8 @@ func (client *FirewallPolicyRuleGroupsClient) Do(req *azcore.Request) (*azcore.R
 	return client.p.Do(req)
 }
 
-func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup) (*FirewallPolicyRuleGroupPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, parameters)
+func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsCreateOrUpdateOptions) (*FirewallPolicyRuleGroupPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *FirewallPolicyRuleGroupsClient) ResumeCreateOrUpdate(token string)
 }
 
 // CreateOrUpdate - Creates or updates the specified FirewallPolicyRuleGroup.
-func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, parameters)
+func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdate(ctx context.Context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup) (*azcore.Request, error) {
+func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, parameters FirewallPolicyRuleGroup, options *FirewallPolicyRuleGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -131,8 +131,8 @@ func (client *FirewallPolicyRuleGroupsClient) CreateOrUpdateHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, firewallPolicyName, ruleGroupName)
+func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *FirewallPolicyRuleGroupsClient) ResumeDelete(token string) (HTTPPo
 }
 
 // Delete - Deletes the specified FirewallPolicyRuleGroup.
-func (client *FirewallPolicyRuleGroupsClient) Delete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName)
+func (client *FirewallPolicyRuleGroupsClient) Delete(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *FirewallPolicyRuleGroupsClient) Delete(ctx context.Context, resour
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *FirewallPolicyRuleGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*azcore.Request, error) {
+func (client *FirewallPolicyRuleGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -209,8 +209,8 @@ func (client *FirewallPolicyRuleGroupsClient) DeleteHandleError(resp *azcore.Res
 }
 
 // Get - Gets the specified FirewallPolicyRuleGroup.
-func (client *FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*FirewallPolicyRuleGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName)
+func (client *FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsGetOptions) (*FirewallPolicyRuleGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, firewallPolicyName, ruleGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceG
 }
 
 // GetCreateRequest creates the Get request.
-func (client *FirewallPolicyRuleGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string) (*azcore.Request, error) {
+func (client *FirewallPolicyRuleGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, ruleGroupName string, options *FirewallPolicyRuleGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups/{ruleGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))
@@ -262,11 +262,11 @@ func (client *FirewallPolicyRuleGroupsClient) GetHandleError(resp *azcore.Respon
 }
 
 // List - Lists all FirewallPolicyRuleGroups in a FirewallPolicy resource.
-func (client *FirewallPolicyRuleGroupsClient) List(resourceGroupName string, firewallPolicyName string) FirewallPolicyRuleGroupListResultPager {
+func (client *FirewallPolicyRuleGroupsClient) List(resourceGroupName string, firewallPolicyName string, options *FirewallPolicyRuleGroupsListOptions) FirewallPolicyRuleGroupListResultPager {
 	return &firewallPolicyRuleGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, firewallPolicyName)
+			return client.ListCreateRequest(ctx, resourceGroupName, firewallPolicyName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *FirewallPolicyRuleGroupsClient) List(resourceGroupName string, fir
 }
 
 // ListCreateRequest creates the List request.
-func (client *FirewallPolicyRuleGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string) (*azcore.Request, error) {
+func (client *FirewallPolicyRuleGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, firewallPolicyName string, options *FirewallPolicyRuleGroupsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{firewallPolicyName}", url.PathEscape(firewallPolicyName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -18,17 +18,17 @@ import (
 // FlowLogsOperations contains the methods for the FlowLogs group.
 type FlowLogsOperations interface {
 	// BeginCreateOrUpdate - Create or update a flow log for the specified network security group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog) (*FlowLogPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsCreateOrUpdateOptions) (*FlowLogPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (FlowLogPoller, error)
 	// BeginDelete - Deletes the specified flow log resource.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets a flow log resource by name.
-	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*FlowLogResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsGetOptions) (*FlowLogResponse, error)
 	// List - Lists all flow log resources for the specified Network Watcher.
-	List(resourceGroupName string, networkWatcherName string) FlowLogListResultPager
+	List(resourceGroupName string, networkWatcherName string, options *FlowLogsListOptions) FlowLogListResultPager
 }
 
 // FlowLogsClient implements the FlowLogsOperations interface.
@@ -48,8 +48,8 @@ func (client *FlowLogsClient) Do(req *azcore.Request) (*azcore.Response, error) 
 	return client.p.Do(req)
 }
 
-func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog) (*FlowLogPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkWatcherName, flowLogName, parameters)
+func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsCreateOrUpdateOptions) (*FlowLogPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkWatcherName, flowLogName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *FlowLogsClient) ResumeCreateOrUpdate(token string) (FlowLogPoller,
 }
 
 // CreateOrUpdate - Create or update a flow log for the specified network security group.
-func (client *FlowLogsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName, parameters)
+func (client *FlowLogsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *FlowLogsClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *FlowLogsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog) (*azcore.Request, error) {
+func (client *FlowLogsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, parameters FlowLog, options *FlowLogsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -131,8 +131,8 @@ func (client *FlowLogsClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, flowLogName)
+func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, flowLogName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *FlowLogsClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes the specified flow log resource.
-func (client *FlowLogsClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName)
+func (client *FlowLogsClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *FlowLogsClient) Delete(ctx context.Context, resourceGroupName stri
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *FlowLogsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*azcore.Request, error) {
+func (client *FlowLogsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -209,8 +209,8 @@ func (client *FlowLogsClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets a flow log resource by name.
-func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*FlowLogResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName)
+func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsGetOptions) (*FlowLogResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, flowLogName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string,
 }
 
 // GetCreateRequest creates the Get request.
-func (client *FlowLogsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string) (*azcore.Request, error) {
+func (client *FlowLogsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, flowLogName string, options *FlowLogsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -262,11 +262,11 @@ func (client *FlowLogsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all flow log resources for the specified Network Watcher.
-func (client *FlowLogsClient) List(resourceGroupName string, networkWatcherName string) FlowLogListResultPager {
+func (client *FlowLogsClient) List(resourceGroupName string, networkWatcherName string, options *FlowLogsListOptions) FlowLogListResultPager {
 	return &flowLogListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *FlowLogsClient) List(resourceGroupName string, networkWatcherName 
 }
 
 // ListCreateRequest creates the List request.
-func (client *FlowLogsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+func (client *FlowLogsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *FlowLogsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -16,9 +16,9 @@ import (
 // HubVirtualNetworkConnectionsOperations contains the methods for the HubVirtualNetworkConnections group.
 type HubVirtualNetworkConnectionsOperations interface {
 	// Get - Retrieves the details of a HubVirtualNetworkConnection.
-	Get(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string) (*HubVirtualNetworkConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string, options *HubVirtualNetworkConnectionsGetOptions) (*HubVirtualNetworkConnectionResponse, error)
 	// List - Retrieves the details of all HubVirtualNetworkConnections.
-	List(resourceGroupName string, virtualHubName string) ListHubVirtualNetworkConnectionsResultPager
+	List(resourceGroupName string, virtualHubName string, options *HubVirtualNetworkConnectionsListOptions) ListHubVirtualNetworkConnectionsResultPager
 }
 
 // HubVirtualNetworkConnectionsClient implements the HubVirtualNetworkConnectionsOperations interface.
@@ -39,8 +39,8 @@ func (client *HubVirtualNetworkConnectionsClient) Do(req *azcore.Request) (*azco
 }
 
 // Get - Retrieves the details of a HubVirtualNetworkConnection.
-func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string) (*HubVirtualNetworkConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName, connectionName)
+func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string, options *HubVirtualNetworkConnectionsGetOptions) (*HubVirtualNetworkConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resou
 }
 
 // GetCreateRequest creates the Get request.
-func (client *HubVirtualNetworkConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string) (*azcore.Request, error) {
+func (client *HubVirtualNetworkConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, connectionName string, options *HubVirtualNetworkConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -92,11 +92,11 @@ func (client *HubVirtualNetworkConnectionsClient) GetHandleError(resp *azcore.Re
 }
 
 // List - Retrieves the details of all HubVirtualNetworkConnections.
-func (client *HubVirtualNetworkConnectionsClient) List(resourceGroupName string, virtualHubName string) ListHubVirtualNetworkConnectionsResultPager {
+func (client *HubVirtualNetworkConnectionsClient) List(resourceGroupName string, virtualHubName string, options *HubVirtualNetworkConnectionsListOptions) ListHubVirtualNetworkConnectionsResultPager {
 	return &listHubVirtualNetworkConnectionsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *HubVirtualNetworkConnectionsClient) List(resourceGroupName string,
 }
 
 // ListCreateRequest creates the List request.
-func (client *HubVirtualNetworkConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+func (client *HubVirtualNetworkConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, options *HubVirtualNetworkConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -18,17 +18,17 @@ import (
 // InboundNatRulesOperations contains the methods for the InboundNatRules group.
 type InboundNatRulesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a load balancer inbound nat rule.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule) (*InboundNatRulePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesCreateOrUpdateOptions) (*InboundNatRulePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (InboundNatRulePoller, error)
 	// BeginDelete - Deletes the specified load balancer inbound nat rule.
-	BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified load balancer inbound nat rule.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRulesGetOptions *InboundNatRulesGetOptions) (*InboundNatRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesGetOptions) (*InboundNatRuleResponse, error)
 	// List - Gets all the inbound nat rules in a load balancer.
-	List(resourceGroupName string, loadBalancerName string) InboundNatRuleListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *InboundNatRulesListOptions) InboundNatRuleListResultPager
 }
 
 // InboundNatRulesClient implements the InboundNatRulesOperations interface.
@@ -48,8 +48,8 @@ func (client *InboundNatRulesClient) Do(req *azcore.Request) (*azcore.Response, 
 	return client.p.Do(req)
 }
 
-func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule) (*InboundNatRulePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRuleParameters)
+func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesCreateOrUpdateOptions) (*InboundNatRulePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *InboundNatRulesClient) ResumeCreateOrUpdate(token string) (Inbound
 }
 
 // CreateOrUpdate - Creates or updates a load balancer inbound nat rule.
-func (client *InboundNatRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRuleParameters)
+func (client *InboundNatRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *InboundNatRulesClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *InboundNatRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule) (*azcore.Request, error) {
+func (client *InboundNatRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRuleParameters InboundNatRule, options *InboundNatRulesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -131,8 +131,8 @@ func (client *InboundNatRulesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName)
+func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *InboundNatRulesClient) ResumeDelete(token string) (HTTPPoller, err
 }
 
 // Delete - Deletes the specified load balancer inbound nat rule.
-func (client *InboundNatRulesClient) Delete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName)
+func (client *InboundNatRulesClient) Delete(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *InboundNatRulesClient) Delete(ctx context.Context, resourceGroupNa
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *InboundNatRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string) (*azcore.Request, error) {
+func (client *InboundNatRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -209,8 +209,8 @@ func (client *InboundNatRulesClient) DeleteHandleError(resp *azcore.Response) er
 }
 
 // Get - Gets the specified load balancer inbound nat rule.
-func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRulesGetOptions *InboundNatRulesGetOptions) (*InboundNatRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, inboundNatRulesGetOptions)
+func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesGetOptions) (*InboundNatRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, inboundNatRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *InboundNatRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, inboundNatRulesGetOptions *InboundNatRulesGetOptions) (*azcore.Request, error) {
+func (client *InboundNatRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, inboundNatRuleName string, options *InboundNatRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -241,8 +241,8 @@ func (client *InboundNatRulesClient) GetCreateRequest(ctx context.Context, resou
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if inboundNatRulesGetOptions != nil && inboundNatRulesGetOptions.Expand != nil {
-		query.Set("$expand", *inboundNatRulesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -265,11 +265,11 @@ func (client *InboundNatRulesClient) GetHandleError(resp *azcore.Response) error
 }
 
 // List - Gets all the inbound nat rules in a load balancer.
-func (client *InboundNatRulesClient) List(resourceGroupName string, loadBalancerName string) InboundNatRuleListResultPager {
+func (client *InboundNatRulesClient) List(resourceGroupName string, loadBalancerName string, options *InboundNatRulesListOptions) InboundNatRuleListResultPager {
 	return &inboundNatRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -280,7 +280,7 @@ func (client *InboundNatRulesClient) List(resourceGroupName string, loadBalancer
 }
 
 // ListCreateRequest creates the List request.
-func (client *InboundNatRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *InboundNatRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *InboundNatRulesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -18,21 +18,21 @@ import (
 // IPAllocationsOperations contains the methods for the IPAllocations group.
 type IPAllocationsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an IpAllocation in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation) (*IPAllocationPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsCreateOrUpdateOptions) (*IPAllocationPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (IPAllocationPoller, error)
 	// BeginDelete - Deletes the specified IpAllocation.
-	BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified IpAllocation by resource group.
-	Get(ctx context.Context, resourceGroupName string, ipAllocationName string, ipAllocationsGetOptions *IPAllocationsGetOptions) (*IPAllocationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsGetOptions) (*IPAllocationResponse, error)
 	// List - Gets all IpAllocations in a subscription.
-	List() IPAllocationListResultPager
+	List(options *IPAllocationsListOptions) IPAllocationListResultPager
 	// ListByResourceGroup - Gets all IpAllocations in a resource group.
-	ListByResourceGroup(resourceGroupName string) IPAllocationListResultPager
+	ListByResourceGroup(resourceGroupName string, options *IPAllocationsListByResourceGroupOptions) IPAllocationListResultPager
 	// UpdateTags - Updates a IpAllocation tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject) (*IPAllocationResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject, options *IPAllocationsUpdateTagsOptions) (*IPAllocationResponse, error)
 }
 
 // IPAllocationsClient implements the IPAllocationsOperations interface.
@@ -52,8 +52,8 @@ func (client *IPAllocationsClient) Do(req *azcore.Request) (*azcore.Response, er
 	return client.p.Do(req)
 }
 
-func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation) (*IPAllocationPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ipAllocationName, parameters)
+func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsCreateOrUpdateOptions) (*IPAllocationPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ipAllocationName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *IPAllocationsClient) ResumeCreateOrUpdate(token string) (IPAllocat
 }
 
 // CreateOrUpdate - Creates or updates an IpAllocation in the specified resource group.
-func (client *IPAllocationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ipAllocationName, parameters)
+func (client *IPAllocationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ipAllocationName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *IPAllocationsClient) CreateOrUpdate(ctx context.Context, resourceG
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *IPAllocationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation) (*azcore.Request, error) {
+func (client *IPAllocationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters IPAllocation, options *IPAllocationsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
@@ -134,8 +134,8 @@ func (client *IPAllocationsClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, ipAllocationName)
+func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, ipAllocationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *IPAllocationsClient) ResumeDelete(token string) (HTTPPoller, error
 }
 
 // Delete - Deletes the specified IpAllocation.
-func (client *IPAllocationsClient) Delete(ctx context.Context, resourceGroupName string, ipAllocationName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ipAllocationName)
+func (client *IPAllocationsClient) Delete(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ipAllocationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *IPAllocationsClient) Delete(ctx context.Context, resourceGroupName
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *IPAllocationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string) (*azcore.Request, error) {
+func (client *IPAllocationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
@@ -211,8 +211,8 @@ func (client *IPAllocationsClient) DeleteHandleError(resp *azcore.Response) erro
 }
 
 // Get - Gets the specified IpAllocation by resource group.
-func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName string, ipAllocationName string, ipAllocationsGetOptions *IPAllocationsGetOptions) (*IPAllocationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, ipAllocationName, ipAllocationsGetOptions)
+func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsGetOptions) (*IPAllocationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, ipAllocationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName st
 }
 
 // GetCreateRequest creates the Get request.
-func (client *IPAllocationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, ipAllocationsGetOptions *IPAllocationsGetOptions) (*azcore.Request, error) {
+func (client *IPAllocationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, options *IPAllocationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))
@@ -242,8 +242,8 @@ func (client *IPAllocationsClient) GetCreateRequest(ctx context.Context, resourc
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if ipAllocationsGetOptions != nil && ipAllocationsGetOptions.Expand != nil {
-		query.Set("$expand", *ipAllocationsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *IPAllocationsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all IpAllocations in a subscription.
-func (client *IPAllocationsClient) List() IPAllocationListResultPager {
+func (client *IPAllocationsClient) List(options *IPAllocationsListOptions) IPAllocationListResultPager {
 	return &ipAllocationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *IPAllocationsClient) List() IPAllocationListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *IPAllocationsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IPAllocationsClient) ListCreateRequest(ctx context.Context, options *IPAllocationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -311,11 +311,11 @@ func (client *IPAllocationsClient) ListHandleError(resp *azcore.Response) error 
 }
 
 // ListByResourceGroup - Gets all IpAllocations in a resource group.
-func (client *IPAllocationsClient) ListByResourceGroup(resourceGroupName string) IPAllocationListResultPager {
+func (client *IPAllocationsClient) ListByResourceGroup(resourceGroupName string, options *IPAllocationsListByResourceGroupOptions) IPAllocationListResultPager {
 	return &ipAllocationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -326,7 +326,7 @@ func (client *IPAllocationsClient) ListByResourceGroup(resourceGroupName string)
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *IPAllocationsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *IPAllocationsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *IPAllocationsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -357,8 +357,8 @@ func (client *IPAllocationsClient) ListByResourceGroupHandleError(resp *azcore.R
 }
 
 // UpdateTags - Updates a IpAllocation tags.
-func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject) (*IPAllocationResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ipAllocationName, parameters)
+func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject, options *IPAllocationsUpdateTagsOptions) (*IPAllocationResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, ipAllocationName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroup
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *IPAllocationsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *IPAllocationsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, ipAllocationName string, parameters TagsObject, options *IPAllocationsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipAllocationName}", url.PathEscape(ipAllocationName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -18,21 +18,21 @@ import (
 // IPGroupsOperations contains the methods for the IPGroups group.
 type IPGroupsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an ipGroups in a specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup) (*IPGroupPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsCreateOrUpdateOptions) (*IPGroupPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (IPGroupPoller, error)
 	// BeginDelete - Deletes the specified ipGroups.
-	BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified ipGroups.
-	Get(ctx context.Context, resourceGroupName string, ipGroupsName string, ipGroupsGetOptions *IPGroupsGetOptions) (*IPGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsGetOptions) (*IPGroupResponse, error)
 	// List - Gets all IpGroups in a subscription.
-	List() IPGroupListResultPager
+	List(options *IPGroupsListOptions) IPGroupListResultPager
 	// ListByResourceGroup - Gets all IpGroups in a resource group.
-	ListByResourceGroup(resourceGroupName string) IPGroupListResultPager
+	ListByResourceGroup(resourceGroupName string, options *IPGroupsListByResourceGroupOptions) IPGroupListResultPager
 	// UpdateGroups - Updates tags of an IpGroups resource.
-	UpdateGroups(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject) (*IPGroupResponse, error)
+	UpdateGroups(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject, options *IPGroupsUpdateGroupsOptions) (*IPGroupResponse, error)
 }
 
 // IPGroupsClient implements the IPGroupsOperations interface.
@@ -52,8 +52,8 @@ func (client *IPGroupsClient) Do(req *azcore.Request) (*azcore.Response, error) 
 	return client.p.Do(req)
 }
 
-func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup) (*IPGroupPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ipGroupsName, parameters)
+func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsCreateOrUpdateOptions) (*IPGroupPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, ipGroupsName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *IPGroupsClient) ResumeCreateOrUpdate(token string) (IPGroupPoller,
 }
 
 // CreateOrUpdate - Creates or updates an ipGroups in a specified resource group.
-func (client *IPGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ipGroupsName, parameters)
+func (client *IPGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, ipGroupsName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *IPGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *IPGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup) (*azcore.Request, error) {
+func (client *IPGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters IPGroup, options *IPGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
@@ -134,8 +134,8 @@ func (client *IPGroupsClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, ipGroupsName)
+func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, ipGroupsName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *IPGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes the specified ipGroups.
-func (client *IPGroupsClient) Delete(ctx context.Context, resourceGroupName string, ipGroupsName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ipGroupsName)
+func (client *IPGroupsClient) Delete(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, ipGroupsName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *IPGroupsClient) Delete(ctx context.Context, resourceGroupName stri
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *IPGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string) (*azcore.Request, error) {
+func (client *IPGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
@@ -211,8 +211,8 @@ func (client *IPGroupsClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets the specified ipGroups.
-func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string, ipGroupsName string, ipGroupsGetOptions *IPGroupsGetOptions) (*IPGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, ipGroupsName, ipGroupsGetOptions)
+func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsGetOptions) (*IPGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, ipGroupsName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string,
 }
 
 // GetCreateRequest creates the Get request.
-func (client *IPGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, ipGroupsGetOptions *IPGroupsGetOptions) (*azcore.Request, error) {
+func (client *IPGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, options *IPGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))
@@ -242,8 +242,8 @@ func (client *IPGroupsClient) GetCreateRequest(ctx context.Context, resourceGrou
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if ipGroupsGetOptions != nil && ipGroupsGetOptions.Expand != nil {
-		query.Set("$expand", *ipGroupsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *IPGroupsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all IpGroups in a subscription.
-func (client *IPGroupsClient) List() IPGroupListResultPager {
+func (client *IPGroupsClient) List(options *IPGroupsListOptions) IPGroupListResultPager {
 	return &ipGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *IPGroupsClient) List() IPGroupListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *IPGroupsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *IPGroupsClient) ListCreateRequest(ctx context.Context, options *IPGroupsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -311,11 +311,11 @@ func (client *IPGroupsClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Gets all IpGroups in a resource group.
-func (client *IPGroupsClient) ListByResourceGroup(resourceGroupName string) IPGroupListResultPager {
+func (client *IPGroupsClient) ListByResourceGroup(resourceGroupName string, options *IPGroupsListByResourceGroupOptions) IPGroupListResultPager {
 	return &ipGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -326,7 +326,7 @@ func (client *IPGroupsClient) ListByResourceGroup(resourceGroupName string) IPGr
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *IPGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *IPGroupsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *IPGroupsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -357,8 +357,8 @@ func (client *IPGroupsClient) ListByResourceGroupHandleError(resp *azcore.Respon
 }
 
 // UpdateGroups - Updates tags of an IpGroups resource.
-func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject) (*IPGroupResponse, error) {
-	req, err := client.UpdateGroupsCreateRequest(ctx, resourceGroupName, ipGroupsName, parameters)
+func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject, options *IPGroupsUpdateGroupsOptions) (*IPGroupResponse, error) {
+	req, err := client.UpdateGroupsCreateRequest(ctx, resourceGroupName, ipGroupsName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupNam
 }
 
 // UpdateGroupsCreateRequest creates the UpdateGroups request.
-func (client *IPGroupsClient) UpdateGroupsCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *IPGroupsClient) UpdateGroupsCreateRequest(ctx context.Context, resourceGroupName string, ipGroupsName string, parameters TagsObject, options *IPGroupsUpdateGroupsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{ipGroupsName}", url.PathEscape(ipGroupsName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -16,9 +16,9 @@ import (
 // LoadBalancerBackendAddressPoolsOperations contains the methods for the LoadBalancerBackendAddressPools group.
 type LoadBalancerBackendAddressPoolsOperations interface {
 	// Get - Gets load balancer backend address pool.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string) (*BackendAddressPoolResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string, options *LoadBalancerBackendAddressPoolsGetOptions) (*BackendAddressPoolResponse, error)
 	// List - Gets all the load balancer backed address pools.
-	List(resourceGroupName string, loadBalancerName string) LoadBalancerBackendAddressPoolListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerBackendAddressPoolsListOptions) LoadBalancerBackendAddressPoolListResultPager
 }
 
 // LoadBalancerBackendAddressPoolsClient implements the LoadBalancerBackendAddressPoolsOperations interface.
@@ -39,8 +39,8 @@ func (client *LoadBalancerBackendAddressPoolsClient) Do(req *azcore.Request) (*a
 }
 
 // Get - Gets load balancer backend address pool.
-func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string) (*BackendAddressPoolResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, backendAddressPoolName)
+func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string, options *LoadBalancerBackendAddressPoolsGetOptions) (*BackendAddressPoolResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, backendAddressPoolName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, re
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancerBackendAddressPoolsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string) (*azcore.Request, error) {
+func (client *LoadBalancerBackendAddressPoolsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, backendAddressPoolName string, options *LoadBalancerBackendAddressPoolsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -92,11 +92,11 @@ func (client *LoadBalancerBackendAddressPoolsClient) GetHandleError(resp *azcore
 }
 
 // List - Gets all the load balancer backed address pools.
-func (client *LoadBalancerBackendAddressPoolsClient) List(resourceGroupName string, loadBalancerName string) LoadBalancerBackendAddressPoolListResultPager {
+func (client *LoadBalancerBackendAddressPoolsClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerBackendAddressPoolsListOptions) LoadBalancerBackendAddressPoolListResultPager {
 	return &loadBalancerBackendAddressPoolListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) List(resourceGroupName stri
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerBackendAddressPoolsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerBackendAddressPoolsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerBackendAddressPoolsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -16,9 +16,9 @@ import (
 // LoadBalancerFrontendIPConfigurationsOperations contains the methods for the LoadBalancerFrontendIPConfigurations group.
 type LoadBalancerFrontendIPConfigurationsOperations interface {
 	// Get - Gets load balancer frontend IP configuration.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string) (*FrontendIPConfigurationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string, options *LoadBalancerFrontendIPConfigurationsGetOptions) (*FrontendIPConfigurationResponse, error)
 	// List - Gets all the load balancer frontend IP configurations.
-	List(resourceGroupName string, loadBalancerName string) LoadBalancerFrontendIPConfigurationListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerFrontendIPConfigurationsListOptions) LoadBalancerFrontendIPConfigurationListResultPager
 }
 
 // LoadBalancerFrontendIPConfigurationsClient implements the LoadBalancerFrontendIPConfigurationsOperations interface.
@@ -39,8 +39,8 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) Do(req *azcore.Request
 }
 
 // Get - Gets load balancer frontend IP configuration.
-func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string) (*FrontendIPConfigurationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, frontendIPConfigurationName)
+func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string, options *LoadBalancerFrontendIPConfigurationsGetOptions) (*FrontendIPConfigurationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, frontendIPConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Contex
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancerFrontendIPConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string) (*azcore.Request, error) {
+func (client *LoadBalancerFrontendIPConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, frontendIPConfigurationName string, options *LoadBalancerFrontendIPConfigurationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations/{frontendIPConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -92,11 +92,11 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) GetHandleError(resp *a
 }
 
 // List - Gets all the load balancer frontend IP configurations.
-func (client *LoadBalancerFrontendIPConfigurationsClient) List(resourceGroupName string, loadBalancerName string) LoadBalancerFrontendIPConfigurationListResultPager {
+func (client *LoadBalancerFrontendIPConfigurationsClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerFrontendIPConfigurationsListOptions) LoadBalancerFrontendIPConfigurationListResultPager {
 	return &loadBalancerFrontendIPConfigurationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) List(resourceGroupName
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerFrontendIPConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerFrontendIPConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerFrontendIPConfigurationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -16,9 +16,9 @@ import (
 // LoadBalancerLoadBalancingRulesOperations contains the methods for the LoadBalancerLoadBalancingRules group.
 type LoadBalancerLoadBalancingRulesOperations interface {
 	// Get - Gets the specified load balancer load balancing rule.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string) (*LoadBalancingRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string, options *LoadBalancerLoadBalancingRulesGetOptions) (*LoadBalancingRuleResponse, error)
 	// List - Gets all the load balancing rules in a load balancer.
-	List(resourceGroupName string, loadBalancerName string) LoadBalancerLoadBalancingRuleListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerLoadBalancingRulesListOptions) LoadBalancerLoadBalancingRuleListResultPager
 }
 
 // LoadBalancerLoadBalancingRulesClient implements the LoadBalancerLoadBalancingRulesOperations interface.
@@ -39,8 +39,8 @@ func (client *LoadBalancerLoadBalancingRulesClient) Do(req *azcore.Request) (*az
 }
 
 // Get - Gets the specified load balancer load balancing rule.
-func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string) (*LoadBalancingRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, loadBalancingRuleName)
+func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string, options *LoadBalancerLoadBalancingRulesGetOptions) (*LoadBalancingRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, loadBalancingRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, res
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancerLoadBalancingRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string) (*azcore.Request, error) {
+func (client *LoadBalancerLoadBalancingRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancingRuleName string, options *LoadBalancerLoadBalancingRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -92,11 +92,11 @@ func (client *LoadBalancerLoadBalancingRulesClient) GetHandleError(resp *azcore.
 }
 
 // List - Gets all the load balancing rules in a load balancer.
-func (client *LoadBalancerLoadBalancingRulesClient) List(resourceGroupName string, loadBalancerName string) LoadBalancerLoadBalancingRuleListResultPager {
+func (client *LoadBalancerLoadBalancingRulesClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerLoadBalancingRulesListOptions) LoadBalancerLoadBalancingRuleListResultPager {
 	return &loadBalancerLoadBalancingRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) List(resourceGroupName strin
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerLoadBalancingRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerLoadBalancingRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerLoadBalancingRulesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -16,7 +16,7 @@ import (
 // LoadBalancerNetworkInterfacesOperations contains the methods for the LoadBalancerNetworkInterfaces group.
 type LoadBalancerNetworkInterfacesOperations interface {
 	// List - Gets associated load balancer network interfaces.
-	List(resourceGroupName string, loadBalancerName string) NetworkInterfaceListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerNetworkInterfacesListOptions) NetworkInterfaceListResultPager
 }
 
 // LoadBalancerNetworkInterfacesClient implements the LoadBalancerNetworkInterfacesOperations interface.
@@ -37,11 +37,11 @@ func (client *LoadBalancerNetworkInterfacesClient) Do(req *azcore.Request) (*azc
 }
 
 // List - Gets associated load balancer network interfaces.
-func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string, loadBalancerName string) NetworkInterfaceListResultPager {
+func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerNetworkInterfacesListOptions) NetworkInterfaceListResultPager {
 	return &networkInterfaceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerNetworkInterfacesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerNetworkInterfacesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerNetworkInterfacesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -16,9 +16,9 @@ import (
 // LoadBalancerOutboundRulesOperations contains the methods for the LoadBalancerOutboundRules group.
 type LoadBalancerOutboundRulesOperations interface {
 	// Get - Gets the specified load balancer outbound rule.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string) (*OutboundRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string, options *LoadBalancerOutboundRulesGetOptions) (*OutboundRuleResponse, error)
 	// List - Gets all the outbound rules in a load balancer.
-	List(resourceGroupName string, loadBalancerName string) LoadBalancerOutboundRuleListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerOutboundRulesListOptions) LoadBalancerOutboundRuleListResultPager
 }
 
 // LoadBalancerOutboundRulesClient implements the LoadBalancerOutboundRulesOperations interface.
@@ -39,8 +39,8 @@ func (client *LoadBalancerOutboundRulesClient) Do(req *azcore.Request) (*azcore.
 }
 
 // Get - Gets the specified load balancer outbound rule.
-func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string) (*OutboundRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, outboundRuleName)
+func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string, options *LoadBalancerOutboundRulesGetOptions) (*OutboundRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, outboundRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resource
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancerOutboundRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string) (*azcore.Request, error) {
+func (client *LoadBalancerOutboundRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, outboundRuleName string, options *LoadBalancerOutboundRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules/{outboundRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -92,11 +92,11 @@ func (client *LoadBalancerOutboundRulesClient) GetHandleError(resp *azcore.Respo
 }
 
 // List - Gets all the outbound rules in a load balancer.
-func (client *LoadBalancerOutboundRulesClient) List(resourceGroupName string, loadBalancerName string) LoadBalancerOutboundRuleListResultPager {
+func (client *LoadBalancerOutboundRulesClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerOutboundRulesListOptions) LoadBalancerOutboundRuleListResultPager {
 	return &loadBalancerOutboundRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *LoadBalancerOutboundRulesClient) List(resourceGroupName string, lo
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerOutboundRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerOutboundRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerOutboundRulesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -16,9 +16,9 @@ import (
 // LoadBalancerProbesOperations contains the methods for the LoadBalancerProbes group.
 type LoadBalancerProbesOperations interface {
 	// Get - Gets load balancer probe.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string) (*ProbeResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string, options *LoadBalancerProbesGetOptions) (*ProbeResponse, error)
 	// List - Gets all the load balancer probes.
-	List(resourceGroupName string, loadBalancerName string) LoadBalancerProbeListResultPager
+	List(resourceGroupName string, loadBalancerName string, options *LoadBalancerProbesListOptions) LoadBalancerProbeListResultPager
 }
 
 // LoadBalancerProbesClient implements the LoadBalancerProbesOperations interface.
@@ -39,8 +39,8 @@ func (client *LoadBalancerProbesClient) Do(req *azcore.Request) (*azcore.Respons
 }
 
 // Get - Gets load balancer probe.
-func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string) (*ProbeResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, probeName)
+func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string, options *LoadBalancerProbesGetOptions) (*ProbeResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, probeName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupNa
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancerProbesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string) (*azcore.Request, error) {
+func (client *LoadBalancerProbesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, probeName string, options *LoadBalancerProbesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -92,11 +92,11 @@ func (client *LoadBalancerProbesClient) GetHandleError(resp *azcore.Response) er
 }
 
 // List - Gets all the load balancer probes.
-func (client *LoadBalancerProbesClient) List(resourceGroupName string, loadBalancerName string) LoadBalancerProbeListResultPager {
+func (client *LoadBalancerProbesClient) List(resourceGroupName string, loadBalancerName string, options *LoadBalancerProbesListOptions) LoadBalancerProbeListResultPager {
 	return &loadBalancerProbeListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName)
+			return client.ListCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *LoadBalancerProbesClient) List(resourceGroupName string, loadBalan
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancerProbesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancerProbesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancerProbesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -18,21 +18,21 @@ import (
 // LoadBalancersOperations contains the methods for the LoadBalancers group.
 type LoadBalancersOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a load balancer.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*LoadBalancerPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersCreateOrUpdateOptions) (*LoadBalancerPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (LoadBalancerPoller, error)
 	// BeginDelete - Deletes the specified load balancer.
-	BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified load balancer.
-	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancersGetOptions *LoadBalancersGetOptions) (*LoadBalancerResponse, error)
+	Get(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersGetOptions) (*LoadBalancerResponse, error)
 	// List - Gets all the load balancers in a resource group.
-	List(resourceGroupName string) LoadBalancerListResultPager
+	List(resourceGroupName string, options *LoadBalancersListOptions) LoadBalancerListResultPager
 	// ListAll - Gets all the load balancers in a subscription.
-	ListAll() LoadBalancerListResultPager
+	ListAll(options *LoadBalancersListAllOptions) LoadBalancerListResultPager
 	// UpdateTags - Updates a load balancer tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject) (*LoadBalancerResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject, options *LoadBalancersUpdateTagsOptions) (*LoadBalancerResponse, error)
 }
 
 // LoadBalancersClient implements the LoadBalancersOperations interface.
@@ -52,8 +52,8 @@ func (client *LoadBalancersClient) Do(req *azcore.Request) (*azcore.Response, er
 	return client.p.Do(req)
 }
 
-func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*LoadBalancerPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, loadBalancerName, parameters)
+func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersCreateOrUpdateOptions) (*LoadBalancerPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, loadBalancerName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *LoadBalancersClient) ResumeCreateOrUpdate(token string) (LoadBalan
 }
 
 // CreateOrUpdate - Creates or updates a load balancer.
-func (client *LoadBalancersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, loadBalancerName, parameters)
+func (client *LoadBalancersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, loadBalancerName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *LoadBalancersClient) CreateOrUpdate(ctx context.Context, resourceG
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *LoadBalancersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer) (*azcore.Request, error) {
+func (client *LoadBalancersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters LoadBalancer, options *LoadBalancersCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -134,8 +134,8 @@ func (client *LoadBalancersClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, loadBalancerName)
+func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, loadBalancerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *LoadBalancersClient) ResumeDelete(token string) (HTTPPoller, error
 }
 
 // Delete - Deletes the specified load balancer.
-func (client *LoadBalancersClient) Delete(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, loadBalancerName)
+func (client *LoadBalancersClient) Delete(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *LoadBalancersClient) Delete(ctx context.Context, resourceGroupName
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *LoadBalancersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string) (*azcore.Request, error) {
+func (client *LoadBalancersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -211,8 +211,8 @@ func (client *LoadBalancersClient) DeleteHandleError(resp *azcore.Response) erro
 }
 
 // Get - Gets the specified load balancer.
-func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancersGetOptions *LoadBalancersGetOptions) (*LoadBalancerResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, loadBalancersGetOptions)
+func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersGetOptions) (*LoadBalancerResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, loadBalancerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName st
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LoadBalancersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, loadBalancersGetOptions *LoadBalancersGetOptions) (*azcore.Request, error) {
+func (client *LoadBalancersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, options *LoadBalancersGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))
@@ -242,8 +242,8 @@ func (client *LoadBalancersClient) GetCreateRequest(ctx context.Context, resourc
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if loadBalancersGetOptions != nil && loadBalancersGetOptions.Expand != nil {
-		query.Set("$expand", *loadBalancersGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *LoadBalancersClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all the load balancers in a resource group.
-func (client *LoadBalancersClient) List(resourceGroupName string) LoadBalancerListResultPager {
+func (client *LoadBalancersClient) List(resourceGroupName string, options *LoadBalancersListOptions) LoadBalancerListResultPager {
 	return &loadBalancerListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *LoadBalancersClient) List(resourceGroupName string) LoadBalancerLi
 }
 
 // ListCreateRequest creates the List request.
-func (client *LoadBalancersClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *LoadBalancersClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *LoadBalancersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,11 +312,11 @@ func (client *LoadBalancersClient) ListHandleError(resp *azcore.Response) error 
 }
 
 // ListAll - Gets all the load balancers in a subscription.
-func (client *LoadBalancersClient) ListAll() LoadBalancerListResultPager {
+func (client *LoadBalancersClient) ListAll(options *LoadBalancersListAllOptions) LoadBalancerListResultPager {
 	return &loadBalancerListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -327,7 +327,7 @@ func (client *LoadBalancersClient) ListAll() LoadBalancerListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *LoadBalancersClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *LoadBalancersClient) ListAllCreateRequest(ctx context.Context, options *LoadBalancersListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -357,8 +357,8 @@ func (client *LoadBalancersClient) ListAllHandleError(resp *azcore.Response) err
 }
 
 // UpdateTags - Updates a load balancer tags.
-func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject) (*LoadBalancerResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, loadBalancerName, parameters)
+func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject, options *LoadBalancersUpdateTagsOptions) (*LoadBalancerResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, loadBalancerName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroup
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *LoadBalancersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *LoadBalancersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, loadBalancerName string, parameters TagsObject, options *LoadBalancersUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{loadBalancerName}", url.PathEscape(loadBalancerName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -18,19 +18,19 @@ import (
 // LocalNetworkGatewaysOperations contains the methods for the LocalNetworkGateways group.
 type LocalNetworkGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a local network gateway in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*LocalNetworkGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysCreateOrUpdateOptions) (*LocalNetworkGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (LocalNetworkGatewayPoller, error)
 	// BeginDelete - Deletes the specified local network gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified local network gateway in a resource group.
-	Get(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*LocalNetworkGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysGetOptions) (*LocalNetworkGatewayResponse, error)
 	// List - Gets all the local network gateways in a resource group.
-	List(resourceGroupName string) LocalNetworkGatewayListResultPager
+	List(resourceGroupName string, options *LocalNetworkGatewaysListOptions) LocalNetworkGatewayListResultPager
 	// UpdateTags - Updates a local network gateway tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject) (*LocalNetworkGatewayResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject, options *LocalNetworkGatewaysUpdateTagsOptions) (*LocalNetworkGatewayResponse, error)
 }
 
 // LocalNetworkGatewaysClient implements the LocalNetworkGatewaysOperations interface.
@@ -50,8 +50,8 @@ func (client *LocalNetworkGatewaysClient) Do(req *azcore.Request) (*azcore.Respo
 	return client.p.Do(req)
 }
 
-func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*LocalNetworkGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, localNetworkGatewayName, parameters)
+func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysCreateOrUpdateOptions) (*LocalNetworkGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, localNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *LocalNetworkGatewaysClient) ResumeCreateOrUpdate(token string) (Lo
 }
 
 // CreateOrUpdate - Creates or updates a local network gateway in the specified resource group.
-func (client *LocalNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, parameters)
+func (client *LocalNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, re
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *LocalNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway) (*azcore.Request, error) {
+func (client *LocalNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters LocalNetworkGateway, options *LocalNetworkGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
@@ -132,8 +132,8 @@ func (client *LocalNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, localNetworkGatewayName)
+func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, localNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *LocalNetworkGatewaysClient) ResumeDelete(token string) (HTTPPoller
 }
 
 // Delete - Deletes the specified local network gateway.
-func (client *LocalNetworkGatewaysClient) Delete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, localNetworkGatewayName)
+func (client *LocalNetworkGatewaysClient) Delete(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *LocalNetworkGatewaysClient) Delete(ctx context.Context, resourceGr
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *LocalNetworkGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*azcore.Request, error) {
+func (client *LocalNetworkGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
@@ -209,8 +209,8 @@ func (client *LocalNetworkGatewaysClient) DeleteHandleError(resp *azcore.Respons
 }
 
 // Get - Gets the specified local network gateway in a resource group.
-func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*LocalNetworkGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, localNetworkGatewayName)
+func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysGetOptions) (*LocalNetworkGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *LocalNetworkGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string) (*azcore.Request, error) {
+func (client *LocalNetworkGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, options *LocalNetworkGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))
@@ -261,11 +261,11 @@ func (client *LocalNetworkGatewaysClient) GetHandleError(resp *azcore.Response) 
 }
 
 // List - Gets all the local network gateways in a resource group.
-func (client *LocalNetworkGatewaysClient) List(resourceGroupName string) LocalNetworkGatewayListResultPager {
+func (client *LocalNetworkGatewaysClient) List(resourceGroupName string, options *LocalNetworkGatewaysListOptions) LocalNetworkGatewayListResultPager {
 	return &localNetworkGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -276,7 +276,7 @@ func (client *LocalNetworkGatewaysClient) List(resourceGroupName string) LocalNe
 }
 
 // ListCreateRequest creates the List request.
-func (client *LocalNetworkGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *LocalNetworkGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *LocalNetworkGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -307,8 +307,8 @@ func (client *LocalNetworkGatewaysClient) ListHandleError(resp *azcore.Response)
 }
 
 // UpdateTags - Updates a local network gateway tags.
-func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject) (*LocalNetworkGatewayResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, parameters)
+func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject, options *LocalNetworkGatewaysUpdateTagsOptions) (*LocalNetworkGatewayResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, localNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resour
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *LocalNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *LocalNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, localNetworkGatewayName string, parameters TagsObject, options *LocalNetworkGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{localNetworkGatewayName}", url.PathEscape(localNetworkGatewayName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -1192,6 +1192,88 @@ type ApplicationGatewaysBackendHealthOptions struct {
 	Expand *string
 }
 
+// ApplicationGatewaysCreateOrUpdateOptions contains the optional parameters for the ApplicationGateways.CreateOrUpdate method.
+type ApplicationGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysDeleteOptions contains the optional parameters for the ApplicationGateways.Delete method.
+type ApplicationGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysGetOptions contains the optional parameters for the ApplicationGateways.Get method.
+type ApplicationGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysGetSslPredefinedPolicyOptions contains the optional parameters for the ApplicationGateways.GetSslPredefinedPolicy
+// method.
+type ApplicationGatewaysGetSslPredefinedPolicyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAllOptions contains the optional parameters for the ApplicationGateways.ListAll method.
+type ApplicationGatewaysListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableRequestHeadersOptions contains the optional parameters for the ApplicationGateways.ListAvailableRequestHeaders
+// method.
+type ApplicationGatewaysListAvailableRequestHeadersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableResponseHeadersOptions contains the optional parameters for the ApplicationGateways.ListAvailableResponseHeaders
+// method.
+type ApplicationGatewaysListAvailableResponseHeadersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableServerVariablesOptions contains the optional parameters for the ApplicationGateways.ListAvailableServerVariables
+// method.
+type ApplicationGatewaysListAvailableServerVariablesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableSslOptionsOptions contains the optional parameters for the ApplicationGateways.ListAvailableSslOptions
+// method.
+type ApplicationGatewaysListAvailableSslOptionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableSslPredefinedPoliciesOptions contains the optional parameters for the ApplicationGateways.ListAvailableSslPredefinedPolicies
+// method.
+type ApplicationGatewaysListAvailableSslPredefinedPoliciesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListAvailableWafRuleSetsOptions contains the optional parameters for the ApplicationGateways.ListAvailableWafRuleSets
+// method.
+type ApplicationGatewaysListAvailableWafRuleSetsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysListOptions contains the optional parameters for the ApplicationGateways.List method.
+type ApplicationGatewaysListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysStartOptions contains the optional parameters for the ApplicationGateways.Start method.
+type ApplicationGatewaysStartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysStopOptions contains the optional parameters for the ApplicationGateways.Stop method.
+type ApplicationGatewaysStopOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationGatewaysUpdateTagsOptions contains the optional parameters for the ApplicationGateways.UpdateTags method.
+type ApplicationGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Rule condition of type application.
 type ApplicationRuleCondition struct {
 	FirewallPolicyRuleCondition
@@ -1346,6 +1428,38 @@ type ApplicationSecurityGroupResponse struct {
 	RawResponse *http.Response
 }
 
+// ApplicationSecurityGroupsCreateOrUpdateOptions contains the optional parameters for the ApplicationSecurityGroups.CreateOrUpdate
+// method.
+type ApplicationSecurityGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationSecurityGroupsDeleteOptions contains the optional parameters for the ApplicationSecurityGroups.Delete method.
+type ApplicationSecurityGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationSecurityGroupsGetOptions contains the optional parameters for the ApplicationSecurityGroups.Get method.
+type ApplicationSecurityGroupsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationSecurityGroupsListAllOptions contains the optional parameters for the ApplicationSecurityGroups.ListAll method.
+type ApplicationSecurityGroupsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationSecurityGroupsListOptions contains the optional parameters for the ApplicationSecurityGroups.List method.
+type ApplicationSecurityGroupsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ApplicationSecurityGroupsUpdateTagsOptions contains the optional parameters for the ApplicationSecurityGroups.UpdateTags
+// method.
+type ApplicationSecurityGroupsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ListAuthorizations API service call retrieves all authorizations that belongs to an ExpressRouteCircuit.
 type AuthorizationListResult struct {
 	// The URL to get the next set of results.
@@ -1431,6 +1545,11 @@ type AvailableDelegation struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// AvailableDelegationsListOptions contains the optional parameters for the AvailableDelegations.List method.
+type AvailableDelegationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // An array of available delegations.
 type AvailableDelegationsResult struct {
 	// The URL to get the next set of results.
@@ -1449,6 +1568,11 @@ type AvailableDelegationsResultResponse struct {
 	RawResponse *http.Response
 }
 
+// AvailableEndpointServicesListOptions contains the optional parameters for the AvailableEndpointServices.List method.
+type AvailableEndpointServicesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The information of an AvailablePrivateEndpointType.
 type AvailablePrivateEndpointType struct {
 	// A unique identifier of the AvailablePrivateEndpoint Type resource.
@@ -1462,6 +1586,17 @@ type AvailablePrivateEndpointType struct {
 
 	// Resource type.
 	Type *string `json:"type,omitempty"`
+}
+
+// AvailablePrivateEndpointTypesListByResourceGroupOptions contains the optional parameters for the AvailablePrivateEndpointTypes.ListByResourceGroup
+// method.
+type AvailablePrivateEndpointTypesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailablePrivateEndpointTypesListOptions contains the optional parameters for the AvailablePrivateEndpointTypes.List method.
+type AvailablePrivateEndpointTypesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // An array of available PrivateEndpoint types.
@@ -1559,6 +1694,12 @@ type AvailableProvidersListState struct {
 	StateName *string `json:"stateName,omitempty"`
 }
 
+// AvailableResourceGroupDelegationsListOptions contains the optional parameters for the AvailableResourceGroupDelegations.List
+// method.
+type AvailableResourceGroupDelegationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The available service alias.
 type AvailableServiceAlias struct {
 	// The ID of the service alias.
@@ -1572,6 +1713,17 @@ type AvailableServiceAlias struct {
 
 	// The type of the resource.
 	Type *string `json:"type,omitempty"`
+}
+
+// AvailableServiceAliasesListByResourceGroupOptions contains the optional parameters for the AvailableServiceAliases.ListByResourceGroup
+// method.
+type AvailableServiceAliasesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AvailableServiceAliasesListOptions contains the optional parameters for the AvailableServiceAliases.List method.
+type AvailableServiceAliasesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // An array of available service aliases.
@@ -1716,6 +1868,11 @@ type AzureFirewallFqdnTagPropertiesFormat struct {
 
 	// The provisioning state of the Azure firewall FQDN tag resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// AzureFirewallFqdnTagsListAllOptions contains the optional parameters for the AzureFirewallFqdnTags.ListAll method.
+type AzureFirewallFqdnTagsListAllOptions struct {
+	// placeholder for future optional parameters
 }
 
 // IP configuration of an Azure Firewall.
@@ -1983,6 +2140,36 @@ type AzureFirewallSKU struct {
 
 	// Tier of an Azure Firewall.
 	Tier *AzureFirewallSKUTier `json:"tier,omitempty"`
+}
+
+// AzureFirewallsCreateOrUpdateOptions contains the optional parameters for the AzureFirewalls.CreateOrUpdate method.
+type AzureFirewallsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AzureFirewallsDeleteOptions contains the optional parameters for the AzureFirewalls.Delete method.
+type AzureFirewallsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AzureFirewallsGetOptions contains the optional parameters for the AzureFirewalls.Get method.
+type AzureFirewallsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AzureFirewallsListAllOptions contains the optional parameters for the AzureFirewalls.ListAll method.
+type AzureFirewallsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AzureFirewallsListOptions contains the optional parameters for the AzureFirewalls.List method.
+type AzureFirewallsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// AzureFirewallsUpdateTagsOptions contains the optional parameters for the AzureFirewalls.UpdateTags method.
+type AzureFirewallsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Azure reachability report details.
@@ -2382,6 +2569,31 @@ type BastionHostResponse struct {
 	RawResponse *http.Response
 }
 
+// BastionHostsCreateOrUpdateOptions contains the optional parameters for the BastionHosts.CreateOrUpdate method.
+type BastionHostsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BastionHostsDeleteOptions contains the optional parameters for the BastionHosts.Delete method.
+type BastionHostsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BastionHostsGetOptions contains the optional parameters for the BastionHosts.Get method.
+type BastionHostsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BastionHostsListByResourceGroupOptions contains the optional parameters for the BastionHosts.ListByResourceGroup method.
+type BastionHostsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BastionHostsListOptions contains the optional parameters for the BastionHosts.List method.
+type BastionHostsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for DisconnectActiveSessions.
 type BastionSessionDeleteResult struct {
 	// The URL to get the next set of results.
@@ -2539,6 +2751,11 @@ type BgpPeerStatusListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// BgpServiceCommunitiesListOptions contains the optional parameters for the BgpServiceCommunities.List method.
+type BgpServiceCommunitiesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Service Community Properties.
@@ -3095,6 +3312,46 @@ type ConnectionMonitorWorkspaceSettings struct {
 	WorkspaceResourceID *string `json:"workspaceResourceId,omitempty"`
 }
 
+// ConnectionMonitorsCreateOrUpdateOptions contains the optional parameters for the ConnectionMonitors.CreateOrUpdate method.
+type ConnectionMonitorsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsDeleteOptions contains the optional parameters for the ConnectionMonitors.Delete method.
+type ConnectionMonitorsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsGetOptions contains the optional parameters for the ConnectionMonitors.Get method.
+type ConnectionMonitorsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsListOptions contains the optional parameters for the ConnectionMonitors.List method.
+type ConnectionMonitorsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsQueryOptions contains the optional parameters for the ConnectionMonitors.Query method.
+type ConnectionMonitorsQueryOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsStartOptions contains the optional parameters for the ConnectionMonitors.Start method.
+type ConnectionMonitorsStartOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsStopOptions contains the optional parameters for the ConnectionMonitors.Stop method.
+type ConnectionMonitorsStopOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ConnectionMonitorsUpdateTagsOptions contains the optional parameters for the ConnectionMonitors.UpdateTags method.
+type ConnectionMonitorsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The virtual network connection reset shared key.
 type ConnectionResetSharedKey struct {
 	// The virtual network connection reset shared key length, should between 1 and 128.
@@ -3522,6 +3779,26 @@ type DNSNameAvailabilityResultResponse struct {
 	RawResponse *http.Response
 }
 
+// DdosCustomPoliciesCreateOrUpdateOptions contains the optional parameters for the DdosCustomPolicies.CreateOrUpdate method.
+type DdosCustomPoliciesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosCustomPoliciesDeleteOptions contains the optional parameters for the DdosCustomPolicies.Delete method.
+type DdosCustomPoliciesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosCustomPoliciesGetOptions contains the optional parameters for the DdosCustomPolicies.Get method.
+type DdosCustomPoliciesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosCustomPoliciesUpdateTagsOptions contains the optional parameters for the DdosCustomPolicies.UpdateTags method.
+type DdosCustomPoliciesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // A DDoS custom policy in a resource group.
 type DdosCustomPolicy struct {
 	Resource
@@ -3647,6 +3924,37 @@ type DdosProtectionPlanResponse struct {
 	RawResponse *http.Response
 }
 
+// DdosProtectionPlansCreateOrUpdateOptions contains the optional parameters for the DdosProtectionPlans.CreateOrUpdate method.
+type DdosProtectionPlansCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosProtectionPlansDeleteOptions contains the optional parameters for the DdosProtectionPlans.Delete method.
+type DdosProtectionPlansDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosProtectionPlansGetOptions contains the optional parameters for the DdosProtectionPlans.Get method.
+type DdosProtectionPlansGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosProtectionPlansListByResourceGroupOptions contains the optional parameters for the DdosProtectionPlans.ListByResourceGroup
+// method.
+type DdosProtectionPlansListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosProtectionPlansListOptions contains the optional parameters for the DdosProtectionPlans.List method.
+type DdosProtectionPlansListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DdosProtectionPlansUpdateTagsOptions contains the optional parameters for the DdosProtectionPlans.UpdateTags method.
+type DdosProtectionPlansUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Contains the DDoS protection settings of the public IP.
 type DdosSettings struct {
 	// The DDoS custom policy associated with the public IP.
@@ -3657,6 +3965,16 @@ type DdosSettings struct {
 
 	// The DDoS protection policy customizability of the public IP. Only standard coverage will have the ability to be customized.
 	ProtectionCoverage *DdosSettingsProtectionCoverage `json:"protectionCoverage,omitempty"`
+}
+
+// DefaultSecurityRulesGetOptions contains the optional parameters for the DefaultSecurityRules.Get method.
+type DefaultSecurityRulesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DefaultSecurityRulesListOptions contains the optional parameters for the DefaultSecurityRules.List method.
+type DefaultSecurityRulesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Details the service to which the subnet is delegated.
@@ -4048,6 +4366,30 @@ type ExpressRouteCircuitAuthorizationResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitAuthorizations.CreateOrUpdate
+// method.
+type ExpressRouteCircuitAuthorizationsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitAuthorizationsDeleteOptions contains the optional parameters for the ExpressRouteCircuitAuthorizations.Delete
+// method.
+type ExpressRouteCircuitAuthorizationsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitAuthorizationsGetOptions contains the optional parameters for the ExpressRouteCircuitAuthorizations.Get
+// method.
+type ExpressRouteCircuitAuthorizationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitAuthorizationsListOptions contains the optional parameters for the ExpressRouteCircuitAuthorizations.List
+// method.
+type ExpressRouteCircuitAuthorizationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.
 type ExpressRouteCircuitConnection struct {
 	SubResource
@@ -4130,6 +4472,29 @@ type ExpressRouteCircuitConnectionResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteCircuitConnectionsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitConnections.CreateOrUpdate
+// method.
+type ExpressRouteCircuitConnectionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitConnectionsDeleteOptions contains the optional parameters for the ExpressRouteCircuitConnections.Delete
+// method.
+type ExpressRouteCircuitConnectionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitConnectionsGetOptions contains the optional parameters for the ExpressRouteCircuitConnections.Get method.
+type ExpressRouteCircuitConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitConnectionsListOptions contains the optional parameters for the ExpressRouteCircuitConnections.List
+// method.
+type ExpressRouteCircuitConnectionsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for ListExpressRouteCircuit API service call.
@@ -4296,6 +4661,27 @@ type ExpressRouteCircuitPeeringResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteCircuitPeeringsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitPeerings.CreateOrUpdate
+// method.
+type ExpressRouteCircuitPeeringsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitPeeringsDeleteOptions contains the optional parameters for the ExpressRouteCircuitPeerings.Delete method.
+type ExpressRouteCircuitPeeringsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitPeeringsGetOptions contains the optional parameters for the ExpressRouteCircuitPeerings.Get method.
+type ExpressRouteCircuitPeeringsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitPeeringsListOptions contains the optional parameters for the ExpressRouteCircuitPeerings.List method.
+type ExpressRouteCircuitPeeringsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ExpressRouteCircuitPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuit
@@ -4488,6 +4874,60 @@ type ExpressRouteCircuitsArpTableListResultResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRouteCircuitsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuits.CreateOrUpdate
+// method.
+type ExpressRouteCircuitsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsDeleteOptions contains the optional parameters for the ExpressRouteCircuits.Delete method.
+type ExpressRouteCircuitsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsGetOptions contains the optional parameters for the ExpressRouteCircuits.Get method.
+type ExpressRouteCircuitsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsGetPeeringStatsOptions contains the optional parameters for the ExpressRouteCircuits.GetPeeringStats
+// method.
+type ExpressRouteCircuitsGetPeeringStatsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsGetStatsOptions contains the optional parameters for the ExpressRouteCircuits.GetStats method.
+type ExpressRouteCircuitsGetStatsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsListAllOptions contains the optional parameters for the ExpressRouteCircuits.ListAll method.
+type ExpressRouteCircuitsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsListArpTableOptions contains the optional parameters for the ExpressRouteCircuits.ListArpTable method.
+type ExpressRouteCircuitsListArpTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsListOptions contains the optional parameters for the ExpressRouteCircuits.List method.
+type ExpressRouteCircuitsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsListRoutesTableOptions contains the optional parameters for the ExpressRouteCircuits.ListRoutesTable
+// method.
+type ExpressRouteCircuitsListRoutesTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCircuitsListRoutesTableSummaryOptions contains the optional parameters for the ExpressRouteCircuits.ListRoutesTableSummary
+// method.
+type ExpressRouteCircuitsListRoutesTableSummaryOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ListRoutesTable associated with the Express Route Circuits API.
 type ExpressRouteCircuitsRoutesTableListResult struct {
 	// The URL to get the next set of results.
@@ -4550,6 +4990,11 @@ type ExpressRouteCircuitsRoutesTableSummaryListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteCircuitsUpdateTagsOptions contains the optional parameters for the ExpressRouteCircuits.UpdateTags method.
+type ExpressRouteCircuitsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ExpressRouteConnection resource.
@@ -4621,6 +5066,27 @@ type ExpressRouteConnectionResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteConnectionsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteConnections.CreateOrUpdate
+// method.
+type ExpressRouteConnectionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteConnectionsDeleteOptions contains the optional parameters for the ExpressRouteConnections.Delete method.
+type ExpressRouteConnectionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteConnectionsGetOptions contains the optional parameters for the ExpressRouteConnections.Get method.
+type ExpressRouteConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteConnectionsListOptions contains the optional parameters for the ExpressRouteConnections.List method.
+type ExpressRouteConnectionsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ExpressRouteCrossConnection resource.
@@ -4755,6 +5221,30 @@ type ExpressRouteCrossConnectionPeeringResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnectionPeerings.CreateOrUpdate
+// method.
+type ExpressRouteCrossConnectionPeeringsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionPeeringsDeleteOptions contains the optional parameters for the ExpressRouteCrossConnectionPeerings.Delete
+// method.
+type ExpressRouteCrossConnectionPeeringsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionPeeringsGetOptions contains the optional parameters for the ExpressRouteCrossConnectionPeerings.Get
+// method.
+type ExpressRouteCrossConnectionPeeringsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionPeeringsListOptions contains the optional parameters for the ExpressRouteCrossConnectionPeerings.List
+// method.
+type ExpressRouteCrossConnectionPeeringsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ExpressRouteCrossConnectionPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCrossConnection
 // type.
 type ExpressRouteCrossConnectionPollerResponse struct {
@@ -4826,6 +5316,46 @@ type ExpressRouteCrossConnectionRoutesTableSummary struct {
 	UpDown *string `json:"upDown,omitempty"`
 }
 
+// ExpressRouteCrossConnectionsCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnections.CreateOrUpdate
+// method.
+type ExpressRouteCrossConnectionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsGetOptions contains the optional parameters for the ExpressRouteCrossConnections.Get method.
+type ExpressRouteCrossConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsListArpTableOptions contains the optional parameters for the ExpressRouteCrossConnections.ListArpTable
+// method.
+type ExpressRouteCrossConnectionsListArpTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsListByResourceGroupOptions contains the optional parameters for the ExpressRouteCrossConnections.ListByResourceGroup
+// method.
+type ExpressRouteCrossConnectionsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsListOptions contains the optional parameters for the ExpressRouteCrossConnections.List method.
+type ExpressRouteCrossConnectionsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsListRoutesTableOptions contains the optional parameters for the ExpressRouteCrossConnections.ListRoutesTable
+// method.
+type ExpressRouteCrossConnectionsListRoutesTableOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteCrossConnectionsListRoutesTableSummaryOptions contains the optional parameters for the ExpressRouteCrossConnections.ListRoutesTableSummary
+// method.
+type ExpressRouteCrossConnectionsListRoutesTableSummaryOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ListRoutesTable associated with the Express Route Cross Connections.
 type ExpressRouteCrossConnectionsRoutesTableSummaryListResult struct {
 	// The URL to get the next set of results.
@@ -4856,6 +5386,12 @@ type ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteCrossConnectionsUpdateTagsOptions contains the optional parameters for the ExpressRouteCrossConnections.UpdateTags
+// method.
+type ExpressRouteCrossConnectionsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ExpressRoute gateway resource.
@@ -4935,6 +5471,34 @@ type ExpressRouteGatewayResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRouteGatewaysCreateOrUpdateOptions contains the optional parameters for the ExpressRouteGateways.CreateOrUpdate
+// method.
+type ExpressRouteGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteGatewaysDeleteOptions contains the optional parameters for the ExpressRouteGateways.Delete method.
+type ExpressRouteGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteGatewaysGetOptions contains the optional parameters for the ExpressRouteGateways.Get method.
+type ExpressRouteGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteGatewaysListByResourceGroupOptions contains the optional parameters for the ExpressRouteGateways.ListByResourceGroup
+// method.
+type ExpressRouteGatewaysListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteGatewaysListBySubscriptionOptions contains the optional parameters for the ExpressRouteGateways.ListBySubscription
+// method.
+type ExpressRouteGatewaysListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ExpressRouteLink child resource definition.
 type ExpressRouteLink struct {
 	SubResource
@@ -5012,6 +5576,16 @@ type ExpressRouteLinkResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// ExpressRouteLinksGetOptions contains the optional parameters for the ExpressRouteLinks.Get method.
+type ExpressRouteLinksGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRouteLinksListOptions contains the optional parameters for the ExpressRouteLinks.List method.
+type ExpressRouteLinksListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ExpressRoutePort resource definition.
@@ -5102,6 +5676,32 @@ type ExpressRoutePortResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRoutePortsCreateOrUpdateOptions contains the optional parameters for the ExpressRoutePorts.CreateOrUpdate method.
+type ExpressRoutePortsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsDeleteOptions contains the optional parameters for the ExpressRoutePorts.Delete method.
+type ExpressRoutePortsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsGetOptions contains the optional parameters for the ExpressRoutePorts.Get method.
+type ExpressRoutePortsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsListByResourceGroupOptions contains the optional parameters for the ExpressRoutePorts.ListByResourceGroup
+// method.
+type ExpressRoutePortsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsListOptions contains the optional parameters for the ExpressRoutePorts.List method.
+type ExpressRoutePortsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Definition of the ExpressRoutePorts peering location resource.
 type ExpressRoutePortsLocation struct {
 	Resource
@@ -5161,6 +5761,21 @@ type ExpressRoutePortsLocationResponse struct {
 	RawResponse *http.Response
 }
 
+// ExpressRoutePortsLocationsGetOptions contains the optional parameters for the ExpressRoutePortsLocations.Get method.
+type ExpressRoutePortsLocationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsLocationsListOptions contains the optional parameters for the ExpressRoutePortsLocations.List method.
+type ExpressRoutePortsLocationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ExpressRoutePortsUpdateTagsOptions contains the optional parameters for the ExpressRoutePorts.UpdateTags method.
+type ExpressRoutePortsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // A ExpressRouteResourceProvider object.
 type ExpressRouteServiceProvider struct {
 	Resource
@@ -5208,10 +5823,35 @@ type ExpressRouteServiceProviderPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
+// ExpressRouteServiceProvidersListOptions contains the optional parameters for the ExpressRouteServiceProviders.List method.
+type ExpressRouteServiceProvidersListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPoliciesCreateOrUpdateOptions contains the optional parameters for the FirewallPolicies.CreateOrUpdate method.
+type FirewallPoliciesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPoliciesDeleteOptions contains the optional parameters for the FirewallPolicies.Delete method.
+type FirewallPoliciesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // FirewallPoliciesGetOptions contains the optional parameters for the FirewallPolicies.Get method.
 type FirewallPoliciesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// FirewallPoliciesListAllOptions contains the optional parameters for the FirewallPolicies.ListAll method.
+type FirewallPoliciesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPoliciesListOptions contains the optional parameters for the FirewallPolicies.List method.
+type FirewallPoliciesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // FirewallPolicy Resource.
@@ -5666,6 +6306,27 @@ type FirewallPolicyRuleGroupResponse struct {
 	RawResponse *http.Response
 }
 
+// FirewallPolicyRuleGroupsCreateOrUpdateOptions contains the optional parameters for the FirewallPolicyRuleGroups.CreateOrUpdate
+// method.
+type FirewallPolicyRuleGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPolicyRuleGroupsDeleteOptions contains the optional parameters for the FirewallPolicyRuleGroups.Delete method.
+type FirewallPolicyRuleGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPolicyRuleGroupsGetOptions contains the optional parameters for the FirewallPolicyRuleGroups.Get method.
+type FirewallPolicyRuleGroupsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FirewallPolicyRuleGroupsListOptions contains the optional parameters for the FirewallPolicyRuleGroups.List method.
+type FirewallPolicyRuleGroupsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // A flow log resource.
 type FlowLog struct {
 	Resource
@@ -5804,6 +6465,26 @@ type FlowLogResponse struct {
 type FlowLogStatusParameters struct {
 	// The target resource where getting the flow log and traffic analytics (optional) status.
 	TargetResourceID *string `json:"targetResourceId,omitempty"`
+}
+
+// FlowLogsCreateOrUpdateOptions contains the optional parameters for the FlowLogs.CreateOrUpdate method.
+type FlowLogsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FlowLogsDeleteOptions contains the optional parameters for the FlowLogs.Delete method.
+type FlowLogsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FlowLogsGetOptions contains the optional parameters for the FlowLogs.Get method.
+type FlowLogsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// FlowLogsListOptions contains the optional parameters for the FlowLogs.List method.
+type FlowLogsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Frontend IP address of the load balancer.
@@ -6014,6 +6695,16 @@ type HubVirtualNetworkConnectionResponse struct {
 	RawResponse *http.Response
 }
 
+// HubVirtualNetworkConnectionsGetOptions contains the optional parameters for the HubVirtualNetworkConnections.Get method.
+type HubVirtualNetworkConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// HubVirtualNetworkConnectionsListOptions contains the optional parameters for the HubVirtualNetworkConnections.List method.
+type HubVirtualNetworkConnectionsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for CheckIPAddressAvailability API service call.
 type IPAddressAvailabilityResult struct {
 	// Private IP address availability.
@@ -6108,10 +6799,35 @@ type IPAllocationResponse struct {
 	RawResponse *http.Response
 }
 
+// IPAllocationsCreateOrUpdateOptions contains the optional parameters for the IPAllocations.CreateOrUpdate method.
+type IPAllocationsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPAllocationsDeleteOptions contains the optional parameters for the IPAllocations.Delete method.
+type IPAllocationsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // IPAllocationsGetOptions contains the optional parameters for the IPAllocations.Get method.
 type IPAllocationsGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// IPAllocationsListByResourceGroupOptions contains the optional parameters for the IPAllocations.ListByResourceGroup method.
+type IPAllocationsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPAllocationsListOptions contains the optional parameters for the IPAllocations.List method.
+type IPAllocationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPAllocationsUpdateTagsOptions contains the optional parameters for the IPAllocations.UpdateTags method.
+type IPAllocationsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // IP configuration.
@@ -6246,10 +6962,35 @@ type IPGroupResponse struct {
 	RawResponse *http.Response
 }
 
+// IPGroupsCreateOrUpdateOptions contains the optional parameters for the IPGroups.CreateOrUpdate method.
+type IPGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPGroupsDeleteOptions contains the optional parameters for the IPGroups.Delete method.
+type IPGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // IPGroupsGetOptions contains the optional parameters for the IPGroups.Get method.
 type IPGroupsGetOptions struct {
 	// Expands resourceIds (of Firewalls/Network Security Groups etc.) back referenced by the IpGroups resource.
 	Expand *string
+}
+
+// IPGroupsListByResourceGroupOptions contains the optional parameters for the IPGroups.ListByResourceGroup method.
+type IPGroupsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPGroupsListOptions contains the optional parameters for the IPGroups.List method.
+type IPGroupsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IPGroupsUpdateGroupsOptions contains the optional parameters for the IPGroups.UpdateGroups method.
+type IPGroupsUpdateGroupsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Contains the IpTag associated with the object.
@@ -6460,10 +7201,25 @@ type InboundNatRuleResponse struct {
 	RawResponse *http.Response
 }
 
+// InboundNatRulesCreateOrUpdateOptions contains the optional parameters for the InboundNatRules.CreateOrUpdate method.
+type InboundNatRulesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// InboundNatRulesDeleteOptions contains the optional parameters for the InboundNatRules.Delete method.
+type InboundNatRulesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // InboundNatRulesGetOptions contains the optional parameters for the InboundNatRules.Get method.
 type InboundNatRulesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// InboundNatRulesListOptions contains the optional parameters for the InboundNatRules.List method.
+type InboundNatRulesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // List of HubVirtualNetworkConnections and a URL nextLink to get the next set of results.
@@ -6716,6 +7472,18 @@ type LoadBalancerBackendAddressPoolListResultResponse struct {
 	RawResponse *http.Response
 }
 
+// LoadBalancerBackendAddressPoolsGetOptions contains the optional parameters for the LoadBalancerBackendAddressPools.Get
+// method.
+type LoadBalancerBackendAddressPoolsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerBackendAddressPoolsListOptions contains the optional parameters for the LoadBalancerBackendAddressPools.List
+// method.
+type LoadBalancerBackendAddressPoolsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ListFrontendIPConfiguration API service call.
 type LoadBalancerFrontendIPConfigurationListResult struct {
 	// The URL to get the next set of results.
@@ -6733,6 +7501,18 @@ type LoadBalancerFrontendIPConfigurationListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// LoadBalancerFrontendIPConfigurationsGetOptions contains the optional parameters for the LoadBalancerFrontendIPConfigurations.Get
+// method.
+type LoadBalancerFrontendIPConfigurationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerFrontendIPConfigurationsListOptions contains the optional parameters for the LoadBalancerFrontendIPConfigurations.List
+// method.
+type LoadBalancerFrontendIPConfigurationsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for ListLoadBalancers API service call.
@@ -6772,6 +7552,22 @@ type LoadBalancerLoadBalancingRuleListResultResponse struct {
 	RawResponse *http.Response
 }
 
+// LoadBalancerLoadBalancingRulesGetOptions contains the optional parameters for the LoadBalancerLoadBalancingRules.Get method.
+type LoadBalancerLoadBalancingRulesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerLoadBalancingRulesListOptions contains the optional parameters for the LoadBalancerLoadBalancingRules.List
+// method.
+type LoadBalancerLoadBalancingRulesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerNetworkInterfacesListOptions contains the optional parameters for the LoadBalancerNetworkInterfaces.List method.
+type LoadBalancerNetworkInterfacesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ListOutboundRule API service call.
 type LoadBalancerOutboundRuleListResult struct {
 	// The URL to get the next set of results.
@@ -6789,6 +7585,16 @@ type LoadBalancerOutboundRuleListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// LoadBalancerOutboundRulesGetOptions contains the optional parameters for the LoadBalancerOutboundRules.Get method.
+type LoadBalancerOutboundRulesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerOutboundRulesListOptions contains the optional parameters for the LoadBalancerOutboundRules.List method.
+type LoadBalancerOutboundRulesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // LoadBalancerPollerResponse is the response envelope for operations that asynchronously return a LoadBalancer type.
@@ -6819,6 +7625,16 @@ type LoadBalancerProbeListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// LoadBalancerProbesGetOptions contains the optional parameters for the LoadBalancerProbes.Get method.
+type LoadBalancerProbesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancerProbesListOptions contains the optional parameters for the LoadBalancerProbes.List method.
+type LoadBalancerProbesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Properties of the load balancer.
@@ -6872,10 +7688,35 @@ type LoadBalancerSKU struct {
 	Name *LoadBalancerSKUName `json:"name,omitempty"`
 }
 
+// LoadBalancersCreateOrUpdateOptions contains the optional parameters for the LoadBalancers.CreateOrUpdate method.
+type LoadBalancersCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancersDeleteOptions contains the optional parameters for the LoadBalancers.Delete method.
+type LoadBalancersDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // LoadBalancersGetOptions contains the optional parameters for the LoadBalancers.Get method.
 type LoadBalancersGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// LoadBalancersListAllOptions contains the optional parameters for the LoadBalancers.ListAll method.
+type LoadBalancersListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancersListOptions contains the optional parameters for the LoadBalancers.List method.
+type LoadBalancersListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LoadBalancersUpdateTagsOptions contains the optional parameters for the LoadBalancers.UpdateTags method.
+type LoadBalancersUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A load balancing rule for a load balancer.
@@ -7020,6 +7861,32 @@ type LocalNetworkGatewayResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// LocalNetworkGatewaysCreateOrUpdateOptions contains the optional parameters for the LocalNetworkGateways.CreateOrUpdate
+// method.
+type LocalNetworkGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LocalNetworkGatewaysDeleteOptions contains the optional parameters for the LocalNetworkGateways.Delete method.
+type LocalNetworkGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LocalNetworkGatewaysGetOptions contains the optional parameters for the LocalNetworkGateways.Get method.
+type LocalNetworkGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LocalNetworkGatewaysListOptions contains the optional parameters for the LocalNetworkGateways.List method.
+type LocalNetworkGatewaysListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// LocalNetworkGatewaysUpdateTagsOptions contains the optional parameters for the LocalNetworkGateways.UpdateTags method.
+type LocalNetworkGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Description of logging specification.
@@ -7253,10 +8120,35 @@ type NatGatewaySKU struct {
 	Name *NatGatewaySKUName `json:"name,omitempty"`
 }
 
+// NatGatewaysCreateOrUpdateOptions contains the optional parameters for the NatGateways.CreateOrUpdate method.
+type NatGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NatGatewaysDeleteOptions contains the optional parameters for the NatGateways.Delete method.
+type NatGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NatGatewaysGetOptions contains the optional parameters for the NatGateways.Get method.
 type NatGatewaysGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// NatGatewaysListAllOptions contains the optional parameters for the NatGateways.ListAll method.
+type NatGatewaysListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NatGatewaysListOptions contains the optional parameters for the NatGateways.List method.
+type NatGatewaysListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NatGatewaysUpdateTagsOptions contains the optional parameters for the NatGateways.UpdateTags method.
+type NatGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Rule condition of type nat.
@@ -7562,6 +8454,18 @@ type NetworkInterfaceIPConfigurationResponse struct {
 	RawResponse *http.Response
 }
 
+// NetworkInterfaceIPConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceIPConfigurations.Get
+// method.
+type NetworkInterfaceIPConfigurationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfaceIPConfigurationsListOptions contains the optional parameters for the NetworkInterfaceIPConfigurations.List
+// method.
+type NetworkInterfaceIPConfigurationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for the ListNetworkInterface API service call.
 type NetworkInterfaceListResult struct {
 	// The URL to get the next set of results.
@@ -7597,6 +8501,11 @@ type NetworkInterfaceLoadBalancerListResultResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// NetworkInterfaceLoadBalancersListOptions contains the optional parameters for the NetworkInterfaceLoadBalancers.List method.
+type NetworkInterfaceLoadBalancersListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // NetworkInterfacePollerResponse is the response envelope for operations that asynchronously return a NetworkInterface type.
@@ -7729,6 +8638,46 @@ type NetworkInterfaceTapConfigurationResponse struct {
 	RawResponse *http.Response
 }
 
+// NetworkInterfaceTapConfigurationsCreateOrUpdateOptions contains the optional parameters for the NetworkInterfaceTapConfigurations.CreateOrUpdate
+// method.
+type NetworkInterfaceTapConfigurationsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfaceTapConfigurationsDeleteOptions contains the optional parameters for the NetworkInterfaceTapConfigurations.Delete
+// method.
+type NetworkInterfaceTapConfigurationsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfaceTapConfigurationsGetOptions contains the optional parameters for the NetworkInterfaceTapConfigurations.Get
+// method.
+type NetworkInterfaceTapConfigurationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfaceTapConfigurationsListOptions contains the optional parameters for the NetworkInterfaceTapConfigurations.List
+// method.
+type NetworkInterfaceTapConfigurationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesCreateOrUpdateOptions contains the optional parameters for the NetworkInterfaces.CreateOrUpdate method.
+type NetworkInterfacesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesDeleteOptions contains the optional parameters for the NetworkInterfaces.Delete method.
+type NetworkInterfacesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesGetEffectiveRouteTableOptions contains the optional parameters for the NetworkInterfaces.GetEffectiveRouteTable
+// method.
+type NetworkInterfacesGetEffectiveRouteTableOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NetworkInterfacesGetOptions contains the optional parameters for the NetworkInterfaces.Get method.
 type NetworkInterfacesGetOptions struct {
 	// Expands referenced resources.
@@ -7749,11 +8698,92 @@ type NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions struct {
 	Expand *string
 }
 
+// NetworkInterfacesListAllOptions contains the optional parameters for the NetworkInterfaces.ListAll method.
+type NetworkInterfacesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions contains the optional parameters for the NetworkInterfaces.ListEffectiveNetworkSecurityGroups
+// method.
+type NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesListOptions contains the optional parameters for the NetworkInterfaces.List method.
+type NetworkInterfacesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions contains the optional parameters for the NetworkInterfaces.ListVirtualMachineScaleSetIPConfigurations
 // method.
 type NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions contains the optional parameters for the NetworkInterfaces.ListVirtualMachineScaleSetNetworkInterfaces
+// method.
+type NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions contains the optional parameters for the NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfaces
+// method.
+type NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkInterfacesUpdateTagsOptions contains the optional parameters for the NetworkInterfaces.UpdateTags method.
+type NetworkInterfacesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientCheckDNSNameAvailabilityOptions contains the optional parameters for the NetworkManagementClient.CheckDNSNameAvailability
+// method.
+type NetworkManagementClientCheckDNSNameAvailabilityOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientDeleteBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.DeleteBastionShareableLink
+// method.
+type NetworkManagementClientDeleteBastionShareableLinkOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientDisconnectActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.DisconnectActiveSessions
+// method.
+type NetworkManagementClientDisconnectActiveSessionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions contains the optional parameters for the
+// NetworkManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile method.
+type NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientGetActiveSessionsOptions contains the optional parameters for the NetworkManagementClient.GetActiveSessions
+// method.
+type NetworkManagementClientGetActiveSessionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientGetBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.GetBastionShareableLink
+// method.
+type NetworkManagementClientGetBastionShareableLinkOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientPutBastionShareableLinkOptions contains the optional parameters for the NetworkManagementClient.PutBastionShareableLink
+// method.
+type NetworkManagementClientPutBastionShareableLinkOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkManagementClientSupportedSecurityProvidersOptions contains the optional parameters for the NetworkManagementClient.SupportedSecurityProviders
+// method.
+type NetworkManagementClientSupportedSecurityProvidersOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Network profile resource.
@@ -7808,10 +8838,35 @@ type NetworkProfileResponse struct {
 	RawResponse *http.Response
 }
 
+// NetworkProfilesCreateOrUpdateOptions contains the optional parameters for the NetworkProfiles.CreateOrUpdate method.
+type NetworkProfilesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkProfilesDeleteOptions contains the optional parameters for the NetworkProfiles.Delete method.
+type NetworkProfilesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NetworkProfilesGetOptions contains the optional parameters for the NetworkProfiles.Get method.
 type NetworkProfilesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// NetworkProfilesListAllOptions contains the optional parameters for the NetworkProfiles.ListAll method.
+type NetworkProfilesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkProfilesListOptions contains the optional parameters for the NetworkProfiles.List method.
+type NetworkProfilesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkProfilesUpdateTagsOptions contains the optional parameters for the NetworkProfiles.UpdateTags method.
+type NetworkProfilesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Rule condition of type network.
@@ -7991,10 +9046,36 @@ type NetworkSecurityGroupResult struct {
 	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
 }
 
+// NetworkSecurityGroupsCreateOrUpdateOptions contains the optional parameters for the NetworkSecurityGroups.CreateOrUpdate
+// method.
+type NetworkSecurityGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkSecurityGroupsDeleteOptions contains the optional parameters for the NetworkSecurityGroups.Delete method.
+type NetworkSecurityGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NetworkSecurityGroupsGetOptions contains the optional parameters for the NetworkSecurityGroups.Get method.
 type NetworkSecurityGroupsGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// NetworkSecurityGroupsListAllOptions contains the optional parameters for the NetworkSecurityGroups.ListAll method.
+type NetworkSecurityGroupsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkSecurityGroupsListOptions contains the optional parameters for the NetworkSecurityGroups.List method.
+type NetworkSecurityGroupsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkSecurityGroupsUpdateTagsOptions contains the optional parameters for the NetworkSecurityGroups.UpdateTags method.
+type NetworkSecurityGroupsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Network security rules evaluation result.
@@ -8096,10 +9177,38 @@ type NetworkVirtualApplianceResponse struct {
 	RawResponse *http.Response
 }
 
+// NetworkVirtualAppliancesCreateOrUpdateOptions contains the optional parameters for the NetworkVirtualAppliances.CreateOrUpdate
+// method.
+type NetworkVirtualAppliancesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkVirtualAppliancesDeleteOptions contains the optional parameters for the NetworkVirtualAppliances.Delete method.
+type NetworkVirtualAppliancesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NetworkVirtualAppliancesGetOptions contains the optional parameters for the NetworkVirtualAppliances.Get method.
 type NetworkVirtualAppliancesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// NetworkVirtualAppliancesListByResourceGroupOptions contains the optional parameters for the NetworkVirtualAppliances.ListByResourceGroup
+// method.
+type NetworkVirtualAppliancesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkVirtualAppliancesListOptions contains the optional parameters for the NetworkVirtualAppliances.List method.
+type NetworkVirtualAppliancesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkVirtualAppliancesUpdateTagsOptions contains the optional parameters for the NetworkVirtualAppliances.UpdateTags
+// method.
+type NetworkVirtualAppliancesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Network watcher in a resource group.
@@ -8140,6 +9249,101 @@ type NetworkWatcherResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// NetworkWatchersCheckConnectivityOptions contains the optional parameters for the NetworkWatchers.CheckConnectivity method.
+type NetworkWatchersCheckConnectivityOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersCreateOrUpdateOptions contains the optional parameters for the NetworkWatchers.CreateOrUpdate method.
+type NetworkWatchersCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersDeleteOptions contains the optional parameters for the NetworkWatchers.Delete method.
+type NetworkWatchersDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetAzureReachabilityReportOptions contains the optional parameters for the NetworkWatchers.GetAzureReachabilityReport
+// method.
+type NetworkWatchersGetAzureReachabilityReportOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetFlowLogStatusOptions contains the optional parameters for the NetworkWatchers.GetFlowLogStatus method.
+type NetworkWatchersGetFlowLogStatusOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetNetworkConfigurationDiagnosticOptions contains the optional parameters for the NetworkWatchers.GetNetworkConfigurationDiagnostic
+// method.
+type NetworkWatchersGetNetworkConfigurationDiagnosticOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetNextHopOptions contains the optional parameters for the NetworkWatchers.GetNextHop method.
+type NetworkWatchersGetNextHopOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetOptions contains the optional parameters for the NetworkWatchers.Get method.
+type NetworkWatchersGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetTopologyOptions contains the optional parameters for the NetworkWatchers.GetTopology method.
+type NetworkWatchersGetTopologyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetTroubleshootingOptions contains the optional parameters for the NetworkWatchers.GetTroubleshooting method.
+type NetworkWatchersGetTroubleshootingOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetTroubleshootingResultOptions contains the optional parameters for the NetworkWatchers.GetTroubleshootingResult
+// method.
+type NetworkWatchersGetTroubleshootingResultOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersGetVMSecurityRulesOptions contains the optional parameters for the NetworkWatchers.GetVMSecurityRules method.
+type NetworkWatchersGetVMSecurityRulesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersListAllOptions contains the optional parameters for the NetworkWatchers.ListAll method.
+type NetworkWatchersListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersListAvailableProvidersOptions contains the optional parameters for the NetworkWatchers.ListAvailableProviders
+// method.
+type NetworkWatchersListAvailableProvidersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersListOptions contains the optional parameters for the NetworkWatchers.List method.
+type NetworkWatchersListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersSetFlowLogConfigurationOptions contains the optional parameters for the NetworkWatchers.SetFlowLogConfiguration
+// method.
+type NetworkWatchersSetFlowLogConfigurationOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersUpdateTagsOptions contains the optional parameters for the NetworkWatchers.UpdateTags method.
+type NetworkWatchersUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NetworkWatchersVerifyIPFlowOptions contains the optional parameters for the NetworkWatchers.VerifyIPFlow method.
+type NetworkWatchersVerifyIPFlowOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Parameters that define the source and destination endpoint.
@@ -8255,6 +9459,11 @@ type OperationPropertiesFormatServiceSpecification struct {
 
 	// Operation service specification.
 	MetricSpecifications *[]MetricSpecification `json:"metricSpecifications,omitempty"`
+}
+
+// OperationsListOptions contains the optional parameters for the Operations.List method.
+type OperationsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Outbound rule of the load balancer.
@@ -8436,6 +9645,59 @@ type P2SVpnGatewayResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// P2SVpnGatewaysCreateOrUpdateOptions contains the optional parameters for the P2SVpnGateways.CreateOrUpdate method.
+type P2SVpnGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysDeleteOptions contains the optional parameters for the P2SVpnGateways.Delete method.
+type P2SVpnGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions contains the optional parameters for the P2SVpnGateways.DisconnectP2SVpnConnections
+// method.
+type P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysGenerateVpnProfileOptions contains the optional parameters for the P2SVpnGateways.GenerateVpnProfile method.
+type P2SVpnGatewaysGenerateVpnProfileOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysGetOptions contains the optional parameters for the P2SVpnGateways.Get method.
+type P2SVpnGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions contains the optional parameters for the P2SVpnGateways.GetP2SVpnConnectionHealthDetailed
+// method.
+type P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysGetP2SVpnConnectionHealthOptions contains the optional parameters for the P2SVpnGateways.GetP2SVpnConnectionHealth
+// method.
+type P2SVpnGatewaysGetP2SVpnConnectionHealthOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysListByResourceGroupOptions contains the optional parameters for the P2SVpnGateways.ListByResourceGroup method.
+type P2SVpnGatewaysListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysListOptions contains the optional parameters for the P2SVpnGateways.List method.
+type P2SVpnGatewaysListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// P2SVpnGatewaysUpdateTagsOptions contains the optional parameters for the P2SVpnGateways.UpdateTags method.
+type P2SVpnGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Vpn Client Parameters for package generation.
@@ -8685,6 +9947,36 @@ type PacketCaptureStorageLocation struct {
 	StoragePath *string `json:"storagePath,omitempty"`
 }
 
+// PacketCapturesCreateOptions contains the optional parameters for the PacketCaptures.Create method.
+type PacketCapturesCreateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PacketCapturesDeleteOptions contains the optional parameters for the PacketCaptures.Delete method.
+type PacketCapturesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PacketCapturesGetOptions contains the optional parameters for the PacketCaptures.Get method.
+type PacketCapturesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PacketCapturesGetStatusOptions contains the optional parameters for the PacketCaptures.GetStatus method.
+type PacketCapturesGetStatusOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PacketCapturesListOptions contains the optional parameters for the PacketCaptures.List method.
+type PacketCapturesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PacketCapturesStopOptions contains the optional parameters for the PacketCaptures.Stop method.
+type PacketCapturesStopOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Route Filter Resource.
 type PatchRouteFilter struct {
 	SubResource
@@ -8788,6 +10080,18 @@ type PeerExpressRouteCircuitConnectionResponse struct {
 	RawResponse *http.Response
 }
 
+// PeerExpressRouteCircuitConnectionsGetOptions contains the optional parameters for the PeerExpressRouteCircuitConnections.Get
+// method.
+type PeerExpressRouteCircuitConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PeerExpressRouteCircuitConnectionsListOptions contains the optional parameters for the PeerExpressRouteCircuitConnections.List
+// method.
+type PeerExpressRouteCircuitConnectionsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Defines contents of a web application firewall global configuration.
 type PolicySettings struct {
 	// Maximum file upload size in Mb for WAF.
@@ -8885,6 +10189,27 @@ type PrivateDNSZoneGroupResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+// PrivateDNSZoneGroupsCreateOrUpdateOptions contains the optional parameters for the PrivateDNSZoneGroups.CreateOrUpdate
+// method.
+type PrivateDNSZoneGroupsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateDNSZoneGroupsDeleteOptions contains the optional parameters for the PrivateDNSZoneGroups.Delete method.
+type PrivateDNSZoneGroupsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateDNSZoneGroupsGetOptions contains the optional parameters for the PrivateDNSZoneGroups.Get method.
+type PrivateDNSZoneGroupsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateDNSZoneGroupsListOptions contains the optional parameters for the PrivateDNSZoneGroups.List method.
+type PrivateDNSZoneGroupsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Properties of the private dns zone configuration resource.
@@ -9026,10 +10351,31 @@ type PrivateEndpointResponse struct {
 	RawResponse *http.Response
 }
 
+// PrivateEndpointsCreateOrUpdateOptions contains the optional parameters for the PrivateEndpoints.CreateOrUpdate method.
+type PrivateEndpointsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateEndpointsDeleteOptions contains the optional parameters for the PrivateEndpoints.Delete method.
+type PrivateEndpointsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PrivateEndpointsGetOptions contains the optional parameters for the PrivateEndpoints.Get method.
 type PrivateEndpointsGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// PrivateEndpointsListBySubscriptionOptions contains the optional parameters for the PrivateEndpoints.ListBySubscription
+// method.
+type PrivateEndpointsListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateEndpointsListOptions contains the optional parameters for the PrivateEndpoints.List method.
+type PrivateEndpointsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Private link service resource.
@@ -9238,6 +10584,34 @@ type PrivateLinkServiceVisibilityResponse struct {
 	RawResponse *http.Response
 }
 
+// PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions contains the optional parameters for the PrivateLinkServices.CheckPrivateLinkServiceVisibilityByResourceGroup
+// method.
+type PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions contains the optional parameters for the PrivateLinkServices.CheckPrivateLinkServiceVisibility
+// method.
+type PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesCreateOrUpdateOptions contains the optional parameters for the PrivateLinkServices.CreateOrUpdate method.
+type PrivateLinkServicesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesDeleteOptions contains the optional parameters for the PrivateLinkServices.Delete method.
+type PrivateLinkServicesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesDeletePrivateEndpointConnectionOptions contains the optional parameters for the PrivateLinkServices.DeletePrivateEndpointConnection
+// method.
+type PrivateLinkServicesDeletePrivateEndpointConnectionOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PrivateLinkServicesGetOptions contains the optional parameters for the PrivateLinkServices.Get method.
 type PrivateLinkServicesGetOptions struct {
 	// Expands referenced resources.
@@ -9249,6 +10623,41 @@ type PrivateLinkServicesGetOptions struct {
 type PrivateLinkServicesGetPrivateEndpointConnectionOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupOptions contains the optional parameters for the PrivateLinkServices.ListAutoApprovedPrivateLinkServicesByResourceGroup
+// method.
+type PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesListAutoApprovedPrivateLinkServicesOptions contains the optional parameters for the PrivateLinkServices.ListAutoApprovedPrivateLinkServices
+// method.
+type PrivateLinkServicesListAutoApprovedPrivateLinkServicesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesListBySubscriptionOptions contains the optional parameters for the PrivateLinkServices.ListBySubscription
+// method.
+type PrivateLinkServicesListBySubscriptionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesListOptions contains the optional parameters for the PrivateLinkServices.List method.
+type PrivateLinkServicesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesListPrivateEndpointConnectionsOptions contains the optional parameters for the PrivateLinkServices.ListPrivateEndpointConnections
+// method.
+type PrivateLinkServicesListPrivateEndpointConnectionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PrivateLinkServicesUpdatePrivateEndpointConnectionOptions contains the optional parameters for the PrivateLinkServices.UpdatePrivateEndpointConnection
+// method.
+type PrivateLinkServicesUpdatePrivateEndpointConnectionOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A load balancer probe.
@@ -9442,6 +10851,16 @@ type PublicIPAddressSKU struct {
 	Name *PublicIPAddressSKUName `json:"name,omitempty"`
 }
 
+// PublicIPAddressesCreateOrUpdateOptions contains the optional parameters for the PublicIPAddresses.CreateOrUpdate method.
+type PublicIPAddressesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPAddressesDeleteOptions contains the optional parameters for the PublicIPAddresses.Delete method.
+type PublicIPAddressesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PublicIPAddressesGetOptions contains the optional parameters for the PublicIPAddresses.Get method.
 type PublicIPAddressesGetOptions struct {
 	// Expands referenced resources.
@@ -9453,6 +10872,33 @@ type PublicIPAddressesGetOptions struct {
 type PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// PublicIPAddressesListAllOptions contains the optional parameters for the PublicIPAddresses.ListAll method.
+type PublicIPAddressesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPAddressesListOptions contains the optional parameters for the PublicIPAddresses.List method.
+type PublicIPAddressesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesOptions contains the optional parameters for the PublicIPAddresses.ListVirtualMachineScaleSetPublicIPAddresses
+// method.
+type PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPAddressesListVirtualMachineScaleSetVMPublicIPaddressesOptions contains the optional parameters for the PublicIPAddresses.ListVirtualMachineScaleSetVMPublicIPaddresses
+// method.
+type PublicIPAddressesListVirtualMachineScaleSetVMPublicIPaddressesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPAddressesUpdateTagsOptions contains the optional parameters for the PublicIPAddresses.UpdateTags method.
+type PublicIPAddressesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Public IP prefix resource.
@@ -9543,10 +10989,35 @@ type PublicIPPrefixSKU struct {
 	Name *PublicIPPrefixSKUName `json:"name,omitempty"`
 }
 
+// PublicIPPrefixesCreateOrUpdateOptions contains the optional parameters for the PublicIPPrefixes.CreateOrUpdate method.
+type PublicIPPrefixesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPPrefixesDeleteOptions contains the optional parameters for the PublicIPPrefixes.Delete method.
+type PublicIPPrefixesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // PublicIPPrefixesGetOptions contains the optional parameters for the PublicIPPrefixes.Get method.
 type PublicIPPrefixesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// PublicIPPrefixesListAllOptions contains the optional parameters for the PublicIPPrefixes.ListAll method.
+type PublicIPPrefixesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPPrefixesListOptions contains the optional parameters for the PublicIPPrefixes.List method.
+type PublicIPPrefixesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PublicIPPrefixesUpdateTagsOptions contains the optional parameters for the PublicIPPrefixes.UpdateTags method.
+type PublicIPPrefixesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Parameters that define the resource to query the troubleshooting result.
@@ -9638,6 +11109,11 @@ type ResourceNavigationLinkFormat struct {
 
 	// The provisioning state of the resource navigation link resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// ResourceNavigationLinksListOptions contains the optional parameters for the ResourceNavigationLinks.List method.
+type ResourceNavigationLinksListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for ResourceNavigationLinks_List operation.
@@ -9821,10 +11297,55 @@ type RouteFilterRuleResponse struct {
 	RouteFilterRule *RouteFilterRule
 }
 
+// RouteFilterRulesCreateOrUpdateOptions contains the optional parameters for the RouteFilterRules.CreateOrUpdate method.
+type RouteFilterRulesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFilterRulesDeleteOptions contains the optional parameters for the RouteFilterRules.Delete method.
+type RouteFilterRulesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFilterRulesGetOptions contains the optional parameters for the RouteFilterRules.Get method.
+type RouteFilterRulesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFilterRulesListByRouteFilterOptions contains the optional parameters for the RouteFilterRules.ListByRouteFilter method.
+type RouteFilterRulesListByRouteFilterOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFiltersCreateOrUpdateOptions contains the optional parameters for the RouteFilters.CreateOrUpdate method.
+type RouteFiltersCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFiltersDeleteOptions contains the optional parameters for the RouteFilters.Delete method.
+type RouteFiltersDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // RouteFiltersGetOptions contains the optional parameters for the RouteFilters.Get method.
 type RouteFiltersGetOptions struct {
 	// Expands referenced express route bgp peering resources.
 	Expand *string
+}
+
+// RouteFiltersListByResourceGroupOptions contains the optional parameters for the RouteFilters.ListByResourceGroup method.
+type RouteFiltersListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFiltersListOptions contains the optional parameters for the RouteFilters.List method.
+type RouteFiltersListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteFiltersUpdateTagsOptions contains the optional parameters for the RouteFilters.UpdateTags method.
+type RouteFiltersUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for the ListRoute API service call.
@@ -9945,10 +11466,55 @@ type RouteTableResponse struct {
 	RouteTable *RouteTable
 }
 
+// RouteTablesCreateOrUpdateOptions contains the optional parameters for the RouteTables.CreateOrUpdate method.
+type RouteTablesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteTablesDeleteOptions contains the optional parameters for the RouteTables.Delete method.
+type RouteTablesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // RouteTablesGetOptions contains the optional parameters for the RouteTables.Get method.
 type RouteTablesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// RouteTablesListAllOptions contains the optional parameters for the RouteTables.ListAll method.
+type RouteTablesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteTablesListOptions contains the optional parameters for the RouteTables.List method.
+type RouteTablesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RouteTablesUpdateTagsOptions contains the optional parameters for the RouteTables.UpdateTags method.
+type RouteTablesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RoutesCreateOrUpdateOptions contains the optional parameters for the Routes.CreateOrUpdate method.
+type RoutesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RoutesDeleteOptions contains the optional parameters for the Routes.Delete method.
+type RoutesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RoutesGetOptions contains the optional parameters for the Routes.Get method.
+type RoutesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// RoutesListOptions contains the optional parameters for the Routes.List method.
+type RoutesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Network interface and all its associated security rules.
@@ -10058,6 +11624,39 @@ type SecurityPartnerProviderResponse struct {
 
 	// Security Partner Provider resource.
 	SecurityPartnerProvider *SecurityPartnerProvider
+}
+
+// SecurityPartnerProvidersCreateOrUpdateOptions contains the optional parameters for the SecurityPartnerProviders.CreateOrUpdate
+// method.
+type SecurityPartnerProvidersCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityPartnerProvidersDeleteOptions contains the optional parameters for the SecurityPartnerProviders.Delete method.
+type SecurityPartnerProvidersDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityPartnerProvidersGetOptions contains the optional parameters for the SecurityPartnerProviders.Get method.
+type SecurityPartnerProvidersGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityPartnerProvidersListByResourceGroupOptions contains the optional parameters for the SecurityPartnerProviders.ListByResourceGroup
+// method.
+type SecurityPartnerProvidersListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityPartnerProvidersListOptions contains the optional parameters for the SecurityPartnerProviders.List method.
+type SecurityPartnerProvidersListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityPartnerProvidersUpdateTagsOptions contains the optional parameters for the SecurityPartnerProviders.UpdateTags
+// method.
+type SecurityPartnerProvidersUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Network security rule.
@@ -10182,6 +11781,26 @@ type SecurityRuleResponse struct {
 	SecurityRule *SecurityRule
 }
 
+// SecurityRulesCreateOrUpdateOptions contains the optional parameters for the SecurityRules.CreateOrUpdate method.
+type SecurityRulesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityRulesDeleteOptions contains the optional parameters for the SecurityRules.Delete method.
+type SecurityRulesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityRulesGetOptions contains the optional parameters for the SecurityRules.Get method.
+type SecurityRulesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SecurityRulesListOptions contains the optional parameters for the SecurityRules.List method.
+type SecurityRulesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ServiceAssociationLink resource.
 type ServiceAssociationLink struct {
 	SubResource
@@ -10216,6 +11835,11 @@ type ServiceAssociationLinkPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
+// ServiceAssociationLinksListOptions contains the optional parameters for the ServiceAssociationLinks.List method.
+type ServiceAssociationLinksListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Response for ServiceAssociationLinks_List operation.
 type ServiceAssociationLinksListResult struct {
 	// The URL to get the next set of results.
@@ -10247,10 +11871,37 @@ type ServiceDelegationPropertiesFormat struct {
 	ServiceName *string `json:"serviceName,omitempty"`
 }
 
+// ServiceEndpointPoliciesCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPolicies.CreateOrUpdate
+// method.
+type ServiceEndpointPoliciesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPoliciesDeleteOptions contains the optional parameters for the ServiceEndpointPolicies.Delete method.
+type ServiceEndpointPoliciesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ServiceEndpointPoliciesGetOptions contains the optional parameters for the ServiceEndpointPolicies.Get method.
 type ServiceEndpointPoliciesGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// ServiceEndpointPoliciesListByResourceGroupOptions contains the optional parameters for the ServiceEndpointPolicies.ListByResourceGroup
+// method.
+type ServiceEndpointPoliciesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPoliciesListOptions contains the optional parameters for the ServiceEndpointPolicies.List method.
+type ServiceEndpointPoliciesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPoliciesUpdateTagsOptions contains the optional parameters for the ServiceEndpointPolicies.UpdateTags method.
+type ServiceEndpointPoliciesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Service End point policy resource.
@@ -10333,6 +11984,30 @@ type ServiceEndpointPolicyDefinitionResponse struct {
 
 	// Service Endpoint policy definitions.
 	ServiceEndpointPolicyDefinition *ServiceEndpointPolicyDefinition
+}
+
+// ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPolicyDefinitions.CreateOrUpdate
+// method.
+type ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPolicyDefinitionsDeleteOptions contains the optional parameters for the ServiceEndpointPolicyDefinitions.Delete
+// method.
+type ServiceEndpointPolicyDefinitionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPolicyDefinitionsGetOptions contains the optional parameters for the ServiceEndpointPolicyDefinitions.Get
+// method.
+type ServiceEndpointPolicyDefinitionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ServiceEndpointPolicyDefinitionsListByResourceGroupOptions contains the optional parameters for the ServiceEndpointPolicyDefinitions.ListByResourceGroup
+// method.
+type ServiceEndpointPolicyDefinitionsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for ListServiceEndpointPolicies API service call.
@@ -10428,6 +12103,11 @@ type ServiceTagInformationPropertiesFormat struct {
 
 	// The name of system service.
 	SystemService *string `json:"systemService,omitempty" azure:"ro"`
+}
+
+// ServiceTagsListOptions contains the optional parameters for the ServiceTags.List method.
+type ServiceTagsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for the ListServiceTags API service call.
@@ -10618,10 +12298,35 @@ type SubnetResponse struct {
 	Subnet *Subnet
 }
 
+// SubnetsCreateOrUpdateOptions contains the optional parameters for the Subnets.CreateOrUpdate method.
+type SubnetsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubnetsDeleteOptions contains the optional parameters for the Subnets.Delete method.
+type SubnetsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SubnetsGetOptions contains the optional parameters for the Subnets.Get method.
 type SubnetsGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// SubnetsListOptions contains the optional parameters for the Subnets.List method.
+type SubnetsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubnetsPrepareNetworkPoliciesOptions contains the optional parameters for the Subnets.PrepareNetworkPolicies method.
+type SubnetsPrepareNetworkPoliciesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SubnetsUnprepareNetworkPoliciesOptions contains the optional parameters for the Subnets.UnprepareNetworkPolicies method.
+type SubnetsUnprepareNetworkPoliciesOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Tags object for patch operations.
@@ -10983,6 +12688,11 @@ type UsageName struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// UsagesListOptions contains the optional parameters for the Usages.List method.
+type UsagesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The list usages operation response.
 type UsagesListResult struct {
 	// URL to get the next set of results.
@@ -11233,6 +12943,27 @@ type VirtualHubRouteTableV2Response struct {
 	VirtualHubRouteTableV2 *VirtualHubRouteTableV2
 }
 
+// VirtualHubRouteTableV2SCreateOrUpdateOptions contains the optional parameters for the VirtualHubRouteTableV2S.CreateOrUpdate
+// method.
+type VirtualHubRouteTableV2SCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubRouteTableV2SDeleteOptions contains the optional parameters for the VirtualHubRouteTableV2S.Delete method.
+type VirtualHubRouteTableV2SDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubRouteTableV2SGetOptions contains the optional parameters for the VirtualHubRouteTableV2S.Get method.
+type VirtualHubRouteTableV2SGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubRouteTableV2SListOptions contains the optional parameters for the VirtualHubRouteTableV2S.List method.
+type VirtualHubRouteTableV2SListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualHubRouteTableV2 route.
 type VirtualHubRouteV2 struct {
 	// The type of destinations.
@@ -11246,6 +12977,36 @@ type VirtualHubRouteV2 struct {
 
 	// NextHops ip address.
 	NextHops *[]string `json:"nextHops,omitempty"`
+}
+
+// VirtualHubsCreateOrUpdateOptions contains the optional parameters for the VirtualHubs.CreateOrUpdate method.
+type VirtualHubsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubsDeleteOptions contains the optional parameters for the VirtualHubs.Delete method.
+type VirtualHubsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubsGetOptions contains the optional parameters for the VirtualHubs.Get method.
+type VirtualHubsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubsListByResourceGroupOptions contains the optional parameters for the VirtualHubs.ListByResourceGroup method.
+type VirtualHubsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubsListOptions contains the optional parameters for the VirtualHubs.List method.
+type VirtualHubsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualHubsUpdateTagsOptions contains the optional parameters for the VirtualHubs.UpdateTags method.
+type VirtualHubsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Virtual Network resource.
@@ -11477,11 +13238,65 @@ type VirtualNetworkGatewayConnectionResponse struct {
 	VirtualNetworkGatewayConnection *VirtualNetworkGatewayConnection
 }
 
+// VirtualNetworkGatewayConnectionsCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewayConnections.CreateOrUpdate
+// method.
+type VirtualNetworkGatewayConnectionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsDeleteOptions contains the optional parameters for the VirtualNetworkGatewayConnections.Delete
+// method.
+type VirtualNetworkGatewayConnectionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsGetOptions contains the optional parameters for the VirtualNetworkGatewayConnections.Get
+// method.
+type VirtualNetworkGatewayConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsGetSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewayConnections.GetSharedKey
+// method.
+type VirtualNetworkGatewayConnectionsGetSharedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsListOptions contains the optional parameters for the VirtualNetworkGatewayConnections.List
+// method.
+type VirtualNetworkGatewayConnectionsListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsResetSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewayConnections.ResetSharedKey
+// method.
+type VirtualNetworkGatewayConnectionsResetSharedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsSetSharedKeyOptions contains the optional parameters for the VirtualNetworkGatewayConnections.SetSharedKey
+// method.
+type VirtualNetworkGatewayConnectionsSetSharedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualNetworkGatewayConnectionsStartPacketCaptureOptions contains the optional parameters for the VirtualNetworkGatewayConnections.StartPacketCapture
 // method.
 type VirtualNetworkGatewayConnectionsStartPacketCaptureOptions struct {
 	// Virtual network gateway packet capture parameters supplied to start packet capture on gateway connection.
 	Parameters *VpnPacketCaptureStartParameters
+}
+
+// VirtualNetworkGatewayConnectionsStopPacketCaptureOptions contains the optional parameters for the VirtualNetworkGatewayConnections.StopPacketCapture
+// method.
+type VirtualNetworkGatewayConnectionsStopPacketCaptureOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewayConnectionsUpdateTagsOptions contains the optional parameters for the VirtualNetworkGatewayConnections.UpdateTags
+// method.
+type VirtualNetworkGatewayConnectionsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // IP configuration for virtual network gateway.
@@ -11640,11 +13455,86 @@ type VirtualNetworkGatewaySKU struct {
 	Tier *VirtualNetworkGatewaySKUTier `json:"tier,omitempty"`
 }
 
+// VirtualNetworkGatewaysCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGateways.CreateOrUpdate
+// method.
+type VirtualNetworkGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysDeleteOptions contains the optional parameters for the VirtualNetworkGateways.Delete method.
+type VirtualNetworkGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions contains the optional parameters for the VirtualNetworkGateways.DisconnectVirtualNetworkGatewayVpnConnections
+// method.
+type VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGenerateVpnProfileOptions contains the optional parameters for the VirtualNetworkGateways.GenerateVpnProfile
+// method.
+type VirtualNetworkGatewaysGenerateVpnProfileOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGeneratevpnclientpackageOptions contains the optional parameters for the VirtualNetworkGateways.Generatevpnclientpackage
+// method.
+type VirtualNetworkGatewaysGeneratevpnclientpackageOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGetAdvertisedRoutesOptions contains the optional parameters for the VirtualNetworkGateways.GetAdvertisedRoutes
+// method.
+type VirtualNetworkGatewaysGetAdvertisedRoutesOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualNetworkGatewaysGetBgpPeerStatusOptions contains the optional parameters for the VirtualNetworkGateways.GetBgpPeerStatus
 // method.
 type VirtualNetworkGatewaysGetBgpPeerStatusOptions struct {
 	// The IP address of the peer to retrieve the status of.
 	Peer *string
+}
+
+// VirtualNetworkGatewaysGetLearnedRoutesOptions contains the optional parameters for the VirtualNetworkGateways.GetLearnedRoutes
+// method.
+type VirtualNetworkGatewaysGetLearnedRoutesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGetOptions contains the optional parameters for the VirtualNetworkGateways.Get method.
+type VirtualNetworkGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGetVpnProfilePackageURLOptions contains the optional parameters for the VirtualNetworkGateways.GetVpnProfilePackageURL
+// method.
+type VirtualNetworkGatewaysGetVpnProfilePackageURLOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions contains the optional parameters for the VirtualNetworkGateways.GetVpnclientConnectionHealth
+// method.
+type VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions contains the optional parameters for the VirtualNetworkGateways.GetVpnclientIPsecParameters
+// method.
+type VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysListConnectionsOptions contains the optional parameters for the VirtualNetworkGateways.ListConnections
+// method.
+type VirtualNetworkGatewaysListConnectionsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysListOptions contains the optional parameters for the VirtualNetworkGateways.List method.
+type VirtualNetworkGatewaysListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualNetworkGatewaysResetOptions contains the optional parameters for the VirtualNetworkGateways.Reset method.
@@ -11653,11 +13543,46 @@ type VirtualNetworkGatewaysResetOptions struct {
 	GatewayVip *string
 }
 
+// VirtualNetworkGatewaysResetVpnClientSharedKeyOptions contains the optional parameters for the VirtualNetworkGateways.ResetVpnClientSharedKey
+// method.
+type VirtualNetworkGatewaysResetVpnClientSharedKeyOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions contains the optional parameters for the VirtualNetworkGateways.SetVpnclientIPsecParameters
+// method.
+type VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualNetworkGatewaysStartPacketCaptureOptions contains the optional parameters for the VirtualNetworkGateways.StartPacketCapture
 // method.
 type VirtualNetworkGatewaysStartPacketCaptureOptions struct {
 	// Virtual network gateway packet capture parameters supplied to start packet capture on gateway.
 	Parameters *VpnPacketCaptureStartParameters
+}
+
+// VirtualNetworkGatewaysStopPacketCaptureOptions contains the optional parameters for the VirtualNetworkGateways.StopPacketCapture
+// method.
+type VirtualNetworkGatewaysStopPacketCaptureOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysSupportedVpnDevicesOptions contains the optional parameters for the VirtualNetworkGateways.SupportedVpnDevices
+// method.
+type VirtualNetworkGatewaysSupportedVpnDevicesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysUpdateTagsOptions contains the optional parameters for the VirtualNetworkGateways.UpdateTags method.
+type VirtualNetworkGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkGatewaysVpnDeviceConfigurationScriptOptions contains the optional parameters for the VirtualNetworkGateways.VpnDeviceConfigurationScript
+// method.
+type VirtualNetworkGatewaysVpnDeviceConfigurationScriptOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Response for the ListVirtualNetworks API service call.
@@ -11779,6 +13704,27 @@ type VirtualNetworkPeeringResponse struct {
 
 	// Peerings in a virtual network resource.
 	VirtualNetworkPeering *VirtualNetworkPeering
+}
+
+// VirtualNetworkPeeringsCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkPeerings.CreateOrUpdate
+// method.
+type VirtualNetworkPeeringsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkPeeringsDeleteOptions contains the optional parameters for the VirtualNetworkPeerings.Delete method.
+type VirtualNetworkPeeringsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkPeeringsGetOptions contains the optional parameters for the VirtualNetworkPeerings.Get method.
+type VirtualNetworkPeeringsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkPeeringsListOptions contains the optional parameters for the VirtualNetworkPeerings.List method.
+type VirtualNetworkPeeringsListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualNetworkPollerResponse is the response envelope for operations that asynchronously return a VirtualNetwork type.
@@ -11910,6 +13856,37 @@ type VirtualNetworkTapResponse struct {
 	VirtualNetworkTap *VirtualNetworkTap
 }
 
+// VirtualNetworkTapsCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkTaps.CreateOrUpdate method.
+type VirtualNetworkTapsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkTapsDeleteOptions contains the optional parameters for the VirtualNetworkTaps.Delete method.
+type VirtualNetworkTapsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkTapsGetOptions contains the optional parameters for the VirtualNetworkTaps.Get method.
+type VirtualNetworkTapsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkTapsListAllOptions contains the optional parameters for the VirtualNetworkTaps.ListAll method.
+type VirtualNetworkTapsListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkTapsListByResourceGroupOptions contains the optional parameters for the VirtualNetworkTaps.ListByResourceGroup
+// method.
+type VirtualNetworkTapsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworkTapsUpdateTagsOptions contains the optional parameters for the VirtualNetworkTaps.UpdateTags method.
+type VirtualNetworkTapsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Usage details for subnet.
 type VirtualNetworkUsage struct {
 	// Indicates number of IPs used from the Subnet.
@@ -11937,10 +13914,46 @@ type VirtualNetworkUsageName struct {
 	Value *string `json:"value,omitempty" azure:"ro"`
 }
 
+// VirtualNetworksCheckIPAddressAvailabilityOptions contains the optional parameters for the VirtualNetworks.CheckIPAddressAvailability
+// method.
+type VirtualNetworksCheckIPAddressAvailabilityOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworksCreateOrUpdateOptions contains the optional parameters for the VirtualNetworks.CreateOrUpdate method.
+type VirtualNetworksCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworksDeleteOptions contains the optional parameters for the VirtualNetworks.Delete method.
+type VirtualNetworksDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualNetworksGetOptions contains the optional parameters for the VirtualNetworks.Get method.
 type VirtualNetworksGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// VirtualNetworksListAllOptions contains the optional parameters for the VirtualNetworks.ListAll method.
+type VirtualNetworksListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworksListOptions contains the optional parameters for the VirtualNetworks.List method.
+type VirtualNetworksListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworksListUsageOptions contains the optional parameters for the VirtualNetworks.ListUsage method.
+type VirtualNetworksListUsageOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualNetworksUpdateTagsOptions contains the optional parameters for the VirtualNetworks.UpdateTags method.
+type VirtualNetworksUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualRouter Resource.
@@ -12040,6 +14053,27 @@ type VirtualRouterPeeringResponse struct {
 	VirtualRouterPeering *VirtualRouterPeering
 }
 
+// VirtualRouterPeeringsCreateOrUpdateOptions contains the optional parameters for the VirtualRouterPeerings.CreateOrUpdate
+// method.
+type VirtualRouterPeeringsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualRouterPeeringsDeleteOptions contains the optional parameters for the VirtualRouterPeerings.Delete method.
+type VirtualRouterPeeringsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualRouterPeeringsGetOptions contains the optional parameters for the VirtualRouterPeerings.Get method.
+type VirtualRouterPeeringsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualRouterPeeringsListOptions contains the optional parameters for the VirtualRouterPeerings.List method.
+type VirtualRouterPeeringsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualRouterPollerResponse is the response envelope for operations that asynchronously return a VirtualRouter type.
 type VirtualRouterPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -12082,10 +14116,30 @@ type VirtualRouterResponse struct {
 	VirtualRouter *VirtualRouter
 }
 
+// VirtualRoutersCreateOrUpdateOptions contains the optional parameters for the VirtualRouters.CreateOrUpdate method.
+type VirtualRoutersCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualRoutersDeleteOptions contains the optional parameters for the VirtualRouters.Delete method.
+type VirtualRoutersDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VirtualRoutersGetOptions contains the optional parameters for the VirtualRouters.Get method.
 type VirtualRoutersGetOptions struct {
 	// Expands referenced resources.
 	Expand *string
+}
+
+// VirtualRoutersListByResourceGroupOptions contains the optional parameters for the VirtualRouters.ListByResourceGroup method.
+type VirtualRoutersListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualRoutersListOptions contains the optional parameters for the VirtualRouters.List method.
+type VirtualRoutersListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VirtualWAN Resource.
@@ -12180,6 +14234,36 @@ type VirtualWanVpnProfileParameters struct {
 
 	// VpnServerConfiguration partial resource uri with which VirtualWan is associated to.
 	VpnServerConfigurationResourceID *string `json:"vpnServerConfigurationResourceId,omitempty"`
+}
+
+// VirtualWansCreateOrUpdateOptions contains the optional parameters for the VirtualWans.CreateOrUpdate method.
+type VirtualWansCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualWansDeleteOptions contains the optional parameters for the VirtualWans.Delete method.
+type VirtualWansDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualWansGetOptions contains the optional parameters for the VirtualWans.Get method.
+type VirtualWansGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualWansListByResourceGroupOptions contains the optional parameters for the VirtualWans.ListByResourceGroup method.
+type VirtualWansListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualWansListOptions contains the optional parameters for the VirtualWans.List method.
+type VirtualWansListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VirtualWansUpdateTagsOptions contains the optional parameters for the VirtualWans.UpdateTags method.
+type VirtualWansUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VpnClientConfiguration for P2S client.
@@ -12499,6 +14583,26 @@ type VpnConnectionResponse struct {
 	VpnConnection *VpnConnection
 }
 
+// VpnConnectionsCreateOrUpdateOptions contains the optional parameters for the VpnConnections.CreateOrUpdate method.
+type VpnConnectionsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnConnectionsDeleteOptions contains the optional parameters for the VpnConnections.Delete method.
+type VpnConnectionsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnConnectionsGetOptions contains the optional parameters for the VpnConnections.Get method.
+type VpnConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnConnectionsListByVpnGatewayOptions contains the optional parameters for the VpnConnections.ListByVpnGateway method.
+type VpnConnectionsListByVpnGatewayOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Vpn device configuration script generation parameters.
 type VpnDeviceScriptParameters struct {
 	// The device family for the vpn device.
@@ -12560,6 +14664,41 @@ type VpnGatewayResponse struct {
 	VpnGateway *VpnGateway
 }
 
+// VpnGatewaysCreateOrUpdateOptions contains the optional parameters for the VpnGateways.CreateOrUpdate method.
+type VpnGatewaysCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysDeleteOptions contains the optional parameters for the VpnGateways.Delete method.
+type VpnGatewaysDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysGetOptions contains the optional parameters for the VpnGateways.Get method.
+type VpnGatewaysGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysListByResourceGroupOptions contains the optional parameters for the VpnGateways.ListByResourceGroup method.
+type VpnGatewaysListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysListOptions contains the optional parameters for the VpnGateways.List method.
+type VpnGatewaysListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysResetOptions contains the optional parameters for the VpnGateways.Reset method.
+type VpnGatewaysResetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnGatewaysUpdateTagsOptions contains the optional parameters for the VpnGateways.UpdateTags method.
+type VpnGatewaysUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // BGP settings details for a link.
 type VpnLinkBgpSettings struct {
 	// The BGP speaker's ASN.
@@ -12567,6 +14706,12 @@ type VpnLinkBgpSettings struct {
 
 	// The BGP peering address and BGP identifier of this BGP speaker.
 	BgpPeeringAddress *string `json:"bgpPeeringAddress,omitempty"`
+}
+
+// VpnLinkConnectionsListByVpnConnectionOptions contains the optional parameters for the VpnLinkConnections.ListByVpnConnection
+// method.
+type VpnLinkConnectionsListByVpnConnectionOptions struct {
+	// placeholder for future optional parameters
 }
 
 // List of properties of a link provider.
@@ -12734,6 +14879,39 @@ type VpnServerConfigurationResponse struct {
 	VpnServerConfiguration *VpnServerConfiguration
 }
 
+// VpnServerConfigurationsAssociatedWithVirtualWanListOptions contains the optional parameters for the VpnServerConfigurationsAssociatedWithVirtualWan.List
+// method.
+type VpnServerConfigurationsAssociatedWithVirtualWanListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnServerConfigurationsCreateOrUpdateOptions contains the optional parameters for the VpnServerConfigurations.CreateOrUpdate
+// method.
+type VpnServerConfigurationsCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnServerConfigurationsDeleteOptions contains the optional parameters for the VpnServerConfigurations.Delete method.
+type VpnServerConfigurationsDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnServerConfigurationsGetOptions contains the optional parameters for the VpnServerConfigurations.Get method.
+type VpnServerConfigurationsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnServerConfigurationsListByResourceGroupOptions contains the optional parameters for the VpnServerConfigurations.ListByResourceGroup
+// method.
+type VpnServerConfigurationsListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnServerConfigurationsListOptions contains the optional parameters for the VpnServerConfigurations.List method.
+type VpnServerConfigurationsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // VpnServerConfigurations list associated with VirtualWan Response.
 type VpnServerConfigurationsResponse struct {
 	// List of VpnServerConfigurations associated with VirtualWan.
@@ -12761,6 +14939,11 @@ type VpnServerConfigurationsResponseResponse struct {
 
 	// VpnServerConfigurations list associated with VirtualWan Response.
 	VpnServerConfigurationsResponse *VpnServerConfigurationsResponse
+}
+
+// VpnServerConfigurationsUpdateTagsOptions contains the optional parameters for the VpnServerConfigurations.UpdateTags method.
+type VpnServerConfigurationsUpdateTagsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VpnSite Resource.
@@ -12865,6 +15048,11 @@ type VpnSiteLinkConnectionResponse struct {
 	VpnSiteLinkConnection *VpnSiteLinkConnection
 }
 
+// VpnSiteLinkConnectionsGetOptions contains the optional parameters for the VpnSiteLinkConnections.Get method.
+type VpnSiteLinkConnectionsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Parameters for VpnSite.
 type VpnSiteLinkProperties struct {
 	// The set of bgp properties.
@@ -12890,6 +15078,16 @@ type VpnSiteLinkResponse struct {
 
 	// VpnSiteLink Resource.
 	VpnSiteLink *VpnSiteLink
+}
+
+// VpnSiteLinksGetOptions contains the optional parameters for the VpnSiteLinks.Get method.
+type VpnSiteLinksGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSiteLinksListByVpnSiteOptions contains the optional parameters for the VpnSiteLinks.ListByVpnSite method.
+type VpnSiteLinksListByVpnSiteOptions struct {
+	// placeholder for future optional parameters
 }
 
 // VpnSitePollerResponse is the response envelope for operations that asynchronously return a VpnSite type.
@@ -12943,6 +15141,41 @@ type VpnSiteResponse struct {
 	VpnSite *VpnSite
 }
 
+// VpnSitesConfigurationDownloadOptions contains the optional parameters for the VpnSitesConfiguration.Download method.
+type VpnSitesConfigurationDownloadOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesCreateOrUpdateOptions contains the optional parameters for the VpnSites.CreateOrUpdate method.
+type VpnSitesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesDeleteOptions contains the optional parameters for the VpnSites.Delete method.
+type VpnSitesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesGetOptions contains the optional parameters for the VpnSites.Get method.
+type VpnSitesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesListByResourceGroupOptions contains the optional parameters for the VpnSites.ListByResourceGroup method.
+type VpnSitesListByResourceGroupOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesListOptions contains the optional parameters for the VpnSites.List method.
+type VpnSitesListOptions struct {
+	// placeholder for future optional parameters
+}
+
+// VpnSitesUpdateTagsOptions contains the optional parameters for the VpnSites.UpdateTags method.
+type VpnSitesUpdateTagsOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Defines contents of a web application rule.
 type WebApplicationFirewallCustomRule struct {
 	// Type of Actions.
@@ -12962,6 +15195,35 @@ type WebApplicationFirewallCustomRule struct {
 
 	// The rule type.
 	RuleType *WebApplicationFirewallRuleType `json:"ruleType,omitempty"`
+}
+
+// WebApplicationFirewallPoliciesCreateOrUpdateOptions contains the optional parameters for the WebApplicationFirewallPolicies.CreateOrUpdate
+// method.
+type WebApplicationFirewallPoliciesCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// WebApplicationFirewallPoliciesDeleteOptions contains the optional parameters for the WebApplicationFirewallPolicies.Delete
+// method.
+type WebApplicationFirewallPoliciesDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// WebApplicationFirewallPoliciesGetOptions contains the optional parameters for the WebApplicationFirewallPolicies.Get method.
+type WebApplicationFirewallPoliciesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// WebApplicationFirewallPoliciesListAllOptions contains the optional parameters for the WebApplicationFirewallPolicies.ListAll
+// method.
+type WebApplicationFirewallPoliciesListAllOptions struct {
+	// placeholder for future optional parameters
+}
+
+// WebApplicationFirewallPoliciesListOptions contains the optional parameters for the WebApplicationFirewallPolicies.List
+// method.
+type WebApplicationFirewallPoliciesListOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Defines web application firewall policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -18,21 +18,21 @@ import (
 // NatGatewaysOperations contains the methods for the NatGateways group.
 type NatGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a nat gateway.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway) (*NatGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysCreateOrUpdateOptions) (*NatGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (NatGatewayPoller, error)
 	// BeginDelete - Deletes the specified nat gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified nat gateway in a specified resource group.
-	Get(ctx context.Context, resourceGroupName string, natGatewayName string, natGatewaysGetOptions *NatGatewaysGetOptions) (*NatGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysGetOptions) (*NatGatewayResponse, error)
 	// List - Gets all nat gateways in a resource group.
-	List(resourceGroupName string) NatGatewayListResultPager
+	List(resourceGroupName string, options *NatGatewaysListOptions) NatGatewayListResultPager
 	// ListAll - Gets all the Nat Gateways in a subscription.
-	ListAll() NatGatewayListResultPager
+	ListAll(options *NatGatewaysListAllOptions) NatGatewayListResultPager
 	// UpdateTags - Updates nat gateway tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject) (*NatGatewayResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject, options *NatGatewaysUpdateTagsOptions) (*NatGatewayResponse, error)
 }
 
 // NatGatewaysClient implements the NatGatewaysOperations interface.
@@ -52,8 +52,8 @@ func (client *NatGatewaysClient) Do(req *azcore.Request) (*azcore.Response, erro
 	return client.p.Do(req)
 }
 
-func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway) (*NatGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, natGatewayName, parameters)
+func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysCreateOrUpdateOptions) (*NatGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, natGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *NatGatewaysClient) ResumeCreateOrUpdate(token string) (NatGatewayP
 }
 
 // CreateOrUpdate - Creates or updates a nat gateway.
-func (client *NatGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, natGatewayName, parameters)
+func (client *NatGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, natGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *NatGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NatGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway) (*azcore.Request, error) {
+func (client *NatGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, parameters NatGateway, options *NatGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
@@ -134,8 +134,8 @@ func (client *NatGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, natGatewayName)
+func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, natGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *NatGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) 
 }
 
 // Delete - Deletes the specified nat gateway.
-func (client *NatGatewaysClient) Delete(ctx context.Context, resourceGroupName string, natGatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, natGatewayName)
+func (client *NatGatewaysClient) Delete(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, natGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *NatGatewaysClient) Delete(ctx context.Context, resourceGroupName s
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NatGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string) (*azcore.Request, error) {
+func (client *NatGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
@@ -211,8 +211,8 @@ func (client *NatGatewaysClient) DeleteHandleError(resp *azcore.Response) error 
 }
 
 // Get - Gets the specified nat gateway in a specified resource group.
-func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName string, natGatewayName string, natGatewaysGetOptions *NatGatewaysGetOptions) (*NatGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, natGatewayName, natGatewaysGetOptions)
+func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysGetOptions) (*NatGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, natGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NatGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, natGatewaysGetOptions *NatGatewaysGetOptions) (*azcore.Request, error) {
+func (client *NatGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, options *NatGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))
@@ -242,8 +242,8 @@ func (client *NatGatewaysClient) GetCreateRequest(ctx context.Context, resourceG
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if natGatewaysGetOptions != nil && natGatewaysGetOptions.Expand != nil {
-		query.Set("$expand", *natGatewaysGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *NatGatewaysClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all nat gateways in a resource group.
-func (client *NatGatewaysClient) List(resourceGroupName string) NatGatewayListResultPager {
+func (client *NatGatewaysClient) List(resourceGroupName string, options *NatGatewaysListOptions) NatGatewayListResultPager {
 	return &natGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *NatGatewaysClient) List(resourceGroupName string) NatGatewayListRe
 }
 
 // ListCreateRequest creates the List request.
-func (client *NatGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NatGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *NatGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,11 +312,11 @@ func (client *NatGatewaysClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListAll - Gets all the Nat Gateways in a subscription.
-func (client *NatGatewaysClient) ListAll() NatGatewayListResultPager {
+func (client *NatGatewaysClient) ListAll(options *NatGatewaysListAllOptions) NatGatewayListResultPager {
 	return &natGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -327,7 +327,7 @@ func (client *NatGatewaysClient) ListAll() NatGatewayListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *NatGatewaysClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NatGatewaysClient) ListAllCreateRequest(ctx context.Context, options *NatGatewaysListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/natGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -357,8 +357,8 @@ func (client *NatGatewaysClient) ListAllHandleError(resp *azcore.Response) error
 }
 
 // UpdateTags - Updates nat gateway tags.
-func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject) (*NatGatewayResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, natGatewayName, parameters)
+func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject, options *NatGatewaysUpdateTagsOptions) (*NatGatewayResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, natGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NatGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NatGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, natGatewayName string, parameters TagsObject, options *NatGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{natGatewayName}", url.PathEscape(natGatewayName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -16,9 +16,9 @@ import (
 // NetworkInterfaceIPConfigurationsOperations contains the methods for the NetworkInterfaceIPConfigurations group.
 type NetworkInterfaceIPConfigurationsOperations interface {
 	// Get - Gets the specified network interface ip configuration.
-	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string) (*NetworkInterfaceIPConfigurationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (*NetworkInterfaceIPConfigurationResponse, error)
 	// List - Get all ip configurations in a network interface.
-	List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceIPConfigurationListResultPager
+	List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) NetworkInterfaceIPConfigurationListResultPager
 }
 
 // NetworkInterfaceIPConfigurationsClient implements the NetworkInterfaceIPConfigurationsOperations interface.
@@ -39,8 +39,8 @@ func (client *NetworkInterfaceIPConfigurationsClient) Do(req *azcore.Request) (*
 }
 
 // Get - Gets the specified network interface ip configuration.
-func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string) (*NetworkInterfaceIPConfigurationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, ipConfigurationName)
+func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (*NetworkInterfaceIPConfigurationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, ipConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, r
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkInterfaceIPConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceIPConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfaceIPConfigurationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -92,11 +92,11 @@ func (client *NetworkInterfaceIPConfigurationsClient) GetHandleError(resp *azcor
 }
 
 // List - Get all ip configurations in a network interface.
-func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceIPConfigurationListResultPager {
+func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) NetworkInterfaceIPConfigurationListResultPager {
 	return &networkInterfaceIPConfigurationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -107,7 +107,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName str
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkInterfaceIPConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceIPConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceIPConfigurationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -16,7 +16,7 @@ import (
 // NetworkInterfaceLoadBalancersOperations contains the methods for the NetworkInterfaceLoadBalancers group.
 type NetworkInterfaceLoadBalancersOperations interface {
 	// List - List all load balancers in a network interface.
-	List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceLoadBalancerListResultPager
+	List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) NetworkInterfaceLoadBalancerListResultPager
 }
 
 // NetworkInterfaceLoadBalancersClient implements the NetworkInterfaceLoadBalancersOperations interface.
@@ -37,11 +37,11 @@ func (client *NetworkInterfaceLoadBalancersClient) Do(req *azcore.Request) (*azc
 }
 
 // List - List all load balancers in a network interface.
-func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceLoadBalancerListResultPager {
+func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) NetworkInterfaceLoadBalancerListResultPager {
 	return &networkInterfaceLoadBalancerListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkInterfaceLoadBalancersClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceLoadBalancersClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceLoadBalancersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/loadBalancers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -18,39 +18,39 @@ import (
 // NetworkInterfacesOperations contains the methods for the NetworkInterfaces group.
 type NetworkInterfacesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a network interface.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface) (*NetworkInterfacePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesCreateOrUpdateOptions) (*NetworkInterfacePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (NetworkInterfacePoller, error)
 	// BeginDelete - Deletes the specified network interface.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified network interface.
-	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, networkInterfacesGetOptions *NetworkInterfacesGetOptions) (*NetworkInterfaceResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (*NetworkInterfaceResponse, error)
 	// BeginGetEffectiveRouteTable - Gets all route tables applied to a network interface.
-	BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveRouteListResultPollerResponse, error)
+	BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetEffectiveRouteTableOptions) (*EffectiveRouteListResultPollerResponse, error)
 	// ResumeGetEffectiveRouteTable - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetEffectiveRouteTable(token string) (EffectiveRouteListResultPoller, error)
 	// GetVirtualMachineScaleSetIPConfiguration - Get the specified network interface ip configuration in a virtual machine scale set.
-	GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*NetworkInterfaceIPConfigurationResponse, error)
+	GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*NetworkInterfaceIPConfigurationResponse, error)
 	// GetVirtualMachineScaleSetNetworkInterface - Get the specified network interface in a virtual machine scale set.
-	GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*NetworkInterfaceResponse, error)
+	GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*NetworkInterfaceResponse, error)
 	// List - Gets all network interfaces in a resource group.
-	List(resourceGroupName string) NetworkInterfaceListResultPager
+	List(resourceGroupName string, options *NetworkInterfacesListOptions) NetworkInterfaceListResultPager
 	// ListAll - Gets all network interfaces in a subscription.
-	ListAll() NetworkInterfaceListResultPager
+	ListAll(options *NetworkInterfacesListAllOptions) NetworkInterfaceListResultPager
 	// BeginListEffectiveNetworkSecurityGroups - Gets all network security groups applied to a network interface.
-	BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error)
+	BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error)
 	// ResumeListEffectiveNetworkSecurityGroups - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListEffectiveNetworkSecurityGroups(token string) (EffectiveNetworkSecurityGroupListResultPoller, error)
 	// ListVirtualMachineScaleSetIPConfigurations - Get the specified network interface ip configuration in a virtual machine scale set.
-	ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) NetworkInterfaceIPConfigurationListResultPager
+	ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) NetworkInterfaceIPConfigurationListResultPager
 	// ListVirtualMachineScaleSetNetworkInterfaces - Gets all network interfaces in a virtual machine scale set.
-	ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string) NetworkInterfaceListResultPager
+	ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) NetworkInterfaceListResultPager
 	// ListVirtualMachineScaleSetVMNetworkInterfaces - Gets information about all network interfaces in a virtual machine in a virtual machine scale set.
-	ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) NetworkInterfaceListResultPager
+	ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) NetworkInterfaceListResultPager
 	// UpdateTags - Updates a network interface tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject) (*NetworkInterfaceResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (*NetworkInterfaceResponse, error)
 }
 
 // NetworkInterfacesClient implements the NetworkInterfacesOperations interface.
@@ -70,8 +70,8 @@ func (client *NetworkInterfacesClient) Do(req *azcore.Request) (*azcore.Response
 	return client.p.Do(req)
 }
 
-func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface) (*NetworkInterfacePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkInterfaceName, parameters)
+func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesCreateOrUpdateOptions) (*NetworkInterfacePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (client *NetworkInterfacesClient) ResumeCreateOrUpdate(token string) (Netwo
 }
 
 // CreateOrUpdate - Creates or updates a network interface.
-func (client *NetworkInterfacesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters)
+func (client *NetworkInterfacesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (client *NetworkInterfacesClient) CreateOrUpdate(ctx context.Context, resou
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkInterfacesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters NetworkInterface, options *NetworkInterfacesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -152,8 +152,8 @@ func (client *NetworkInterfacesClient) CreateOrUpdateHandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,8 +187,8 @@ func (client *NetworkInterfacesClient) ResumeDelete(token string) (HTTPPoller, e
 }
 
 // Delete - Deletes the specified network interface.
-func (client *NetworkInterfacesClient) Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (client *NetworkInterfacesClient) Delete(ctx context.Context, resourceGroup
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkInterfacesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -229,8 +229,8 @@ func (client *NetworkInterfacesClient) DeleteHandleError(resp *azcore.Response) 
 }
 
 // Get - Gets information about the specified network interface.
-func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, networkInterfacesGetOptions *NetworkInterfacesGetOptions) (*NetworkInterfaceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, networkInterfacesGetOptions)
+func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (*NetworkInterfaceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (client *NetworkInterfacesClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkInterfacesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, networkInterfacesGetOptions *NetworkInterfacesGetOptions) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -260,8 +260,8 @@ func (client *NetworkInterfacesClient) GetCreateRequest(ctx context.Context, res
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if networkInterfacesGetOptions != nil && networkInterfacesGetOptions.Expand != nil {
-		query.Set("$expand", *networkInterfacesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -283,8 +283,8 @@ func (client *NetworkInterfacesClient) GetHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveRouteListResultPollerResponse, error) {
-	resp, err := client.GetEffectiveRouteTable(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetEffectiveRouteTableOptions) (*EffectiveRouteListResultPollerResponse, error) {
+	resp, err := client.GetEffectiveRouteTable(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -318,8 +318,8 @@ func (client *NetworkInterfacesClient) ResumeGetEffectiveRouteTable(token string
 }
 
 // GetEffectiveRouteTable - Gets all route tables applied to a network interface.
-func (client *NetworkInterfacesClient) GetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Response, error) {
-	req, err := client.GetEffectiveRouteTableCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) GetEffectiveRouteTable(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetEffectiveRouteTableOptions) (*azcore.Response, error) {
+	req, err := client.GetEffectiveRouteTableCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +334,7 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTable(ctx context.Contex
 }
 
 // GetEffectiveRouteTableCreateRequest creates the GetEffectiveRouteTable request.
-func (client *NetworkInterfacesClient) GetEffectiveRouteTableCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) GetEffectiveRouteTableCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesGetEffectiveRouteTableOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -366,8 +366,8 @@ func (client *NetworkInterfacesClient) GetEffectiveRouteTableHandleError(resp *a
 }
 
 // GetVirtualMachineScaleSetIPConfiguration - Get the specified network interface ip configuration in a virtual machine scale set.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*NetworkInterfaceIPConfigurationResponse, error) {
-	req, err := client.GetVirtualMachineScaleSetIPConfigurationCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions)
+func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*NetworkInterfaceIPConfigurationResponse, error) {
+	req, err := client.GetVirtualMachineScaleSetIPConfigurationCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(
 }
 
 // GetVirtualMachineScaleSetIPConfigurationCreateRequest creates the GetVirtualMachineScaleSetIPConfiguration request.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -400,8 +400,8 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationC
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
-	if networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions != nil && networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions.Expand != nil {
-		query.Set("$expand", *networkInterfacesGetVirtualMachineScaleSetIPConfigurationOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -424,8 +424,8 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfigurationH
 }
 
 // GetVirtualMachineScaleSetNetworkInterface - Get the specified network interface in a virtual machine scale set.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*NetworkInterfaceResponse, error) {
-	req, err := client.GetVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions)
+func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*NetworkInterfaceResponse, error) {
+	req, err := client.GetVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 }
 
 // GetVirtualMachineScaleSetNetworkInterfaceCreateRequest creates the GetVirtualMachineScaleSetNetworkInterface request.
-func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterfaceCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -457,8 +457,8 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
-	if networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions != nil && networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions.Expand != nil {
-		query.Set("$expand", *networkInterfacesGetVirtualMachineScaleSetNetworkInterfaceOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -481,11 +481,11 @@ func (client *NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface
 }
 
 // List - Gets all network interfaces in a resource group.
-func (client *NetworkInterfacesClient) List(resourceGroupName string) NetworkInterfaceListResultPager {
+func (client *NetworkInterfacesClient) List(resourceGroupName string, options *NetworkInterfacesListOptions) NetworkInterfaceListResultPager {
 	return &networkInterfaceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -496,7 +496,7 @@ func (client *NetworkInterfacesClient) List(resourceGroupName string) NetworkInt
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkInterfacesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkInterfacesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -527,11 +527,11 @@ func (client *NetworkInterfacesClient) ListHandleError(resp *azcore.Response) er
 }
 
 // ListAll - Gets all network interfaces in a subscription.
-func (client *NetworkInterfacesClient) ListAll() NetworkInterfaceListResultPager {
+func (client *NetworkInterfacesClient) ListAll(options *NetworkInterfacesListAllOptions) NetworkInterfaceListResultPager {
 	return &networkInterfaceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -542,7 +542,7 @@ func (client *NetworkInterfacesClient) ListAll() NetworkInterfaceListResultPager
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *NetworkInterfacesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListAllCreateRequest(ctx context.Context, options *NetworkInterfacesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -571,8 +571,8 @@ func (client *NetworkInterfacesClient) ListAllHandleError(resp *azcore.Response)
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error) {
-	resp, err := client.ListEffectiveNetworkSecurityGroups(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions) (*EffectiveNetworkSecurityGroupListResultPollerResponse, error) {
+	resp, err := client.ListEffectiveNetworkSecurityGroups(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -606,8 +606,8 @@ func (client *NetworkInterfacesClient) ResumeListEffectiveNetworkSecurityGroups(
 }
 
 // ListEffectiveNetworkSecurityGroups - Gets all network security groups applied to a network interface.
-func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Response, error) {
-	req, err := client.ListEffectiveNetworkSecurityGroupsCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroups(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions) (*azcore.Response, error) {
+	req, err := client.ListEffectiveNetworkSecurityGroupsCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +622,7 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroups(ctx co
 }
 
 // ListEffectiveNetworkSecurityGroupsCreateRequest creates the ListEffectiveNetworkSecurityGroups request.
-func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfacesListEffectiveNetworkSecurityGroupsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -654,11 +654,11 @@ func (client *NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsHandleE
 }
 
 // ListVirtualMachineScaleSetIPConfigurations - Get the specified network interface ip configuration in a virtual machine scale set.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) NetworkInterfaceIPConfigurationListResultPager {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurations(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) NetworkInterfaceIPConfigurationListResultPager {
 	return &networkInterfaceIPConfigurationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions)
+			return client.ListVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, options)
 		},
 		responder: client.ListVirtualMachineScaleSetIPConfigurationsHandleResponse,
 		errorer:   client.ListVirtualMachineScaleSetIPConfigurationsHandleError,
@@ -669,7 +669,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 }
 
 // ListVirtualMachineScaleSetIPConfigurationsCreateRequest creates the ListVirtualMachineScaleSetIPConfigurations request.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, options *NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -682,8 +682,8 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
-	if networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions != nil && networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions.Expand != nil {
-		query.Set("$expand", *networkInterfacesListVirtualMachineScaleSetIPConfigurationsOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -706,11 +706,11 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 }
 
 // ListVirtualMachineScaleSetNetworkInterfaces - Gets all network interfaces in a virtual machine scale set.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string) NetworkInterfaceListResultPager {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) NetworkInterfaceListResultPager {
 	return &networkInterfaceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName)
+			return client.ListVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
 		},
 		responder: client.ListVirtualMachineScaleSetNetworkInterfacesHandleResponse,
 		errorer:   client.ListVirtualMachineScaleSetNetworkInterfacesHandleError,
@@ -721,7 +721,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 }
 
 // ListVirtualMachineScaleSetNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetNetworkInterfaces request.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, options *NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -753,11 +753,11 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfaces - Gets information about all network interfaces in a virtual machine in a virtual machine scale set.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) NetworkInterfaceListResultPager {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) NetworkInterfaceListResultPager {
 	return &networkInterfaceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex)
+			return client.ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, options)
 		},
 		responder: client.ListVirtualMachineScaleSetVMNetworkInterfacesHandleResponse,
 		errorer:   client.ListVirtualMachineScaleSetVMNetworkInterfacesHandleError,
@@ -768,7 +768,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 }
 
 // ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest creates the ListVirtualMachineScaleSetVMNetworkInterfaces request.
-func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, options *NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -801,8 +801,8 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 }
 
 // UpdateTags - Updates a network interface tags.
-func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject) (*NetworkInterfaceResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters)
+func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (*NetworkInterfaceResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkInterfaceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -821,7 +821,7 @@ func (client *NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceG
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkInterfacesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NetworkInterfacesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, parameters TagsObject, options *NetworkInterfacesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -18,17 +18,17 @@ import (
 // NetworkInterfaceTapConfigurationsOperations contains the methods for the NetworkInterfaceTapConfigurations group.
 type NetworkInterfaceTapConfigurationsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a Tap configuration in the specified NetworkInterface.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration) (*NetworkInterfaceTapConfigurationPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsCreateOrUpdateOptions) (*NetworkInterfaceTapConfigurationPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (NetworkInterfaceTapConfigurationPoller, error)
 	// BeginDelete - Deletes the specified tap configuration from the NetworkInterface.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Get the specified tap configuration on a network interface.
-	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*NetworkInterfaceTapConfigurationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (*NetworkInterfaceTapConfigurationResponse, error)
 	// List - Get all Tap configurations in a network interface.
-	List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceTapConfigurationListResultPager
+	List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) NetworkInterfaceTapConfigurationListResultPager
 }
 
 // NetworkInterfaceTapConfigurationsClient implements the NetworkInterfaceTapConfigurationsOperations interface.
@@ -48,8 +48,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) Do(req *azcore.Request) (
 	return client.p.Do(req)
 }
 
-func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration) (*NetworkInterfaceTapConfigurationPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters)
+func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsCreateOrUpdateOptions) (*NetworkInterfaceTapConfigurationPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) ResumeCreateOrUpdate(toke
 }
 
 // CreateOrUpdate - Creates or updates a Tap configuration in the specified NetworkInterface.
-func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters)
+func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, tapConfigurationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdate(ctx contex
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration) (*azcore.Request, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, tapConfigurationParameters NetworkInterfaceTapConfiguration, options *NetworkInterfaceTapConfigurationsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -131,8 +131,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) CreateOrUpdateHandleError
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName)
+func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) ResumeDelete(token string
 }
 
 // Delete - Deletes the specified tap configuration from the NetworkInterface.
-func (client *NetworkInterfaceTapConfigurationsClient) Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName)
+func (client *NetworkInterfaceTapConfigurationsClient) Delete(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) Delete(ctx context.Contex
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkInterfaceTapConfigurationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -209,8 +209,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) DeleteHandleError(resp *a
 }
 
 // Get - Get the specified tap configuration on a network interface.
-func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*NetworkInterfaceTapConfigurationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName)
+func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (*NetworkInterfaceTapConfigurationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkInterfaceName, tapConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkInterfaceTapConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, tapConfigurationName string, options *NetworkInterfaceTapConfigurationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))
@@ -262,11 +262,11 @@ func (client *NetworkInterfaceTapConfigurationsClient) GetHandleError(resp *azco
 }
 
 // List - Get all Tap configurations in a network interface.
-func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName string, networkInterfaceName string) NetworkInterfaceTapConfigurationListResultPager {
+func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) NetworkInterfaceTapConfigurationListResultPager {
 	return &networkInterfaceTapConfigurationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkInterfaceName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName st
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkInterfaceTapConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string) (*azcore.Request, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkInterfaceName string, options *NetworkInterfaceTapConfigurationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkInterfaceName}", url.PathEscape(networkInterfaceName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -18,29 +18,29 @@ import (
 // NetworkManagementClientOperations contains the methods for the NetworkManagementClient group.
 type NetworkManagementClientOperations interface {
 	// CheckDNSNameAvailability - Checks whether a domain name in the cloudapp.azure.com zone is available for use.
-	CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string) (*DNSNameAvailabilityResultResponse, error)
+	CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (*DNSNameAvailabilityResultResponse, error)
 	// BeginDeleteBastionShareableLink - Deletes the Bastion Shareable Links for all the VMs specified in the request.
-	BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*HTTPPollerResponse, error)
+	BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientDeleteBastionShareableLinkOptions) (*HTTPPollerResponse, error)
 	// ResumeDeleteBastionShareableLink - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeleteBastionShareableLink(token string) (HTTPPoller, error)
 	// DisconnectActiveSessions - Returns the list of currently active sessions on the Bastion.
-	DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIds SessionIDs) BastionSessionDeleteResultPager
+	DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIds SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) BastionSessionDeleteResultPager
 	// BeginGeneratevirtualwanvpnserverconfigurationvpnprofile - Generates a unique VPN profile for P2S clients for VirtualWan and associated VpnServerConfiguration combination in the specified resource group.
-	BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*VpnProfileResponsePollerResponse, error)
+	BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters, options *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*VpnProfileResponsePollerResponse, error)
 	// ResumeGeneratevirtualwanvpnserverconfigurationvpnprofile - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGeneratevirtualwanvpnserverconfigurationvpnprofile(token string) (VpnProfileResponsePoller, error)
 	// BeginGetActiveSessions - Returns the list of currently active sessions on the Bastion.
-	BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string) (*BastionActiveSessionListResultPagerPollerResponse, error)
+	BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientGetActiveSessionsOptions) (*BastionActiveSessionListResultPagerPollerResponse, error)
 	// ResumeGetActiveSessions - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetActiveSessions(token string) (BastionActiveSessionListResultPagerPoller, error)
 	// GetBastionShareableLink - Return the Bastion Shareable Links for all the VMs specified in the request.
-	GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) BastionShareableLinkListResultPager
+	GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) BastionShareableLinkListResultPager
 	// BeginPutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.
-	BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*BastionShareableLinkListResultPagerPollerResponse, error)
+	BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientPutBastionShareableLinkOptions) (*BastionShareableLinkListResultPagerPollerResponse, error)
 	// ResumePutBastionShareableLink - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePutBastionShareableLink(token string) (BastionShareableLinkListResultPagerPoller, error)
 	// SupportedSecurityProviders - Gives the supported security providers for the virtual wan.
-	SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWanName string) (*VirtualWanSecurityProvidersResponse, error)
+	SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWanName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (*VirtualWanSecurityProvidersResponse, error)
 }
 
 // NetworkManagementClient implements the NetworkManagementClientOperations interface.
@@ -61,8 +61,8 @@ func (client *NetworkManagementClient) Do(req *azcore.Request) (*azcore.Response
 }
 
 // CheckDNSNameAvailability - Checks whether a domain name in the cloudapp.azure.com zone is available for use.
-func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string) (*DNSNameAvailabilityResultResponse, error) {
-	req, err := client.CheckDNSNameAvailabilityCreateRequest(ctx, location, domainNameLabel)
+func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (*DNSNameAvailabilityResultResponse, error) {
+	req, err := client.CheckDNSNameAvailabilityCreateRequest(ctx, location, domainNameLabel, options)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (client *NetworkManagementClient) CheckDNSNameAvailability(ctx context.Cont
 }
 
 // CheckDNSNameAvailabilityCreateRequest creates the CheckDNSNameAvailability request.
-func (client *NetworkManagementClient) CheckDNSNameAvailabilityCreateRequest(ctx context.Context, location string, domainNameLabel string) (*azcore.Request, error) {
+func (client *NetworkManagementClient) CheckDNSNameAvailabilityCreateRequest(ctx context.Context, location string, domainNameLabel string, options *NetworkManagementClientCheckDNSNameAvailabilityOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/CheckDnsNameAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -112,8 +112,8 @@ func (client *NetworkManagementClient) CheckDNSNameAvailabilityHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.DeleteBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest)
+func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientDeleteBastionShareableLinkOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeleteBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -147,8 +147,8 @@ func (client *NetworkManagementClient) ResumeDeleteBastionShareableLink(token st
 }
 
 // DeleteBastionShareableLink - Deletes the Bastion Shareable Links for all the VMs specified in the request.
-func (client *NetworkManagementClient) DeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Response, error) {
-	req, err := client.DeleteBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest)
+func (client *NetworkManagementClient) DeleteBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientDeleteBastionShareableLinkOptions) (*azcore.Response, error) {
+	req, err := client.DeleteBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (client *NetworkManagementClient) DeleteBastionShareableLink(ctx context.Co
 }
 
 // DeleteBastionShareableLinkCreateRequest creates the DeleteBastionShareableLink request.
-func (client *NetworkManagementClient) DeleteBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+func (client *NetworkManagementClient) DeleteBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientDeleteBastionShareableLinkOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -189,11 +189,11 @@ func (client *NetworkManagementClient) DeleteBastionShareableLinkHandleError(res
 }
 
 // DisconnectActiveSessions - Returns the list of currently active sessions on the Bastion.
-func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIds SessionIDs) BastionSessionDeleteResultPager {
+func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupName string, bastionHostName string, sessionIds SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) BastionSessionDeleteResultPager {
 	return &bastionSessionDeleteResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.DisconnectActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, sessionIds)
+			return client.DisconnectActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, sessionIds, options)
 		},
 		responder: client.DisconnectActiveSessionsHandleResponse,
 		errorer:   client.DisconnectActiveSessionsHandleError,
@@ -204,7 +204,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupNam
 }
 
 // DisconnectActiveSessionsCreateRequest creates the DisconnectActiveSessions request.
-func (client *NetworkManagementClient) DisconnectActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, sessionIds SessionIDs) (*azcore.Request, error) {
+func (client *NetworkManagementClient) DisconnectActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, sessionIds SessionIDs, options *NetworkManagementClientDisconnectActiveSessionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/disconnectActiveSessions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -235,8 +235,8 @@ func (client *NetworkManagementClient) DisconnectActiveSessionsHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*VpnProfileResponsePollerResponse, error) {
-	resp, err := client.Generatevirtualwanvpnserverconfigurationvpnprofile(ctx, resourceGroupName, virtualWanName, vpnClientParams)
+func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters, options *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*VpnProfileResponsePollerResponse, error) {
+	resp, err := client.Generatevirtualwanvpnserverconfigurationvpnprofile(ctx, resourceGroupName, virtualWanName, vpnClientParams, options)
 	if err != nil {
 		return nil, err
 	}
@@ -270,8 +270,8 @@ func (client *NetworkManagementClient) ResumeGeneratevirtualwanvpnserverconfigur
 }
 
 // Generatevirtualwanvpnserverconfigurationvpnprofile - Generates a unique VPN profile for P2S clients for VirtualWan and associated VpnServerConfiguration combination in the specified resource group.
-func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*azcore.Response, error) {
-	req, err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx, resourceGroupName, virtualWanName, vpnClientParams)
+func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters, options *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*azcore.Response, error) {
+	req, err := client.GeneratevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx, resourceGroupName, virtualWanName, vpnClientParams, options)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 }
 
 // GeneratevirtualwanvpnserverconfigurationvpnprofileCreateRequest creates the Generatevirtualwanvpnserverconfigurationvpnprofile request.
-func (client *NetworkManagementClient) GeneratevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters) (*azcore.Request, error) {
+func (client *NetworkManagementClient) GeneratevirtualwanvpnserverconfigurationvpnprofileCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, vpnClientParams VirtualWanVpnProfileParameters, options *NetworkManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/GenerateVpnProfile"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -317,8 +317,8 @@ func (client *NetworkManagementClient) Generatevirtualwanvpnserverconfigurationv
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string) (*BastionActiveSessionListResultPagerPollerResponse, error) {
-	resp, err := client.GetActiveSessions(ctx, resourceGroupName, bastionHostName)
+func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientGetActiveSessionsOptions) (*BastionActiveSessionListResultPagerPollerResponse, error) {
+	resp, err := client.GetActiveSessions(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +362,8 @@ func (client *NetworkManagementClient) ResumeGetActiveSessions(token string) (Ba
 }
 
 // GetActiveSessions - Returns the list of currently active sessions on the Bastion.
-func (client *NetworkManagementClient) GetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string) (*azcore.Response, error) {
-	req, err := client.GetActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName)
+func (client *NetworkManagementClient) GetActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientGetActiveSessionsOptions) (*azcore.Response, error) {
+	req, err := client.GetActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (client *NetworkManagementClient) GetActiveSessions(ctx context.Context, re
 }
 
 // GetActiveSessionsCreateRequest creates the GetActiveSessions request.
-func (client *NetworkManagementClient) GetActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string) (*azcore.Request, error) {
+func (client *NetworkManagementClient) GetActiveSessionsCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, options *NetworkManagementClientGetActiveSessionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getActiveSessions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -410,11 +410,11 @@ func (client *NetworkManagementClient) GetActiveSessionsHandleError(resp *azcore
 }
 
 // GetBastionShareableLink - Return the Bastion Shareable Links for all the VMs specified in the request.
-func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) BastionShareableLinkListResultPager {
+func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) BastionShareableLinkListResultPager {
 	return &bastionShareableLinkListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest)
+			return client.GetBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 		},
 		responder: client.GetBastionShareableLinkHandleResponse,
 		errorer:   client.GetBastionShareableLinkHandleError,
@@ -425,7 +425,7 @@ func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName
 }
 
 // GetBastionShareableLinkCreateRequest creates the GetBastionShareableLink request.
-func (client *NetworkManagementClient) GetBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+func (client *NetworkManagementClient) GetBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientGetBastionShareableLinkOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -456,8 +456,8 @@ func (client *NetworkManagementClient) GetBastionShareableLinkHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*BastionShareableLinkListResultPagerPollerResponse, error) {
-	resp, err := client.PutBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest)
+func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientPutBastionShareableLinkOptions) (*BastionShareableLinkListResultPagerPollerResponse, error) {
+	resp, err := client.PutBastionShareableLink(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -501,8 +501,8 @@ func (client *NetworkManagementClient) ResumePutBastionShareableLink(token strin
 }
 
 // PutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.
-func (client *NetworkManagementClient) PutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Response, error) {
-	req, err := client.PutBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest)
+func (client *NetworkManagementClient) PutBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientPutBastionShareableLinkOptions) (*azcore.Response, error) {
+	req, err := client.PutBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)
 	if err != nil {
 		return nil, err
 	}
@@ -517,7 +517,7 @@ func (client *NetworkManagementClient) PutBastionShareableLink(ctx context.Conte
 }
 
 // PutBastionShareableLinkCreateRequest creates the PutBastionShareableLink request.
-func (client *NetworkManagementClient) PutBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest) (*azcore.Request, error) {
+func (client *NetworkManagementClient) PutBastionShareableLinkCreateRequest(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *NetworkManagementClientPutBastionShareableLinkOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/createShareableLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{bastionHostName}", url.PathEscape(bastionHostName))
@@ -549,8 +549,8 @@ func (client *NetworkManagementClient) PutBastionShareableLinkHandleError(resp *
 }
 
 // SupportedSecurityProviders - Gives the supported security providers for the virtual wan.
-func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWanName string) (*VirtualWanSecurityProvidersResponse, error) {
-	req, err := client.SupportedSecurityProvidersCreateRequest(ctx, resourceGroupName, virtualWanName)
+func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Context, resourceGroupName string, virtualWanName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (*VirtualWanSecurityProvidersResponse, error) {
+	req, err := client.SupportedSecurityProvidersCreateRequest(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (client *NetworkManagementClient) SupportedSecurityProviders(ctx context.Co
 }
 
 // SupportedSecurityProvidersCreateRequest creates the SupportedSecurityProviders request.
-func (client *NetworkManagementClient) SupportedSecurityProvidersCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+func (client *NetworkManagementClient) SupportedSecurityProvidersCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, options *NetworkManagementClientSupportedSecurityProvidersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/supportedSecurityProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -18,19 +18,19 @@ import (
 // NetworkProfilesOperations contains the methods for the NetworkProfiles group.
 type NetworkProfilesOperations interface {
 	// CreateOrUpdate - Creates or updates a network profile.
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile) (*NetworkProfileResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile, options *NetworkProfilesCreateOrUpdateOptions) (*NetworkProfileResponse, error)
 	// BeginDelete - Deletes the specified network profile.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified network profile in a specified resource group.
-	Get(ctx context.Context, resourceGroupName string, networkProfileName string, networkProfilesGetOptions *NetworkProfilesGetOptions) (*NetworkProfileResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (*NetworkProfileResponse, error)
 	// List - Gets all network profiles in a resource group.
-	List(resourceGroupName string) NetworkProfileListResultPager
+	List(resourceGroupName string, options *NetworkProfilesListOptions) NetworkProfileListResultPager
 	// ListAll - Gets all the network profiles in a subscription.
-	ListAll() NetworkProfileListResultPager
+	ListAll(options *NetworkProfilesListAllOptions) NetworkProfileListResultPager
 	// UpdateTags - Updates network profile tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject) (*NetworkProfileResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (*NetworkProfileResponse, error)
 }
 
 // NetworkProfilesClient implements the NetworkProfilesOperations interface.
@@ -51,8 +51,8 @@ func (client *NetworkProfilesClient) Do(req *azcore.Request) (*azcore.Response, 
 }
 
 // CreateOrUpdate - Creates or updates a network profile.
-func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile) (*NetworkProfileResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkProfileName, parameters)
+func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile, options *NetworkProfilesCreateOrUpdateOptions) (*NetworkProfileResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkProfileName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (client *NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkProfilesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters NetworkProfile, options *NetworkProfilesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
@@ -102,8 +102,8 @@ func (client *NetworkProfilesClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkProfileName)
+func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -137,8 +137,8 @@ func (client *NetworkProfilesClient) ResumeDelete(token string) (HTTPPoller, err
 }
 
 // Delete - Deletes the specified network profile.
-func (client *NetworkProfilesClient) Delete(ctx context.Context, resourceGroupName string, networkProfileName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkProfileName)
+func (client *NetworkProfilesClient) Delete(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (client *NetworkProfilesClient) Delete(ctx context.Context, resourceGroupNa
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkProfilesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
@@ -179,8 +179,8 @@ func (client *NetworkProfilesClient) DeleteHandleError(resp *azcore.Response) er
 }
 
 // Get - Gets the specified network profile in a specified resource group.
-func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName string, networkProfileName string, networkProfilesGetOptions *NetworkProfilesGetOptions) (*NetworkProfileResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkProfileName, networkProfilesGetOptions)
+func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (*NetworkProfileResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkProfileName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (client *NetworkProfilesClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkProfilesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, networkProfilesGetOptions *NetworkProfilesGetOptions) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, options *NetworkProfilesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))
@@ -210,8 +210,8 @@ func (client *NetworkProfilesClient) GetCreateRequest(ctx context.Context, resou
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if networkProfilesGetOptions != nil && networkProfilesGetOptions.Expand != nil {
-		query.Set("$expand", *networkProfilesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -234,11 +234,11 @@ func (client *NetworkProfilesClient) GetHandleError(resp *azcore.Response) error
 }
 
 // List - Gets all network profiles in a resource group.
-func (client *NetworkProfilesClient) List(resourceGroupName string) NetworkProfileListResultPager {
+func (client *NetworkProfilesClient) List(resourceGroupName string, options *NetworkProfilesListOptions) NetworkProfileListResultPager {
 	return &networkProfileListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -249,7 +249,7 @@ func (client *NetworkProfilesClient) List(resourceGroupName string) NetworkProfi
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkProfilesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkProfilesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -280,11 +280,11 @@ func (client *NetworkProfilesClient) ListHandleError(resp *azcore.Response) erro
 }
 
 // ListAll - Gets all the network profiles in a subscription.
-func (client *NetworkProfilesClient) ListAll() NetworkProfileListResultPager {
+func (client *NetworkProfilesClient) ListAll(options *NetworkProfilesListAllOptions) NetworkProfileListResultPager {
 	return &networkProfileListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -295,7 +295,7 @@ func (client *NetworkProfilesClient) ListAll() NetworkProfileListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *NetworkProfilesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) ListAllCreateRequest(ctx context.Context, options *NetworkProfilesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -325,8 +325,8 @@ func (client *NetworkProfilesClient) ListAllHandleError(resp *azcore.Response) e
 }
 
 // UpdateTags - Updates network profile tags.
-func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject) (*NetworkProfileResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkProfileName, parameters)
+func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (*NetworkProfileResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkProfileName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -345,7 +345,7 @@ func (client *NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGro
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkProfilesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NetworkProfilesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkProfileName string, parameters TagsObject, options *NetworkProfilesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkProfileName}", url.PathEscape(networkProfileName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -18,21 +18,21 @@ import (
 // NetworkSecurityGroupsOperations contains the methods for the NetworkSecurityGroups group.
 type NetworkSecurityGroupsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a network security group in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup) (*NetworkSecurityGroupPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsCreateOrUpdateOptions) (*NetworkSecurityGroupPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (NetworkSecurityGroupPoller, error)
 	// BeginDelete - Deletes the specified network security group.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified network security group.
-	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, networkSecurityGroupsGetOptions *NetworkSecurityGroupsGetOptions) (*NetworkSecurityGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (*NetworkSecurityGroupResponse, error)
 	// List - Gets all network security groups in a resource group.
-	List(resourceGroupName string) NetworkSecurityGroupListResultPager
+	List(resourceGroupName string, options *NetworkSecurityGroupsListOptions) NetworkSecurityGroupListResultPager
 	// ListAll - Gets all network security groups in a subscription.
-	ListAll() NetworkSecurityGroupListResultPager
+	ListAll(options *NetworkSecurityGroupsListAllOptions) NetworkSecurityGroupListResultPager
 	// UpdateTags - Updates a network security group tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject) (*NetworkSecurityGroupResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (*NetworkSecurityGroupResponse, error)
 }
 
 // NetworkSecurityGroupsClient implements the NetworkSecurityGroupsOperations interface.
@@ -52,8 +52,8 @@ func (client *NetworkSecurityGroupsClient) Do(req *azcore.Request) (*azcore.Resp
 	return client.p.Do(req)
 }
 
-func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup) (*NetworkSecurityGroupPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, parameters)
+func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsCreateOrUpdateOptions) (*NetworkSecurityGroupPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *NetworkSecurityGroupsClient) ResumeCreateOrUpdate(token string) (N
 }
 
 // CreateOrUpdate - Creates or updates a network security group in the specified resource group.
-func (client *NetworkSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters)
+func (client *NetworkSecurityGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdate(ctx context.Context, r
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters NetworkSecurityGroup, options *NetworkSecurityGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -134,8 +134,8 @@ func (client *NetworkSecurityGroupsClient) CreateOrUpdateHandleError(resp *azcor
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkSecurityGroupName)
+func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *NetworkSecurityGroupsClient) ResumeDelete(token string) (HTTPPolle
 }
 
 // Delete - Deletes the specified network security group.
-func (client *NetworkSecurityGroupsClient) Delete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkSecurityGroupName)
+func (client *NetworkSecurityGroupsClient) Delete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *NetworkSecurityGroupsClient) Delete(ctx context.Context, resourceG
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkSecurityGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -211,8 +211,8 @@ func (client *NetworkSecurityGroupsClient) DeleteHandleError(resp *azcore.Respon
 }
 
 // Get - Gets the specified network security group.
-func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, networkSecurityGroupsGetOptions *NetworkSecurityGroupsGetOptions) (*NetworkSecurityGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, networkSecurityGroupsGetOptions)
+func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (*NetworkSecurityGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGrou
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkSecurityGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, networkSecurityGroupsGetOptions *NetworkSecurityGroupsGetOptions) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *NetworkSecurityGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -242,8 +242,8 @@ func (client *NetworkSecurityGroupsClient) GetCreateRequest(ctx context.Context,
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if networkSecurityGroupsGetOptions != nil && networkSecurityGroupsGetOptions.Expand != nil {
-		query.Set("$expand", *networkSecurityGroupsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *NetworkSecurityGroupsClient) GetHandleError(resp *azcore.Response)
 }
 
 // List - Gets all network security groups in a resource group.
-func (client *NetworkSecurityGroupsClient) List(resourceGroupName string) NetworkSecurityGroupListResultPager {
+func (client *NetworkSecurityGroupsClient) List(resourceGroupName string, options *NetworkSecurityGroupsListOptions) NetworkSecurityGroupListResultPager {
 	return &networkSecurityGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *NetworkSecurityGroupsClient) List(resourceGroupName string) Networ
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkSecurityGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkSecurityGroupsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,11 +312,11 @@ func (client *NetworkSecurityGroupsClient) ListHandleError(resp *azcore.Response
 }
 
 // ListAll - Gets all network security groups in a subscription.
-func (client *NetworkSecurityGroupsClient) ListAll() NetworkSecurityGroupListResultPager {
+func (client *NetworkSecurityGroupsClient) ListAll(options *NetworkSecurityGroupsListAllOptions) NetworkSecurityGroupListResultPager {
 	return &networkSecurityGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -327,7 +327,7 @@ func (client *NetworkSecurityGroupsClient) ListAll() NetworkSecurityGroupListRes
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *NetworkSecurityGroupsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) ListAllCreateRequest(ctx context.Context, options *NetworkSecurityGroupsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -357,8 +357,8 @@ func (client *NetworkSecurityGroupsClient) ListAllHandleError(resp *azcore.Respo
 }
 
 // UpdateTags - Updates a network security group tags.
-func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject) (*NetworkSecurityGroupResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters)
+func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (*NetworkSecurityGroupResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resou
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NetworkSecurityGroupsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, parameters TagsObject, options *NetworkSecurityGroupsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -18,21 +18,21 @@ import (
 // NetworkVirtualAppliancesOperations contains the methods for the NetworkVirtualAppliances group.
 type NetworkVirtualAppliancesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Network Virtual Appliance.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance) (*NetworkVirtualAppliancePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesCreateOrUpdateOptions) (*NetworkVirtualAppliancePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (NetworkVirtualAppliancePoller, error)
 	// BeginDelete - Deletes the specified Network Virtual Appliance.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Network Virtual Appliance.
-	Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, networkVirtualAppliancesGetOptions *NetworkVirtualAppliancesGetOptions) (*NetworkVirtualApplianceResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (*NetworkVirtualApplianceResponse, error)
 	// List - Gets all Network Virtual Appliances in a subscription.
-	List() NetworkVirtualApplianceListResultPager
+	List(options *NetworkVirtualAppliancesListOptions) NetworkVirtualApplianceListResultPager
 	// ListByResourceGroup - Lists all Network Virtual Appliances in a resource group.
-	ListByResourceGroup(resourceGroupName string) NetworkVirtualApplianceListResultPager
+	ListByResourceGroup(resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) NetworkVirtualApplianceListResultPager
 	// UpdateTags - Updates a Network Virtual Appliance.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject) (*NetworkVirtualApplianceResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (*NetworkVirtualApplianceResponse, error)
 }
 
 // NetworkVirtualAppliancesClient implements the NetworkVirtualAppliancesOperations interface.
@@ -52,8 +52,8 @@ func (client *NetworkVirtualAppliancesClient) Do(req *azcore.Request) (*azcore.R
 	return client.p.Do(req)
 }
 
-func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance) (*NetworkVirtualAppliancePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkVirtualApplianceName, parameters)
+func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesCreateOrUpdateOptions) (*NetworkVirtualAppliancePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *NetworkVirtualAppliancesClient) ResumeCreateOrUpdate(token string)
 }
 
 // CreateOrUpdate - Creates or updates the specified Network Virtual Appliance.
-func (client *NetworkVirtualAppliancesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters)
+func (client *NetworkVirtualAppliancesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdate(ctx context.Context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkVirtualAppliancesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters NetworkVirtualAppliance, options *NetworkVirtualAppliancesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
@@ -134,8 +134,8 @@ func (client *NetworkVirtualAppliancesClient) CreateOrUpdateHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkVirtualApplianceName)
+func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *NetworkVirtualAppliancesClient) ResumeDelete(token string) (HTTPPo
 }
 
 // Delete - Deletes the specified Network Virtual Appliance.
-func (client *NetworkVirtualAppliancesClient) Delete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName)
+func (client *NetworkVirtualAppliancesClient) Delete(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *NetworkVirtualAppliancesClient) Delete(ctx context.Context, resour
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkVirtualAppliancesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
@@ -211,8 +211,8 @@ func (client *NetworkVirtualAppliancesClient) DeleteHandleError(resp *azcore.Res
 }
 
 // Get - Gets the specified Network Virtual Appliance.
-func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, networkVirtualAppliancesGetOptions *NetworkVirtualAppliancesGetOptions) (*NetworkVirtualApplianceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, networkVirtualAppliancesGetOptions)
+func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (*NetworkVirtualApplianceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceG
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkVirtualAppliancesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, networkVirtualAppliancesGetOptions *NetworkVirtualAppliancesGetOptions) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, options *NetworkVirtualAppliancesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
@@ -242,8 +242,8 @@ func (client *NetworkVirtualAppliancesClient) GetCreateRequest(ctx context.Conte
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if networkVirtualAppliancesGetOptions != nil && networkVirtualAppliancesGetOptions.Expand != nil {
-		query.Set("$expand", *networkVirtualAppliancesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *NetworkVirtualAppliancesClient) GetHandleError(resp *azcore.Respon
 }
 
 // List - Gets all Network Virtual Appliances in a subscription.
-func (client *NetworkVirtualAppliancesClient) List() NetworkVirtualApplianceListResultPager {
+func (client *NetworkVirtualAppliancesClient) List(options *NetworkVirtualAppliancesListOptions) NetworkVirtualApplianceListResultPager {
 	return &networkVirtualApplianceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *NetworkVirtualAppliancesClient) List() NetworkVirtualApplianceList
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkVirtualAppliancesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) ListCreateRequest(ctx context.Context, options *NetworkVirtualAppliancesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -311,11 +311,11 @@ func (client *NetworkVirtualAppliancesClient) ListHandleError(resp *azcore.Respo
 }
 
 // ListByResourceGroup - Lists all Network Virtual Appliances in a resource group.
-func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupName string) NetworkVirtualApplianceListResultPager {
+func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) NetworkVirtualApplianceListResultPager {
 	return &networkVirtualApplianceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -326,7 +326,7 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupN
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *NetworkVirtualAppliancesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkVirtualAppliancesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -357,8 +357,8 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroupHandleError(res
 }
 
 // UpdateTags - Updates a Network Virtual Appliance.
-func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject) (*NetworkVirtualApplianceResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters)
+func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (*NetworkVirtualApplianceResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkVirtualApplianceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, re
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkVirtualAppliancesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NetworkVirtualAppliancesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkVirtualApplianceName string, parameters TagsObject, options *NetworkVirtualAppliancesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -18,63 +18,63 @@ import (
 // NetworkWatchersOperations contains the methods for the NetworkWatchers group.
 type NetworkWatchersOperations interface {
 	// BeginCheckConnectivity - Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given endpoint including another VM or an arbitrary remote server.
-	BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters) (*ConnectivityInformationPollerResponse, error)
+	BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersCheckConnectivityOptions) (*ConnectivityInformationPollerResponse, error)
 	// ResumeCheckConnectivity - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCheckConnectivity(token string) (ConnectivityInformationPoller, error)
 	// CreateOrUpdate - Creates or updates a network watcher in the specified resource group.
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher) (*NetworkWatcherResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher, options *NetworkWatchersCreateOrUpdateOptions) (*NetworkWatcherResponse, error)
 	// BeginDelete - Deletes the specified network watcher resource.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified network watcher by resource group.
-	Get(ctx context.Context, resourceGroupName string, networkWatcherName string) (*NetworkWatcherResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (*NetworkWatcherResponse, error)
 	// BeginGetAzureReachabilityReport - NOTE: This feature is currently in preview and still being tested for stability. Gets the relative latency score for internet service providers from a specified location to Azure regions.
-	BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*AzureReachabilityReportPollerResponse, error)
+	BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersGetAzureReachabilityReportOptions) (*AzureReachabilityReportPollerResponse, error)
 	// ResumeGetAzureReachabilityReport - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetAzureReachabilityReport(token string) (AzureReachabilityReportPoller, error)
 	// BeginGetFlowLogStatus - Queries status of flow log and traffic analytics (optional) on a specified resource.
-	BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*FlowLogInformationPollerResponse, error)
+	BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersGetFlowLogStatusOptions) (*FlowLogInformationPollerResponse, error)
 	// ResumeGetFlowLogStatus - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetFlowLogStatus(token string) (FlowLogInformationPoller, error)
 	// BeginGetNetworkConfigurationDiagnostic - Gets Network Configuration Diagnostic data to help customers understand and debug network behavior. It provides detailed information on what security rules were applied to a specified traffic flow and the result of evaluating these rules. Customers must provide details of a flow like source, destination, protocol, etc. The API returns whether traffic was allowed or denied, the rules evaluated for the specified flow and the evaluation results.
-	BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*NetworkConfigurationDiagnosticResponsePollerResponse, error)
+	BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersGetNetworkConfigurationDiagnosticOptions) (*NetworkConfigurationDiagnosticResponsePollerResponse, error)
 	// ResumeGetNetworkConfigurationDiagnostic - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetNetworkConfigurationDiagnostic(token string) (NetworkConfigurationDiagnosticResponsePoller, error)
 	// BeginGetNextHop - Gets the next hop from the specified VM.
-	BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*NextHopResultPollerResponse, error)
+	BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersGetNextHopOptions) (*NextHopResultPollerResponse, error)
 	// ResumeGetNextHop - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetNextHop(token string) (NextHopResultPoller, error)
 	// GetTopology - Gets the current network topology by resource group.
-	GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters) (*TopologyResponse, error)
+	GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (*TopologyResponse, error)
 	// BeginGetTroubleshooting - Initiate troubleshooting on a specified resource.
-	BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*TroubleshootingResultPollerResponse, error)
+	BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersGetTroubleshootingOptions) (*TroubleshootingResultPollerResponse, error)
 	// ResumeGetTroubleshooting - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetTroubleshooting(token string) (TroubleshootingResultPoller, error)
 	// BeginGetTroubleshootingResult - Get the last completed troubleshooting result on a specified resource.
-	BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*TroubleshootingResultPollerResponse, error)
+	BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersGetTroubleshootingResultOptions) (*TroubleshootingResultPollerResponse, error)
 	// ResumeGetTroubleshootingResult - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetTroubleshootingResult(token string) (TroubleshootingResultPoller, error)
 	// BeginGetVMSecurityRules - Gets the configured and effective security group rules on the specified VM.
-	BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*SecurityGroupViewResultPollerResponse, error)
+	BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersGetVMSecurityRulesOptions) (*SecurityGroupViewResultPollerResponse, error)
 	// ResumeGetVMSecurityRules - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetVMSecurityRules(token string) (SecurityGroupViewResultPoller, error)
 	// List - Gets all network watchers by resource group.
-	List(ctx context.Context, resourceGroupName string) (*NetworkWatcherListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (*NetworkWatcherListResultResponse, error)
 	// ListAll - Gets all network watchers by subscription.
-	ListAll(ctx context.Context) (*NetworkWatcherListResultResponse, error)
+	ListAll(ctx context.Context, options *NetworkWatchersListAllOptions) (*NetworkWatcherListResultResponse, error)
 	// BeginListAvailableProviders - NOTE: This feature is currently in preview and still being tested for stability. Lists all available internet service providers for a specified Azure region.
-	BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*AvailableProvidersListPollerResponse, error)
+	BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersListAvailableProvidersOptions) (*AvailableProvidersListPollerResponse, error)
 	// ResumeListAvailableProviders - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeListAvailableProviders(token string) (AvailableProvidersListPoller, error)
 	// BeginSetFlowLogConfiguration - Configures flow log and traffic analytics (optional) on a specified resource.
-	BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*FlowLogInformationPollerResponse, error)
+	BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersSetFlowLogConfigurationOptions) (*FlowLogInformationPollerResponse, error)
 	// ResumeSetFlowLogConfiguration - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeSetFlowLogConfiguration(token string) (FlowLogInformationPoller, error)
 	// UpdateTags - Updates a network watcher tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject) (*NetworkWatcherResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (*NetworkWatcherResponse, error)
 	// BeginVerifyIPFlow - Verify IP flow from the specified VM to a location given the currently configured NSG rules.
-	BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*VerificationIPFlowResultPollerResponse, error)
+	BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersVerifyIPFlowOptions) (*VerificationIPFlowResultPollerResponse, error)
 	// ResumeVerifyIPFlow - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeVerifyIPFlow(token string) (VerificationIPFlowResultPoller, error)
 }
@@ -96,8 +96,8 @@ func (client *NetworkWatchersClient) Do(req *azcore.Request) (*azcore.Response, 
 	return client.p.Do(req)
 }
 
-func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters) (*ConnectivityInformationPollerResponse, error) {
-	resp, err := client.CheckConnectivity(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersCheckConnectivityOptions) (*ConnectivityInformationPollerResponse, error) {
+	resp, err := client.CheckConnectivity(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +131,8 @@ func (client *NetworkWatchersClient) ResumeCheckConnectivity(token string) (Conn
 }
 
 // CheckConnectivity - Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given endpoint including another VM or an arbitrary remote server.
-func (client *NetworkWatchersClient) CheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters) (*azcore.Response, error) {
-	req, err := client.CheckConnectivityCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) CheckConnectivity(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersCheckConnectivityOptions) (*azcore.Response, error) {
+	req, err := client.CheckConnectivityCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (client *NetworkWatchersClient) CheckConnectivity(ctx context.Context, reso
 }
 
 // CheckConnectivityCreateRequest creates the CheckConnectivity request.
-func (client *NetworkWatchersClient) CheckConnectivityCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) CheckConnectivityCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters ConnectivityParameters, options *NetworkWatchersCheckConnectivityOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -179,8 +179,8 @@ func (client *NetworkWatchersClient) CheckConnectivityHandleError(resp *azcore.R
 }
 
 // CreateOrUpdate - Creates or updates a network watcher in the specified resource group.
-func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher) (*NetworkWatcherResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher, options *NetworkWatchersCreateOrUpdateOptions) (*NetworkWatcherResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (client *NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *NetworkWatchersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkWatcher, options *NetworkWatchersCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -230,8 +230,8 @@ func (client *NetworkWatchersClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName)
+func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -265,8 +265,8 @@ func (client *NetworkWatchersClient) ResumeDelete(token string) (HTTPPoller, err
 }
 
 // Delete - Deletes the specified network watcher resource.
-func (client *NetworkWatchersClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName)
+func (client *NetworkWatchersClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (client *NetworkWatchersClient) Delete(ctx context.Context, resourceGroupNa
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *NetworkWatchersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -307,8 +307,8 @@ func (client *NetworkWatchersClient) DeleteHandleError(resp *azcore.Response) er
 }
 
 // Get - Gets the specified network watcher by resource group.
-func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string) (*NetworkWatcherResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName)
+func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (*NetworkWatcherResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +327,7 @@ func (client *NetworkWatchersClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *NetworkWatchersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *NetworkWatchersGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -358,8 +358,8 @@ func (client *NetworkWatchersClient) GetHandleError(resp *azcore.Response) error
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*AzureReachabilityReportPollerResponse, error) {
-	resp, err := client.GetAzureReachabilityReport(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersGetAzureReachabilityReportOptions) (*AzureReachabilityReportPollerResponse, error) {
+	resp, err := client.GetAzureReachabilityReport(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +393,8 @@ func (client *NetworkWatchersClient) ResumeGetAzureReachabilityReport(token stri
 }
 
 // GetAzureReachabilityReport - NOTE: This feature is currently in preview and still being tested for stability. Gets the relative latency score for internet service providers from a specified location to Azure regions.
-func (client *NetworkWatchersClient) GetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*azcore.Response, error) {
-	req, err := client.GetAzureReachabilityReportCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetAzureReachabilityReport(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersGetAzureReachabilityReportOptions) (*azcore.Response, error) {
+	req, err := client.GetAzureReachabilityReportCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReport(ctx context.Cont
 }
 
 // GetAzureReachabilityReportCreateRequest creates the GetAzureReachabilityReport request.
-func (client *NetworkWatchersClient) GetAzureReachabilityReportCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetAzureReachabilityReportCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AzureReachabilityReportParameters, options *NetworkWatchersGetAzureReachabilityReportOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -440,8 +440,8 @@ func (client *NetworkWatchersClient) GetAzureReachabilityReportHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*FlowLogInformationPollerResponse, error) {
-	resp, err := client.GetFlowLogStatus(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersGetFlowLogStatusOptions) (*FlowLogInformationPollerResponse, error) {
+	resp, err := client.GetFlowLogStatus(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -475,8 +475,8 @@ func (client *NetworkWatchersClient) ResumeGetFlowLogStatus(token string) (FlowL
 }
 
 // GetFlowLogStatus - Queries status of flow log and traffic analytics (optional) on a specified resource.
-func (client *NetworkWatchersClient) GetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*azcore.Response, error) {
-	req, err := client.GetFlowLogStatusCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetFlowLogStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersGetFlowLogStatusOptions) (*azcore.Response, error) {
+	req, err := client.GetFlowLogStatusCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (client *NetworkWatchersClient) GetFlowLogStatus(ctx context.Context, resou
 }
 
 // GetFlowLogStatusCreateRequest creates the GetFlowLogStatus request.
-func (client *NetworkWatchersClient) GetFlowLogStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetFlowLogStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogStatusParameters, options *NetworkWatchersGetFlowLogStatusOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -522,8 +522,8 @@ func (client *NetworkWatchersClient) GetFlowLogStatusHandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*NetworkConfigurationDiagnosticResponsePollerResponse, error) {
-	resp, err := client.GetNetworkConfigurationDiagnostic(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersGetNetworkConfigurationDiagnosticOptions) (*NetworkConfigurationDiagnosticResponsePollerResponse, error) {
+	resp, err := client.GetNetworkConfigurationDiagnostic(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -557,8 +557,8 @@ func (client *NetworkWatchersClient) ResumeGetNetworkConfigurationDiagnostic(tok
 }
 
 // GetNetworkConfigurationDiagnostic - Gets Network Configuration Diagnostic data to help customers understand and debug network behavior. It provides detailed information on what security rules were applied to a specified traffic flow and the result of evaluating these rules. Customers must provide details of a flow like source, destination, protocol, etc. The API returns whether traffic was allowed or denied, the rules evaluated for the specified flow and the evaluation results.
-func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*azcore.Response, error) {
-	req, err := client.GetNetworkConfigurationDiagnosticCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnostic(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersGetNetworkConfigurationDiagnosticOptions) (*azcore.Response, error) {
+	req, err := client.GetNetworkConfigurationDiagnosticCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +573,7 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnostic(ctx conte
 }
 
 // GetNetworkConfigurationDiagnosticCreateRequest creates the GetNetworkConfigurationDiagnostic request.
-func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NetworkConfigurationDiagnosticParameters, options *NetworkWatchersGetNetworkConfigurationDiagnosticOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/networkConfigurationDiagnostic"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -604,8 +604,8 @@ func (client *NetworkWatchersClient) GetNetworkConfigurationDiagnosticHandleErro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*NextHopResultPollerResponse, error) {
-	resp, err := client.GetNextHop(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersGetNextHopOptions) (*NextHopResultPollerResponse, error) {
+	resp, err := client.GetNextHop(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -639,8 +639,8 @@ func (client *NetworkWatchersClient) ResumeGetNextHop(token string) (NextHopResu
 }
 
 // GetNextHop - Gets the next hop from the specified VM.
-func (client *NetworkWatchersClient) GetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*azcore.Response, error) {
-	req, err := client.GetNextHopCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetNextHop(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersGetNextHopOptions) (*azcore.Response, error) {
+	req, err := client.GetNextHopCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func (client *NetworkWatchersClient) GetNextHop(ctx context.Context, resourceGro
 }
 
 // GetNextHopCreateRequest creates the GetNextHop request.
-func (client *NetworkWatchersClient) GetNextHopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetNextHopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters NextHopParameters, options *NetworkWatchersGetNextHopOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -687,8 +687,8 @@ func (client *NetworkWatchersClient) GetNextHopHandleError(resp *azcore.Response
 }
 
 // GetTopology - Gets the current network topology by resource group.
-func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters) (*TopologyResponse, error) {
-	req, err := client.GetTopologyCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (*TopologyResponse, error) {
+	req, err := client.GetTopologyCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +707,7 @@ func (client *NetworkWatchersClient) GetTopology(ctx context.Context, resourceGr
 }
 
 // GetTopologyCreateRequest creates the GetTopology request.
-func (client *NetworkWatchersClient) GetTopologyCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetTopologyCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TopologyParameters, options *NetworkWatchersGetTopologyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/topology"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -738,8 +738,8 @@ func (client *NetworkWatchersClient) GetTopologyHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*TroubleshootingResultPollerResponse, error) {
-	resp, err := client.GetTroubleshooting(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersGetTroubleshootingOptions) (*TroubleshootingResultPollerResponse, error) {
+	resp, err := client.GetTroubleshooting(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -773,8 +773,8 @@ func (client *NetworkWatchersClient) ResumeGetTroubleshooting(token string) (Tro
 }
 
 // GetTroubleshooting - Initiate troubleshooting on a specified resource.
-func (client *NetworkWatchersClient) GetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*azcore.Response, error) {
-	req, err := client.GetTroubleshootingCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetTroubleshooting(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersGetTroubleshootingOptions) (*azcore.Response, error) {
+	req, err := client.GetTroubleshootingCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +789,7 @@ func (client *NetworkWatchersClient) GetTroubleshooting(ctx context.Context, res
 }
 
 // GetTroubleshootingCreateRequest creates the GetTroubleshooting request.
-func (client *NetworkWatchersClient) GetTroubleshootingCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetTroubleshootingCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TroubleshootingParameters, options *NetworkWatchersGetTroubleshootingOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -820,8 +820,8 @@ func (client *NetworkWatchersClient) GetTroubleshootingHandleError(resp *azcore.
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*TroubleshootingResultPollerResponse, error) {
-	resp, err := client.GetTroubleshootingResult(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersGetTroubleshootingResultOptions) (*TroubleshootingResultPollerResponse, error) {
+	resp, err := client.GetTroubleshootingResult(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -855,8 +855,8 @@ func (client *NetworkWatchersClient) ResumeGetTroubleshootingResult(token string
 }
 
 // GetTroubleshootingResult - Get the last completed troubleshooting result on a specified resource.
-func (client *NetworkWatchersClient) GetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*azcore.Response, error) {
-	req, err := client.GetTroubleshootingResultCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetTroubleshootingResult(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersGetTroubleshootingResultOptions) (*azcore.Response, error) {
+	req, err := client.GetTroubleshootingResultCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -871,7 +871,7 @@ func (client *NetworkWatchersClient) GetTroubleshootingResult(ctx context.Contex
 }
 
 // GetTroubleshootingResultCreateRequest creates the GetTroubleshootingResult request.
-func (client *NetworkWatchersClient) GetTroubleshootingResultCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetTroubleshootingResultCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters QueryTroubleshootingParameters, options *NetworkWatchersGetTroubleshootingResultOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -902,8 +902,8 @@ func (client *NetworkWatchersClient) GetTroubleshootingResultHandleError(resp *a
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*SecurityGroupViewResultPollerResponse, error) {
-	resp, err := client.GetVMSecurityRules(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersGetVMSecurityRulesOptions) (*SecurityGroupViewResultPollerResponse, error) {
+	resp, err := client.GetVMSecurityRules(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -937,8 +937,8 @@ func (client *NetworkWatchersClient) ResumeGetVMSecurityRules(token string) (Sec
 }
 
 // GetVMSecurityRules - Gets the configured and effective security group rules on the specified VM.
-func (client *NetworkWatchersClient) GetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*azcore.Response, error) {
-	req, err := client.GetVMSecurityRulesCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) GetVMSecurityRules(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersGetVMSecurityRulesOptions) (*azcore.Response, error) {
+	req, err := client.GetVMSecurityRulesCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -953,7 +953,7 @@ func (client *NetworkWatchersClient) GetVMSecurityRules(ctx context.Context, res
 }
 
 // GetVMSecurityRulesCreateRequest creates the GetVMSecurityRules request.
-func (client *NetworkWatchersClient) GetVMSecurityRulesCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) GetVMSecurityRulesCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters SecurityGroupViewParameters, options *NetworkWatchersGetVMSecurityRulesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -985,8 +985,8 @@ func (client *NetworkWatchersClient) GetVMSecurityRulesHandleError(resp *azcore.
 }
 
 // List - Gets all network watchers by resource group.
-func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName string) (*NetworkWatcherListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName)
+func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (*NetworkWatcherListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1005,7 +1005,7 @@ func (client *NetworkWatchersClient) List(ctx context.Context, resourceGroupName
 }
 
 // ListCreateRequest creates the List request.
-func (client *NetworkWatchersClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *NetworkWatchersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -1036,8 +1036,8 @@ func (client *NetworkWatchersClient) ListHandleError(resp *azcore.Response) erro
 }
 
 // ListAll - Gets all network watchers by subscription.
-func (client *NetworkWatchersClient) ListAll(ctx context.Context) (*NetworkWatcherListResultResponse, error) {
-	req, err := client.ListAllCreateRequest(ctx)
+func (client *NetworkWatchersClient) ListAll(ctx context.Context, options *NetworkWatchersListAllOptions) (*NetworkWatcherListResultResponse, error) {
+	req, err := client.ListAllCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1056,7 +1056,7 @@ func (client *NetworkWatchersClient) ListAll(ctx context.Context) (*NetworkWatch
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *NetworkWatchersClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) ListAllCreateRequest(ctx context.Context, options *NetworkWatchersListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -1085,8 +1085,8 @@ func (client *NetworkWatchersClient) ListAllHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*AvailableProvidersListPollerResponse, error) {
-	resp, err := client.ListAvailableProviders(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersListAvailableProvidersOptions) (*AvailableProvidersListPollerResponse, error) {
+	resp, err := client.ListAvailableProviders(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1120,8 +1120,8 @@ func (client *NetworkWatchersClient) ResumeListAvailableProviders(token string) 
 }
 
 // ListAvailableProviders - NOTE: This feature is currently in preview and still being tested for stability. Lists all available internet service providers for a specified Azure region.
-func (client *NetworkWatchersClient) ListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*azcore.Response, error) {
-	req, err := client.ListAvailableProvidersCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) ListAvailableProviders(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersListAvailableProvidersOptions) (*azcore.Response, error) {
+	req, err := client.ListAvailableProvidersCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1136,7 +1136,7 @@ func (client *NetworkWatchersClient) ListAvailableProviders(ctx context.Context,
 }
 
 // ListAvailableProvidersCreateRequest creates the ListAvailableProviders request.
-func (client *NetworkWatchersClient) ListAvailableProvidersCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) ListAvailableProvidersCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters AvailableProvidersListParameters, options *NetworkWatchersListAvailableProvidersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -1167,8 +1167,8 @@ func (client *NetworkWatchersClient) ListAvailableProvidersHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*FlowLogInformationPollerResponse, error) {
-	resp, err := client.SetFlowLogConfiguration(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersSetFlowLogConfigurationOptions) (*FlowLogInformationPollerResponse, error) {
+	resp, err := client.SetFlowLogConfiguration(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1202,8 +1202,8 @@ func (client *NetworkWatchersClient) ResumeSetFlowLogConfiguration(token string)
 }
 
 // SetFlowLogConfiguration - Configures flow log and traffic analytics (optional) on a specified resource.
-func (client *NetworkWatchersClient) SetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*azcore.Response, error) {
-	req, err := client.SetFlowLogConfigurationCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) SetFlowLogConfiguration(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersSetFlowLogConfigurationOptions) (*azcore.Response, error) {
+	req, err := client.SetFlowLogConfigurationCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1218,7 +1218,7 @@ func (client *NetworkWatchersClient) SetFlowLogConfiguration(ctx context.Context
 }
 
 // SetFlowLogConfigurationCreateRequest creates the SetFlowLogConfiguration request.
-func (client *NetworkWatchersClient) SetFlowLogConfigurationCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) SetFlowLogConfigurationCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters FlowLogInformation, options *NetworkWatchersSetFlowLogConfigurationOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -1250,8 +1250,8 @@ func (client *NetworkWatchersClient) SetFlowLogConfigurationHandleError(resp *az
 }
 
 // UpdateTags - Updates a network watcher tags.
-func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject) (*NetworkWatcherResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (*NetworkWatcherResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1270,7 +1270,7 @@ func (client *NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGro
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *NetworkWatchersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters TagsObject, options *NetworkWatchersUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -1301,8 +1301,8 @@ func (client *NetworkWatchersClient) UpdateTagsHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*VerificationIPFlowResultPollerResponse, error) {
-	resp, err := client.VerifyIPFlow(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersVerifyIPFlowOptions) (*VerificationIPFlowResultPollerResponse, error) {
+	resp, err := client.VerifyIPFlow(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1336,8 +1336,8 @@ func (client *NetworkWatchersClient) ResumeVerifyIPFlow(token string) (Verificat
 }
 
 // VerifyIPFlow - Verify IP flow from the specified VM to a location given the currently configured NSG rules.
-func (client *NetworkWatchersClient) VerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*azcore.Response, error) {
-	req, err := client.VerifyIPFlowCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters)
+func (client *NetworkWatchersClient) VerifyIPFlow(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersVerifyIPFlowOptions) (*azcore.Response, error) {
+	req, err := client.VerifyIPFlowCreateRequest(ctx, resourceGroupName, networkWatcherName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1352,7 +1352,7 @@ func (client *NetworkWatchersClient) VerifyIPFlow(ctx context.Context, resourceG
 }
 
 // VerifyIPFlowCreateRequest creates the VerifyIPFlow request.
-func (client *NetworkWatchersClient) VerifyIPFlowCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters) (*azcore.Request, error) {
+func (client *NetworkWatchersClient) VerifyIPFlowCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, parameters VerificationIPFlowParameters, options *NetworkWatchersVerifyIPFlowOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -14,7 +14,7 @@ import (
 // Operations contains the methods for the Operations group.
 type Operations interface {
 	// List - Lists all of the available Network Rest API operations.
-	List() OperationListResultPager
+	List(options *OperationsListOptions) OperationListResultPager
 }
 
 // OperationsClient implements the Operations interface.
@@ -34,11 +34,11 @@ func (client *OperationsClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // List - Lists all of the available Network Rest API operations.
-func (client *OperationsClient) List() OperationListResultPager {
+func (client *OperationsClient) List(options *OperationsListOptions) OperationListResultPager {
 	return &operationListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -49,7 +49,7 @@ func (client *OperationsClient) List() OperationListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *OperationsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *OperationsClient) ListCreateRequest(ctx context.Context, options *OperationsListOptions) (*azcore.Request, error) {
 	urlPath := "/providers/Microsoft.Network/operations"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -18,37 +18,37 @@ import (
 // P2SVpnGatewaysOperations contains the methods for the P2SVpnGateways group.
 type P2SVpnGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates a virtual wan p2s vpn gateway if it doesn't exist else updates the existing gateway.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway) (*P2SVpnGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway, options *P2SVpnGatewaysCreateOrUpdateOptions) (*P2SVpnGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (P2SVpnGatewayPoller, error)
 	// BeginDelete - Deletes a virtual wan p2s vpn gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// BeginDisconnectP2SVpnConnections - Disconnect P2S vpn connections of the virtual wan P2SVpnGateway in the specified resource group.
-	BeginDisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error)
+	BeginDisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest, options *P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions) (*HTTPPollerResponse, error)
 	// ResumeDisconnectP2SVpnConnections - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDisconnectP2SVpnConnections(token string) (HTTPPoller, error)
 	// BeginGenerateVpnProfile - Generates VPN profile for P2S client of the P2SVpnGateway in the specified resource group.
-	BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*VpnProfileResponsePollerResponse, error)
+	BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters, options *P2SVpnGatewaysGenerateVpnProfileOptions) (*VpnProfileResponsePollerResponse, error)
 	// ResumeGenerateVpnProfile - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGenerateVpnProfile(token string) (VpnProfileResponsePoller, error)
 	// Get - Retrieves the details of a virtual wan p2s vpn gateway.
-	Get(ctx context.Context, resourceGroupName string, gatewayName string) (*P2SVpnGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetOptions) (*P2SVpnGatewayResponse, error)
 	// BeginGetP2SVpnConnectionHealth - Gets the connection health of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.
-	BeginGetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string) (*P2SVpnGatewayPollerResponse, error)
+	BeginGetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetP2SVpnConnectionHealthOptions) (*P2SVpnGatewayPollerResponse, error)
 	// ResumeGetP2SVpnConnectionHealth - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetP2SVpnConnectionHealth(token string) (P2SVpnGatewayPoller, error)
 	// BeginGetP2SVpnConnectionHealthDetailed - Gets the sas url to get the connection health detail of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.
-	BeginGetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*P2SVpnConnectionHealthPollerResponse, error)
+	BeginGetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest, options *P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions) (*P2SVpnConnectionHealthPollerResponse, error)
 	// ResumeGetP2SVpnConnectionHealthDetailed - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetP2SVpnConnectionHealthDetailed(token string) (P2SVpnConnectionHealthPoller, error)
 	// List - Lists all the P2SVpnGateways in a subscription.
-	List() ListP2SVpnGatewaysResultPager
+	List(options *P2SVpnGatewaysListOptions) ListP2SVpnGatewaysResultPager
 	// ListByResourceGroup - Lists all the P2SVpnGateways in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListP2SVpnGatewaysResultPager
+	ListByResourceGroup(resourceGroupName string, options *P2SVpnGatewaysListByResourceGroupOptions) ListP2SVpnGatewaysResultPager
 	// UpdateTags - Updates virtual wan p2s vpn gateway tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject) (*P2SVpnGatewayResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject, options *P2SVpnGatewaysUpdateTagsOptions) (*P2SVpnGatewayResponse, error)
 }
 
 // P2SVpnGatewaysClient implements the P2SVpnGatewaysOperations interface.
@@ -68,8 +68,8 @@ func (client *P2SVpnGatewaysClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *P2SVpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway) (*P2SVpnGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters)
+func (client *P2SVpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway, options *P2SVpnGatewaysCreateOrUpdateOptions) (*P2SVpnGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,8 +103,8 @@ func (client *P2SVpnGatewaysClient) ResumeCreateOrUpdate(token string) (P2SVpnGa
 }
 
 // CreateOrUpdate - Creates a virtual wan p2s vpn gateway if it doesn't exist else updates the existing gateway.
-func (client *P2SVpnGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters)
+func (client *P2SVpnGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway, options *P2SVpnGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *P2SVpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters P2SVpnGateway, options *P2SVpnGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -150,8 +150,8 @@ func (client *P2SVpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *P2SVpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, gatewayName)
+func (client *P2SVpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (client *P2SVpnGatewaysClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Deletes a virtual wan p2s vpn gateway.
-func (client *P2SVpnGatewaysClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *P2SVpnGatewaysClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (client *P2SVpnGatewaysClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *P2SVpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -226,8 +226,8 @@ func (client *P2SVpnGatewaysClient) DeleteHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *P2SVpnGatewaysClient) BeginDisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.DisconnectP2SVpnConnections(ctx, resourceGroupName, p2SVpnGatewayName, request)
+func (client *P2SVpnGatewaysClient) BeginDisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest, options *P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DisconnectP2SVpnConnections(ctx, resourceGroupName, p2SVpnGatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +261,8 @@ func (client *P2SVpnGatewaysClient) ResumeDisconnectP2SVpnConnections(token stri
 }
 
 // DisconnectP2SVpnConnections - Disconnect P2S vpn connections of the virtual wan P2SVpnGateway in the specified resource group.
-func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*azcore.Response, error) {
-	req, err := client.DisconnectP2SVpnConnectionsCreateRequest(ctx, resourceGroupName, p2SVpnGatewayName, request)
+func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnections(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest, options *P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions) (*azcore.Response, error) {
+	req, err := client.DisconnectP2SVpnConnectionsCreateRequest(ctx, resourceGroupName, p2SVpnGatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnections(ctx context.Cont
 }
 
 // DisconnectP2SVpnConnectionsCreateRequest creates the DisconnectP2SVpnConnections request.
-func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsCreateRequest(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsCreateRequest(ctx context.Context, resourceGroupName string, p2SVpnGatewayName string, request P2SVpnConnectionRequest, options *P2SVpnGatewaysDisconnectP2SVpnConnectionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{p2sVpnGatewayName}/disconnectP2sVpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -302,8 +302,8 @@ func (client *P2SVpnGatewaysClient) DisconnectP2SVpnConnectionsHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *P2SVpnGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*VpnProfileResponsePollerResponse, error) {
-	resp, err := client.GenerateVpnProfile(ctx, resourceGroupName, gatewayName, parameters)
+func (client *P2SVpnGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters, options *P2SVpnGatewaysGenerateVpnProfileOptions) (*VpnProfileResponsePollerResponse, error) {
+	resp, err := client.GenerateVpnProfile(ctx, resourceGroupName, gatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -337,8 +337,8 @@ func (client *P2SVpnGatewaysClient) ResumeGenerateVpnProfile(token string) (VpnP
 }
 
 // GenerateVpnProfile - Generates VPN profile for P2S client of the P2SVpnGateway in the specified resource group.
-func (client *P2SVpnGatewaysClient) GenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*azcore.Response, error) {
-	req, err := client.GenerateVpnProfileCreateRequest(ctx, resourceGroupName, gatewayName, parameters)
+func (client *P2SVpnGatewaysClient) GenerateVpnProfile(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters, options *P2SVpnGatewaysGenerateVpnProfileOptions) (*azcore.Response, error) {
+	req, err := client.GenerateVpnProfileCreateRequest(ctx, resourceGroupName, gatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfile(ctx context.Context, reso
 }
 
 // GenerateVpnProfileCreateRequest creates the GenerateVpnProfile request.
-func (client *P2SVpnGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, parameters P2SVpnProfileParameters, options *P2SVpnGatewaysGenerateVpnProfileOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/generatevpnprofile"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
@@ -385,8 +385,8 @@ func (client *P2SVpnGatewaysClient) GenerateVpnProfileHandleError(resp *azcore.R
 }
 
 // Get - Retrieves the details of a virtual wan p2s vpn gateway.
-func (client *P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName string, gatewayName string) (*P2SVpnGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetOptions) (*P2SVpnGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (client *P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *P2SVpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -436,8 +436,8 @@ func (client *P2SVpnGatewaysClient) GetHandleError(resp *azcore.Response) error 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string) (*P2SVpnGatewayPollerResponse, error) {
-	resp, err := client.GetP2SVpnConnectionHealth(ctx, resourceGroupName, gatewayName)
+func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetP2SVpnConnectionHealthOptions) (*P2SVpnGatewayPollerResponse, error) {
+	resp, err := client.GetP2SVpnConnectionHealth(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -471,8 +471,8 @@ func (client *P2SVpnGatewaysClient) ResumeGetP2SVpnConnectionHealth(token string
 }
 
 // GetP2SVpnConnectionHealth - Gets the connection health of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.
-func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Response, error) {
-	req, err := client.GetP2SVpnConnectionHealthCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealth(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetP2SVpnConnectionHealthOptions) (*azcore.Response, error) {
+	req, err := client.GetP2SVpnConnectionHealthCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealth(ctx context.Contex
 }
 
 // GetP2SVpnConnectionHealthCreateRequest creates the GetP2SVpnConnectionHealth request.
-func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *P2SVpnGatewaysGetP2SVpnConnectionHealthOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
@@ -518,8 +518,8 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthHandleError(resp *a
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*P2SVpnConnectionHealthPollerResponse, error) {
-	resp, err := client.GetP2SVpnConnectionHealthDetailed(ctx, resourceGroupName, gatewayName, request)
+func (client *P2SVpnGatewaysClient) BeginGetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest, options *P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions) (*P2SVpnConnectionHealthPollerResponse, error) {
+	resp, err := client.GetP2SVpnConnectionHealthDetailed(ctx, resourceGroupName, gatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -553,8 +553,8 @@ func (client *P2SVpnGatewaysClient) ResumeGetP2SVpnConnectionHealthDetailed(toke
 }
 
 // GetP2SVpnConnectionHealthDetailed - Gets the sas url to get the connection health detail of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.
-func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*azcore.Response, error) {
-	req, err := client.GetP2SVpnConnectionHealthDetailedCreateRequest(ctx, resourceGroupName, gatewayName, request)
+func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailed(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest, options *P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions) (*azcore.Response, error) {
+	req, err := client.GetP2SVpnConnectionHealthDetailedCreateRequest(ctx, resourceGroupName, gatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -569,7 +569,7 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailed(ctx contex
 }
 
 // GetP2SVpnConnectionHealthDetailedCreateRequest creates the GetP2SVpnConnectionHealthDetailed request.
-func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, request P2SVpnConnectionHealthRequest, options *P2SVpnGatewaysGetP2SVpnConnectionHealthDetailedOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealthDetailed"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -601,11 +601,11 @@ func (client *P2SVpnGatewaysClient) GetP2SVpnConnectionHealthDetailedHandleError
 }
 
 // List - Lists all the P2SVpnGateways in a subscription.
-func (client *P2SVpnGatewaysClient) List() ListP2SVpnGatewaysResultPager {
+func (client *P2SVpnGatewaysClient) List(options *P2SVpnGatewaysListOptions) ListP2SVpnGatewaysResultPager {
 	return &listP2SVpnGatewaysResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -616,7 +616,7 @@ func (client *P2SVpnGatewaysClient) List() ListP2SVpnGatewaysResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *P2SVpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) ListCreateRequest(ctx context.Context, options *P2SVpnGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -646,11 +646,11 @@ func (client *P2SVpnGatewaysClient) ListHandleError(resp *azcore.Response) error
 }
 
 // ListByResourceGroup - Lists all the P2SVpnGateways in a resource group.
-func (client *P2SVpnGatewaysClient) ListByResourceGroup(resourceGroupName string) ListP2SVpnGatewaysResultPager {
+func (client *P2SVpnGatewaysClient) ListByResourceGroup(resourceGroupName string, options *P2SVpnGatewaysListByResourceGroupOptions) ListP2SVpnGatewaysResultPager {
 	return &listP2SVpnGatewaysResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -661,7 +661,7 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroup(resourceGroupName string
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *P2SVpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *P2SVpnGatewaysListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -692,8 +692,8 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.
 }
 
 // UpdateTags - Updates virtual wan p2s vpn gateway tags.
-func (client *P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject) (*P2SVpnGatewayResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters)
+func (client *P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject, options *P2SVpnGatewaysUpdateTagsOptions) (*P2SVpnGatewayResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, gatewayName, p2SVpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -712,7 +712,7 @@ func (client *P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGrou
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *P2SVpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject) (*azcore.Request, error) {
+func (client *P2SVpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, p2SVpnGatewayParameters TagsObject, options *P2SVpnGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -18,23 +18,23 @@ import (
 // PacketCapturesOperations contains the methods for the PacketCaptures group.
 type PacketCapturesOperations interface {
 	// BeginCreate - Create and start a packet capture on the specified VM.
-	BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture) (*PacketCaptureResultPollerResponse, error)
+	BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesCreateOptions) (*PacketCaptureResultPollerResponse, error)
 	// ResumeCreate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreate(token string) (PacketCaptureResultPoller, error)
 	// BeginDelete - Deletes the specified packet capture session.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets a packet capture session by name.
-	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*PacketCaptureResultResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetOptions) (*PacketCaptureResultResponse, error)
 	// BeginGetStatus - Query the status of a running packet capture session.
-	BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*PacketCaptureQueryStatusResultPollerResponse, error)
+	BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetStatusOptions) (*PacketCaptureQueryStatusResultPollerResponse, error)
 	// ResumeGetStatus - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetStatus(token string) (PacketCaptureQueryStatusResultPoller, error)
 	// List - Lists all packet capture sessions within the specified resource group.
-	List(ctx context.Context, resourceGroupName string, networkWatcherName string) (*PacketCaptureListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *PacketCapturesListOptions) (*PacketCaptureListResultResponse, error)
 	// BeginStop - Stops a specified packet capture session.
-	BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error)
+	BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesStopOptions) (*HTTPPollerResponse, error)
 	// ResumeStop - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStop(token string) (HTTPPoller, error)
 }
@@ -56,8 +56,8 @@ func (client *PacketCapturesClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture) (*PacketCaptureResultPollerResponse, error) {
-	resp, err := client.Create(ctx, resourceGroupName, networkWatcherName, packetCaptureName, parameters)
+func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesCreateOptions) (*PacketCaptureResultPollerResponse, error) {
+	resp, err := client.Create(ctx, resourceGroupName, networkWatcherName, packetCaptureName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +91,8 @@ func (client *PacketCapturesClient) ResumeCreate(token string) (PacketCaptureRes
 }
 
 // Create - Create and start a packet capture on the specified VM.
-func (client *PacketCapturesClient) Create(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture) (*azcore.Response, error) {
-	req, err := client.CreateCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, parameters)
+func (client *PacketCapturesClient) Create(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesCreateOptions) (*azcore.Response, error) {
+	req, err := client.CreateCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (client *PacketCapturesClient) Create(ctx context.Context, resourceGroupNam
 }
 
 // CreateCreateRequest creates the Create request.
-func (client *PacketCapturesClient) CreateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture) (*azcore.Request, error) {
+func (client *PacketCapturesClient) CreateCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, parameters PacketCapture, options *PacketCapturesCreateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -139,8 +139,8 @@ func (client *PacketCapturesClient) CreateHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +174,8 @@ func (client *PacketCapturesClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Deletes the specified packet capture session.
-func (client *PacketCapturesClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) Delete(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (client *PacketCapturesClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PacketCapturesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+func (client *PacketCapturesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -217,8 +217,8 @@ func (client *PacketCapturesClient) DeleteHandleError(resp *azcore.Response) err
 }
 
 // Get - Gets a packet capture session by name.
-func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*PacketCaptureResultResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetOptions) (*PacketCaptureResultResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PacketCapturesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+func (client *PacketCapturesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -269,8 +269,8 @@ func (client *PacketCapturesClient) GetHandleError(resp *azcore.Response) error 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*PacketCaptureQueryStatusResultPollerResponse, error) {
-	resp, err := client.GetStatus(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetStatusOptions) (*PacketCaptureQueryStatusResultPollerResponse, error) {
+	resp, err := client.GetStatus(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +304,8 @@ func (client *PacketCapturesClient) ResumeGetStatus(token string) (PacketCapture
 }
 
 // GetStatus - Query the status of a running packet capture session.
-func (client *PacketCapturesClient) GetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Response, error) {
-	req, err := client.GetStatusCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) GetStatus(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetStatusOptions) (*azcore.Response, error) {
+	req, err := client.GetStatusCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +320,7 @@ func (client *PacketCapturesClient) GetStatus(ctx context.Context, resourceGroup
 }
 
 // GetStatusCreateRequest creates the GetStatus request.
-func (client *PacketCapturesClient) GetStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+func (client *PacketCapturesClient) GetStatusCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesGetStatusOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/queryStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -353,8 +353,8 @@ func (client *PacketCapturesClient) GetStatusHandleError(resp *azcore.Response) 
 }
 
 // List - Lists all packet capture sessions within the specified resource group.
-func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string) (*PacketCaptureListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName)
+func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName string, networkWatcherName string, options *PacketCapturesListOptions) (*PacketCaptureListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, networkWatcherName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (client *PacketCapturesClient) List(ctx context.Context, resourceGroupName 
 }
 
 // ListCreateRequest creates the List request.
-func (client *PacketCapturesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string) (*azcore.Request, error) {
+func (client *PacketCapturesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, options *PacketCapturesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))
@@ -404,8 +404,8 @@ func (client *PacketCapturesClient) ListHandleError(resp *azcore.Response) error
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Stop(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesStopOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Stop(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -439,8 +439,8 @@ func (client *PacketCapturesClient) ResumeStop(token string) (HTTPPoller, error)
 }
 
 // Stop - Stops a specified packet capture session.
-func (client *PacketCapturesClient) Stop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Response, error) {
-	req, err := client.StopCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName)
+func (client *PacketCapturesClient) Stop(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesStopOptions) (*azcore.Response, error) {
+	req, err := client.StopCreateRequest(ctx, resourceGroupName, networkWatcherName, packetCaptureName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +455,7 @@ func (client *PacketCapturesClient) Stop(ctx context.Context, resourceGroupName 
 }
 
 // StopCreateRequest creates the Stop request.
-func (client *PacketCapturesClient) StopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string) (*azcore.Request, error) {
+func (client *PacketCapturesClient) StopCreateRequest(ctx context.Context, resourceGroupName string, networkWatcherName string, packetCaptureName string, options *PacketCapturesStopOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkWatcherName}", url.PathEscape(networkWatcherName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -16,9 +16,9 @@ import (
 // PeerExpressRouteCircuitConnectionsOperations contains the methods for the PeerExpressRouteCircuitConnections group.
 type PeerExpressRouteCircuitConnectionsOperations interface {
 	// Get - Gets the specified Peer Express Route Circuit Connection from the specified express route circuit.
-	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*PeerExpressRouteCircuitConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *PeerExpressRouteCircuitConnectionsGetOptions) (*PeerExpressRouteCircuitConnectionResponse, error)
 	// List - Gets all global reach peer connections associated with a private peering in an express route circuit.
-	List(resourceGroupName string, circuitName string, peeringName string) PeerExpressRouteCircuitConnectionListResultPager
+	List(resourceGroupName string, circuitName string, peeringName string, options *PeerExpressRouteCircuitConnectionsListOptions) PeerExpressRouteCircuitConnectionListResultPager
 }
 
 // PeerExpressRouteCircuitConnectionsClient implements the PeerExpressRouteCircuitConnectionsOperations interface.
@@ -39,8 +39,8 @@ func (client *PeerExpressRouteCircuitConnectionsClient) Do(req *azcore.Request) 
 }
 
 // Get - Gets the specified Peer Express Route Circuit Connection from the specified express route circuit.
-func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*PeerExpressRouteCircuitConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName)
+func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *PeerExpressRouteCircuitConnectionsGetOptions) (*PeerExpressRouteCircuitConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, circuitName, peeringName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context,
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PeerExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string) (*azcore.Request, error) {
+func (client *PeerExpressRouteCircuitConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, connectionName string, options *PeerExpressRouteCircuitConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))
@@ -93,11 +93,11 @@ func (client *PeerExpressRouteCircuitConnectionsClient) GetHandleError(resp *azc
 }
 
 // List - Gets all global reach peer connections associated with a private peering in an express route circuit.
-func (client *PeerExpressRouteCircuitConnectionsClient) List(resourceGroupName string, circuitName string, peeringName string) PeerExpressRouteCircuitConnectionListResultPager {
+func (client *PeerExpressRouteCircuitConnectionsClient) List(resourceGroupName string, circuitName string, peeringName string, options *PeerExpressRouteCircuitConnectionsListOptions) PeerExpressRouteCircuitConnectionListResultPager {
 	return &peerExpressRouteCircuitConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName)
+			return client.ListCreateRequest(ctx, resourceGroupName, circuitName, peeringName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -108,7 +108,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) List(resourceGroupName s
 }
 
 // ListCreateRequest creates the List request.
-func (client *PeerExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string) (*azcore.Request, error) {
+func (client *PeerExpressRouteCircuitConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, circuitName string, peeringName string, options *PeerExpressRouteCircuitConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{circuitName}", url.PathEscape(circuitName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -18,17 +18,17 @@ import (
 // PrivateDNSZoneGroupsOperations contains the methods for the PrivateDNSZoneGroups group.
 type PrivateDNSZoneGroupsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a private dns zone group in the specified private endpoint.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup) (*PrivateDNSZoneGroupPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsCreateOrUpdateOptions) (*PrivateDNSZoneGroupPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (PrivateDNSZoneGroupPoller, error)
 	// BeginDelete - Deletes the specified private dns zone group.
-	BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the private dns zone group resource by specified private dns zone group name.
-	Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*PrivateDNSZoneGroupResponse, error)
+	Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsGetOptions) (*PrivateDNSZoneGroupResponse, error)
 	// List - Gets all private dns zone groups in a private endpoint.
-	List(privateEndpointName string, resourceGroupName string) PrivateDNSZoneGroupListResultPager
+	List(privateEndpointName string, resourceGroupName string, options *PrivateDNSZoneGroupsListOptions) PrivateDNSZoneGroupListResultPager
 }
 
 // PrivateDNSZoneGroupsClient implements the PrivateDNSZoneGroupsOperations interface.
@@ -48,8 +48,8 @@ func (client *PrivateDNSZoneGroupsClient) Do(req *azcore.Request) (*azcore.Respo
 	return client.p.Do(req)
 }
 
-func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup) (*PrivateDNSZoneGroupPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, parameters)
+func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsCreateOrUpdateOptions) (*PrivateDNSZoneGroupPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *PrivateDNSZoneGroupsClient) ResumeCreateOrUpdate(token string) (Pr
 }
 
 // CreateOrUpdate - Creates or updates a private dns zone group in the specified private endpoint.
-func (client *PrivateDNSZoneGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, parameters)
+func (client *PrivateDNSZoneGroupsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdate(ctx context.Context, re
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup) (*azcore.Request, error) {
+func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, parameters PrivateDNSZoneGroup, options *PrivateDNSZoneGroupsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -131,8 +131,8 @@ func (client *PrivateDNSZoneGroupsClient) CreateOrUpdateHandleError(resp *azcore
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName)
+func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *PrivateDNSZoneGroupsClient) ResumeDelete(token string) (HTTPPoller
 }
 
 // Delete - Deletes the specified private dns zone group.
-func (client *PrivateDNSZoneGroupsClient) Delete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName)
+func (client *PrivateDNSZoneGroupsClient) Delete(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *PrivateDNSZoneGroupsClient) Delete(ctx context.Context, resourceGr
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PrivateDNSZoneGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*azcore.Request, error) {
+func (client *PrivateDNSZoneGroupsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -209,8 +209,8 @@ func (client *PrivateDNSZoneGroupsClient) DeleteHandleError(resp *azcore.Respons
 }
 
 // Get - Gets the private dns zone group resource by specified private dns zone group name.
-func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*PrivateDNSZoneGroupResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName)
+func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsGetOptions) (*PrivateDNSZoneGroupResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, privateEndpointName, privateDnsZoneGroupName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroup
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PrivateDNSZoneGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string) (*azcore.Request, error) {
+func (client *PrivateDNSZoneGroupsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateDnsZoneGroupName string, options *PrivateDNSZoneGroupsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -262,11 +262,11 @@ func (client *PrivateDNSZoneGroupsClient) GetHandleError(resp *azcore.Response) 
 }
 
 // List - Gets all private dns zone groups in a private endpoint.
-func (client *PrivateDNSZoneGroupsClient) List(privateEndpointName string, resourceGroupName string) PrivateDNSZoneGroupListResultPager {
+func (client *PrivateDNSZoneGroupsClient) List(privateEndpointName string, resourceGroupName string, options *PrivateDNSZoneGroupsListOptions) PrivateDNSZoneGroupListResultPager {
 	return &privateDnsZoneGroupListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, privateEndpointName, resourceGroupName)
+			return client.ListCreateRequest(ctx, privateEndpointName, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *PrivateDNSZoneGroupsClient) List(privateEndpointName string, resou
 }
 
 // ListCreateRequest creates the List request.
-func (client *PrivateDNSZoneGroupsClient) ListCreateRequest(ctx context.Context, privateEndpointName string, resourceGroupName string) (*azcore.Request, error) {
+func (client *PrivateDNSZoneGroupsClient) ListCreateRequest(ctx context.Context, privateEndpointName string, resourceGroupName string, options *PrivateDNSZoneGroupsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups"
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -18,19 +18,19 @@ import (
 // PrivateEndpointsOperations contains the methods for the PrivateEndpoints group.
 type PrivateEndpointsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates an private endpoint in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint) (*PrivateEndpointPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsCreateOrUpdateOptions) (*PrivateEndpointPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (PrivateEndpointPoller, error)
 	// BeginDelete - Deletes the specified private endpoint.
-	BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified private endpoint by resource group.
-	Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateEndpointsGetOptions *PrivateEndpointsGetOptions) (*PrivateEndpointResponse, error)
+	Get(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsGetOptions) (*PrivateEndpointResponse, error)
 	// List - Gets all private endpoints in a resource group.
-	List(resourceGroupName string) PrivateEndpointListResultPager
+	List(resourceGroupName string, options *PrivateEndpointsListOptions) PrivateEndpointListResultPager
 	// ListBySubscription - Gets all private endpoints in a subscription.
-	ListBySubscription() PrivateEndpointListResultPager
+	ListBySubscription(options *PrivateEndpointsListBySubscriptionOptions) PrivateEndpointListResultPager
 }
 
 // PrivateEndpointsClient implements the PrivateEndpointsOperations interface.
@@ -50,8 +50,8 @@ func (client *PrivateEndpointsClient) Do(req *azcore.Request) (*azcore.Response,
 	return client.p.Do(req)
 }
 
-func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint) (*PrivateEndpointPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, privateEndpointName, parameters)
+func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsCreateOrUpdateOptions) (*PrivateEndpointPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, privateEndpointName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *PrivateEndpointsClient) ResumeCreateOrUpdate(token string) (Privat
 }
 
 // CreateOrUpdate - Creates or updates an private endpoint in the specified resource group.
-func (client *PrivateEndpointsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, privateEndpointName, parameters)
+func (client *PrivateEndpointsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, privateEndpointName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *PrivateEndpointsClient) CreateOrUpdate(ctx context.Context, resour
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *PrivateEndpointsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint) (*azcore.Request, error) {
+func (client *PrivateEndpointsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, parameters PrivateEndpoint, options *PrivateEndpointsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -132,8 +132,8 @@ func (client *PrivateEndpointsClient) CreateOrUpdateHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, privateEndpointName)
+func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, privateEndpointName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *PrivateEndpointsClient) ResumeDelete(token string) (HTTPPoller, er
 }
 
 // Delete - Deletes the specified private endpoint.
-func (client *PrivateEndpointsClient) Delete(ctx context.Context, resourceGroupName string, privateEndpointName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, privateEndpointName)
+func (client *PrivateEndpointsClient) Delete(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, privateEndpointName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *PrivateEndpointsClient) Delete(ctx context.Context, resourceGroupN
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PrivateEndpointsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string) (*azcore.Request, error) {
+func (client *PrivateEndpointsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -209,8 +209,8 @@ func (client *PrivateEndpointsClient) DeleteHandleError(resp *azcore.Response) e
 }
 
 // Get - Gets the specified private endpoint by resource group.
-func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName string, privateEndpointName string, privateEndpointsGetOptions *PrivateEndpointsGetOptions) (*PrivateEndpointResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, privateEndpointName, privateEndpointsGetOptions)
+func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsGetOptions) (*PrivateEndpointResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, privateEndpointName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PrivateEndpointsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, privateEndpointsGetOptions *PrivateEndpointsGetOptions) (*azcore.Request, error) {
+func (client *PrivateEndpointsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, privateEndpointName string, options *PrivateEndpointsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{privateEndpointName}", url.PathEscape(privateEndpointName))
@@ -240,8 +240,8 @@ func (client *PrivateEndpointsClient) GetCreateRequest(ctx context.Context, reso
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if privateEndpointsGetOptions != nil && privateEndpointsGetOptions.Expand != nil {
-		query.Set("$expand", *privateEndpointsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -264,11 +264,11 @@ func (client *PrivateEndpointsClient) GetHandleError(resp *azcore.Response) erro
 }
 
 // List - Gets all private endpoints in a resource group.
-func (client *PrivateEndpointsClient) List(resourceGroupName string) PrivateEndpointListResultPager {
+func (client *PrivateEndpointsClient) List(resourceGroupName string, options *PrivateEndpointsListOptions) PrivateEndpointListResultPager {
 	return &privateEndpointListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -279,7 +279,7 @@ func (client *PrivateEndpointsClient) List(resourceGroupName string) PrivateEndp
 }
 
 // ListCreateRequest creates the List request.
-func (client *PrivateEndpointsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *PrivateEndpointsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *PrivateEndpointsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -310,11 +310,11 @@ func (client *PrivateEndpointsClient) ListHandleError(resp *azcore.Response) err
 }
 
 // ListBySubscription - Gets all private endpoints in a subscription.
-func (client *PrivateEndpointsClient) ListBySubscription() PrivateEndpointListResultPager {
+func (client *PrivateEndpointsClient) ListBySubscription(options *PrivateEndpointsListBySubscriptionOptions) PrivateEndpointListResultPager {
 	return &privateEndpointListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -325,7 +325,7 @@ func (client *PrivateEndpointsClient) ListBySubscription() PrivateEndpointListRe
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *PrivateEndpointsClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrivateEndpointsClient) ListBySubscriptionCreateRequest(ctx context.Context, options *PrivateEndpointsListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateEndpoints"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -18,41 +18,41 @@ import (
 // PrivateLinkServicesOperations contains the methods for the PrivateLinkServices group.
 type PrivateLinkServicesOperations interface {
 	// BeginCheckPrivateLinkServiceVisibility - Checks whether the subscription is visible to private link service.
-	BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest) (*PrivateLinkServiceVisibilityPollerResponse, error)
+	BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions) (*PrivateLinkServiceVisibilityPollerResponse, error)
 	// ResumeCheckPrivateLinkServiceVisibility - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCheckPrivateLinkServiceVisibility(token string) (PrivateLinkServiceVisibilityPoller, error)
 	// BeginCheckPrivateLinkServiceVisibilityByResourceGroup - Checks whether the subscription is visible to private link service in the specified resource group.
-	BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*PrivateLinkServiceVisibilityPollerResponse, error)
+	BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (*PrivateLinkServiceVisibilityPollerResponse, error)
 	// ResumeCheckPrivateLinkServiceVisibilityByResourceGroup - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCheckPrivateLinkServiceVisibilityByResourceGroup(token string) (PrivateLinkServiceVisibilityPoller, error)
 	// BeginCreateOrUpdate - Creates or updates an private link service in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService) (*PrivateLinkServicePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesCreateOrUpdateOptions) (*PrivateLinkServicePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (PrivateLinkServicePoller, error)
 	// BeginDelete - Deletes the specified private link service.
-	BeginDelete(ctx context.Context, resourceGroupName string, serviceName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// BeginDeletePrivateEndpointConnection - Delete private end point connection for a private link service in a subscription.
-	BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string) (*HTTPPollerResponse, error)
+	BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesDeletePrivateEndpointConnectionOptions) (*HTTPPollerResponse, error)
 	// ResumeDeletePrivateEndpointConnection - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDeletePrivateEndpointConnection(token string) (HTTPPoller, error)
 	// Get - Gets the specified private link service by resource group.
-	Get(ctx context.Context, resourceGroupName string, serviceName string, privateLinkServicesGetOptions *PrivateLinkServicesGetOptions) (*PrivateLinkServiceResponse, error)
+	Get(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesGetOptions) (*PrivateLinkServiceResponse, error)
 	// GetPrivateEndpointConnection - Get the specific private end point connection by specific private link service in the resource group.
-	GetPrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, privateLinkServicesGetPrivateEndpointConnectionOptions *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error)
+	GetPrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error)
 	// List - Gets all private link services in a resource group.
-	List(resourceGroupName string) PrivateLinkServiceListResultPager
+	List(resourceGroupName string, options *PrivateLinkServicesListOptions) PrivateLinkServiceListResultPager
 	// ListAutoApprovedPrivateLinkServices - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
-	ListAutoApprovedPrivateLinkServices(location string) AutoApprovedPrivateLinkServicesResultPager
+	ListAutoApprovedPrivateLinkServices(location string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesOptions) AutoApprovedPrivateLinkServicesResultPager
 	// ListAutoApprovedPrivateLinkServicesByResourceGroup - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
-	ListAutoApprovedPrivateLinkServicesByResourceGroup(location string, resourceGroupName string) AutoApprovedPrivateLinkServicesResultPager
+	ListAutoApprovedPrivateLinkServicesByResourceGroup(location string, resourceGroupName string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupOptions) AutoApprovedPrivateLinkServicesResultPager
 	// ListBySubscription - Gets all private link service in a subscription.
-	ListBySubscription() PrivateLinkServiceListResultPager
+	ListBySubscription(options *PrivateLinkServicesListBySubscriptionOptions) PrivateLinkServiceListResultPager
 	// ListPrivateEndpointConnections - Gets all private end point connections for a specific private link service.
-	ListPrivateEndpointConnections(resourceGroupName string, serviceName string) PrivateEndpointConnectionListResultPager
+	ListPrivateEndpointConnections(resourceGroupName string, serviceName string, options *PrivateLinkServicesListPrivateEndpointConnectionsOptions) PrivateEndpointConnectionListResultPager
 	// UpdatePrivateEndpointConnection - Approve or reject private end point connection for a private link service in a subscription.
-	UpdatePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection) (*PrivateEndpointConnectionResponse, error)
+	UpdatePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection, options *PrivateLinkServicesUpdatePrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error)
 }
 
 // PrivateLinkServicesClient implements the PrivateLinkServicesOperations interface.
@@ -72,8 +72,8 @@ func (client *PrivateLinkServicesClient) Do(req *azcore.Request) (*azcore.Respon
 	return client.p.Do(req)
 }
 
-func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest) (*PrivateLinkServiceVisibilityPollerResponse, error) {
-	resp, err := client.CheckPrivateLinkServiceVisibility(ctx, location, parameters)
+func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions) (*PrivateLinkServiceVisibilityPollerResponse, error) {
+	resp, err := client.CheckPrivateLinkServiceVisibility(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,8 +107,8 @@ func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibility
 }
 
 // CheckPrivateLinkServiceVisibility - Checks whether the subscription is visible to private link service.
-func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Response, error) {
-	req, err := client.CheckPrivateLinkServiceVisibilityCreateRequest(ctx, location, parameters)
+func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibility(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions) (*azcore.Response, error) {
+	req, err := client.CheckPrivateLinkServiceVisibilityCreateRequest(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibility(ctx c
 }
 
 // CheckPrivateLinkServiceVisibilityCreateRequest creates the CheckPrivateLinkServiceVisibility request.
-func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityCreateRequest(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityCreateRequest(ctx context.Context, location string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -153,8 +153,8 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityHandle
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*PrivateLinkServiceVisibilityPollerResponse, error) {
-	resp, err := client.CheckPrivateLinkServiceVisibilityByResourceGroup(ctx, location, resourceGroupName, parameters)
+func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (*PrivateLinkServiceVisibilityPollerResponse, error) {
+	resp, err := client.CheckPrivateLinkServiceVisibilityByResourceGroup(ctx, location, resourceGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +188,8 @@ func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibility
 }
 
 // CheckPrivateLinkServiceVisibilityByResourceGroup - Checks whether the subscription is visible to private link service in the specified resource group.
-func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Response, error) {
-	req, err := client.CheckPrivateLinkServiceVisibilityByResourceGroupCreateRequest(ctx, location, resourceGroupName, parameters)
+func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (*azcore.Response, error) {
+	req, err := client.CheckPrivateLinkServiceVisibilityByResourceGroupCreateRequest(ctx, location, resourceGroupName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 }
 
 // CheckPrivateLinkServiceVisibilityByResourceGroupCreateRequest creates the CheckPrivateLinkServiceVisibilityByResourceGroup request.
-func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string, parameters CheckPrivateLinkServiceVisibilityRequest, options *PrivateLinkServicesCheckPrivateLinkServiceVisibilityByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -235,8 +235,8 @@ func (client *PrivateLinkServicesClient) CheckPrivateLinkServiceVisibilityByReso
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService) (*PrivateLinkServicePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceName, parameters)
+func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesCreateOrUpdateOptions) (*PrivateLinkServicePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -270,8 +270,8 @@ func (client *PrivateLinkServicesClient) ResumeCreateOrUpdate(token string) (Pri
 }
 
 // CreateOrUpdate - Creates or updates an private link service in the specified resource group.
-func (client *PrivateLinkServicesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceName, parameters)
+func (client *PrivateLinkServicesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (client *PrivateLinkServicesClient) CreateOrUpdate(ctx context.Context, res
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *PrivateLinkServicesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, parameters PrivateLinkService, options *PrivateLinkServicesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -317,8 +317,8 @@ func (client *PrivateLinkServicesClient) CreateOrUpdateHandleError(resp *azcore.
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, serviceName)
+func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, serviceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -352,8 +352,8 @@ func (client *PrivateLinkServicesClient) ResumeDelete(token string) (HTTPPoller,
 }
 
 // Delete - Deletes the specified private link service.
-func (client *PrivateLinkServicesClient) Delete(ctx context.Context, resourceGroupName string, serviceName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceName)
+func (client *PrivateLinkServicesClient) Delete(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (client *PrivateLinkServicesClient) Delete(ctx context.Context, resourceGro
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PrivateLinkServicesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceName string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -393,8 +393,8 @@ func (client *PrivateLinkServicesClient) DeleteHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.DeletePrivateEndpointConnection(ctx, resourceGroupName, serviceName, peConnectionName)
+func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesDeletePrivateEndpointConnectionOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DeletePrivateEndpointConnection(ctx, resourceGroupName, serviceName, peConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -428,8 +428,8 @@ func (client *PrivateLinkServicesClient) ResumeDeletePrivateEndpointConnection(t
 }
 
 // DeletePrivateEndpointConnection - Delete private end point connection for a private link service in a subscription.
-func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string) (*azcore.Response, error) {
-	req, err := client.DeletePrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName)
+func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesDeletePrivateEndpointConnectionOptions) (*azcore.Response, error) {
+	req, err := client.DeletePrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnection(ctx con
 }
 
 // DeletePrivateEndpointConnectionCreateRequest creates the DeletePrivateEndpointConnection request.
-func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesDeletePrivateEndpointConnectionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -471,8 +471,8 @@ func (client *PrivateLinkServicesClient) DeletePrivateEndpointConnectionHandleEr
 }
 
 // Get - Gets the specified private link service by resource group.
-func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupName string, serviceName string, privateLinkServicesGetOptions *PrivateLinkServicesGetOptions) (*PrivateLinkServiceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceName, privateLinkServicesGetOptions)
+func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesGetOptions) (*PrivateLinkServiceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupN
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PrivateLinkServicesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, privateLinkServicesGetOptions *PrivateLinkServicesGetOptions) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -502,8 +502,8 @@ func (client *PrivateLinkServicesClient) GetCreateRequest(ctx context.Context, r
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if privateLinkServicesGetOptions != nil && privateLinkServicesGetOptions.Expand != nil {
-		query.Set("$expand", *privateLinkServicesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -526,8 +526,8 @@ func (client *PrivateLinkServicesClient) GetHandleError(resp *azcore.Response) e
 }
 
 // GetPrivateEndpointConnection - Get the specific private end point connection by specific private link service in the resource group.
-func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, privateLinkServicesGetPrivateEndpointConnectionOptions *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error) {
-	req, err := client.GetPrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName, privateLinkServicesGetPrivateEndpointConnectionOptions)
+func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error) {
+	req, err := client.GetPrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +546,7 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx contex
 }
 
 // GetPrivateEndpointConnectionCreateRequest creates the GetPrivateEndpointConnection request.
-func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, privateLinkServicesGetPrivateEndpointConnectionOptions *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, options *PrivateLinkServicesGetPrivateEndpointConnectionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -558,8 +558,8 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionCreateReque
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if privateLinkServicesGetPrivateEndpointConnectionOptions != nil && privateLinkServicesGetPrivateEndpointConnectionOptions.Expand != nil {
-		query.Set("$expand", *privateLinkServicesGetPrivateEndpointConnectionOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -582,11 +582,11 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnectionHandleError
 }
 
 // List - Gets all private link services in a resource group.
-func (client *PrivateLinkServicesClient) List(resourceGroupName string) PrivateLinkServiceListResultPager {
+func (client *PrivateLinkServicesClient) List(resourceGroupName string, options *PrivateLinkServicesListOptions) PrivateLinkServiceListResultPager {
 	return &privateLinkServiceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -597,7 +597,7 @@ func (client *PrivateLinkServicesClient) List(resourceGroupName string) PrivateL
 }
 
 // ListCreateRequest creates the List request.
-func (client *PrivateLinkServicesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *PrivateLinkServicesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -628,11 +628,11 @@ func (client *PrivateLinkServicesClient) ListHandleError(resp *azcore.Response) 
 }
 
 // ListAutoApprovedPrivateLinkServices - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
-func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServices(location string) AutoApprovedPrivateLinkServicesResultPager {
+func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServices(location string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesOptions) AutoApprovedPrivateLinkServicesResultPager {
 	return &autoApprovedPrivateLinkServicesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAutoApprovedPrivateLinkServicesCreateRequest(ctx, location)
+			return client.ListAutoApprovedPrivateLinkServicesCreateRequest(ctx, location, options)
 		},
 		responder: client.ListAutoApprovedPrivateLinkServicesHandleResponse,
 		errorer:   client.ListAutoApprovedPrivateLinkServicesHandleError,
@@ -643,7 +643,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServices(loc
 }
 
 // ListAutoApprovedPrivateLinkServicesCreateRequest creates the ListAutoApprovedPrivateLinkServices request.
-func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesCreateRequest(ctx context.Context, location string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -674,11 +674,11 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesHand
 }
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroup - Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.
-func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroup(location string, resourceGroupName string) AutoApprovedPrivateLinkServicesResultPager {
+func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroup(location string, resourceGroupName string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupOptions) AutoApprovedPrivateLinkServicesResultPager {
 	return &autoApprovedPrivateLinkServicesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx, location, resourceGroupName)
+			return client.ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx, location, resourceGroupName, options)
 		},
 		responder: client.ListAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse,
 		errorer:   client.ListAutoApprovedPrivateLinkServicesByResourceGroupHandleError,
@@ -689,7 +689,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 }
 
 // ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest creates the ListAutoApprovedPrivateLinkServicesByResourceGroup request.
-func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByResourceGroupCreateRequest(ctx context.Context, location string, resourceGroupName string, options *PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -721,11 +721,11 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 }
 
 // ListBySubscription - Gets all private link service in a subscription.
-func (client *PrivateLinkServicesClient) ListBySubscription() PrivateLinkServiceListResultPager {
+func (client *PrivateLinkServicesClient) ListBySubscription(options *PrivateLinkServicesListBySubscriptionOptions) PrivateLinkServiceListResultPager {
 	return &privateLinkServiceListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBySubscriptionCreateRequest(ctx)
+			return client.ListBySubscriptionCreateRequest(ctx, options)
 		},
 		responder: client.ListBySubscriptionHandleResponse,
 		errorer:   client.ListBySubscriptionHandleError,
@@ -736,7 +736,7 @@ func (client *PrivateLinkServicesClient) ListBySubscription() PrivateLinkService
 }
 
 // ListBySubscriptionCreateRequest creates the ListBySubscription request.
-func (client *PrivateLinkServicesClient) ListBySubscriptionCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) ListBySubscriptionCreateRequest(ctx context.Context, options *PrivateLinkServicesListBySubscriptionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateLinkServices"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -766,11 +766,11 @@ func (client *PrivateLinkServicesClient) ListBySubscriptionHandleError(resp *azc
 }
 
 // ListPrivateEndpointConnections - Gets all private end point connections for a specific private link service.
-func (client *PrivateLinkServicesClient) ListPrivateEndpointConnections(resourceGroupName string, serviceName string) PrivateEndpointConnectionListResultPager {
+func (client *PrivateLinkServicesClient) ListPrivateEndpointConnections(resourceGroupName string, serviceName string, options *PrivateLinkServicesListPrivateEndpointConnectionsOptions) PrivateEndpointConnectionListResultPager {
 	return &privateEndpointConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListPrivateEndpointConnectionsCreateRequest(ctx, resourceGroupName, serviceName)
+			return client.ListPrivateEndpointConnectionsCreateRequest(ctx, resourceGroupName, serviceName, options)
 		},
 		responder: client.ListPrivateEndpointConnectionsHandleResponse,
 		errorer:   client.ListPrivateEndpointConnectionsHandleError,
@@ -781,7 +781,7 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnections(resource
 }
 
 // ListPrivateEndpointConnectionsCreateRequest creates the ListPrivateEndpointConnections request.
-func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsCreateRequest(ctx context.Context, resourceGroupName string, serviceName string) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, options *PrivateLinkServicesListPrivateEndpointConnectionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))
@@ -813,8 +813,8 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnectionsHandleErr
 }
 
 // UpdatePrivateEndpointConnection - Approve or reject private end point connection for a private link service in a subscription.
-func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection) (*PrivateEndpointConnectionResponse, error) {
-	req, err := client.UpdatePrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName, parameters)
+func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection, options *PrivateLinkServicesUpdatePrivateEndpointConnectionOptions) (*PrivateEndpointConnectionResponse, error) {
+	req, err := client.UpdatePrivateEndpointConnectionCreateRequest(ctx, resourceGroupName, serviceName, peConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -833,7 +833,7 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx con
 }
 
 // UpdatePrivateEndpointConnectionCreateRequest creates the UpdatePrivateEndpointConnection request.
-func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection) (*azcore.Request, error) {
+func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnectionCreateRequest(ctx context.Context, resourceGroupName string, serviceName string, peConnectionName string, parameters PrivateEndpointConnection, options *PrivateLinkServicesUpdatePrivateEndpointConnectionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceName}", url.PathEscape(serviceName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -18,27 +18,27 @@ import (
 // PublicIPAddressesOperations contains the methods for the PublicIPAddresses group.
 type PublicIPAddressesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a static or dynamic public IP address.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*PublicIPAddressPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesCreateOrUpdateOptions) (*PublicIPAddressPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (PublicIPAddressPoller, error)
 	// BeginDelete - Deletes the specified public IP address.
-	BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified public IP address in a specified resource group.
-	Get(ctx context.Context, resourceGroupName string, publicIPAddressName string, publicIPAddressesGetOptions *PublicIPAddressesGetOptions) (*PublicIPAddressResponse, error)
+	Get(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesGetOptions) (*PublicIPAddressResponse, error)
 	// GetVirtualMachineScaleSetPublicIPAddress - Get the specified public IP address in a virtual machine scale set.
-	GetVirtualMachineScaleSetPublicIPAddress(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*PublicIPAddressResponse, error)
+	GetVirtualMachineScaleSetPublicIPAddress(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, options *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*PublicIPAddressResponse, error)
 	// List - Gets all public IP addresses in a resource group.
-	List(resourceGroupName string) PublicIPAddressListResultPager
+	List(resourceGroupName string, options *PublicIPAddressesListOptions) PublicIPAddressListResultPager
 	// ListAll - Gets all the public IP addresses in a subscription.
-	ListAll() PublicIPAddressListResultPager
+	ListAll(options *PublicIPAddressesListAllOptions) PublicIPAddressListResultPager
 	// ListVirtualMachineScaleSetPublicIPAddresses - Gets information about all public IP addresses on a virtual machine scale set level.
-	ListVirtualMachineScaleSetPublicIPAddresses(resourceGroupName string, virtualMachineScaleSetName string) PublicIPAddressListResultPager
+	ListVirtualMachineScaleSetPublicIPAddresses(resourceGroupName string, virtualMachineScaleSetName string, options *PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesOptions) PublicIPAddressListResultPager
 	// ListVirtualMachineScaleSetVMPublicIPaddresses - Gets information about all public IP addresses in a virtual machine IP configuration in a virtual machine scale set.
-	ListVirtualMachineScaleSetVMPublicIPaddresses(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string) PublicIPAddressListResultPager
+	ListVirtualMachineScaleSetVMPublicIPaddresses(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *PublicIPAddressesListVirtualMachineScaleSetVMPublicIPaddressesOptions) PublicIPAddressListResultPager
 	// UpdateTags - Updates public IP address tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject) (*PublicIPAddressResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject, options *PublicIPAddressesUpdateTagsOptions) (*PublicIPAddressResponse, error)
 }
 
 // PublicIPAddressesClient implements the PublicIPAddressesOperations interface.
@@ -58,8 +58,8 @@ func (client *PublicIPAddressesClient) Do(req *azcore.Request) (*azcore.Response
 	return client.p.Do(req)
 }
 
-func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*PublicIPAddressPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, publicIPAddressName, parameters)
+func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesCreateOrUpdateOptions) (*PublicIPAddressPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, publicIPAddressName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +93,8 @@ func (client *PublicIPAddressesClient) ResumeCreateOrUpdate(token string) (Publi
 }
 
 // CreateOrUpdate - Creates or updates a static or dynamic public IP address.
-func (client *PublicIPAddressesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, publicIPAddressName, parameters)
+func (client *PublicIPAddressesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, publicIPAddressName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (client *PublicIPAddressesClient) CreateOrUpdate(ctx context.Context, resou
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *PublicIPAddressesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters PublicIPAddress, options *PublicIPAddressesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
@@ -140,8 +140,8 @@ func (client *PublicIPAddressesClient) CreateOrUpdateHandleError(resp *azcore.Re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, publicIPAddressName)
+func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, publicIPAddressName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +175,8 @@ func (client *PublicIPAddressesClient) ResumeDelete(token string) (HTTPPoller, e
 }
 
 // Delete - Deletes the specified public IP address.
-func (client *PublicIPAddressesClient) Delete(ctx context.Context, resourceGroupName string, publicIPAddressName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, publicIPAddressName)
+func (client *PublicIPAddressesClient) Delete(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, publicIPAddressName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (client *PublicIPAddressesClient) Delete(ctx context.Context, resourceGroup
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PublicIPAddressesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
@@ -217,8 +217,8 @@ func (client *PublicIPAddressesClient) DeleteHandleError(resp *azcore.Response) 
 }
 
 // Get - Gets the specified public IP address in a specified resource group.
-func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupName string, publicIPAddressName string, publicIPAddressesGetOptions *PublicIPAddressesGetOptions) (*PublicIPAddressResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, publicIPAddressName, publicIPAddressesGetOptions)
+func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesGetOptions) (*PublicIPAddressResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, publicIPAddressName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupNam
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PublicIPAddressesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, publicIPAddressesGetOptions *PublicIPAddressesGetOptions) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, options *PublicIPAddressesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))
@@ -248,8 +248,8 @@ func (client *PublicIPAddressesClient) GetCreateRequest(ctx context.Context, res
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if publicIPAddressesGetOptions != nil && publicIPAddressesGetOptions.Expand != nil {
-		query.Set("$expand", *publicIPAddressesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -272,8 +272,8 @@ func (client *PublicIPAddressesClient) GetHandleError(resp *azcore.Response) err
 }
 
 // GetVirtualMachineScaleSetPublicIPAddress - Get the specified public IP address in a virtual machine scale set.
-func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*PublicIPAddressResponse, error) {
-	req, err := client.GetVirtualMachineScaleSetPublicIPAddressCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, publicIPAddressName, publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions)
+func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, options *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*PublicIPAddressResponse, error) {
+	req, err := client.GetVirtualMachineScaleSetPublicIPAddressCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, publicIPAddressName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(
 }
 
 // GetVirtualMachineScaleSetPublicIPAddressCreateRequest creates the GetVirtualMachineScaleSetPublicIPAddress request.
-func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, publicIPAddressName string, options *PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -307,8 +307,8 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressC
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2018-10-01")
-	if publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions != nil && publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions.Expand != nil {
-		query.Set("$expand", *publicIPAddressesGetVirtualMachineScaleSetPublicIpaddressOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -331,11 +331,11 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddressH
 }
 
 // List - Gets all public IP addresses in a resource group.
-func (client *PublicIPAddressesClient) List(resourceGroupName string) PublicIPAddressListResultPager {
+func (client *PublicIPAddressesClient) List(resourceGroupName string, options *PublicIPAddressesListOptions) PublicIPAddressListResultPager {
 	return &publicIPAddressListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -346,7 +346,7 @@ func (client *PublicIPAddressesClient) List(resourceGroupName string) PublicIPAd
 }
 
 // ListCreateRequest creates the List request.
-func (client *PublicIPAddressesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *PublicIPAddressesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -377,11 +377,11 @@ func (client *PublicIPAddressesClient) ListHandleError(resp *azcore.Response) er
 }
 
 // ListAll - Gets all the public IP addresses in a subscription.
-func (client *PublicIPAddressesClient) ListAll() PublicIPAddressListResultPager {
+func (client *PublicIPAddressesClient) ListAll(options *PublicIPAddressesListAllOptions) PublicIPAddressListResultPager {
 	return &publicIPAddressListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -392,7 +392,7 @@ func (client *PublicIPAddressesClient) ListAll() PublicIPAddressListResultPager 
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *PublicIPAddressesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) ListAllCreateRequest(ctx context.Context, options *PublicIPAddressesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -422,11 +422,11 @@ func (client *PublicIPAddressesClient) ListAllHandleError(resp *azcore.Response)
 }
 
 // ListVirtualMachineScaleSetPublicIPAddresses - Gets information about all public IP addresses on a virtual machine scale set level.
-func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddresses(resourceGroupName string, virtualMachineScaleSetName string) PublicIPAddressListResultPager {
+func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddresses(resourceGroupName string, virtualMachineScaleSetName string, options *PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesOptions) PublicIPAddressListResultPager {
 	return &publicIPAddressListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName)
+			return client.ListVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, options)
 		},
 		responder: client.ListVirtualMachineScaleSetPublicIPAddressesHandleResponse,
 		errorer:   client.ListVirtualMachineScaleSetPublicIPAddressesHandleError,
@@ -437,7 +437,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 }
 
 // ListVirtualMachineScaleSetPublicIPAddressesCreateRequest creates the ListVirtualMachineScaleSetPublicIPAddresses request.
-func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddressesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, options *PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/publicipaddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -469,11 +469,11 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 }
 
 // ListVirtualMachineScaleSetVMPublicIPaddresses - Gets information about all public IP addresses in a virtual machine IP configuration in a virtual machine scale set.
-func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddresses(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string) PublicIPAddressListResultPager {
+func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddresses(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *PublicIPAddressesListVirtualMachineScaleSetVMPublicIPaddressesOptions) PublicIPAddressListResultPager {
 	return &publicIPAddressListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName)
+			return client.ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest(ctx, resourceGroupName, virtualMachineScaleSetName, virtualmachineIndex, networkInterfaceName, ipConfigurationName, options)
 		},
 		responder: client.ListVirtualMachineScaleSetVMPublicIPaddressesHandleResponse,
 		errorer:   client.ListVirtualMachineScaleSetVMPublicIPaddressesHandleError,
@@ -484,7 +484,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 }
 
 // ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest creates the ListVirtualMachineScaleSetVMPublicIPaddresses request.
-func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddressesCreateRequest(ctx context.Context, resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, ipConfigurationName string, options *PublicIPAddressesListVirtualMachineScaleSetVMPublicIPaddressesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines/{virtualmachineIndex}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualMachineScaleSetName}", url.PathEscape(virtualMachineScaleSetName))
@@ -519,8 +519,8 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 }
 
 // UpdateTags - Updates public IP address tags.
-func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject) (*PublicIPAddressResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, publicIPAddressName, parameters)
+func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject, options *PublicIPAddressesUpdateTagsOptions) (*PublicIPAddressResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, publicIPAddressName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceG
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *PublicIPAddressesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *PublicIPAddressesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, publicIPAddressName string, parameters TagsObject, options *PublicIPAddressesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpAddressName}", url.PathEscape(publicIPAddressName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -18,21 +18,21 @@ import (
 // PublicIPPrefixesOperations contains the methods for the PublicIPPrefixes group.
 type PublicIPPrefixesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a static or dynamic public IP prefix.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix) (*PublicIPPrefixPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesCreateOrUpdateOptions) (*PublicIPPrefixPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (PublicIPPrefixPoller, error)
 	// BeginDelete - Deletes the specified public IP prefix.
-	BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified public IP prefix in a specified resource group.
-	Get(ctx context.Context, resourceGroupName string, publicIPPrefixName string, publicIPPrefixesGetOptions *PublicIPPrefixesGetOptions) (*PublicIPPrefixResponse, error)
+	Get(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesGetOptions) (*PublicIPPrefixResponse, error)
 	// List - Gets all public IP prefixes in a resource group.
-	List(resourceGroupName string) PublicIPPrefixListResultPager
+	List(resourceGroupName string, options *PublicIPPrefixesListOptions) PublicIPPrefixListResultPager
 	// ListAll - Gets all the public IP prefixes in a subscription.
-	ListAll() PublicIPPrefixListResultPager
+	ListAll(options *PublicIPPrefixesListAllOptions) PublicIPPrefixListResultPager
 	// UpdateTags - Updates public IP prefix tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject) (*PublicIPPrefixResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject, options *PublicIPPrefixesUpdateTagsOptions) (*PublicIPPrefixResponse, error)
 }
 
 // PublicIPPrefixesClient implements the PublicIPPrefixesOperations interface.
@@ -52,8 +52,8 @@ func (client *PublicIPPrefixesClient) Do(req *azcore.Request) (*azcore.Response,
 	return client.p.Do(req)
 }
 
-func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix) (*PublicIPPrefixPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, publicIPPrefixName, parameters)
+func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesCreateOrUpdateOptions) (*PublicIPPrefixPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, publicIPPrefixName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *PublicIPPrefixesClient) ResumeCreateOrUpdate(token string) (Public
 }
 
 // CreateOrUpdate - Creates or updates a static or dynamic public IP prefix.
-func (client *PublicIPPrefixesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, publicIPPrefixName, parameters)
+func (client *PublicIPPrefixesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, publicIPPrefixName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *PublicIPPrefixesClient) CreateOrUpdate(ctx context.Context, resour
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *PublicIPPrefixesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters PublicIPPrefix, options *PublicIPPrefixesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
@@ -134,8 +134,8 @@ func (client *PublicIPPrefixesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, publicIPPrefixName)
+func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, publicIPPrefixName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *PublicIPPrefixesClient) ResumeDelete(token string) (HTTPPoller, er
 }
 
 // Delete - Deletes the specified public IP prefix.
-func (client *PublicIPPrefixesClient) Delete(ctx context.Context, resourceGroupName string, publicIPPrefixName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, publicIPPrefixName)
+func (client *PublicIPPrefixesClient) Delete(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, publicIPPrefixName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *PublicIPPrefixesClient) Delete(ctx context.Context, resourceGroupN
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *PublicIPPrefixesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
@@ -211,8 +211,8 @@ func (client *PublicIPPrefixesClient) DeleteHandleError(resp *azcore.Response) e
 }
 
 // Get - Gets the specified public IP prefix in a specified resource group.
-func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName string, publicIPPrefixName string, publicIPPrefixesGetOptions *PublicIPPrefixesGetOptions) (*PublicIPPrefixResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, publicIPPrefixName, publicIPPrefixesGetOptions)
+func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesGetOptions) (*PublicIPPrefixResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, publicIPPrefixName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName
 }
 
 // GetCreateRequest creates the Get request.
-func (client *PublicIPPrefixesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, publicIPPrefixesGetOptions *PublicIPPrefixesGetOptions) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, options *PublicIPPrefixesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))
@@ -242,8 +242,8 @@ func (client *PublicIPPrefixesClient) GetCreateRequest(ctx context.Context, reso
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if publicIPPrefixesGetOptions != nil && publicIPPrefixesGetOptions.Expand != nil {
-		query.Set("$expand", *publicIPPrefixesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *PublicIPPrefixesClient) GetHandleError(resp *azcore.Response) erro
 }
 
 // List - Gets all public IP prefixes in a resource group.
-func (client *PublicIPPrefixesClient) List(resourceGroupName string) PublicIPPrefixListResultPager {
+func (client *PublicIPPrefixesClient) List(resourceGroupName string, options *PublicIPPrefixesListOptions) PublicIPPrefixListResultPager {
 	return &publicIPPrefixListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *PublicIPPrefixesClient) List(resourceGroupName string) PublicIPPre
 }
 
 // ListCreateRequest creates the List request.
-func (client *PublicIPPrefixesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *PublicIPPrefixesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,11 +312,11 @@ func (client *PublicIPPrefixesClient) ListHandleError(resp *azcore.Response) err
 }
 
 // ListAll - Gets all the public IP prefixes in a subscription.
-func (client *PublicIPPrefixesClient) ListAll() PublicIPPrefixListResultPager {
+func (client *PublicIPPrefixesClient) ListAll(options *PublicIPPrefixesListAllOptions) PublicIPPrefixListResultPager {
 	return &publicIPPrefixListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -327,7 +327,7 @@ func (client *PublicIPPrefixesClient) ListAll() PublicIPPrefixListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *PublicIPPrefixesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) ListAllCreateRequest(ctx context.Context, options *PublicIPPrefixesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPPrefixes"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -357,8 +357,8 @@ func (client *PublicIPPrefixesClient) ListAllHandleError(resp *azcore.Response) 
 }
 
 // UpdateTags - Updates public IP prefix tags.
-func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject) (*PublicIPPrefixResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, publicIPPrefixName, parameters)
+func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject, options *PublicIPPrefixesUpdateTagsOptions) (*PublicIPPrefixResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, publicIPPrefixName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGr
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *PublicIPPrefixesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *PublicIPPrefixesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, publicIPPrefixName string, parameters TagsObject, options *PublicIPPrefixesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{publicIpPrefixName}", url.PathEscape(publicIPPrefixName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -16,7 +16,7 @@ import (
 // ResourceNavigationLinksOperations contains the methods for the ResourceNavigationLinks group.
 type ResourceNavigationLinksOperations interface {
 	// List - Gets a list of resource navigation links for a subnet.
-	List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*ResourceNavigationLinksListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ResourceNavigationLinksListOptions) (*ResourceNavigationLinksListResultResponse, error)
 }
 
 // ResourceNavigationLinksClient implements the ResourceNavigationLinksOperations interface.
@@ -37,8 +37,8 @@ func (client *ResourceNavigationLinksClient) Do(req *azcore.Request) (*azcore.Re
 }
 
 // List - Gets a list of resource navigation links for a subnet.
-func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*ResourceNavigationLinksListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName)
+func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ResourceNavigationLinksListOptions) (*ResourceNavigationLinksListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceG
 }
 
 // ListCreateRequest creates the List request.
-func (client *ResourceNavigationLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+func (client *ResourceNavigationLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ResourceNavigationLinksListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/ResourceNavigationLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -18,17 +18,17 @@ import (
 // RouteFilterRulesOperations contains the methods for the RouteFilterRules group.
 type RouteFilterRulesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a route in the specified route filter.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule) (*RouteFilterRulePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesCreateOrUpdateOptions) (*RouteFilterRulePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (RouteFilterRulePoller, error)
 	// BeginDelete - Deletes the specified rule from a route filter.
-	BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified rule from a route filter.
-	Get(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*RouteFilterRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesGetOptions) (*RouteFilterRuleResponse, error)
 	// ListByRouteFilter - Gets all RouteFilterRules in a route filter.
-	ListByRouteFilter(resourceGroupName string, routeFilterName string) RouteFilterRuleListResultPager
+	ListByRouteFilter(resourceGroupName string, routeFilterName string, options *RouteFilterRulesListByRouteFilterOptions) RouteFilterRuleListResultPager
 }
 
 // RouteFilterRulesClient implements the RouteFilterRulesOperations interface.
@@ -48,8 +48,8 @@ func (client *RouteFilterRulesClient) Do(req *azcore.Request) (*azcore.Response,
 	return client.p.Do(req)
 }
 
-func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule) (*RouteFilterRulePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters)
+func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesCreateOrUpdateOptions) (*RouteFilterRulePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *RouteFilterRulesClient) ResumeCreateOrUpdate(token string) (RouteF
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route filter.
-func (client *RouteFilterRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters)
+func (client *RouteFilterRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName, routeFilterRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *RouteFilterRulesClient) CreateOrUpdate(ctx context.Context, resour
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *RouteFilterRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule) (*azcore.Request, error) {
+func (client *RouteFilterRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, routeFilterRuleParameters RouteFilterRule, options *RouteFilterRulesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -131,8 +131,8 @@ func (client *RouteFilterRulesClient) CreateOrUpdateHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, routeFilterName, ruleName)
+func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, routeFilterName, ruleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *RouteFilterRulesClient) ResumeDelete(token string) (HTTPPoller, er
 }
 
 // Delete - Deletes the specified rule from a route filter.
-func (client *RouteFilterRulesClient) Delete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName)
+func (client *RouteFilterRulesClient) Delete(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *RouteFilterRulesClient) Delete(ctx context.Context, resourceGroupN
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *RouteFilterRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*azcore.Request, error) {
+func (client *RouteFilterRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -209,8 +209,8 @@ func (client *RouteFilterRulesClient) DeleteHandleError(resp *azcore.Response) e
 }
 
 // Get - Gets the specified rule from a route filter.
-func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*RouteFilterRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName)
+func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesGetOptions) (*RouteFilterRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeFilterName, ruleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName
 }
 
 // GetCreateRequest creates the Get request.
-func (client *RouteFilterRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string) (*azcore.Request, error) {
+func (client *RouteFilterRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, ruleName string, options *RouteFilterRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -262,11 +262,11 @@ func (client *RouteFilterRulesClient) GetHandleError(resp *azcore.Response) erro
 }
 
 // ListByRouteFilter - Gets all RouteFilterRules in a route filter.
-func (client *RouteFilterRulesClient) ListByRouteFilter(resourceGroupName string, routeFilterName string) RouteFilterRuleListResultPager {
+func (client *RouteFilterRulesClient) ListByRouteFilter(resourceGroupName string, routeFilterName string, options *RouteFilterRulesListByRouteFilterOptions) RouteFilterRuleListResultPager {
 	return &routeFilterRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByRouteFilterCreateRequest(ctx, resourceGroupName, routeFilterName)
+			return client.ListByRouteFilterCreateRequest(ctx, resourceGroupName, routeFilterName, options)
 		},
 		responder: client.ListByRouteFilterHandleResponse,
 		errorer:   client.ListByRouteFilterHandleError,
@@ -277,7 +277,7 @@ func (client *RouteFilterRulesClient) ListByRouteFilter(resourceGroupName string
 }
 
 // ListByRouteFilterCreateRequest creates the ListByRouteFilter request.
-func (client *RouteFilterRulesClient) ListByRouteFilterCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string) (*azcore.Request, error) {
+func (client *RouteFilterRulesClient) ListByRouteFilterCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFilterRulesListByRouteFilterOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -18,21 +18,21 @@ import (
 // RouteFiltersOperations contains the methods for the RouteFilters group.
 type RouteFiltersOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a route filter in a specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter) (*RouteFilterPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersCreateOrUpdateOptions) (*RouteFilterPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (RouteFilterPoller, error)
 	// BeginDelete - Deletes the specified route filter.
-	BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified route filter.
-	Get(ctx context.Context, resourceGroupName string, routeFilterName string, routeFiltersGetOptions *RouteFiltersGetOptions) (*RouteFilterResponse, error)
+	Get(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersGetOptions) (*RouteFilterResponse, error)
 	// List - Gets all route filters in a subscription.
-	List() RouteFilterListResultPager
+	List(options *RouteFiltersListOptions) RouteFilterListResultPager
 	// ListByResourceGroup - Gets all route filters in a resource group.
-	ListByResourceGroup(resourceGroupName string) RouteFilterListResultPager
+	ListByResourceGroup(resourceGroupName string, options *RouteFiltersListByResourceGroupOptions) RouteFilterListResultPager
 	// UpdateTags - Updates tags of a route filter.
-	UpdateTags(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject) (*RouteFilterResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject, options *RouteFiltersUpdateTagsOptions) (*RouteFilterResponse, error)
 }
 
 // RouteFiltersClient implements the RouteFiltersOperations interface.
@@ -52,8 +52,8 @@ func (client *RouteFiltersClient) Do(req *azcore.Request) (*azcore.Response, err
 	return client.p.Do(req)
 }
 
-func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter) (*RouteFilterPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeFilterName, routeFilterParameters)
+func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersCreateOrUpdateOptions) (*RouteFilterPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeFilterName, routeFilterParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *RouteFiltersClient) ResumeCreateOrUpdate(token string) (RouteFilte
 }
 
 // CreateOrUpdate - Creates or updates a route filter in a specified resource group.
-func (client *RouteFiltersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeFilterName, routeFilterParameters)
+func (client *RouteFiltersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeFilterName, routeFilterParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *RouteFiltersClient) CreateOrUpdate(ctx context.Context, resourceGr
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *RouteFiltersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter) (*azcore.Request, error) {
+func (client *RouteFiltersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, routeFilterParameters RouteFilter, options *RouteFiltersCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -134,8 +134,8 @@ func (client *RouteFiltersClient) CreateOrUpdateHandleError(resp *azcore.Respons
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, routeFilterName)
+func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, routeFilterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *RouteFiltersClient) ResumeDelete(token string) (HTTPPoller, error)
 }
 
 // Delete - Deletes the specified route filter.
-func (client *RouteFiltersClient) Delete(ctx context.Context, resourceGroupName string, routeFilterName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeFilterName)
+func (client *RouteFiltersClient) Delete(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeFilterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *RouteFiltersClient) Delete(ctx context.Context, resourceGroupName 
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *RouteFiltersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string) (*azcore.Request, error) {
+func (client *RouteFiltersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -211,8 +211,8 @@ func (client *RouteFiltersClient) DeleteHandleError(resp *azcore.Response) error
 }
 
 // Get - Gets the specified route filter.
-func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName string, routeFilterName string, routeFiltersGetOptions *RouteFiltersGetOptions) (*RouteFilterResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeFilterName, routeFiltersGetOptions)
+func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersGetOptions) (*RouteFilterResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeFilterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName str
 }
 
 // GetCreateRequest creates the Get request.
-func (client *RouteFiltersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, routeFiltersGetOptions *RouteFiltersGetOptions) (*azcore.Request, error) {
+func (client *RouteFiltersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, options *RouteFiltersGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))
@@ -242,8 +242,8 @@ func (client *RouteFiltersClient) GetCreateRequest(ctx context.Context, resource
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if routeFiltersGetOptions != nil && routeFiltersGetOptions.Expand != nil {
-		query.Set("$expand", *routeFiltersGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *RouteFiltersClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all route filters in a subscription.
-func (client *RouteFiltersClient) List() RouteFilterListResultPager {
+func (client *RouteFiltersClient) List(options *RouteFiltersListOptions) RouteFilterListResultPager {
 	return &routeFilterListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *RouteFiltersClient) List() RouteFilterListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *RouteFiltersClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *RouteFiltersClient) ListCreateRequest(ctx context.Context, options *RouteFiltersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -311,11 +311,11 @@ func (client *RouteFiltersClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Gets all route filters in a resource group.
-func (client *RouteFiltersClient) ListByResourceGroup(resourceGroupName string) RouteFilterListResultPager {
+func (client *RouteFiltersClient) ListByResourceGroup(resourceGroupName string, options *RouteFiltersListByResourceGroupOptions) RouteFilterListResultPager {
 	return &routeFilterListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -326,7 +326,7 @@ func (client *RouteFiltersClient) ListByResourceGroup(resourceGroupName string) 
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *RouteFiltersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *RouteFiltersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *RouteFiltersListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -357,8 +357,8 @@ func (client *RouteFiltersClient) ListByResourceGroupHandleError(resp *azcore.Re
 }
 
 // UpdateTags - Updates tags of a route filter.
-func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject) (*RouteFilterResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, routeFilterName, parameters)
+func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject, options *RouteFiltersUpdateTagsOptions) (*RouteFilterResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, routeFilterName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupN
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *RouteFiltersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *RouteFiltersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, routeFilterName string, parameters TagsObject, options *RouteFiltersUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeFilterName}", url.PathEscape(routeFilterName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -18,17 +18,17 @@ import (
 // RoutesOperations contains the methods for the Routes group.
 type RoutesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a route in the specified route table.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*RoutePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesCreateOrUpdateOptions) (*RoutePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (RoutePoller, error)
 	// BeginDelete - Deletes the specified route from a route table.
-	BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified route from a route table.
-	Get(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*RouteResponse, error)
+	Get(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesGetOptions) (*RouteResponse, error)
 	// List - Gets all routes in a route table.
-	List(resourceGroupName string, routeTableName string) RouteListResultPager
+	List(resourceGroupName string, routeTableName string, options *RoutesListOptions) RouteListResultPager
 }
 
 // RoutesClient implements the RoutesOperations interface.
@@ -48,8 +48,8 @@ func (client *RoutesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*RoutePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeTableName, routeName, routeParameters)
+func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesCreateOrUpdateOptions) (*RoutePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeTableName, routeName, routeParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *RoutesClient) ResumeCreateOrUpdate(token string) (RoutePoller, err
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route table.
-func (client *RoutesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeTableName, routeName, routeParameters)
+func (client *RoutesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeTableName, routeName, routeParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *RoutesClient) CreateOrUpdate(ctx context.Context, resourceGroupNam
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *RoutesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route) (*azcore.Request, error) {
+func (client *RoutesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, routeParameters Route, options *RoutesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -131,8 +131,8 @@ func (client *RoutesClient) CreateOrUpdateHandleError(resp *azcore.Response) err
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, routeTableName, routeName)
+func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, routeTableName, routeName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *RoutesClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes the specified route from a route table.
-func (client *RoutesClient) Delete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeTableName, routeName)
+func (client *RoutesClient) Delete(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeTableName, routeName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *RoutesClient) Delete(ctx context.Context, resourceGroupName string
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *RoutesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*azcore.Request, error) {
+func (client *RoutesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -209,8 +209,8 @@ func (client *RoutesClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets the specified route from a route table.
-func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*RouteResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeTableName, routeName)
+func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesGetOptions) (*RouteResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeTableName, routeName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, r
 }
 
 // GetCreateRequest creates the Get request.
-func (client *RoutesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string) (*azcore.Request, error) {
+func (client *RoutesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeName string, options *RoutesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -262,11 +262,11 @@ func (client *RoutesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all routes in a route table.
-func (client *RoutesClient) List(resourceGroupName string, routeTableName string) RouteListResultPager {
+func (client *RoutesClient) List(resourceGroupName string, routeTableName string, options *RoutesListOptions) RouteListResultPager {
 	return &routeListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, routeTableName)
+			return client.ListCreateRequest(ctx, resourceGroupName, routeTableName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *RoutesClient) List(resourceGroupName string, routeTableName string
 }
 
 // ListCreateRequest creates the List request.
-func (client *RoutesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string) (*azcore.Request, error) {
+func (client *RoutesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, options *RoutesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -18,21 +18,21 @@ import (
 // RouteTablesOperations contains the methods for the RouteTables group.
 type RouteTablesOperations interface {
 	// BeginCreateOrUpdate - Create or updates a route table in a specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable) (*RouteTablePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesCreateOrUpdateOptions) (*RouteTablePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (RouteTablePoller, error)
 	// BeginDelete - Deletes the specified route table.
-	BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified route table.
-	Get(ctx context.Context, resourceGroupName string, routeTableName string, routeTablesGetOptions *RouteTablesGetOptions) (*RouteTableResponse, error)
+	Get(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesGetOptions) (*RouteTableResponse, error)
 	// List - Gets all route tables in a resource group.
-	List(resourceGroupName string) RouteTableListResultPager
+	List(resourceGroupName string, options *RouteTablesListOptions) RouteTableListResultPager
 	// ListAll - Gets all route tables in a subscription.
-	ListAll() RouteTableListResultPager
+	ListAll(options *RouteTablesListAllOptions) RouteTableListResultPager
 	// UpdateTags - Updates a route table tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject) (*RouteTableResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject, options *RouteTablesUpdateTagsOptions) (*RouteTableResponse, error)
 }
 
 // RouteTablesClient implements the RouteTablesOperations interface.
@@ -52,8 +52,8 @@ func (client *RouteTablesClient) Do(req *azcore.Request) (*azcore.Response, erro
 	return client.p.Do(req)
 }
 
-func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable) (*RouteTablePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeTableName, parameters)
+func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesCreateOrUpdateOptions) (*RouteTablePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, routeTableName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *RouteTablesClient) ResumeCreateOrUpdate(token string) (RouteTableP
 }
 
 // CreateOrUpdate - Create or updates a route table in a specified resource group.
-func (client *RouteTablesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeTableName, parameters)
+func (client *RouteTablesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, routeTableName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *RouteTablesClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *RouteTablesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable) (*azcore.Request, error) {
+func (client *RouteTablesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, parameters RouteTable, options *RouteTablesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -134,8 +134,8 @@ func (client *RouteTablesClient) CreateOrUpdateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, routeTableName)
+func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *RouteTablesClient) ResumeDelete(token string) (HTTPPoller, error) 
 }
 
 // Delete - Deletes the specified route table.
-func (client *RouteTablesClient) Delete(ctx context.Context, resourceGroupName string, routeTableName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeTableName)
+func (client *RouteTablesClient) Delete(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *RouteTablesClient) Delete(ctx context.Context, resourceGroupName s
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *RouteTablesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string) (*azcore.Request, error) {
+func (client *RouteTablesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -211,8 +211,8 @@ func (client *RouteTablesClient) DeleteHandleError(resp *azcore.Response) error 
 }
 
 // Get - Gets the specified route table.
-func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName string, routeTableName string, routeTablesGetOptions *RouteTablesGetOptions) (*RouteTableResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeTableName, routeTablesGetOptions)
+func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesGetOptions) (*RouteTableResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *RouteTablesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, routeTablesGetOptions *RouteTablesGetOptions) (*azcore.Request, error) {
+func (client *RouteTablesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, options *RouteTablesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
@@ -242,8 +242,8 @@ func (client *RouteTablesClient) GetCreateRequest(ctx context.Context, resourceG
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if routeTablesGetOptions != nil && routeTablesGetOptions.Expand != nil {
-		query.Set("$expand", *routeTablesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *RouteTablesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all route tables in a resource group.
-func (client *RouteTablesClient) List(resourceGroupName string) RouteTableListResultPager {
+func (client *RouteTablesClient) List(resourceGroupName string, options *RouteTablesListOptions) RouteTableListResultPager {
 	return &routeTableListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *RouteTablesClient) List(resourceGroupName string) RouteTableListRe
 }
 
 // ListCreateRequest creates the List request.
-func (client *RouteTablesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *RouteTablesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *RouteTablesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -312,11 +312,11 @@ func (client *RouteTablesClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListAll - Gets all route tables in a subscription.
-func (client *RouteTablesClient) ListAll() RouteTableListResultPager {
+func (client *RouteTablesClient) ListAll(options *RouteTablesListAllOptions) RouteTableListResultPager {
 	return &routeTableListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -327,7 +327,7 @@ func (client *RouteTablesClient) ListAll() RouteTableListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *RouteTablesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *RouteTablesClient) ListAllCreateRequest(ctx context.Context, options *RouteTablesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -357,8 +357,8 @@ func (client *RouteTablesClient) ListAllHandleError(resp *azcore.Response) error
 }
 
 // UpdateTags - Updates a route table tags.
-func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject) (*RouteTableResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, routeTableName, parameters)
+func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject, options *RouteTablesUpdateTagsOptions) (*RouteTableResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, routeTableName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupNa
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *RouteTablesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *RouteTablesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, routeTableName string, parameters TagsObject, options *RouteTablesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -18,21 +18,21 @@ import (
 // SecurityPartnerProvidersOperations contains the methods for the SecurityPartnerProviders group.
 type SecurityPartnerProvidersOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Security Partner Provider.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider) (*SecurityPartnerProviderPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersCreateOrUpdateOptions) (*SecurityPartnerProviderPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (SecurityPartnerProviderPoller, error)
 	// BeginDelete - Deletes the specified Security Partner Provider.
-	BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Security Partner Provider.
-	Get(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*SecurityPartnerProviderResponse, error)
+	Get(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersGetOptions) (*SecurityPartnerProviderResponse, error)
 	// List - Gets all the Security Partner Providers in a subscription.
-	List() SecurityPartnerProviderListResultPager
+	List(options *SecurityPartnerProvidersListOptions) SecurityPartnerProviderListResultPager
 	// ListByResourceGroup - Lists all Security Partner Providers in a resource group.
-	ListByResourceGroup(resourceGroupName string) SecurityPartnerProviderListResultPager
+	ListByResourceGroup(resourceGroupName string, options *SecurityPartnerProvidersListByResourceGroupOptions) SecurityPartnerProviderListResultPager
 	// UpdateTags - Updates tags of a Security Partner Provider resource.
-	UpdateTags(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject) (*SecurityPartnerProviderResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject, options *SecurityPartnerProvidersUpdateTagsOptions) (*SecurityPartnerProviderResponse, error)
 }
 
 // SecurityPartnerProvidersClient implements the SecurityPartnerProvidersOperations interface.
@@ -52,8 +52,8 @@ func (client *SecurityPartnerProvidersClient) Do(req *azcore.Request) (*azcore.R
 	return client.p.Do(req)
 }
 
-func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider) (*SecurityPartnerProviderPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, securityPartnerProviderName, parameters)
+func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersCreateOrUpdateOptions) (*SecurityPartnerProviderPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, securityPartnerProviderName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *SecurityPartnerProvidersClient) ResumeCreateOrUpdate(token string)
 }
 
 // CreateOrUpdate - Creates or updates the specified Security Partner Provider.
-func (client *SecurityPartnerProvidersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, parameters)
+func (client *SecurityPartnerProvidersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdate(ctx context.Context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *SecurityPartnerProvidersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters SecurityPartnerProvider, options *SecurityPartnerProvidersCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
@@ -134,8 +134,8 @@ func (client *SecurityPartnerProvidersClient) CreateOrUpdateHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, securityPartnerProviderName)
+func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, securityPartnerProviderName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *SecurityPartnerProvidersClient) ResumeDelete(token string) (HTTPPo
 }
 
 // Delete - Deletes the specified Security Partner Provider.
-func (client *SecurityPartnerProvidersClient) Delete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, securityPartnerProviderName)
+func (client *SecurityPartnerProvidersClient) Delete(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *SecurityPartnerProvidersClient) Delete(ctx context.Context, resour
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *SecurityPartnerProvidersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
@@ -211,8 +211,8 @@ func (client *SecurityPartnerProvidersClient) DeleteHandleError(resp *azcore.Res
 }
 
 // Get - Gets the specified Security Partner Provider.
-func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*SecurityPartnerProviderResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, securityPartnerProviderName)
+func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersGetOptions) (*SecurityPartnerProviderResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceG
 }
 
 // GetCreateRequest creates the Get request.
-func (client *SecurityPartnerProvidersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, options *SecurityPartnerProvidersGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))
@@ -263,11 +263,11 @@ func (client *SecurityPartnerProvidersClient) GetHandleError(resp *azcore.Respon
 }
 
 // List - Gets all the Security Partner Providers in a subscription.
-func (client *SecurityPartnerProvidersClient) List() SecurityPartnerProviderListResultPager {
+func (client *SecurityPartnerProvidersClient) List(options *SecurityPartnerProvidersListOptions) SecurityPartnerProviderListResultPager {
 	return &securityPartnerProviderListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *SecurityPartnerProvidersClient) List() SecurityPartnerProviderList
 }
 
 // ListCreateRequest creates the List request.
-func (client *SecurityPartnerProvidersClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) ListCreateRequest(ctx context.Context, options *SecurityPartnerProvidersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *SecurityPartnerProvidersClient) ListHandleError(resp *azcore.Respo
 }
 
 // ListByResourceGroup - Lists all Security Partner Providers in a resource group.
-func (client *SecurityPartnerProvidersClient) ListByResourceGroup(resourceGroupName string) SecurityPartnerProviderListResultPager {
+func (client *SecurityPartnerProvidersClient) ListByResourceGroup(resourceGroupName string, options *SecurityPartnerProvidersListByResourceGroupOptions) SecurityPartnerProviderListResultPager {
 	return &securityPartnerProviderListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroup(resourceGroupN
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *SecurityPartnerProvidersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *SecurityPartnerProvidersListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -354,8 +354,8 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroupHandleError(res
 }
 
 // UpdateTags - Updates tags of a Security Partner Provider resource.
-func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject) (*SecurityPartnerProviderResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, parameters)
+func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject, options *SecurityPartnerProvidersUpdateTagsOptions) (*SecurityPartnerProviderResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, securityPartnerProviderName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, re
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *SecurityPartnerProvidersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *SecurityPartnerProvidersClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, securityPartnerProviderName string, parameters TagsObject, options *SecurityPartnerProvidersUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{securityPartnerProviderName}", url.PathEscape(securityPartnerProviderName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -18,17 +18,17 @@ import (
 // SecurityRulesOperations contains the methods for the SecurityRules group.
 type SecurityRulesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a security rule in the specified network security group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*SecurityRulePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesCreateOrUpdateOptions) (*SecurityRulePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (SecurityRulePoller, error)
 	// BeginDelete - Deletes the specified network security rule.
-	BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Get the specified network security rule.
-	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*SecurityRuleResponse, error)
+	Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesGetOptions) (*SecurityRuleResponse, error)
 	// List - Gets all security rules in a network security group.
-	List(resourceGroupName string, networkSecurityGroupName string) SecurityRuleListResultPager
+	List(resourceGroupName string, networkSecurityGroupName string, options *SecurityRulesListOptions) SecurityRuleListResultPager
 }
 
 // SecurityRulesClient implements the SecurityRulesOperations interface.
@@ -48,8 +48,8 @@ func (client *SecurityRulesClient) Do(req *azcore.Request) (*azcore.Response, er
 	return client.p.Do(req)
 }
 
-func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*SecurityRulePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters)
+func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesCreateOrUpdateOptions) (*SecurityRulePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *SecurityRulesClient) ResumeCreateOrUpdate(token string) (SecurityR
 }
 
 // CreateOrUpdate - Creates or updates a security rule in the specified network security group.
-func (client *SecurityRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters)
+func (client *SecurityRulesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, securityRuleParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *SecurityRulesClient) CreateOrUpdate(ctx context.Context, resourceG
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *SecurityRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule) (*azcore.Request, error) {
+func (client *SecurityRulesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, securityRuleParameters SecurityRule, options *SecurityRulesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -131,8 +131,8 @@ func (client *SecurityRulesClient) CreateOrUpdateHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName)
+func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *SecurityRulesClient) ResumeDelete(token string) (HTTPPoller, error
 }
 
 // Delete - Deletes the specified network security rule.
-func (client *SecurityRulesClient) Delete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName)
+func (client *SecurityRulesClient) Delete(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *SecurityRulesClient) Delete(ctx context.Context, resourceGroupName
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *SecurityRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*azcore.Request, error) {
+func (client *SecurityRulesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -209,8 +209,8 @@ func (client *SecurityRulesClient) DeleteHandleError(resp *azcore.Response) erro
 }
 
 // Get - Get the specified network security rule.
-func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*SecurityRuleResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName)
+func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesGetOptions) (*SecurityRuleResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, securityRuleName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName st
 }
 
 // GetCreateRequest creates the Get request.
-func (client *SecurityRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string) (*azcore.Request, error) {
+func (client *SecurityRulesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, securityRuleName string, options *SecurityRulesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))
@@ -262,11 +262,11 @@ func (client *SecurityRulesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all security rules in a network security group.
-func (client *SecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string) SecurityRuleListResultPager {
+func (client *SecurityRulesClient) List(resourceGroupName string, networkSecurityGroupName string, options *SecurityRulesListOptions) SecurityRuleListResultPager {
 	return &securityRuleListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, networkSecurityGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *SecurityRulesClient) List(resourceGroupName string, networkSecurit
 }
 
 // ListCreateRequest creates the List request.
-func (client *SecurityRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string) (*azcore.Request, error) {
+func (client *SecurityRulesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, networkSecurityGroupName string, options *SecurityRulesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{networkSecurityGroupName}", url.PathEscape(networkSecurityGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -16,7 +16,7 @@ import (
 // ServiceAssociationLinksOperations contains the methods for the ServiceAssociationLinks group.
 type ServiceAssociationLinksOperations interface {
 	// List - Gets a list of service association links for a subnet.
-	List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*ServiceAssociationLinksListResultResponse, error)
+	List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ServiceAssociationLinksListOptions) (*ServiceAssociationLinksListResultResponse, error)
 }
 
 // ServiceAssociationLinksClient implements the ServiceAssociationLinksOperations interface.
@@ -37,8 +37,8 @@ func (client *ServiceAssociationLinksClient) Do(req *azcore.Request) (*azcore.Re
 }
 
 // List - Gets a list of service association links for a subnet.
-func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*ServiceAssociationLinksListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName)
+func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ServiceAssociationLinksListOptions) (*ServiceAssociationLinksListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceG
 }
 
 // ListCreateRequest creates the List request.
-func (client *ServiceAssociationLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+func (client *ServiceAssociationLinksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *ServiceAssociationLinksListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/ServiceAssociationLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -18,21 +18,21 @@ import (
 // ServiceEndpointPoliciesOperations contains the methods for the ServiceEndpointPolicies group.
 type ServiceEndpointPoliciesOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a service Endpoint Policies.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy) (*ServiceEndpointPolicyPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesCreateOrUpdateOptions) (*ServiceEndpointPolicyPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ServiceEndpointPolicyPoller, error)
 	// BeginDelete - Deletes the specified service endpoint policy.
-	BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified service Endpoint Policies in a specified resource group.
-	Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPoliciesGetOptions *ServiceEndpointPoliciesGetOptions) (*ServiceEndpointPolicyResponse, error)
+	Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesGetOptions) (*ServiceEndpointPolicyResponse, error)
 	// List - Gets all the service endpoint policies in a subscription.
-	List() ServiceEndpointPolicyListResultPager
+	List(options *ServiceEndpointPoliciesListOptions) ServiceEndpointPolicyListResultPager
 	// ListByResourceGroup - Gets all service endpoint Policies in a resource group.
-	ListByResourceGroup(resourceGroupName string) ServiceEndpointPolicyListResultPager
+	ListByResourceGroup(resourceGroupName string, options *ServiceEndpointPoliciesListByResourceGroupOptions) ServiceEndpointPolicyListResultPager
 	// UpdateTags - Updates tags of a service endpoint policy.
-	UpdateTags(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject) (*ServiceEndpointPolicyResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject, options *ServiceEndpointPoliciesUpdateTagsOptions) (*ServiceEndpointPolicyResponse, error)
 }
 
 // ServiceEndpointPoliciesClient implements the ServiceEndpointPoliciesOperations interface.
@@ -52,8 +52,8 @@ func (client *ServiceEndpointPoliciesClient) Do(req *azcore.Request) (*azcore.Re
 	return client.p.Do(req)
 }
 
-func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy) (*ServiceEndpointPolicyPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, parameters)
+func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesCreateOrUpdateOptions) (*ServiceEndpointPolicyPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *ServiceEndpointPoliciesClient) ResumeCreateOrUpdate(token string) 
 }
 
 // CreateOrUpdate - Creates or updates a service Endpoint Policies.
-func (client *ServiceEndpointPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, parameters)
+func (client *ServiceEndpointPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdate(ctx context.Context,
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ServiceEndpointPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters ServiceEndpointPolicy, options *ServiceEndpointPoliciesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -134,8 +134,8 @@ func (client *ServiceEndpointPoliciesClient) CreateOrUpdateHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, serviceEndpointPolicyName)
+func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, serviceEndpointPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *ServiceEndpointPoliciesClient) ResumeDelete(token string) (HTTPPol
 }
 
 // Delete - Deletes the specified service endpoint policy.
-func (client *ServiceEndpointPoliciesClient) Delete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName)
+func (client *ServiceEndpointPoliciesClient) Delete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *ServiceEndpointPoliciesClient) Delete(ctx context.Context, resourc
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ServiceEndpointPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -211,8 +211,8 @@ func (client *ServiceEndpointPoliciesClient) DeleteHandleError(resp *azcore.Resp
 }
 
 // Get - Gets the specified service Endpoint Policies in a specified resource group.
-func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPoliciesGetOptions *ServiceEndpointPoliciesGetOptions) (*ServiceEndpointPolicyResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPoliciesGetOptions)
+func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesGetOptions) (*ServiceEndpointPolicyResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGr
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ServiceEndpointPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPoliciesGetOptions *ServiceEndpointPoliciesGetOptions) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPoliciesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -242,8 +242,8 @@ func (client *ServiceEndpointPoliciesClient) GetCreateRequest(ctx context.Contex
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if serviceEndpointPoliciesGetOptions != nil && serviceEndpointPoliciesGetOptions.Expand != nil {
-		query.Set("$expand", *serviceEndpointPoliciesGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -266,11 +266,11 @@ func (client *ServiceEndpointPoliciesClient) GetHandleError(resp *azcore.Respons
 }
 
 // List - Gets all the service endpoint policies in a subscription.
-func (client *ServiceEndpointPoliciesClient) List() ServiceEndpointPolicyListResultPager {
+func (client *ServiceEndpointPoliciesClient) List(options *ServiceEndpointPoliciesListOptions) ServiceEndpointPolicyListResultPager {
 	return &serviceEndpointPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -281,7 +281,7 @@ func (client *ServiceEndpointPoliciesClient) List() ServiceEndpointPolicyListRes
 }
 
 // ListCreateRequest creates the List request.
-func (client *ServiceEndpointPoliciesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) ListCreateRequest(ctx context.Context, options *ServiceEndpointPoliciesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ServiceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -311,11 +311,11 @@ func (client *ServiceEndpointPoliciesClient) ListHandleError(resp *azcore.Respon
 }
 
 // ListByResourceGroup - Gets all service endpoint Policies in a resource group.
-func (client *ServiceEndpointPoliciesClient) ListByResourceGroup(resourceGroupName string) ServiceEndpointPolicyListResultPager {
+func (client *ServiceEndpointPoliciesClient) ListByResourceGroup(resourceGroupName string, options *ServiceEndpointPoliciesListByResourceGroupOptions) ServiceEndpointPolicyListResultPager {
 	return &serviceEndpointPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -326,7 +326,7 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroup(resourceGroupNa
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ServiceEndpointPoliciesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *ServiceEndpointPoliciesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -357,8 +357,8 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroupHandleError(resp
 }
 
 // UpdateTags - Updates tags of a service endpoint policy.
-func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject) (*ServiceEndpointPolicyResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, parameters)
+func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject, options *ServiceEndpointPoliciesUpdateTagsOptions) (*ServiceEndpointPolicyResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, res
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *ServiceEndpointPoliciesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *ServiceEndpointPoliciesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, parameters TagsObject, options *ServiceEndpointPoliciesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -18,17 +18,17 @@ import (
 // ServiceEndpointPolicyDefinitionsOperations contains the methods for the ServiceEndpointPolicyDefinitions group.
 type ServiceEndpointPolicyDefinitionsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a service endpoint policy definition in the specified service endpoint policy.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition) (*ServiceEndpointPolicyDefinitionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions) (*ServiceEndpointPolicyDefinitionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (ServiceEndpointPolicyDefinitionPoller, error)
 	// BeginDelete - Deletes the specified ServiceEndpoint policy definitions.
-	BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Get the specified service endpoint policy definitions from service endpoint policy.
-	Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*ServiceEndpointPolicyDefinitionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsGetOptions) (*ServiceEndpointPolicyDefinitionResponse, error)
 	// ListByResourceGroup - Gets all service endpoint policy definitions in a service end point policy.
-	ListByResourceGroup(resourceGroupName string, serviceEndpointPolicyName string) ServiceEndpointPolicyDefinitionListResultPager
+	ListByResourceGroup(resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPolicyDefinitionsListByResourceGroupOptions) ServiceEndpointPolicyDefinitionListResultPager
 }
 
 // ServiceEndpointPolicyDefinitionsClient implements the ServiceEndpointPolicyDefinitionsOperations interface.
@@ -48,8 +48,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Do(req *azcore.Request) (*
 	return client.p.Do(req)
 }
 
-func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition) (*ServiceEndpointPolicyDefinitionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, serviceEndpointPolicyDefinitions)
+func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions) (*ServiceEndpointPolicyDefinitionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, serviceEndpointPolicyDefinitions, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ResumeCreateOrUpdate(token
 }
 
 // CreateOrUpdate - Creates or updates a service endpoint policy definition in the specified service endpoint policy.
-func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, serviceEndpointPolicyDefinitions)
+func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, serviceEndpointPolicyDefinitions, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdate(ctx context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition) (*azcore.Request, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, serviceEndpointPolicyDefinitions ServiceEndpointPolicyDefinition, options *ServiceEndpointPolicyDefinitionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -131,8 +131,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) CreateOrUpdateHandleError(
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName)
+func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ResumeDelete(token string)
 }
 
 // Delete - Deletes the specified ServiceEndpoint policy definitions.
-func (client *ServiceEndpointPolicyDefinitionsClient) Delete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName)
+func (client *ServiceEndpointPolicyDefinitionsClient) Delete(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Delete(ctx context.Context
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *ServiceEndpointPolicyDefinitionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*azcore.Request, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -209,8 +209,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) DeleteHandleError(resp *az
 }
 
 // Get - Get the specified service endpoint policy definitions from service endpoint policy.
-func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*ServiceEndpointPolicyDefinitionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName)
+func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsGetOptions) (*ServiceEndpointPolicyDefinitionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, serviceEndpointPolicyDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, r
 }
 
 // GetCreateRequest creates the Get request.
-func (client *ServiceEndpointPolicyDefinitionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string) (*azcore.Request, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, serviceEndpointPolicyDefinitionName string, options *ServiceEndpointPolicyDefinitionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))
@@ -262,11 +262,11 @@ func (client *ServiceEndpointPolicyDefinitionsClient) GetHandleError(resp *azcor
 }
 
 // ListByResourceGroup - Gets all service endpoint policy definitions in a service end point policy.
-func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroup(resourceGroupName string, serviceEndpointPolicyName string) ServiceEndpointPolicyDefinitionListResultPager {
+func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroup(resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPolicyDefinitionsListByResourceGroupOptions) ServiceEndpointPolicyDefinitionListResultPager {
 	return &serviceEndpointPolicyDefinitionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, serviceEndpointPolicyName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -277,7 +277,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroup(resour
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string) (*azcore.Request, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, serviceEndpointPolicyName string, options *ServiceEndpointPolicyDefinitionsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{serviceEndpointPolicyName}", url.PathEscape(serviceEndpointPolicyName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -16,7 +16,7 @@ import (
 // ServiceTagsOperations contains the methods for the ServiceTags group.
 type ServiceTagsOperations interface {
 	// List - Gets a list of service tag information resources.
-	List(ctx context.Context, location string) (*ServiceTagsListResultResponse, error)
+	List(ctx context.Context, location string, options *ServiceTagsListOptions) (*ServiceTagsListResultResponse, error)
 }
 
 // ServiceTagsClient implements the ServiceTagsOperations interface.
@@ -37,8 +37,8 @@ func (client *ServiceTagsClient) Do(req *azcore.Request) (*azcore.Response, erro
 }
 
 // List - Gets a list of service tag information resources.
-func (client *ServiceTagsClient) List(ctx context.Context, location string) (*ServiceTagsListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx, location)
+func (client *ServiceTagsClient) List(ctx context.Context, location string, options *ServiceTagsListOptions) (*ServiceTagsListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, location, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (client *ServiceTagsClient) List(ctx context.Context, location string) (*Se
 }
 
 // ListCreateRequest creates the List request.
-func (client *ServiceTagsClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *ServiceTagsClient) ListCreateRequest(ctx context.Context, location string, options *ServiceTagsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTags"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -18,23 +18,23 @@ import (
 // SubnetsOperations contains the methods for the Subnets group.
 type SubnetsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a subnet in the specified virtual network.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*SubnetPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsCreateOrUpdateOptions) (*SubnetPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (SubnetPoller, error)
 	// BeginDelete - Deletes the specified subnet.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified subnet by virtual network and resource group.
-	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetsGetOptions *SubnetsGetOptions) (*SubnetResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsGetOptions) (*SubnetResponse, error)
 	// List - Gets all subnets in a virtual network.
-	List(resourceGroupName string, virtualNetworkName string) SubnetListResultPager
+	List(resourceGroupName string, virtualNetworkName string, options *SubnetsListOptions) SubnetListResultPager
 	// BeginPrepareNetworkPolicies - Prepares a subnet by applying network intent policies.
-	BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*HTTPPollerResponse, error)
+	BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsPrepareNetworkPoliciesOptions) (*HTTPPollerResponse, error)
 	// ResumePrepareNetworkPolicies - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumePrepareNetworkPolicies(token string) (HTTPPoller, error)
 	// BeginUnprepareNetworkPolicies - Unprepares a subnet by removing network intent policies.
-	BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*HTTPPollerResponse, error)
+	BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsUnprepareNetworkPoliciesOptions) (*HTTPPollerResponse, error)
 	// ResumeUnprepareNetworkPolicies - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUnprepareNetworkPolicies(token string) (HTTPPoller, error)
 }
@@ -56,8 +56,8 @@ func (client *SubnetsClient) Do(req *azcore.Request) (*azcore.Response, error) {
 	return client.p.Do(req)
 }
 
-func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*SubnetPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
+func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsCreateOrUpdateOptions) (*SubnetPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +91,8 @@ func (client *SubnetsClient) ResumeCreateOrUpdate(token string) (SubnetPoller, e
 }
 
 // CreateOrUpdate - Creates or updates a subnet in the specified virtual network.
-func (client *SubnetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters)
+func (client *SubnetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (client *SubnetsClient) CreateOrUpdate(ctx context.Context, resourceGroupNa
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *SubnetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet) (*azcore.Request, error) {
+func (client *SubnetsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetParameters Subnet, options *SubnetsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -139,8 +139,8 @@ func (client *SubnetsClient) CreateOrUpdateHandleError(resp *azcore.Response) er
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName, subnetName)
+func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +174,8 @@ func (client *SubnetsClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes the specified subnet.
-func (client *SubnetsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName)
+func (client *SubnetsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (client *SubnetsClient) Delete(ctx context.Context, resourceGroupName strin
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *SubnetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string) (*azcore.Request, error) {
+func (client *SubnetsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -217,8 +217,8 @@ func (client *SubnetsClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Gets the specified subnet by virtual network and resource group.
-func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetsGetOptions *SubnetsGetOptions) (*SubnetResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, subnetsGetOptions)
+func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsGetOptions) (*SubnetResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *SubnetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, subnetsGetOptions *SubnetsGetOptions) (*azcore.Request, error) {
+func (client *SubnetsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, options *SubnetsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -249,8 +249,8 @@ func (client *SubnetsClient) GetCreateRequest(ctx context.Context, resourceGroup
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if subnetsGetOptions != nil && subnetsGetOptions.Expand != nil {
-		query.Set("$expand", *subnetsGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -273,11 +273,11 @@ func (client *SubnetsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Gets all subnets in a virtual network.
-func (client *SubnetsClient) List(resourceGroupName string, virtualNetworkName string) SubnetListResultPager {
+func (client *SubnetsClient) List(resourceGroupName string, virtualNetworkName string, options *SubnetsListOptions) SubnetListResultPager {
 	return &subnetListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -288,7 +288,7 @@ func (client *SubnetsClient) List(resourceGroupName string, virtualNetworkName s
 }
 
 // ListCreateRequest creates the List request.
-func (client *SubnetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+func (client *SubnetsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *SubnetsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -319,8 +319,8 @@ func (client *SubnetsClient) ListHandleError(resp *azcore.Response) error {
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.PrepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, prepareNetworkPoliciesRequestParameters)
+func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsPrepareNetworkPoliciesOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.PrepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, prepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +354,8 @@ func (client *SubnetsClient) ResumePrepareNetworkPolicies(token string) (HTTPPol
 }
 
 // PrepareNetworkPolicies - Prepares a subnet by applying network intent policies.
-func (client *SubnetsClient) PrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*azcore.Response, error) {
-	req, err := client.PrepareNetworkPoliciesCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, prepareNetworkPoliciesRequestParameters)
+func (client *SubnetsClient) PrepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsPrepareNetworkPoliciesOptions) (*azcore.Response, error) {
+	req, err := client.PrepareNetworkPoliciesCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, prepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ func (client *SubnetsClient) PrepareNetworkPolicies(ctx context.Context, resourc
 }
 
 // PrepareNetworkPoliciesCreateRequest creates the PrepareNetworkPolicies request.
-func (client *SubnetsClient) PrepareNetworkPoliciesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest) (*azcore.Request, error) {
+func (client *SubnetsClient) PrepareNetworkPoliciesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, prepareNetworkPoliciesRequestParameters PrepareNetworkPoliciesRequest, options *SubnetsPrepareNetworkPoliciesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/PrepareNetworkPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -396,8 +396,8 @@ func (client *SubnetsClient) PrepareNetworkPoliciesHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.UnprepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, unprepareNetworkPoliciesRequestParameters)
+func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsUnprepareNetworkPoliciesOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.UnprepareNetworkPolicies(ctx, resourceGroupName, virtualNetworkName, subnetName, unprepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -431,8 +431,8 @@ func (client *SubnetsClient) ResumeUnprepareNetworkPolicies(token string) (HTTPP
 }
 
 // UnprepareNetworkPolicies - Unprepares a subnet by removing network intent policies.
-func (client *SubnetsClient) UnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*azcore.Response, error) {
-	req, err := client.UnprepareNetworkPoliciesCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, unprepareNetworkPoliciesRequestParameters)
+func (client *SubnetsClient) UnprepareNetworkPolicies(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsUnprepareNetworkPoliciesOptions) (*azcore.Response, error) {
+	req, err := client.UnprepareNetworkPoliciesCreateRequest(ctx, resourceGroupName, virtualNetworkName, subnetName, unprepareNetworkPoliciesRequestParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (client *SubnetsClient) UnprepareNetworkPolicies(ctx context.Context, resou
 }
 
 // UnprepareNetworkPoliciesCreateRequest creates the UnprepareNetworkPolicies request.
-func (client *SubnetsClient) UnprepareNetworkPoliciesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest) (*azcore.Request, error) {
+func (client *SubnetsClient) UnprepareNetworkPoliciesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, subnetName string, unprepareNetworkPoliciesRequestParameters UnprepareNetworkPoliciesRequest, options *SubnetsUnprepareNetworkPoliciesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/UnprepareNetworkPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -16,7 +16,7 @@ import (
 // UsagesOperations contains the methods for the Usages group.
 type UsagesOperations interface {
 	// List - List network usages for a subscription.
-	List(location string) UsagesListResultPager
+	List(location string, options *UsagesListOptions) UsagesListResultPager
 }
 
 // UsagesClient implements the UsagesOperations interface.
@@ -37,11 +37,11 @@ func (client *UsagesClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // List - List network usages for a subscription.
-func (client *UsagesClient) List(location string) UsagesListResultPager {
+func (client *UsagesClient) List(location string, options *UsagesListOptions) UsagesListResultPager {
 	return &usagesListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, location)
+			return client.ListCreateRequest(ctx, location, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -52,7 +52,7 @@ func (client *UsagesClient) List(location string) UsagesListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *UsagesClient) ListCreateRequest(ctx context.Context, location string) (*azcore.Request, error) {
+func (client *UsagesClient) ListCreateRequest(ctx context.Context, location string, options *UsagesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{location}", url.PathEscape(location))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -18,17 +18,17 @@ import (
 // VirtualHubRouteTableV2SOperations contains the methods for the VirtualHubRouteTableV2S group.
 type VirtualHubRouteTableV2SOperations interface {
 	// BeginCreateOrUpdate - Creates a VirtualHubRouteTableV2 resource if it doesn't exist else updates the existing VirtualHubRouteTableV2.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2) (*VirtualHubRouteTableV2PollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SCreateOrUpdateOptions) (*VirtualHubRouteTableV2PollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualHubRouteTableV2Poller, error)
 	// BeginDelete - Deletes a VirtualHubRouteTableV2.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a VirtualHubRouteTableV2.
-	Get(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*VirtualHubRouteTableV2Response, error)
+	Get(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SGetOptions) (*VirtualHubRouteTableV2Response, error)
 	// List - Retrieves the details of all VirtualHubRouteTableV2s.
-	List(resourceGroupName string, virtualHubName string) ListVirtualHubRouteTableV2SResultPager
+	List(resourceGroupName string, virtualHubName string, options *VirtualHubRouteTableV2SListOptions) ListVirtualHubRouteTableV2SResultPager
 }
 
 // VirtualHubRouteTableV2SClient implements the VirtualHubRouteTableV2SOperations interface.
@@ -48,8 +48,8 @@ func (client *VirtualHubRouteTableV2SClient) Do(req *azcore.Request) (*azcore.Re
 	return client.p.Do(req)
 }
 
-func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2) (*VirtualHubRouteTableV2PollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualHubName, routeTableName, virtualHubRouteTableV2Parameters)
+func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SCreateOrUpdateOptions) (*VirtualHubRouteTableV2PollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualHubName, routeTableName, virtualHubRouteTableV2Parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *VirtualHubRouteTableV2SClient) ResumeCreateOrUpdate(token string) 
 }
 
 // CreateOrUpdate - Creates a VirtualHubRouteTableV2 resource if it doesn't exist else updates the existing VirtualHubRouteTableV2.
-func (client *VirtualHubRouteTableV2SClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName, virtualHubRouteTableV2Parameters)
+func (client *VirtualHubRouteTableV2SClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName, virtualHubRouteTableV2Parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdate(ctx context.Context,
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2) (*azcore.Request, error) {
+func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, virtualHubRouteTableV2Parameters VirtualHubRouteTableV2, options *VirtualHubRouteTableV2SCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -131,8 +131,8 @@ func (client *VirtualHubRouteTableV2SClient) CreateOrUpdateHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualHubName, routeTableName)
+func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualHubName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *VirtualHubRouteTableV2SClient) ResumeDelete(token string) (HTTPPol
 }
 
 // Delete - Deletes a VirtualHubRouteTableV2.
-func (client *VirtualHubRouteTableV2SClient) Delete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName)
+func (client *VirtualHubRouteTableV2SClient) Delete(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *VirtualHubRouteTableV2SClient) Delete(ctx context.Context, resourc
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualHubRouteTableV2SClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*azcore.Request, error) {
+func (client *VirtualHubRouteTableV2SClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -209,8 +209,8 @@ func (client *VirtualHubRouteTableV2SClient) DeleteHandleError(resp *azcore.Resp
 }
 
 // Get - Retrieves the details of a VirtualHubRouteTableV2.
-func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*VirtualHubRouteTableV2Response, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName)
+func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SGetOptions) (*VirtualHubRouteTableV2Response, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName, routeTableName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGr
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualHubRouteTableV2SClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string) (*azcore.Request, error) {
+func (client *VirtualHubRouteTableV2SClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, routeTableName string, options *VirtualHubRouteTableV2SGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -262,11 +262,11 @@ func (client *VirtualHubRouteTableV2SClient) GetHandleError(resp *azcore.Respons
 }
 
 // List - Retrieves the details of all VirtualHubRouteTableV2s.
-func (client *VirtualHubRouteTableV2SClient) List(resourceGroupName string, virtualHubName string) ListVirtualHubRouteTableV2SResultPager {
+func (client *VirtualHubRouteTableV2SClient) List(resourceGroupName string, virtualHubName string, options *VirtualHubRouteTableV2SListOptions) ListVirtualHubRouteTableV2SResultPager {
 	return &listVirtualHubRouteTableV2SResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualHubName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *VirtualHubRouteTableV2SClient) List(resourceGroupName string, virt
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualHubRouteTableV2SClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+func (client *VirtualHubRouteTableV2SClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubRouteTableV2SListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -18,21 +18,21 @@ import (
 // VirtualHubsOperations contains the methods for the VirtualHubs group.
 type VirtualHubsOperations interface {
 	// BeginCreateOrUpdate - Creates a VirtualHub resource if it doesn't exist else updates the existing VirtualHub.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub) (*VirtualHubPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsCreateOrUpdateOptions) (*VirtualHubPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualHubPoller, error)
 	// BeginDelete - Deletes a VirtualHub.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a VirtualHub.
-	Get(ctx context.Context, resourceGroupName string, virtualHubName string) (*VirtualHubResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsGetOptions) (*VirtualHubResponse, error)
 	// List - Lists all the VirtualHubs in a subscription.
-	List() ListVirtualHubsResultPager
+	List(options *VirtualHubsListOptions) ListVirtualHubsResultPager
 	// ListByResourceGroup - Lists all the VirtualHubs in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListVirtualHubsResultPager
+	ListByResourceGroup(resourceGroupName string, options *VirtualHubsListByResourceGroupOptions) ListVirtualHubsResultPager
 	// UpdateTags - Updates VirtualHub tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject) (*VirtualHubResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject, options *VirtualHubsUpdateTagsOptions) (*VirtualHubResponse, error)
 }
 
 // VirtualHubsClient implements the VirtualHubsOperations interface.
@@ -52,8 +52,8 @@ func (client *VirtualHubsClient) Do(req *azcore.Request) (*azcore.Response, erro
 	return client.p.Do(req)
 }
 
-func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub) (*VirtualHubPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualHubName, virtualHubParameters)
+func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsCreateOrUpdateOptions) (*VirtualHubPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualHubName, virtualHubParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VirtualHubsClient) ResumeCreateOrUpdate(token string) (VirtualHubP
 }
 
 // CreateOrUpdate - Creates a VirtualHub resource if it doesn't exist else updates the existing VirtualHub.
-func (client *VirtualHubsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualHubName, virtualHubParameters)
+func (client *VirtualHubsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualHubName, virtualHubParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VirtualHubsClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualHubsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub) (*azcore.Request, error) {
+func (client *VirtualHubsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters VirtualHub, options *VirtualHubsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -134,8 +134,8 @@ func (client *VirtualHubsClient) CreateOrUpdateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualHubName)
+func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualHubName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *VirtualHubsClient) ResumeDelete(token string) (HTTPPoller, error) 
 }
 
 // Delete - Deletes a VirtualHub.
-func (client *VirtualHubsClient) Delete(ctx context.Context, resourceGroupName string, virtualHubName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualHubName)
+func (client *VirtualHubsClient) Delete(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualHubName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *VirtualHubsClient) Delete(ctx context.Context, resourceGroupName s
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualHubsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+func (client *VirtualHubsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -211,8 +211,8 @@ func (client *VirtualHubsClient) DeleteHandleError(resp *azcore.Response) error 
 }
 
 // Get - Retrieves the details of a VirtualHub.
-func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string) (*VirtualHubResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName)
+func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsGetOptions) (*VirtualHubResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualHubName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualHubsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string) (*azcore.Request, error) {
+func (client *VirtualHubsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, options *VirtualHubsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -263,11 +263,11 @@ func (client *VirtualHubsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all the VirtualHubs in a subscription.
-func (client *VirtualHubsClient) List() ListVirtualHubsResultPager {
+func (client *VirtualHubsClient) List(options *VirtualHubsListOptions) ListVirtualHubsResultPager {
 	return &listVirtualHubsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *VirtualHubsClient) List() ListVirtualHubsResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualHubsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualHubsClient) ListCreateRequest(ctx context.Context, options *VirtualHubsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *VirtualHubsClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all the VirtualHubs in a resource group.
-func (client *VirtualHubsClient) ListByResourceGroup(resourceGroupName string) ListVirtualHubsResultPager {
+func (client *VirtualHubsClient) ListByResourceGroup(resourceGroupName string, options *VirtualHubsListByResourceGroupOptions) ListVirtualHubsResultPager {
 	return &listVirtualHubsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *VirtualHubsClient) ListByResourceGroup(resourceGroupName string) L
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VirtualHubsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualHubsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualHubsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -354,8 +354,8 @@ func (client *VirtualHubsClient) ListByResourceGroupHandleError(resp *azcore.Res
 }
 
 // UpdateTags - Updates VirtualHub tags.
-func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject) (*VirtualHubResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualHubName, virtualHubParameters)
+func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject, options *VirtualHubsUpdateTagsOptions) (*VirtualHubResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualHubName, virtualHubParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupNa
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualHubsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualHubsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualHubName string, virtualHubParameters TagsObject, options *VirtualHubsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -18,37 +18,37 @@ import (
 // VirtualNetworkGatewayConnectionsOperations contains the methods for the VirtualNetworkGatewayConnections group.
 type VirtualNetworkGatewayConnectionsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a virtual network gateway connection in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*VirtualNetworkGatewayConnectionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsCreateOrUpdateOptions) (*VirtualNetworkGatewayConnectionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualNetworkGatewayConnectionPoller, error)
 	// BeginDelete - Deletes the specified virtual network Gateway connection.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified virtual network gateway connection by resource group.
-	Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*VirtualNetworkGatewayConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetOptions) (*VirtualNetworkGatewayConnectionResponse, error)
 	// GetSharedKey - The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves information about the specified virtual network gateway connection shared key through Network resource provider.
-	GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*ConnectionSharedKeyResponse, error)
+	GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetSharedKeyOptions) (*ConnectionSharedKeyResponse, error)
 	// List - The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections created.
-	List(resourceGroupName string) VirtualNetworkGatewayConnectionListResultPager
+	List(resourceGroupName string, options *VirtualNetworkGatewayConnectionsListOptions) VirtualNetworkGatewayConnectionListResultPager
 	// BeginResetSharedKey - The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.
-	BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*ConnectionResetSharedKeyPollerResponse, error)
+	BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsResetSharedKeyOptions) (*ConnectionResetSharedKeyPollerResponse, error)
 	// ResumeResetSharedKey - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeResetSharedKey(token string) (ConnectionResetSharedKeyPoller, error)
 	// BeginSetSharedKey - The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.
-	BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*ConnectionSharedKeyPollerResponse, error)
+	BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsSetSharedKeyOptions) (*ConnectionSharedKeyPollerResponse, error)
 	// ResumeSetSharedKey - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeSetSharedKey(token string) (ConnectionSharedKeyPoller, error)
 	// BeginStartPacketCapture - Starts packet capture on virtual network gateway connection in the specified resource group.
-	BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*StringPollerResponse, error)
+	BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*StringPollerResponse, error)
 	// ResumeStartPacketCapture - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStartPacketCapture(token string) (StringPoller, error)
 	// BeginStopPacketCapture - Stops packet capture on virtual network gateway connection in the specified resource group.
-	BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error)
+	BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsStopPacketCaptureOptions) (*StringPollerResponse, error)
 	// ResumeStopPacketCapture - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStopPacketCapture(token string) (StringPoller, error)
 	// BeginUpdateTags - Updates a virtual network gateway connection tags.
-	BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*VirtualNetworkGatewayConnectionPollerResponse, error)
+	BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsUpdateTagsOptions) (*VirtualNetworkGatewayConnectionPollerResponse, error)
 	// ResumeUpdateTags - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdateTags(token string) (VirtualNetworkGatewayConnectionPoller, error)
 }
@@ -70,8 +70,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) Do(req *azcore.Request) (*
 	return client.p.Do(req)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsCreateOrUpdateOptions) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeCreateOrUpdate(token
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway connection in the specified resource group.
-func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdate(ctx context
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VirtualNetworkGatewayConnection, options *VirtualNetworkGatewayConnectionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -152,8 +152,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) CreateOrUpdateHandleError(
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -187,8 +187,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeDelete(token string)
 }
 
 // Delete - Deletes the specified virtual network Gateway connection.
-func (client *VirtualNetworkGatewayConnectionsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client *VirtualNetworkGatewayConnectionsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) Delete(ctx context.Context
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualNetworkGatewayConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -229,8 +229,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) DeleteHandleError(resp *az
 }
 
 // Get - Gets the specified virtual network gateway connection by resource group.
-func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*VirtualNetworkGatewayConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetOptions) (*VirtualNetworkGatewayConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +249,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, r
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualNetworkGatewayConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -281,8 +281,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetHandleError(resp *azcor
 }
 
 // GetSharedKey - The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves information about the specified virtual network gateway connection shared key through Network resource provider.
-func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*ConnectionSharedKeyResponse, error) {
-	req, err := client.GetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName)
+func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetSharedKeyOptions) (*ConnectionSharedKeyResponse, error) {
+	req, err := client.GetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.C
 }
 
 // GetSharedKeyCreateRequest creates the GetSharedKey request.
-func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsGetSharedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -333,11 +333,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKeyHandleError(re
 }
 
 // List - The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections created.
-func (client *VirtualNetworkGatewayConnectionsClient) List(resourceGroupName string) VirtualNetworkGatewayConnectionListResultPager {
+func (client *VirtualNetworkGatewayConnectionsClient) List(resourceGroupName string, options *VirtualNetworkGatewayConnectionsListOptions) VirtualNetworkGatewayConnectionListResultPager {
 	return &virtualNetworkGatewayConnectionListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -348,7 +348,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) List(resourceGroupName str
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualNetworkGatewayConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualNetworkGatewayConnectionsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -378,8 +378,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ListHandleError(resp *azco
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*ConnectionResetSharedKeyPollerResponse, error) {
-	resp, err := client.ResetSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsResetSharedKeyOptions) (*ConnectionResetSharedKeyPollerResponse, error) {
+	resp, err := client.ResetSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -413,8 +413,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeResetSharedKey(token
 }
 
 // ResetSharedKey - The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.
-func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*azcore.Response, error) {
-	req, err := client.ResetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsResetSharedKeyOptions) (*azcore.Response, error) {
+	req, err := client.ResetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKey(ctx context
 }
 
 // ResetSharedKeyCreateRequest creates the ResetSharedKey request.
-func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionResetSharedKey, options *VirtualNetworkGatewayConnectionsResetSharedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -460,8 +460,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResetSharedKeyHandleError(
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*ConnectionSharedKeyPollerResponse, error) {
-	resp, err := client.SetSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsSetSharedKeyOptions) (*ConnectionSharedKeyPollerResponse, error) {
+	resp, err := client.SetSharedKey(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -495,8 +495,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeSetSharedKey(token s
 }
 
 // SetSharedKey - The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.
-func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*azcore.Response, error) {
-	req, err := client.SetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsSetSharedKeyOptions) (*azcore.Response, error) {
+	req, err := client.SetSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKey(ctx context.C
 }
 
 // SetSharedKeyCreateRequest creates the SetSharedKey request.
-func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters ConnectionSharedKey, options *VirtualNetworkGatewayConnectionsSetSharedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -542,8 +542,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) SetSharedKeyHandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*StringPollerResponse, error) {
-	resp, err := client.StartPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, virtualNetworkGatewayConnectionsStartPacketCaptureOptions)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*StringPollerResponse, error) {
+	resp, err := client.StartPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -577,8 +577,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeStartPacketCapture(t
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway connection in the specified resource group.
-func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*azcore.Response, error) {
-	req, err := client.StartPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, virtualNetworkGatewayConnectionsStartPacketCaptureOptions)
+func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*azcore.Response, error) {
+	req, err := client.StartPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -593,7 +593,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCapture(ctx con
 }
 
 // StartPacketCaptureCreateRequest creates the StartPacketCapture request.
-func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, virtualNetworkGatewayConnectionsStartPacketCaptureOptions *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, options *VirtualNetworkGatewayConnectionsStartPacketCaptureOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/startPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -606,8 +606,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureCreateRe
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if virtualNetworkGatewayConnectionsStartPacketCaptureOptions != nil {
-		return req, req.MarshalAsJSON(virtualNetworkGatewayConnectionsStartPacketCaptureOptions.Parameters)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil
 }
@@ -627,8 +627,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) StartPacketCaptureHandleEr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error) {
-	resp, err := client.StopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsStopPacketCaptureOptions) (*StringPollerResponse, error) {
+	resp, err := client.StopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -662,8 +662,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeStopPacketCapture(to
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway connection in the specified resource group.
-func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*azcore.Response, error) {
-	req, err := client.StopPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsStopPacketCaptureOptions) (*azcore.Response, error) {
+	req, err := client.StopPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +678,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCapture(ctx cont
 }
 
 // StopPacketCaptureCreateRequest creates the StopPacketCapture request.
-func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewayConnectionsStopPacketCaptureOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/stopPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))
@@ -709,8 +709,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) StopPacketCaptureHandleErr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
-	resp, err := client.UpdateTags(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsUpdateTagsOptions) (*VirtualNetworkGatewayConnectionPollerResponse, error) {
+	resp, err := client.UpdateTags(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -744,8 +744,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) ResumeUpdateTags(token str
 }
 
 // UpdateTags - Updates a virtual network gateway connection tags.
-func (client *VirtualNetworkGatewayConnectionsClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*azcore.Response, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewayConnectionsClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsUpdateTagsOptions) (*azcore.Response, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -760,7 +760,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) UpdateTags(ctx context.Con
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters TagsObject, options *VirtualNetworkGatewayConnectionsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -18,83 +18,83 @@ import (
 // VirtualNetworkGatewaysOperations contains the methods for the VirtualNetworkGateways group.
 type VirtualNetworkGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a virtual network gateway in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*VirtualNetworkGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysCreateOrUpdateOptions) (*VirtualNetworkGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualNetworkGatewayPoller, error)
 	// BeginDelete - Deletes the specified virtual network gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// BeginDisconnectVirtualNetworkGatewayVpnConnections - Disconnect vpn connections of virtual network gateway in the specified resource group.
-	BeginDisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error)
+	BeginDisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest, options *VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions) (*HTTPPollerResponse, error)
 	// ResumeDisconnectVirtualNetworkGatewayVpnConnections - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDisconnectVirtualNetworkGatewayVpnConnections(token string) (HTTPPoller, error)
 	// BeginGenerateVpnProfile - Generates VPN profile for P2S client of the virtual network gateway in the specified resource group. Used for IKEV2 and radius based authentication.
-	BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error)
+	BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGenerateVpnProfileOptions) (*StringPollerResponse, error)
 	// ResumeGenerateVpnProfile - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGenerateVpnProfile(token string) (StringPoller, error)
 	// BeginGeneratevpnclientpackage - Generates VPN client package for P2S client of the virtual network gateway in the specified resource group.
-	BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error)
+	BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGeneratevpnclientpackageOptions) (*StringPollerResponse, error)
 	// ResumeGeneratevpnclientpackage - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGeneratevpnclientpackage(token string) (StringPoller, error)
 	// Get - Gets the specified virtual network gateway by resource group.
-	Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VirtualNetworkGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetOptions) (*VirtualNetworkGatewayResponse, error)
 	// BeginGetAdvertisedRoutes - This operation retrieves a list of routes the virtual network gateway is advertising to the specified peer.
-	BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string) (*GatewayRouteListResultPollerResponse, error)
+	BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysGetAdvertisedRoutesOptions) (*GatewayRouteListResultPollerResponse, error)
 	// ResumeGetAdvertisedRoutes - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetAdvertisedRoutes(token string) (GatewayRouteListResultPoller, error)
 	// BeginGetBgpPeerStatus - The GetBgpPeerStatus operation retrieves the status of all BGP peers.
-	BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*BgpPeerStatusListResultPollerResponse, error)
+	BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*BgpPeerStatusListResultPollerResponse, error)
 	// ResumeGetBgpPeerStatus - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetBgpPeerStatus(token string) (BgpPeerStatusListResultPoller, error)
 	// BeginGetLearnedRoutes - This operation retrieves a list of routes the virtual network gateway has learned, including routes learned from BGP peers.
-	BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*GatewayRouteListResultPollerResponse, error)
+	BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetLearnedRoutesOptions) (*GatewayRouteListResultPollerResponse, error)
 	// ResumeGetLearnedRoutes - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetLearnedRoutes(token string) (GatewayRouteListResultPoller, error)
 	// BeginGetVpnProfilePackageURL - Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified resource group. The profile needs to be generated first using generateVpnProfile.
-	BeginGetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*StringPollerResponse, error)
+	BeginGetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnProfilePackageURLOptions) (*StringPollerResponse, error)
 	// ResumeGetVpnProfilePackageURL - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetVpnProfilePackageURL(token string) (StringPoller, error)
 	// BeginGetVpnclientConnectionHealth - Get VPN client connection health detail per P2S client connection of the virtual network gateway in the specified resource group.
-	BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientConnectionHealthDetailListResultPollerResponse, error)
+	BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions) (*VpnClientConnectionHealthDetailListResultPollerResponse, error)
 	// ResumeGetVpnclientConnectionHealth - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetVpnclientConnectionHealth(token string) (VpnClientConnectionHealthDetailListResultPoller, error)
 	// BeginGetVpnclientIPsecParameters - The Get VpnclientIpsecParameters operation retrieves information about the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.
-	BeginGetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientIPsecParametersPollerResponse, error)
+	BeginGetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions) (*VpnClientIPsecParametersPollerResponse, error)
 	// ResumeGetVpnclientIPsecParameters - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeGetVpnclientIPsecParameters(token string) (VpnClientIPsecParametersPoller, error)
 	// List - Gets all virtual network gateways by resource group.
-	List(resourceGroupName string) VirtualNetworkGatewayListResultPager
+	List(resourceGroupName string, options *VirtualNetworkGatewaysListOptions) VirtualNetworkGatewayListResultPager
 	// ListConnections - Gets all the connections in a virtual network gateway.
-	ListConnections(resourceGroupName string, virtualNetworkGatewayName string) VirtualNetworkGatewayListConnectionsResultPager
+	ListConnections(resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysListConnectionsOptions) VirtualNetworkGatewayListConnectionsResultPager
 	// BeginReset - Resets the primary of the virtual network gateway in the specified resource group.
-	BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*VirtualNetworkGatewayPollerResponse, error)
+	BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetOptions) (*VirtualNetworkGatewayPollerResponse, error)
 	// ResumeReset - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReset(token string) (VirtualNetworkGatewayPoller, error)
 	// BeginResetVpnClientSharedKey - Resets the VPN client shared key of the virtual network gateway in the specified resource group.
-	BeginResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error)
+	BeginResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetVpnClientSharedKeyOptions) (*HTTPPollerResponse, error)
 	// ResumeResetVpnClientSharedKey - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeResetVpnClientSharedKey(token string) (HTTPPoller, error)
 	// BeginSetVpnclientIPsecParameters - The Set VpnclientIpsecParameters operation sets the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.
-	BeginSetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*VpnClientIPsecParametersPollerResponse, error)
+	BeginSetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters, options *VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions) (*VpnClientIPsecParametersPollerResponse, error)
 	// ResumeSetVpnclientIPsecParameters - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeSetVpnclientIPsecParameters(token string) (VpnClientIPsecParametersPoller, error)
 	// BeginStartPacketCapture - Starts packet capture on virtual network gateway in the specified resource group.
-	BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*StringPollerResponse, error)
+	BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysStartPacketCaptureOptions) (*StringPollerResponse, error)
 	// ResumeStartPacketCapture - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStartPacketCapture(token string) (StringPoller, error)
 	// BeginStopPacketCapture - Stops packet capture on virtual network gateway in the specified resource group.
-	BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error)
+	BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewaysStopPacketCaptureOptions) (*StringPollerResponse, error)
 	// ResumeStopPacketCapture - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeStopPacketCapture(token string) (StringPoller, error)
 	// SupportedVpnDevices - Gets a xml format representation for supported vpn devices.
-	SupportedVpnDevices(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*StringResponse, error)
+	SupportedVpnDevices(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysSupportedVpnDevicesOptions) (*StringResponse, error)
 	// BeginUpdateTags - Updates a virtual network gateway tags.
-	BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*VirtualNetworkGatewayPollerResponse, error)
+	BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysUpdateTagsOptions) (*VirtualNetworkGatewayPollerResponse, error)
 	// ResumeUpdateTags - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeUpdateTags(token string) (VirtualNetworkGatewayPoller, error)
 	// VpnDeviceConfigurationScript - Gets a xml format representation for vpn device configuration script.
-	VpnDeviceConfigurationScript(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters) (*StringResponse, error)
+	VpnDeviceConfigurationScript(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters, options *VirtualNetworkGatewaysVpnDeviceConfigurationScriptOptions) (*StringResponse, error)
 }
 
 // VirtualNetworkGatewaysClient implements the VirtualNetworkGatewaysOperations interface.
@@ -114,8 +114,8 @@ func (client *VirtualNetworkGatewaysClient) Do(req *azcore.Request) (*azcore.Res
 	return client.p.Do(req)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*VirtualNetworkGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysCreateOrUpdateOptions) (*VirtualNetworkGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +149,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeCreateOrUpdate(token string) (
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdate(ctx context.Context, 
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VirtualNetworkGateway, options *VirtualNetworkGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -196,8 +196,8 @@ func (client *VirtualNetworkGatewaysClient) CreateOrUpdateHandleError(resp *azco
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +231,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeDelete(token string) (HTTPPoll
 }
 
 // Delete - Deletes the specified virtual network gateway.
-func (client *VirtualNetworkGatewaysClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (client *VirtualNetworkGatewaysClient) Delete(ctx context.Context, resource
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualNetworkGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -272,8 +272,8 @@ func (client *VirtualNetworkGatewaysClient) DeleteHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.DisconnectVirtualNetworkGatewayVpnConnections(ctx, resourceGroupName, virtualNetworkGatewayName, request)
+func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest, options *VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.DisconnectVirtualNetworkGatewayVpnConnections(ctx, resourceGroupName, virtualNetworkGatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -307,8 +307,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeDisconnectVirtualNetworkGatewa
 }
 
 // DisconnectVirtualNetworkGatewayVpnConnections - Disconnect vpn connections of virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*azcore.Response, error) {
-	req, err := client.DisconnectVirtualNetworkGatewayVpnConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, request)
+func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnections(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest, options *VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions) (*azcore.Response, error) {
+	req, err := client.DisconnectVirtualNetworkGatewayVpnConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +323,7 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 }
 
 // DisconnectVirtualNetworkGatewayVpnConnectionsCreateRequest creates the DisconnectVirtualNetworkGatewayVpnConnections request.
-func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnectionsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnConnectionsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, request P2SVpnConnectionRequest, options *VirtualNetworkGatewaysDisconnectVirtualNetworkGatewayVpnConnectionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/disconnectVirtualNetworkGatewayVpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -348,8 +348,8 @@ func (client *VirtualNetworkGatewaysClient) DisconnectVirtualNetworkGatewayVpnCo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error) {
-	resp, err := client.GenerateVpnProfile(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) BeginGenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGenerateVpnProfileOptions) (*StringPollerResponse, error) {
+	resp, err := client.GenerateVpnProfile(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -383,8 +383,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGenerateVpnProfile(token strin
 }
 
 // GenerateVpnProfile - Generates VPN profile for P2S client of the virtual network gateway in the specified resource group. Used for IKEV2 and radius based authentication.
-func (client *VirtualNetworkGatewaysClient) GenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Response, error) {
-	req, err := client.GenerateVpnProfileCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) GenerateVpnProfile(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGenerateVpnProfileOptions) (*azcore.Response, error) {
+	req, err := client.GenerateVpnProfileCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfile(ctx context.Conte
 }
 
 // GenerateVpnProfileCreateRequest creates the GenerateVpnProfile request.
-func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGenerateVpnProfileOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnprofile"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -430,8 +430,8 @@ func (client *VirtualNetworkGatewaysClient) GenerateVpnProfileHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*StringPollerResponse, error) {
-	resp, err := client.Generatevpnclientpackage(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGeneratevpnclientpackageOptions) (*StringPollerResponse, error) {
+	resp, err := client.Generatevpnclientpackage(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -465,8 +465,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGeneratevpnclientpackage(token
 }
 
 // Generatevpnclientpackage - Generates VPN client package for P2S client of the virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) Generatevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Response, error) {
-	req, err := client.GeneratevpnclientpackageCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) Generatevpnclientpackage(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGeneratevpnclientpackageOptions) (*azcore.Response, error) {
+	req, err := client.GeneratevpnclientpackageCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (client *VirtualNetworkGatewaysClient) Generatevpnclientpackage(ctx context
 }
 
 // GeneratevpnclientpackageCreateRequest creates the Generatevpnclientpackage request.
-func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnClientParameters, options *VirtualNetworkGatewaysGeneratevpnclientpackageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -513,8 +513,8 @@ func (client *VirtualNetworkGatewaysClient) GeneratevpnclientpackageHandleError(
 }
 
 // Get - Gets the specified virtual network gateway by resource group.
-func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VirtualNetworkGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetOptions) (*VirtualNetworkGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +533,7 @@ func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGro
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualNetworkGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -564,8 +564,8 @@ func (client *VirtualNetworkGatewaysClient) GetHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string) (*GatewayRouteListResultPollerResponse, error) {
-	resp, err := client.GetAdvertisedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName, peer)
+func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysGetAdvertisedRoutesOptions) (*GatewayRouteListResultPollerResponse, error) {
+	resp, err := client.GetAdvertisedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName, peer, options)
 	if err != nil {
 		return nil, err
 	}
@@ -599,8 +599,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetAdvertisedRoutes(token stri
 }
 
 // GetAdvertisedRoutes - This operation retrieves a list of routes the virtual network gateway is advertising to the specified peer.
-func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string) (*azcore.Response, error) {
-	req, err := client.GetAdvertisedRoutesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, peer)
+func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysGetAdvertisedRoutesOptions) (*azcore.Response, error) {
+	req, err := client.GetAdvertisedRoutesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, peer, options)
 	if err != nil {
 		return nil, err
 	}
@@ -615,7 +615,7 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutes(ctx context.Cont
 }
 
 // GetAdvertisedRoutesCreateRequest creates the GetAdvertisedRoutes request.
-func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, peer string, options *VirtualNetworkGatewaysGetAdvertisedRoutesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getAdvertisedRoutes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -647,8 +647,8 @@ func (client *VirtualNetworkGatewaysClient) GetAdvertisedRoutesHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*BgpPeerStatusListResultPollerResponse, error) {
-	resp, err := client.GetBgpPeerStatus(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysGetBgpPeerStatusOptions)
+func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*BgpPeerStatusListResultPollerResponse, error) {
+	resp, err := client.GetBgpPeerStatus(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -682,8 +682,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetBgpPeerStatus(token string)
 }
 
 // GetBgpPeerStatus - The GetBgpPeerStatus operation retrieves the status of all BGP peers.
-func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*azcore.Response, error) {
-	req, err := client.GetBgpPeerStatusCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysGetBgpPeerStatusOptions)
+func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatus(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*azcore.Response, error) {
+	req, err := client.GetBgpPeerStatusCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatus(ctx context.Context
 }
 
 // GetBgpPeerStatusCreateRequest creates the GetBgpPeerStatus request.
-func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysGetBgpPeerStatusOptions *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetBgpPeerStatusOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getBgpPeerStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -708,8 +708,8 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusCreateRequest(ctx co
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualNetworkGatewaysGetBgpPeerStatusOptions != nil && virtualNetworkGatewaysGetBgpPeerStatusOptions.Peer != nil {
-		query.Set("peer", *virtualNetworkGatewaysGetBgpPeerStatusOptions.Peer)
+	if options != nil && options.Peer != nil {
+		query.Set("peer", *options.Peer)
 	}
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
@@ -732,8 +732,8 @@ func (client *VirtualNetworkGatewaysClient) GetBgpPeerStatusHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*GatewayRouteListResultPollerResponse, error) {
-	resp, err := client.GetLearnedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetLearnedRoutesOptions) (*GatewayRouteListResultPollerResponse, error) {
+	resp, err := client.GetLearnedRoutes(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -767,8 +767,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetLearnedRoutes(token string)
 }
 
 // GetLearnedRoutes - This operation retrieves a list of routes the virtual network gateway has learned, including routes learned from BGP peers.
-func (client *VirtualNetworkGatewaysClient) GetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.GetLearnedRoutesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) GetLearnedRoutes(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetLearnedRoutesOptions) (*azcore.Response, error) {
+	req, err := client.GetLearnedRoutesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -783,7 +783,7 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutes(ctx context.Context
 }
 
 // GetLearnedRoutesCreateRequest creates the GetLearnedRoutes request.
-func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetLearnedRoutesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getLearnedRoutes"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -814,8 +814,8 @@ func (client *VirtualNetworkGatewaysClient) GetLearnedRoutesHandleError(resp *az
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*StringPollerResponse, error) {
-	resp, err := client.GetVpnProfilePackageURL(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginGetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnProfilePackageURLOptions) (*StringPollerResponse, error) {
+	resp, err := client.GetVpnProfilePackageURL(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -849,8 +849,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetVpnProfilePackageURL(token 
 }
 
 // GetVpnProfilePackageURL - Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified resource group. The profile needs to be generated first using generateVpnProfile.
-func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.GetVpnProfilePackageURLCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURL(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnProfilePackageURLOptions) (*azcore.Response, error) {
+	req, err := client.GetVpnProfilePackageURLCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -865,7 +865,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURL(ctx context.
 }
 
 // GetVpnProfilePackageURLCreateRequest creates the GetVpnProfilePackageURL request.
-func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnProfilePackageURLOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnprofilepackageurl"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -896,8 +896,8 @@ func (client *VirtualNetworkGatewaysClient) GetVpnProfilePackageURLHandleError(r
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientConnectionHealthDetailListResultPollerResponse, error) {
-	resp, err := client.GetVpnclientConnectionHealth(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions) (*VpnClientConnectionHealthDetailListResultPollerResponse, error) {
+	resp, err := client.GetVpnclientConnectionHealth(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -931,8 +931,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientConnectionHealth(t
 }
 
 // GetVpnclientConnectionHealth - Get VPN client connection health detail per P2S client connection of the virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.GetVpnclientConnectionHealthCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealth(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions) (*azcore.Response, error) {
+	req, err := client.GetVpnclientConnectionHealthCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -947,7 +947,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealth(ctx con
 }
 
 // GetVpnclientConnectionHealthCreateRequest creates the GetVpnclientConnectionHealth request.
-func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientConnectionHealthOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getVpnClientConnectionHealth"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -978,8 +978,8 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientConnectionHealthHandleEr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*VpnClientIPsecParametersPollerResponse, error) {
-	resp, err := client.GetVpnclientIPsecParameters(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions) (*VpnClientIPsecParametersPollerResponse, error) {
+	resp, err := client.GetVpnclientIPsecParameters(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1013,8 +1013,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientIPsecParameters(to
 }
 
 // GetVpnclientIPsecParameters - The Get VpnclientIpsecParameters operation retrieves information about the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.
-func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.GetVpnclientIPsecParametersCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions) (*azcore.Response, error) {
+	req, err := client.GetVpnclientIPsecParametersCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1029,7 +1029,7 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParameters(ctx cont
 }
 
 // GetVpnclientIPsecParametersCreateRequest creates the GetVpnclientIPsecParameters request.
-func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysGetVpnclientIPsecParametersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnclientipsecparameters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1061,11 +1061,11 @@ func (client *VirtualNetworkGatewaysClient) GetVpnclientIPsecParametersHandleErr
 }
 
 // List - Gets all virtual network gateways by resource group.
-func (client *VirtualNetworkGatewaysClient) List(resourceGroupName string) VirtualNetworkGatewayListResultPager {
+func (client *VirtualNetworkGatewaysClient) List(resourceGroupName string, options *VirtualNetworkGatewaysListOptions) VirtualNetworkGatewayListResultPager {
 	return &virtualNetworkGatewayListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -1076,7 +1076,7 @@ func (client *VirtualNetworkGatewaysClient) List(resourceGroupName string) Virtu
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualNetworkGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualNetworkGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -1107,11 +1107,11 @@ func (client *VirtualNetworkGatewaysClient) ListHandleError(resp *azcore.Respons
 }
 
 // ListConnections - Gets all the connections in a virtual network gateway.
-func (client *VirtualNetworkGatewaysClient) ListConnections(resourceGroupName string, virtualNetworkGatewayName string) VirtualNetworkGatewayListConnectionsResultPager {
+func (client *VirtualNetworkGatewaysClient) ListConnections(resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysListConnectionsOptions) VirtualNetworkGatewayListConnectionsResultPager {
 	return &virtualNetworkGatewayListConnectionsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+			return client.ListConnectionsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 		},
 		responder: client.ListConnectionsHandleResponse,
 		errorer:   client.ListConnectionsHandleError,
@@ -1122,7 +1122,7 @@ func (client *VirtualNetworkGatewaysClient) ListConnections(resourceGroupName st
 }
 
 // ListConnectionsCreateRequest creates the ListConnections request.
-func (client *VirtualNetworkGatewaysClient) ListConnectionsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) ListConnectionsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysListConnectionsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/connections"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1153,8 +1153,8 @@ func (client *VirtualNetworkGatewaysClient) ListConnectionsHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*VirtualNetworkGatewayPollerResponse, error) {
-	resp, err := client.Reset(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysResetOptions)
+func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetOptions) (*VirtualNetworkGatewayPollerResponse, error) {
+	resp, err := client.Reset(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1188,8 +1188,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeReset(token string) (VirtualNe
 }
 
 // Reset - Resets the primary of the virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) Reset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*azcore.Response, error) {
-	req, err := client.ResetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysResetOptions)
+func (client *VirtualNetworkGatewaysClient) Reset(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetOptions) (*azcore.Response, error) {
+	req, err := client.ResetCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1204,7 +1204,7 @@ func (client *VirtualNetworkGatewaysClient) Reset(ctx context.Context, resourceG
 }
 
 // ResetCreateRequest creates the Reset request.
-func (client *VirtualNetworkGatewaysClient) ResetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysResetOptions *VirtualNetworkGatewaysResetOptions) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) ResetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1214,8 +1214,8 @@ func (client *VirtualNetworkGatewaysClient) ResetCreateRequest(ctx context.Conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if virtualNetworkGatewaysResetOptions != nil && virtualNetworkGatewaysResetOptions.GatewayVip != nil {
-		query.Set("gatewayVip", *virtualNetworkGatewaysResetOptions.GatewayVip)
+	if options != nil && options.GatewayVip != nil {
+		query.Set("gatewayVip", *options.GatewayVip)
 	}
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
@@ -1238,8 +1238,8 @@ func (client *VirtualNetworkGatewaysClient) ResetHandleError(resp *azcore.Respon
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.ResetVpnClientSharedKey(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) BeginResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetVpnClientSharedKeyOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.ResetVpnClientSharedKey(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1273,8 +1273,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeResetVpnClientSharedKey(token 
 }
 
 // ResetVpnClientSharedKey - Resets the VPN client shared key of the virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Response, error) {
-	req, err := client.ResetVpnClientSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKey(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetVpnClientSharedKeyOptions) (*azcore.Response, error) {
+	req, err := client.ResetVpnClientSharedKeyCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1289,7 +1289,7 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKey(ctx context.
 }
 
 // ResetVpnClientSharedKeyCreateRequest creates the ResetVpnClientSharedKey request.
-func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysResetVpnClientSharedKeyOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/resetvpnclientsharedkey"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1314,8 +1314,8 @@ func (client *VirtualNetworkGatewaysClient) ResetVpnClientSharedKeyHandleError(r
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*VpnClientIPsecParametersPollerResponse, error) {
-	resp, err := client.SetVpnclientIPsecParameters(ctx, resourceGroupName, virtualNetworkGatewayName, vpnclientIpsecParams)
+func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters, options *VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions) (*VpnClientIPsecParametersPollerResponse, error) {
+	resp, err := client.SetVpnclientIPsecParameters(ctx, resourceGroupName, virtualNetworkGatewayName, vpnclientIpsecParams, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,8 +1349,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeSetVpnclientIPsecParameters(to
 }
 
 // SetVpnclientIPsecParameters - The Set VpnclientIpsecParameters operation sets the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.
-func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*azcore.Response, error) {
-	req, err := client.SetVpnclientIPsecParametersCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, vpnclientIpsecParams)
+func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParameters(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters, options *VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions) (*azcore.Response, error) {
+	req, err := client.SetVpnclientIPsecParametersCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, vpnclientIpsecParams, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1365,7 +1365,7 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParameters(ctx cont
 }
 
 // SetVpnclientIPsecParametersCreateRequest creates the SetVpnclientIPsecParameters request.
-func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, vpnclientIpsecParams VpnClientIPsecParameters, options *VirtualNetworkGatewaysSetVpnclientIPsecParametersOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/setvpnclientipsecparameters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1396,8 +1396,8 @@ func (client *VirtualNetworkGatewaysClient) SetVpnclientIPsecParametersHandleErr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*StringPollerResponse, error) {
-	resp, err := client.StartPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysStartPacketCaptureOptions)
+func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysStartPacketCaptureOptions) (*StringPollerResponse, error) {
+	resp, err := client.StartPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1431,8 +1431,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeStartPacketCapture(token strin
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) StartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*azcore.Response, error) {
-	req, err := client.StartPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, virtualNetworkGatewaysStartPacketCaptureOptions)
+func (client *VirtualNetworkGatewaysClient) StartPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysStartPacketCaptureOptions) (*azcore.Response, error) {
+	req, err := client.StartPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1447,7 +1447,7 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCapture(ctx context.Conte
 }
 
 // StartPacketCaptureCreateRequest creates the StartPacketCapture request.
-func (client *VirtualNetworkGatewaysClient) StartPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, virtualNetworkGatewaysStartPacketCaptureOptions *VirtualNetworkGatewaysStartPacketCaptureOptions) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) StartPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysStartPacketCaptureOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1460,8 +1460,8 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureCreateRequest(ctx 
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if virtualNetworkGatewaysStartPacketCaptureOptions != nil {
-		return req, req.MarshalAsJSON(virtualNetworkGatewaysStartPacketCaptureOptions.Parameters)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil
 }
@@ -1481,8 +1481,8 @@ func (client *VirtualNetworkGatewaysClient) StartPacketCaptureHandleError(resp *
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*StringPollerResponse, error) {
-	resp, err := client.StopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewaysStopPacketCaptureOptions) (*StringPollerResponse, error) {
+	resp, err := client.StopPacketCapture(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1516,8 +1516,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeStopPacketCapture(token string
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway in the specified resource group.
-func (client *VirtualNetworkGatewaysClient) StopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*azcore.Response, error) {
-	req, err := client.StopPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) StopPacketCapture(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewaysStopPacketCaptureOptions) (*azcore.Response, error) {
+	req, err := client.StopPacketCaptureCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1532,7 +1532,7 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCapture(ctx context.Contex
 }
 
 // StopPacketCaptureCreateRequest creates the StopPacketCapture request.
-func (client *VirtualNetworkGatewaysClient) StopPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) StopPacketCaptureCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters VpnPacketCaptureStopParameters, options *VirtualNetworkGatewaysStopPacketCaptureOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopPacketCapture"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1564,8 +1564,8 @@ func (client *VirtualNetworkGatewaysClient) StopPacketCaptureHandleError(resp *a
 }
 
 // SupportedVpnDevices - Gets a xml format representation for supported vpn devices.
-func (client *VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*StringResponse, error) {
-	req, err := client.SupportedVpnDevicesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName)
+func (client *VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysSupportedVpnDevicesOptions) (*StringResponse, error) {
+	req, err := client.SupportedVpnDevicesCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1584,7 +1584,7 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Cont
 }
 
 // SupportedVpnDevicesCreateRequest creates the SupportedVpnDevices request.
-func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, options *VirtualNetworkGatewaysSupportedVpnDevicesOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1615,8 +1615,8 @@ func (client *VirtualNetworkGatewaysClient) SupportedVpnDevicesHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*VirtualNetworkGatewayPollerResponse, error) {
-	resp, err := client.UpdateTags(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysUpdateTagsOptions) (*VirtualNetworkGatewayPollerResponse, error) {
+	resp, err := client.UpdateTags(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1650,8 +1650,8 @@ func (client *VirtualNetworkGatewaysClient) ResumeUpdateTags(token string) (Virt
 }
 
 // UpdateTags - Updates a virtual network gateway tags.
-func (client *VirtualNetworkGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*azcore.Response, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters)
+func (client *VirtualNetworkGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysUpdateTagsOptions) (*azcore.Response, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1666,7 +1666,7 @@ func (client *VirtualNetworkGatewaysClient) UpdateTags(ctx context.Context, reso
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayName string, parameters TagsObject, options *VirtualNetworkGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
@@ -1698,8 +1698,8 @@ func (client *VirtualNetworkGatewaysClient) UpdateTagsHandleError(resp *azcore.R
 }
 
 // VpnDeviceConfigurationScript - Gets a xml format representation for vpn device configuration script.
-func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters) (*StringResponse, error) {
-	req, err := client.VpnDeviceConfigurationScriptCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters)
+func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters, options *VirtualNetworkGatewaysVpnDeviceConfigurationScriptOptions) (*StringResponse, error) {
+	req, err := client.VpnDeviceConfigurationScriptCreateRequest(ctx, resourceGroupName, virtualNetworkGatewayConnectionName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1718,7 +1718,7 @@ func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx con
 }
 
 // VpnDeviceConfigurationScriptCreateRequest creates the VpnDeviceConfigurationScript request.
-func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters) (*azcore.Request, error) {
+func (client *VirtualNetworkGatewaysClient) VpnDeviceConfigurationScriptCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkGatewayConnectionName string, parameters VpnDeviceScriptParameters, options *VirtualNetworkGatewaysVpnDeviceConfigurationScriptOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayConnectionName}", url.PathEscape(virtualNetworkGatewayConnectionName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -18,17 +18,17 @@ import (
 // VirtualNetworkPeeringsOperations contains the methods for the VirtualNetworkPeerings group.
 type VirtualNetworkPeeringsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a peering in the specified virtual network.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering) (*VirtualNetworkPeeringPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsCreateOrUpdateOptions) (*VirtualNetworkPeeringPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualNetworkPeeringPoller, error)
 	// BeginDelete - Deletes the specified virtual network peering.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified virtual network peering.
-	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*VirtualNetworkPeeringResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsGetOptions) (*VirtualNetworkPeeringResponse, error)
 	// List - Gets all virtual network peerings in a virtual network.
-	List(resourceGroupName string, virtualNetworkName string) VirtualNetworkPeeringListResultPager
+	List(resourceGroupName string, virtualNetworkName string, options *VirtualNetworkPeeringsListOptions) VirtualNetworkPeeringListResultPager
 }
 
 // VirtualNetworkPeeringsClient implements the VirtualNetworkPeeringsOperations interface.
@@ -48,8 +48,8 @@ func (client *VirtualNetworkPeeringsClient) Do(req *azcore.Request) (*azcore.Res
 	return client.p.Do(req)
 }
 
-func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering) (*VirtualNetworkPeeringPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters)
+func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsCreateOrUpdateOptions) (*VirtualNetworkPeeringPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *VirtualNetworkPeeringsClient) ResumeCreateOrUpdate(token string) (
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified virtual network.
-func (client *VirtualNetworkPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters)
+func (client *VirtualNetworkPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, virtualNetworkPeeringParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdate(ctx context.Context, 
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualNetworkPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering) (*azcore.Request, error) {
+func (client *VirtualNetworkPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, virtualNetworkPeeringParameters VirtualNetworkPeering, options *VirtualNetworkPeeringsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -131,8 +131,8 @@ func (client *VirtualNetworkPeeringsClient) CreateOrUpdateHandleError(resp *azco
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
+func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *VirtualNetworkPeeringsClient) ResumeDelete(token string) (HTTPPoll
 }
 
 // Delete - Deletes the specified virtual network peering.
-func (client *VirtualNetworkPeeringsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
+func (client *VirtualNetworkPeeringsClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *VirtualNetworkPeeringsClient) Delete(ctx context.Context, resource
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualNetworkPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*azcore.Request, error) {
+func (client *VirtualNetworkPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -209,8 +209,8 @@ func (client *VirtualNetworkPeeringsClient) DeleteHandleError(resp *azcore.Respo
 }
 
 // Get - Gets the specified virtual network peering.
-func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*VirtualNetworkPeeringResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName)
+func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsGetOptions) (*VirtualNetworkPeeringResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworkPeeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGro
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualNetworkPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string) (*azcore.Request, error) {
+func (client *VirtualNetworkPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworkPeeringName string, options *VirtualNetworkPeeringsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -262,11 +262,11 @@ func (client *VirtualNetworkPeeringsClient) GetHandleError(resp *azcore.Response
 }
 
 // List - Gets all virtual network peerings in a virtual network.
-func (client *VirtualNetworkPeeringsClient) List(resourceGroupName string, virtualNetworkName string) VirtualNetworkPeeringListResultPager {
+func (client *VirtualNetworkPeeringsClient) List(resourceGroupName string, virtualNetworkName string, options *VirtualNetworkPeeringsListOptions) VirtualNetworkPeeringListResultPager {
 	return &virtualNetworkPeeringListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *VirtualNetworkPeeringsClient) List(resourceGroupName string, virtu
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualNetworkPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+func (client *VirtualNetworkPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworkPeeringsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -18,25 +18,25 @@ import (
 // VirtualNetworksOperations contains the methods for the VirtualNetworks group.
 type VirtualNetworksOperations interface {
 	// CheckIPAddressAvailability - Checks whether a private IP address is available for use.
-	CheckIPAddressAvailability(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string) (*IPAddressAvailabilityResultResponse, error)
+	CheckIPAddressAvailability(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string, options *VirtualNetworksCheckIPAddressAvailabilityOptions) (*IPAddressAvailabilityResultResponse, error)
 	// BeginCreateOrUpdate - Creates or updates a virtual network in the specified resource group.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*VirtualNetworkPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksCreateOrUpdateOptions) (*VirtualNetworkPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualNetworkPoller, error)
 	// BeginDelete - Deletes the specified virtual network.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified virtual network by resource group.
-	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworksGetOptions *VirtualNetworksGetOptions) (*VirtualNetworkResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksGetOptions) (*VirtualNetworkResponse, error)
 	// List - Gets all virtual networks in a resource group.
-	List(resourceGroupName string) VirtualNetworkListResultPager
+	List(resourceGroupName string, options *VirtualNetworksListOptions) VirtualNetworkListResultPager
 	// ListAll - Gets all virtual networks in a subscription.
-	ListAll() VirtualNetworkListResultPager
+	ListAll(options *VirtualNetworksListAllOptions) VirtualNetworkListResultPager
 	// ListUsage - Lists usage stats.
-	ListUsage(resourceGroupName string, virtualNetworkName string) VirtualNetworkListUsageResultPager
+	ListUsage(resourceGroupName string, virtualNetworkName string, options *VirtualNetworksListUsageOptions) VirtualNetworkListUsageResultPager
 	// UpdateTags - Updates a virtual network tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject) (*VirtualNetworkResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject, options *VirtualNetworksUpdateTagsOptions) (*VirtualNetworkResponse, error)
 }
 
 // VirtualNetworksClient implements the VirtualNetworksOperations interface.
@@ -57,8 +57,8 @@ func (client *VirtualNetworksClient) Do(req *azcore.Request) (*azcore.Response, 
 }
 
 // CheckIPAddressAvailability - Checks whether a private IP address is available for use.
-func (client *VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string) (*IPAddressAvailabilityResultResponse, error) {
-	req, err := client.CheckIPAddressAvailabilityCreateRequest(ctx, resourceGroupName, virtualNetworkName, ipAddress)
+func (client *VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string, options *VirtualNetworksCheckIPAddressAvailabilityOptions) (*IPAddressAvailabilityResultResponse, error) {
+	req, err := client.CheckIPAddressAvailabilityCreateRequest(ctx, resourceGroupName, virtualNetworkName, ipAddress, options)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Cont
 }
 
 // CheckIPAddressAvailabilityCreateRequest creates the CheckIPAddressAvailability request.
-func (client *VirtualNetworksClient) CheckIPAddressAvailabilityCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) CheckIPAddressAvailabilityCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, ipAddress string, options *VirtualNetworksCheckIPAddressAvailabilityOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/CheckIPAddressAvailability"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -109,8 +109,8 @@ func (client *VirtualNetworksClient) CheckIPAddressAvailabilityHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*VirtualNetworkPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, parameters)
+func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksCreateOrUpdateOptions) (*VirtualNetworkPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualNetworkName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -144,8 +144,8 @@ func (client *VirtualNetworksClient) ResumeCreateOrUpdate(token string) (Virtual
 }
 
 // CreateOrUpdate - Creates or updates a virtual network in the specified resource group.
-func (client *VirtualNetworksClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, parameters)
+func (client *VirtualNetworksClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualNetworkName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (client *VirtualNetworksClient) CreateOrUpdate(ctx context.Context, resourc
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualNetworksClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters VirtualNetwork, options *VirtualNetworksCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -191,8 +191,8 @@ func (client *VirtualNetworksClient) CreateOrUpdateHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName)
+func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualNetworkName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -226,8 +226,8 @@ func (client *VirtualNetworksClient) ResumeDelete(token string) (HTTPPoller, err
 }
 
 // Delete - Deletes the specified virtual network.
-func (client *VirtualNetworksClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName)
+func (client *VirtualNetworksClient) Delete(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (client *VirtualNetworksClient) Delete(ctx context.Context, resourceGroupNa
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualNetworksClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -268,8 +268,8 @@ func (client *VirtualNetworksClient) DeleteHandleError(resp *azcore.Response) er
 }
 
 // Get - Gets the specified virtual network by resource group.
-func (client *VirtualNetworksClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworksGetOptions *VirtualNetworksGetOptions) (*VirtualNetworkResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, virtualNetworksGetOptions)
+func (client *VirtualNetworksClient) Get(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksGetOptions) (*VirtualNetworkResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (client *VirtualNetworksClient) Get(ctx context.Context, resourceGroupName 
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualNetworksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, virtualNetworksGetOptions *VirtualNetworksGetOptions) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -299,8 +299,8 @@ func (client *VirtualNetworksClient) GetCreateRequest(ctx context.Context, resou
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if virtualNetworksGetOptions != nil && virtualNetworksGetOptions.Expand != nil {
-		query.Set("$expand", *virtualNetworksGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -323,11 +323,11 @@ func (client *VirtualNetworksClient) GetHandleError(resp *azcore.Response) error
 }
 
 // List - Gets all virtual networks in a resource group.
-func (client *VirtualNetworksClient) List(resourceGroupName string) VirtualNetworkListResultPager {
+func (client *VirtualNetworksClient) List(resourceGroupName string, options *VirtualNetworksListOptions) VirtualNetworkListResultPager {
 	return &virtualNetworkListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -338,7 +338,7 @@ func (client *VirtualNetworksClient) List(resourceGroupName string) VirtualNetwo
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualNetworksClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualNetworksListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -369,11 +369,11 @@ func (client *VirtualNetworksClient) ListHandleError(resp *azcore.Response) erro
 }
 
 // ListAll - Gets all virtual networks in a subscription.
-func (client *VirtualNetworksClient) ListAll() VirtualNetworkListResultPager {
+func (client *VirtualNetworksClient) ListAll(options *VirtualNetworksListAllOptions) VirtualNetworkListResultPager {
 	return &virtualNetworkListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -384,7 +384,7 @@ func (client *VirtualNetworksClient) ListAll() VirtualNetworkListResultPager {
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *VirtualNetworksClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) ListAllCreateRequest(ctx context.Context, options *VirtualNetworksListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -414,11 +414,11 @@ func (client *VirtualNetworksClient) ListAllHandleError(resp *azcore.Response) e
 }
 
 // ListUsage - Lists usage stats.
-func (client *VirtualNetworksClient) ListUsage(resourceGroupName string, virtualNetworkName string) VirtualNetworkListUsageResultPager {
+func (client *VirtualNetworksClient) ListUsage(resourceGroupName string, virtualNetworkName string, options *VirtualNetworksListUsageOptions) VirtualNetworkListUsageResultPager {
 	return &virtualNetworkListUsageResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListUsageCreateRequest(ctx, resourceGroupName, virtualNetworkName)
+			return client.ListUsageCreateRequest(ctx, resourceGroupName, virtualNetworkName, options)
 		},
 		responder: client.ListUsageHandleResponse,
 		errorer:   client.ListUsageHandleError,
@@ -429,7 +429,7 @@ func (client *VirtualNetworksClient) ListUsage(resourceGroupName string, virtual
 }
 
 // ListUsageCreateRequest creates the ListUsage request.
-func (client *VirtualNetworksClient) ListUsageCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) ListUsageCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, options *VirtualNetworksListUsageOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/usages"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))
@@ -461,8 +461,8 @@ func (client *VirtualNetworksClient) ListUsageHandleError(resp *azcore.Response)
 }
 
 // UpdateTags - Updates a virtual network tags.
-func (client *VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject) (*VirtualNetworkResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkName, parameters)
+func (client *VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject, options *VirtualNetworksUpdateTagsOptions) (*VirtualNetworkResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualNetworkName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (client *VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGro
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualNetworksClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualNetworksClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualNetworkName string, parameters TagsObject, options *VirtualNetworksUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkName}", url.PathEscape(virtualNetworkName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -18,21 +18,21 @@ import (
 // VirtualNetworkTapsOperations contains the methods for the VirtualNetworkTaps group.
 type VirtualNetworkTapsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates a Virtual Network Tap.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap) (*VirtualNetworkTapPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsCreateOrUpdateOptions) (*VirtualNetworkTapPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualNetworkTapPoller, error)
 	// BeginDelete - Deletes the specified virtual network tap.
-	BeginDelete(ctx context.Context, resourceGroupName string, tapName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets information about the specified virtual network tap.
-	Get(ctx context.Context, resourceGroupName string, tapName string) (*VirtualNetworkTapResponse, error)
+	Get(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsGetOptions) (*VirtualNetworkTapResponse, error)
 	// ListAll - Gets all the VirtualNetworkTaps in a subscription.
-	ListAll() VirtualNetworkTapListResultPager
+	ListAll(options *VirtualNetworkTapsListAllOptions) VirtualNetworkTapListResultPager
 	// ListByResourceGroup - Gets all the VirtualNetworkTaps in a subscription.
-	ListByResourceGroup(resourceGroupName string) VirtualNetworkTapListResultPager
+	ListByResourceGroup(resourceGroupName string, options *VirtualNetworkTapsListByResourceGroupOptions) VirtualNetworkTapListResultPager
 	// UpdateTags - Updates an VirtualNetworkTap tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject) (*VirtualNetworkTapResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject, options *VirtualNetworkTapsUpdateTagsOptions) (*VirtualNetworkTapResponse, error)
 }
 
 // VirtualNetworkTapsClient implements the VirtualNetworkTapsOperations interface.
@@ -52,8 +52,8 @@ func (client *VirtualNetworkTapsClient) Do(req *azcore.Request) (*azcore.Respons
 	return client.p.Do(req)
 }
 
-func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap) (*VirtualNetworkTapPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, tapName, parameters)
+func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsCreateOrUpdateOptions) (*VirtualNetworkTapPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, tapName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VirtualNetworkTapsClient) ResumeCreateOrUpdate(token string) (Virt
 }
 
 // CreateOrUpdate - Creates or updates a Virtual Network Tap.
-func (client *VirtualNetworkTapsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, tapName, parameters)
+func (client *VirtualNetworkTapsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, tapName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdate(ctx context.Context, reso
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualNetworkTapsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, tapName string, parameters VirtualNetworkTap, options *VirtualNetworkTapsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
@@ -134,8 +134,8 @@ func (client *VirtualNetworkTapsClient) CreateOrUpdateHandleError(resp *azcore.R
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourceGroupName string, tapName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, tapName)
+func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, tapName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *VirtualNetworkTapsClient) ResumeDelete(token string) (HTTPPoller, 
 }
 
 // Delete - Deletes the specified virtual network tap.
-func (client *VirtualNetworkTapsClient) Delete(ctx context.Context, resourceGroupName string, tapName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, tapName)
+func (client *VirtualNetworkTapsClient) Delete(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, tapName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *VirtualNetworkTapsClient) Delete(ctx context.Context, resourceGrou
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualNetworkTapsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, tapName string) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
@@ -211,8 +211,8 @@ func (client *VirtualNetworkTapsClient) DeleteHandleError(resp *azcore.Response)
 }
 
 // Get - Gets information about the specified virtual network tap.
-func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupName string, tapName string) (*VirtualNetworkTapResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, tapName)
+func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsGetOptions) (*VirtualNetworkTapResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, tapName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupNa
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualNetworkTapsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, tapName string) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, tapName string, options *VirtualNetworkTapsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))
@@ -263,11 +263,11 @@ func (client *VirtualNetworkTapsClient) GetHandleError(resp *azcore.Response) er
 }
 
 // ListAll - Gets all the VirtualNetworkTaps in a subscription.
-func (client *VirtualNetworkTapsClient) ListAll() VirtualNetworkTapListResultPager {
+func (client *VirtualNetworkTapsClient) ListAll(options *VirtualNetworkTapsListAllOptions) VirtualNetworkTapListResultPager {
 	return &virtualNetworkTapListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -278,7 +278,7 @@ func (client *VirtualNetworkTapsClient) ListAll() VirtualNetworkTapListResultPag
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *VirtualNetworkTapsClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) ListAllCreateRequest(ctx context.Context, options *VirtualNetworkTapsListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *VirtualNetworkTapsClient) ListAllHandleError(resp *azcore.Response
 }
 
 // ListByResourceGroup - Gets all the VirtualNetworkTaps in a subscription.
-func (client *VirtualNetworkTapsClient) ListByResourceGroup(resourceGroupName string) VirtualNetworkTapListResultPager {
+func (client *VirtualNetworkTapsClient) ListByResourceGroup(resourceGroupName string, options *VirtualNetworkTapsListByResourceGroupOptions) VirtualNetworkTapListResultPager {
 	return &virtualNetworkTapListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroup(resourceGroupName st
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VirtualNetworkTapsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualNetworkTapsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -354,8 +354,8 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroupHandleError(resp *azc
 }
 
 // UpdateTags - Updates an VirtualNetworkTap tags.
-func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject) (*VirtualNetworkTapResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, tapName, tapParameters)
+func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject, options *VirtualNetworkTapsUpdateTagsOptions) (*VirtualNetworkTapResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, tapName, tapParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resource
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualNetworkTapsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualNetworkTapsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, tapName string, tapParameters TagsObject, options *VirtualNetworkTapsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{tapName}", url.PathEscape(tapName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -18,17 +18,17 @@ import (
 // VirtualRouterPeeringsOperations contains the methods for the VirtualRouterPeerings group.
 type VirtualRouterPeeringsOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Virtual Router Peering.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering) (*VirtualRouterPeeringPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsCreateOrUpdateOptions) (*VirtualRouterPeeringPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualRouterPeeringPoller, error)
 	// BeginDelete - Deletes the specified peering from a Virtual Router.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Virtual Router Peering.
-	Get(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*VirtualRouterPeeringResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsGetOptions) (*VirtualRouterPeeringResponse, error)
 	// List - Lists all Virtual Router Peerings in a Virtual Router resource.
-	List(resourceGroupName string, virtualRouterName string) VirtualRouterPeeringListResultPager
+	List(resourceGroupName string, virtualRouterName string, options *VirtualRouterPeeringsListOptions) VirtualRouterPeeringListResultPager
 }
 
 // VirtualRouterPeeringsClient implements the VirtualRouterPeeringsOperations interface.
@@ -48,8 +48,8 @@ func (client *VirtualRouterPeeringsClient) Do(req *azcore.Request) (*azcore.Resp
 	return client.p.Do(req)
 }
 
-func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering) (*VirtualRouterPeeringPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualRouterName, peeringName, parameters)
+func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsCreateOrUpdateOptions) (*VirtualRouterPeeringPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualRouterName, peeringName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *VirtualRouterPeeringsClient) ResumeCreateOrUpdate(token string) (V
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router Peering.
-func (client *VirtualRouterPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName, parameters)
+func (client *VirtualRouterPeeringsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdate(ctx context.Context, r
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualRouterPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering) (*azcore.Request, error) {
+func (client *VirtualRouterPeeringsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, parameters VirtualRouterPeering, options *VirtualRouterPeeringsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -131,8 +131,8 @@ func (client *VirtualRouterPeeringsClient) CreateOrUpdateHandleError(resp *azcor
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualRouterName, peeringName)
+func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualRouterName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *VirtualRouterPeeringsClient) ResumeDelete(token string) (HTTPPolle
 }
 
 // Delete - Deletes the specified peering from a Virtual Router.
-func (client *VirtualRouterPeeringsClient) Delete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName)
+func (client *VirtualRouterPeeringsClient) Delete(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *VirtualRouterPeeringsClient) Delete(ctx context.Context, resourceG
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualRouterPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*azcore.Request, error) {
+func (client *VirtualRouterPeeringsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -209,8 +209,8 @@ func (client *VirtualRouterPeeringsClient) DeleteHandleError(resp *azcore.Respon
 }
 
 // Get - Gets the specified Virtual Router Peering.
-func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*VirtualRouterPeeringResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName)
+func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsGetOptions) (*VirtualRouterPeeringResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualRouterName, peeringName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGrou
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualRouterPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string) (*azcore.Request, error) {
+func (client *VirtualRouterPeeringsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, peeringName string, options *VirtualRouterPeeringsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -262,11 +262,11 @@ func (client *VirtualRouterPeeringsClient) GetHandleError(resp *azcore.Response)
 }
 
 // List - Lists all Virtual Router Peerings in a Virtual Router resource.
-func (client *VirtualRouterPeeringsClient) List(resourceGroupName string, virtualRouterName string) VirtualRouterPeeringListResultPager {
+func (client *VirtualRouterPeeringsClient) List(resourceGroupName string, virtualRouterName string, options *VirtualRouterPeeringsListOptions) VirtualRouterPeeringListResultPager {
 	return &virtualRouterPeeringListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName, virtualRouterName)
+			return client.ListCreateRequest(ctx, resourceGroupName, virtualRouterName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -277,7 +277,7 @@ func (client *VirtualRouterPeeringsClient) List(resourceGroupName string, virtua
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualRouterPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string) (*azcore.Request, error) {
+func (client *VirtualRouterPeeringsClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRouterPeeringsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -18,19 +18,19 @@ import (
 // VirtualRoutersOperations contains the methods for the VirtualRouters group.
 type VirtualRoutersOperations interface {
 	// BeginCreateOrUpdate - Creates or updates the specified Virtual Router.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter) (*VirtualRouterPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersCreateOrUpdateOptions) (*VirtualRouterPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualRouterPoller, error)
 	// BeginDelete - Deletes the specified Virtual Router.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Gets the specified Virtual Router.
-	Get(ctx context.Context, resourceGroupName string, virtualRouterName string, virtualRoutersGetOptions *VirtualRoutersGetOptions) (*VirtualRouterResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersGetOptions) (*VirtualRouterResponse, error)
 	// List - Gets all the Virtual Routers in a subscription.
-	List() VirtualRouterListResultPager
+	List(options *VirtualRoutersListOptions) VirtualRouterListResultPager
 	// ListByResourceGroup - Lists all Virtual Routers in a resource group.
-	ListByResourceGroup(resourceGroupName string) VirtualRouterListResultPager
+	ListByResourceGroup(resourceGroupName string, options *VirtualRoutersListByResourceGroupOptions) VirtualRouterListResultPager
 }
 
 // VirtualRoutersClient implements the VirtualRoutersOperations interface.
@@ -50,8 +50,8 @@ func (client *VirtualRoutersClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter) (*VirtualRouterPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualRouterName, parameters)
+func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersCreateOrUpdateOptions) (*VirtualRouterPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualRouterName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -85,8 +85,8 @@ func (client *VirtualRoutersClient) ResumeCreateOrUpdate(token string) (VirtualR
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router.
-func (client *VirtualRoutersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualRouterName, parameters)
+func (client *VirtualRoutersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualRouterName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (client *VirtualRoutersClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualRoutersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter) (*azcore.Request, error) {
+func (client *VirtualRoutersClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, parameters VirtualRouter, options *VirtualRoutersCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -132,8 +132,8 @@ func (client *VirtualRoutersClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualRouterName)
+func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualRouterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,8 @@ func (client *VirtualRoutersClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Deletes the specified Virtual Router.
-func (client *VirtualRoutersClient) Delete(ctx context.Context, resourceGroupName string, virtualRouterName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualRouterName)
+func (client *VirtualRoutersClient) Delete(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualRouterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (client *VirtualRoutersClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualRoutersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string) (*azcore.Request, error) {
+func (client *VirtualRoutersClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -209,8 +209,8 @@ func (client *VirtualRoutersClient) DeleteHandleError(resp *azcore.Response) err
 }
 
 // Get - Gets the specified Virtual Router.
-func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName string, virtualRouterName string, virtualRoutersGetOptions *VirtualRoutersGetOptions) (*VirtualRouterResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualRouterName, virtualRoutersGetOptions)
+func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersGetOptions) (*VirtualRouterResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualRouterName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualRoutersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, virtualRoutersGetOptions *VirtualRoutersGetOptions) (*azcore.Request, error) {
+func (client *VirtualRoutersClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualRouterName string, options *VirtualRoutersGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{virtualRouterName}", url.PathEscape(virtualRouterName))
@@ -240,8 +240,8 @@ func (client *VirtualRoutersClient) GetCreateRequest(ctx context.Context, resour
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2020-03-01")
-	if virtualRoutersGetOptions != nil && virtualRoutersGetOptions.Expand != nil {
-		query.Set("$expand", *virtualRoutersGetOptions.Expand)
+	if options != nil && options.Expand != nil {
+		query.Set("$expand", *options.Expand)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -264,11 +264,11 @@ func (client *VirtualRoutersClient) GetHandleError(resp *azcore.Response) error 
 }
 
 // List - Gets all the Virtual Routers in a subscription.
-func (client *VirtualRoutersClient) List() VirtualRouterListResultPager {
+func (client *VirtualRoutersClient) List(options *VirtualRoutersListOptions) VirtualRouterListResultPager {
 	return &virtualRouterListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -279,7 +279,7 @@ func (client *VirtualRoutersClient) List() VirtualRouterListResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualRoutersClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualRoutersClient) ListCreateRequest(ctx context.Context, options *VirtualRoutersListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -309,11 +309,11 @@ func (client *VirtualRoutersClient) ListHandleError(resp *azcore.Response) error
 }
 
 // ListByResourceGroup - Lists all Virtual Routers in a resource group.
-func (client *VirtualRoutersClient) ListByResourceGroup(resourceGroupName string) VirtualRouterListResultPager {
+func (client *VirtualRoutersClient) ListByResourceGroup(resourceGroupName string, options *VirtualRoutersListByResourceGroupOptions) VirtualRouterListResultPager {
 	return &virtualRouterListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -324,7 +324,7 @@ func (client *VirtualRoutersClient) ListByResourceGroup(resourceGroupName string
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VirtualRoutersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualRoutersClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualRoutersListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -18,21 +18,21 @@ import (
 // VirtualWansOperations contains the methods for the VirtualWans group.
 type VirtualWansOperations interface {
 	// BeginCreateOrUpdate - Creates a VirtualWAN resource if it doesn't exist else updates the existing VirtualWAN.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan) (*VirtualWanPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan, options *VirtualWansCreateOrUpdateOptions) (*VirtualWanPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VirtualWanPoller, error)
 	// BeginDelete - Deletes a VirtualWAN.
-	BeginDelete(ctx context.Context, resourceGroupName string, virtualWanName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a VirtualWAN.
-	Get(ctx context.Context, resourceGroupName string, virtualWanName string) (*VirtualWanResponse, error)
+	Get(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansGetOptions) (*VirtualWanResponse, error)
 	// List - Lists all the VirtualWANs in a subscription.
-	List() ListVirtualWaNsResultPager
+	List(options *VirtualWansListOptions) ListVirtualWaNsResultPager
 	// ListByResourceGroup - Lists all the VirtualWANs in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListVirtualWaNsResultPager
+	ListByResourceGroup(resourceGroupName string, options *VirtualWansListByResourceGroupOptions) ListVirtualWaNsResultPager
 	// UpdateTags - Updates a VirtualWAN tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject) (*VirtualWanResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject, options *VirtualWansUpdateTagsOptions) (*VirtualWanResponse, error)
 }
 
 // VirtualWansClient implements the VirtualWansOperations interface.
@@ -52,8 +52,8 @@ func (client *VirtualWansClient) Do(req *azcore.Request) (*azcore.Response, erro
 	return client.p.Do(req)
 }
 
-func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan) (*VirtualWanPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualWanName, wanParameters)
+func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan, options *VirtualWansCreateOrUpdateOptions) (*VirtualWanPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, virtualWanName, wanParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VirtualWansClient) ResumeCreateOrUpdate(token string) (VirtualWanP
 }
 
 // CreateOrUpdate - Creates a VirtualWAN resource if it doesn't exist else updates the existing VirtualWAN.
-func (client *VirtualWansClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualWanName, wanParameters)
+func (client *VirtualWansClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan, options *VirtualWansCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, virtualWanName, wanParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VirtualWansClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VirtualWansClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan) (*azcore.Request, error) {
+func (client *VirtualWansClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters VirtualWan, options *VirtualWansCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -134,8 +134,8 @@ func (client *VirtualWansClient) CreateOrUpdateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualWanName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, virtualWanName)
+func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *VirtualWansClient) ResumeDelete(token string) (HTTPPoller, error) 
 }
 
 // Delete - Deletes a VirtualWAN.
-func (client *VirtualWansClient) Delete(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualWanName)
+func (client *VirtualWansClient) Delete(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *VirtualWansClient) Delete(ctx context.Context, resourceGroupName s
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VirtualWansClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+func (client *VirtualWansClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -211,8 +211,8 @@ func (client *VirtualWansClient) DeleteHandleError(resp *azcore.Response) error 
 }
 
 // Get - Retrieves the details of a VirtualWAN.
-func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName string, virtualWanName string) (*VirtualWanResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualWanName)
+func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansGetOptions) (*VirtualWanResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VirtualWansClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+func (client *VirtualWansClient) GetCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, options *VirtualWansGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWanName))
@@ -263,11 +263,11 @@ func (client *VirtualWansClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all the VirtualWANs in a subscription.
-func (client *VirtualWansClient) List() ListVirtualWaNsResultPager {
+func (client *VirtualWansClient) List(options *VirtualWansListOptions) ListVirtualWaNsResultPager {
 	return &listVirtualWaNsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *VirtualWansClient) List() ListVirtualWaNsResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *VirtualWansClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VirtualWansClient) ListCreateRequest(ctx context.Context, options *VirtualWansListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *VirtualWansClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all the VirtualWANs in a resource group.
-func (client *VirtualWansClient) ListByResourceGroup(resourceGroupName string) ListVirtualWaNsResultPager {
+func (client *VirtualWansClient) ListByResourceGroup(resourceGroupName string, options *VirtualWansListByResourceGroupOptions) ListVirtualWaNsResultPager {
 	return &listVirtualWaNsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *VirtualWansClient) ListByResourceGroup(resourceGroupName string) L
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VirtualWansClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VirtualWansClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VirtualWansListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -354,8 +354,8 @@ func (client *VirtualWansClient) ListByResourceGroupHandleError(resp *azcore.Res
 }
 
 // UpdateTags - Updates a VirtualWAN tags.
-func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject) (*VirtualWanResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualWanName, wanParameters)
+func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject, options *VirtualWansUpdateTagsOptions) (*VirtualWanResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, virtualWanName, wanParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupNa
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VirtualWansClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject) (*azcore.Request, error) {
+func (client *VirtualWansClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, wanParameters TagsObject, options *VirtualWansUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -18,17 +18,17 @@ import (
 // VpnConnectionsOperations contains the methods for the VpnConnections group.
 type VpnConnectionsOperations interface {
 	// BeginCreateOrUpdate - Creates a vpn connection to a scalable vpn gateway if it doesn't exist else updates the existing connection.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection) (*VpnConnectionPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection, options *VpnConnectionsCreateOrUpdateOptions) (*VpnConnectionPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VpnConnectionPoller, error)
 	// BeginDelete - Deletes a vpn connection.
-	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a vpn connection.
-	Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*VpnConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsGetOptions) (*VpnConnectionResponse, error)
 	// ListByVpnGateway - Retrieves all vpn connections for a particular virtual wan vpn gateway.
-	ListByVpnGateway(resourceGroupName string, gatewayName string) ListVpnConnectionsResultPager
+	ListByVpnGateway(resourceGroupName string, gatewayName string, options *VpnConnectionsListByVpnGatewayOptions) ListVpnConnectionsResultPager
 }
 
 // VpnConnectionsClient implements the VpnConnectionsOperations interface.
@@ -48,8 +48,8 @@ func (client *VpnConnectionsClient) Do(req *azcore.Request) (*azcore.Response, e
 	return client.p.Do(req)
 }
 
-func (client *VpnConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection) (*VpnConnectionPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, connectionName, vpnConnectionParameters)
+func (client *VpnConnectionsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection, options *VpnConnectionsCreateOrUpdateOptions) (*VpnConnectionPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, connectionName, vpnConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func (client *VpnConnectionsClient) ResumeCreateOrUpdate(token string) (VpnConne
 }
 
 // CreateOrUpdate - Creates a vpn connection to a scalable vpn gateway if it doesn't exist else updates the existing connection.
-func (client *VpnConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, vpnConnectionParameters)
+func (client *VpnConnectionsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection, options *VpnConnectionsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, vpnConnectionParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (client *VpnConnectionsClient) CreateOrUpdate(ctx context.Context, resource
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VpnConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection) (*azcore.Request, error) {
+func (client *VpnConnectionsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, vpnConnectionParameters VpnConnection, options *VpnConnectionsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -131,8 +131,8 @@ func (client *VpnConnectionsClient) CreateOrUpdateHandleError(resp *azcore.Respo
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VpnConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, gatewayName, connectionName)
+func (client *VpnConnectionsClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, gatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +166,8 @@ func (client *VpnConnectionsClient) ResumeDelete(token string) (HTTPPoller, erro
 }
 
 // Delete - Deletes a vpn connection.
-func (client *VpnConnectionsClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName, connectionName)
+func (client *VpnConnectionsClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *VpnConnectionsClient) Delete(ctx context.Context, resourceGroupNam
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VpnConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+func (client *VpnConnectionsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -209,8 +209,8 @@ func (client *VpnConnectionsClient) DeleteHandleError(resp *azcore.Response) err
 }
 
 // Get - Retrieves the details of a vpn connection.
-func (client *VpnConnectionsClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*VpnConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, connectionName)
+func (client *VpnConnectionsClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsGetOptions) (*VpnConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func (client *VpnConnectionsClient) Get(ctx context.Context, resourceGroupName s
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+func (client *VpnConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -262,11 +262,11 @@ func (client *VpnConnectionsClient) GetHandleError(resp *azcore.Response) error 
 }
 
 // ListByVpnGateway - Retrieves all vpn connections for a particular virtual wan vpn gateway.
-func (client *VpnConnectionsClient) ListByVpnGateway(resourceGroupName string, gatewayName string) ListVpnConnectionsResultPager {
+func (client *VpnConnectionsClient) ListByVpnGateway(resourceGroupName string, gatewayName string, options *VpnConnectionsListByVpnGatewayOptions) ListVpnConnectionsResultPager {
 	return &listVpnConnectionsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByVpnGatewayCreateRequest(ctx, resourceGroupName, gatewayName)
+			return client.ListByVpnGatewayCreateRequest(ctx, resourceGroupName, gatewayName, options)
 		},
 		responder: client.ListByVpnGatewayHandleResponse,
 		errorer:   client.ListByVpnGatewayHandleError,
@@ -277,7 +277,7 @@ func (client *VpnConnectionsClient) ListByVpnGateway(resourceGroupName string, g
 }
 
 // ListByVpnGatewayCreateRequest creates the ListByVpnGateway request.
-func (client *VpnConnectionsClient) ListByVpnGatewayCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *VpnConnectionsClient) ListByVpnGatewayCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnConnectionsListByVpnGatewayOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -18,25 +18,25 @@ import (
 // VpnGatewaysOperations contains the methods for the VpnGateways group.
 type VpnGatewaysOperations interface {
 	// BeginCreateOrUpdate - Creates a virtual wan vpn gateway if it doesn't exist else updates the existing gateway.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway) (*VpnGatewayPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway, options *VpnGatewaysCreateOrUpdateOptions) (*VpnGatewayPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VpnGatewayPoller, error)
 	// BeginDelete - Deletes a virtual wan vpn gateway.
-	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a virtual wan vpn gateway.
-	Get(ctx context.Context, resourceGroupName string, gatewayName string) (*VpnGatewayResponse, error)
+	Get(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysGetOptions) (*VpnGatewayResponse, error)
 	// List - Lists all the VpnGateways in a subscription.
-	List() ListVpnGatewaysResultPager
+	List(options *VpnGatewaysListOptions) ListVpnGatewaysResultPager
 	// ListByResourceGroup - Lists all the VpnGateways in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListVpnGatewaysResultPager
+	ListByResourceGroup(resourceGroupName string, options *VpnGatewaysListByResourceGroupOptions) ListVpnGatewaysResultPager
 	// BeginReset - Resets the primary of the vpn gateway in the specified resource group.
-	BeginReset(ctx context.Context, resourceGroupName string, gatewayName string) (*VpnGatewayPollerResponse, error)
+	BeginReset(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysResetOptions) (*VpnGatewayPollerResponse, error)
 	// ResumeReset - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeReset(token string) (VpnGatewayPoller, error)
 	// UpdateTags - Updates virtual wan vpn gateway tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject) (*VpnGatewayResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject, options *VpnGatewaysUpdateTagsOptions) (*VpnGatewayResponse, error)
 }
 
 // VpnGatewaysClient implements the VpnGatewaysOperations interface.
@@ -56,8 +56,8 @@ func (client *VpnGatewaysClient) Do(req *azcore.Request) (*azcore.Response, erro
 	return client.p.Do(req)
 }
 
-func (client *VpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway) (*VpnGatewayPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, vpnGatewayParameters)
+func (client *VpnGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway, options *VpnGatewaysCreateOrUpdateOptions) (*VpnGatewayPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, gatewayName, vpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +91,8 @@ func (client *VpnGatewaysClient) ResumeCreateOrUpdate(token string) (VpnGatewayP
 }
 
 // CreateOrUpdate - Creates a virtual wan vpn gateway if it doesn't exist else updates the existing gateway.
-func (client *VpnGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, vpnGatewayParameters)
+func (client *VpnGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway, options *VpnGatewaysCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, gatewayName, vpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (client *VpnGatewaysClient) CreateOrUpdate(ctx context.Context, resourceGro
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters VpnGateway, options *VpnGatewaysCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -138,8 +138,8 @@ func (client *VpnGatewaysClient) CreateOrUpdateHandleError(resp *azcore.Response
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, gatewayName)
+func (client *VpnGatewaysClient) BeginDelete(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -173,8 +173,8 @@ func (client *VpnGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) 
 }
 
 // Delete - Deletes a virtual wan vpn gateway.
-func (client *VpnGatewaysClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *VpnGatewaysClient) Delete(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (client *VpnGatewaysClient) Delete(ctx context.Context, resourceGroupName s
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -215,8 +215,8 @@ func (client *VpnGatewaysClient) DeleteHandleError(resp *azcore.Response) error 
 }
 
 // Get - Retrieves the details of a virtual wan vpn gateway.
-func (client *VpnGatewaysClient) Get(ctx context.Context, resourceGroupName string, gatewayName string) (*VpnGatewayResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *VpnGatewaysClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysGetOptions) (*VpnGatewayResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +235,7 @@ func (client *VpnGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -267,11 +267,11 @@ func (client *VpnGatewaysClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all the VpnGateways in a subscription.
-func (client *VpnGatewaysClient) List() ListVpnGatewaysResultPager {
+func (client *VpnGatewaysClient) List(options *VpnGatewaysListOptions) ListVpnGatewaysResultPager {
 	return &listVpnGatewaysResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -282,7 +282,7 @@ func (client *VpnGatewaysClient) List() ListVpnGatewaysResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *VpnGatewaysClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) ListCreateRequest(ctx context.Context, options *VpnGatewaysListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -312,11 +312,11 @@ func (client *VpnGatewaysClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all the VpnGateways in a resource group.
-func (client *VpnGatewaysClient) ListByResourceGroup(resourceGroupName string) ListVpnGatewaysResultPager {
+func (client *VpnGatewaysClient) ListByResourceGroup(resourceGroupName string, options *VpnGatewaysListByResourceGroupOptions) ListVpnGatewaysResultPager {
 	return &listVpnGatewaysResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -327,7 +327,7 @@ func (client *VpnGatewaysClient) ListByResourceGroup(resourceGroupName string) L
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VpnGatewaysListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -357,8 +357,8 @@ func (client *VpnGatewaysClient) ListByResourceGroupHandleError(resp *azcore.Res
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VpnGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, gatewayName string) (*VpnGatewayPollerResponse, error) {
-	resp, err := client.Reset(ctx, resourceGroupName, gatewayName)
+func (client *VpnGatewaysClient) BeginReset(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysResetOptions) (*VpnGatewayPollerResponse, error) {
+	resp, err := client.Reset(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -392,8 +392,8 @@ func (client *VpnGatewaysClient) ResumeReset(token string) (VpnGatewayPoller, er
 }
 
 // Reset - Resets the primary of the vpn gateway in the specified resource group.
-func (client *VpnGatewaysClient) Reset(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Response, error) {
-	req, err := client.ResetCreateRequest(ctx, resourceGroupName, gatewayName)
+func (client *VpnGatewaysClient) Reset(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysResetOptions) (*azcore.Response, error) {
+	req, err := client.ResetCreateRequest(ctx, resourceGroupName, gatewayName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (client *VpnGatewaysClient) Reset(ctx context.Context, resourceGroupName st
 }
 
 // ResetCreateRequest creates the Reset request.
-func (client *VpnGatewaysClient) ResetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) ResetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, options *VpnGatewaysResetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/reset"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
@@ -440,8 +440,8 @@ func (client *VpnGatewaysClient) ResetHandleError(resp *azcore.Response) error {
 }
 
 // UpdateTags - Updates virtual wan vpn gateway tags.
-func (client *VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject) (*VpnGatewayResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, gatewayName, vpnGatewayParameters)
+func (client *VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject, options *VpnGatewaysUpdateTagsOptions) (*VpnGatewayResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, gatewayName, vpnGatewayParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +460,7 @@ func (client *VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject) (*azcore.Request, error) {
+func (client *VpnGatewaysClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, vpnGatewayParameters TagsObject, options *VpnGatewaysUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -16,7 +16,7 @@ import (
 // VpnLinkConnectionsOperations contains the methods for the VpnLinkConnections group.
 type VpnLinkConnectionsOperations interface {
 	// ListByVpnConnection - Retrieves all vpn site link connections for a particular virtual wan vpn gateway vpn connection.
-	ListByVpnConnection(resourceGroupName string, gatewayName string, connectionName string) ListVpnSiteLinkConnectionsResultPager
+	ListByVpnConnection(resourceGroupName string, gatewayName string, connectionName string, options *VpnLinkConnectionsListByVpnConnectionOptions) ListVpnSiteLinkConnectionsResultPager
 }
 
 // VpnLinkConnectionsClient implements the VpnLinkConnectionsOperations interface.
@@ -37,11 +37,11 @@ func (client *VpnLinkConnectionsClient) Do(req *azcore.Request) (*azcore.Respons
 }
 
 // ListByVpnConnection - Retrieves all vpn site link connections for a particular virtual wan vpn gateway vpn connection.
-func (client *VpnLinkConnectionsClient) ListByVpnConnection(resourceGroupName string, gatewayName string, connectionName string) ListVpnSiteLinkConnectionsResultPager {
+func (client *VpnLinkConnectionsClient) ListByVpnConnection(resourceGroupName string, gatewayName string, connectionName string, options *VpnLinkConnectionsListByVpnConnectionOptions) ListVpnSiteLinkConnectionsResultPager {
 	return &listVpnSiteLinkConnectionsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByVpnConnectionCreateRequest(ctx, resourceGroupName, gatewayName, connectionName)
+			return client.ListByVpnConnectionCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, options)
 		},
 		responder: client.ListByVpnConnectionHandleResponse,
 		errorer:   client.ListByVpnConnectionHandleError,
@@ -52,7 +52,7 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnection(resourceGroupName st
 }
 
 // ListByVpnConnectionCreateRequest creates the ListByVpnConnection request.
-func (client *VpnLinkConnectionsClient) ListByVpnConnectionCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string) (*azcore.Request, error) {
+func (client *VpnLinkConnectionsClient) ListByVpnConnectionCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, options *VpnLinkConnectionsListByVpnConnectionOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -18,21 +18,21 @@ import (
 // VpnServerConfigurationsOperations contains the methods for the VpnServerConfigurations group.
 type VpnServerConfigurationsOperations interface {
 	// BeginCreateOrUpdate - Creates a VpnServerConfiguration resource if it doesn't exist else updates the existing VpnServerConfiguration.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration) (*VpnServerConfigurationPollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration, options *VpnServerConfigurationsCreateOrUpdateOptions) (*VpnServerConfigurationPollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VpnServerConfigurationPoller, error)
 	// BeginDelete - Deletes a VpnServerConfiguration.
-	BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a VpnServerConfiguration.
-	Get(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*VpnServerConfigurationResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsGetOptions) (*VpnServerConfigurationResponse, error)
 	// List - Lists all the VpnServerConfigurations in a subscription.
-	List() ListVpnServerConfigurationsResultPager
+	List(options *VpnServerConfigurationsListOptions) ListVpnServerConfigurationsResultPager
 	// ListByResourceGroup - Lists all the vpnServerConfigurations in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListVpnServerConfigurationsResultPager
+	ListByResourceGroup(resourceGroupName string, options *VpnServerConfigurationsListByResourceGroupOptions) ListVpnServerConfigurationsResultPager
 	// UpdateTags - Updates VpnServerConfiguration tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject) (*VpnServerConfigurationResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject, options *VpnServerConfigurationsUpdateTagsOptions) (*VpnServerConfigurationResponse, error)
 }
 
 // VpnServerConfigurationsClient implements the VpnServerConfigurationsOperations interface.
@@ -52,8 +52,8 @@ func (client *VpnServerConfigurationsClient) Do(req *azcore.Request) (*azcore.Re
 	return client.p.Do(req)
 }
 
-func (client *VpnServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration) (*VpnServerConfigurationPollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters)
+func (client *VpnServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration, options *VpnServerConfigurationsCreateOrUpdateOptions) (*VpnServerConfigurationPollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VpnServerConfigurationsClient) ResumeCreateOrUpdate(token string) 
 }
 
 // CreateOrUpdate - Creates a VpnServerConfiguration resource if it doesn't exist else updates the existing VpnServerConfiguration.
-func (client *VpnServerConfigurationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters)
+func (client *VpnServerConfigurationsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration, options *VpnServerConfigurationsCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdate(ctx context.Context,
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VpnServerConfigurationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters VpnServerConfiguration, options *VpnServerConfigurationsCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -134,8 +134,8 @@ func (client *VpnServerConfigurationsClient) CreateOrUpdateHandleError(resp *azc
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VpnServerConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vpnServerConfigurationName)
+func (client *VpnServerConfigurationsClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vpnServerConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *VpnServerConfigurationsClient) ResumeDelete(token string) (HTTPPol
 }
 
 // Delete - Deletes a VpnServerConfiguration.
-func (client *VpnServerConfigurationsClient) Delete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName)
+func (client *VpnServerConfigurationsClient) Delete(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *VpnServerConfigurationsClient) Delete(ctx context.Context, resourc
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VpnServerConfigurationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -211,8 +211,8 @@ func (client *VpnServerConfigurationsClient) DeleteHandleError(resp *azcore.Resp
 }
 
 // Get - Retrieves the details of a VpnServerConfiguration.
-func (client *VpnServerConfigurationsClient) Get(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*VpnServerConfigurationResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName)
+func (client *VpnServerConfigurationsClient) Get(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsGetOptions) (*VpnServerConfigurationResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *VpnServerConfigurationsClient) Get(ctx context.Context, resourceGr
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnServerConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, options *VpnServerConfigurationsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -263,11 +263,11 @@ func (client *VpnServerConfigurationsClient) GetHandleError(resp *azcore.Respons
 }
 
 // List - Lists all the VpnServerConfigurations in a subscription.
-func (client *VpnServerConfigurationsClient) List() ListVpnServerConfigurationsResultPager {
+func (client *VpnServerConfigurationsClient) List(options *VpnServerConfigurationsListOptions) ListVpnServerConfigurationsResultPager {
 	return &listVpnServerConfigurationsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *VpnServerConfigurationsClient) List() ListVpnServerConfigurationsR
 }
 
 // ListCreateRequest creates the List request.
-func (client *VpnServerConfigurationsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) ListCreateRequest(ctx context.Context, options *VpnServerConfigurationsListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *VpnServerConfigurationsClient) ListHandleError(resp *azcore.Respon
 }
 
 // ListByResourceGroup - Lists all the vpnServerConfigurations in a resource group.
-func (client *VpnServerConfigurationsClient) ListByResourceGroup(resourceGroupName string) ListVpnServerConfigurationsResultPager {
+func (client *VpnServerConfigurationsClient) ListByResourceGroup(resourceGroupName string, options *VpnServerConfigurationsListByResourceGroupOptions) ListVpnServerConfigurationsResultPager {
 	return &listVpnServerConfigurationsResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroup(resourceGroupNa
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VpnServerConfigurationsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VpnServerConfigurationsListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -354,8 +354,8 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroupHandleError(resp
 }
 
 // UpdateTags - Updates VpnServerConfiguration tags.
-func (client *VpnServerConfigurationsClient) UpdateTags(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject) (*VpnServerConfigurationResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters)
+func (client *VpnServerConfigurationsClient) UpdateTags(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject, options *VpnServerConfigurationsUpdateTagsOptions) (*VpnServerConfigurationResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, vpnServerConfigurationName, vpnServerConfigurationParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *VpnServerConfigurationsClient) UpdateTags(ctx context.Context, res
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VpnServerConfigurationsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, vpnServerConfigurationName string, vpnServerConfigurationParameters TagsObject, options *VpnServerConfigurationsUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -18,7 +18,7 @@ import (
 // VpnServerConfigurationsAssociatedWithVirtualWanOperations contains the methods for the VpnServerConfigurationsAssociatedWithVirtualWan group.
 type VpnServerConfigurationsAssociatedWithVirtualWanOperations interface {
 	// BeginList - Gives the list of VpnServerConfigurations associated with Virtual Wan in a resource group.
-	BeginList(ctx context.Context, resourceGroupName string, virtualWanName string) (*VpnServerConfigurationsResponsePollerResponse, error)
+	BeginList(ctx context.Context, resourceGroupName string, virtualWanName string, options *VpnServerConfigurationsAssociatedWithVirtualWanListOptions) (*VpnServerConfigurationsResponsePollerResponse, error)
 	// ResumeList - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeList(token string) (VpnServerConfigurationsResponsePoller, error)
 }
@@ -40,8 +40,8 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) Do(req *azc
 	return client.p.Do(req)
 }
 
-func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) BeginList(ctx context.Context, resourceGroupName string, virtualWanName string) (*VpnServerConfigurationsResponsePollerResponse, error) {
-	resp, err := client.List(ctx, resourceGroupName, virtualWanName)
+func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) BeginList(ctx context.Context, resourceGroupName string, virtualWanName string, options *VpnServerConfigurationsAssociatedWithVirtualWanListOptions) (*VpnServerConfigurationsResponsePollerResponse, error) {
+	resp, err := client.List(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ResumeList(
 }
 
 // List - Gives the list of VpnServerConfigurations associated with Virtual Wan in a resource group.
-func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) List(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Response, error) {
-	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualWanName)
+func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) List(ctx context.Context, resourceGroupName string, virtualWanName string, options *VpnServerConfigurationsAssociatedWithVirtualWanListOptions) (*azcore.Response, error) {
+	req, err := client.ListCreateRequest(ctx, resourceGroupName, virtualWanName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) List(ctx co
 }
 
 // ListCreateRequest creates the List request.
-func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string) (*azcore.Request, error) {
+func (client *VpnServerConfigurationsAssociatedWithVirtualWanClient) ListCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, options *VpnServerConfigurationsAssociatedWithVirtualWanListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnServerConfigurations"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -16,7 +16,7 @@ import (
 // VpnSiteLinkConnectionsOperations contains the methods for the VpnSiteLinkConnections group.
 type VpnSiteLinkConnectionsOperations interface {
 	// Get - Retrieves the details of a vpn site link connection.
-	Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string) (*VpnSiteLinkConnectionResponse, error)
+	Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string, options *VpnSiteLinkConnectionsGetOptions) (*VpnSiteLinkConnectionResponse, error)
 }
 
 // VpnSiteLinkConnectionsClient implements the VpnSiteLinkConnectionsOperations interface.
@@ -37,8 +37,8 @@ func (client *VpnSiteLinkConnectionsClient) Do(req *azcore.Request) (*azcore.Res
 }
 
 // Get - Retrieves the details of a vpn site link connection.
-func (client *VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string) (*VpnSiteLinkConnectionResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, linkConnectionName)
+func (client *VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string, options *VpnSiteLinkConnectionsGetOptions) (*VpnSiteLinkConnectionResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, gatewayName, connectionName, linkConnectionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func (client *VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGro
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnSiteLinkConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string) (*azcore.Request, error) {
+func (client *VpnSiteLinkConnectionsClient) GetCreateRequest(ctx context.Context, resourceGroupName string, gatewayName string, connectionName string, linkConnectionName string, options *VpnSiteLinkConnectionsGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -16,9 +16,9 @@ import (
 // VpnSiteLinksOperations contains the methods for the VpnSiteLinks group.
 type VpnSiteLinksOperations interface {
 	// Get - Retrieves the details of a VPN site link.
-	Get(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string) (*VpnSiteLinkResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string, options *VpnSiteLinksGetOptions) (*VpnSiteLinkResponse, error)
 	// ListByVpnSite - Lists all the vpnSiteLinks in a resource group for a vpn site.
-	ListByVpnSite(resourceGroupName string, vpnSiteName string) ListVpnSiteLinksResultPager
+	ListByVpnSite(resourceGroupName string, vpnSiteName string, options *VpnSiteLinksListByVpnSiteOptions) ListVpnSiteLinksResultPager
 }
 
 // VpnSiteLinksClient implements the VpnSiteLinksOperations interface.
@@ -39,8 +39,8 @@ func (client *VpnSiteLinksClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // Get - Retrieves the details of a VPN site link.
-func (client *VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string) (*VpnSiteLinkResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteLinkName)
+func (client *VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string, options *VpnSiteLinksGetOptions) (*VpnSiteLinkResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteLinkName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (client *VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName str
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnSiteLinksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string) (*azcore.Request, error) {
+func (client *VpnSiteLinksClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteLinkName string, options *VpnSiteLinksGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks/{vpnSiteLinkName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -92,11 +92,11 @@ func (client *VpnSiteLinksClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // ListByVpnSite - Lists all the vpnSiteLinks in a resource group for a vpn site.
-func (client *VpnSiteLinksClient) ListByVpnSite(resourceGroupName string, vpnSiteName string) ListVpnSiteLinksResultPager {
+func (client *VpnSiteLinksClient) ListByVpnSite(resourceGroupName string, vpnSiteName string, options *VpnSiteLinksListByVpnSiteOptions) ListVpnSiteLinksResultPager {
 	return &listVpnSiteLinksResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByVpnSiteCreateRequest(ctx, resourceGroupName, vpnSiteName)
+			return client.ListByVpnSiteCreateRequest(ctx, resourceGroupName, vpnSiteName, options)
 		},
 		responder: client.ListByVpnSiteHandleResponse,
 		errorer:   client.ListByVpnSiteHandleError,
@@ -107,7 +107,7 @@ func (client *VpnSiteLinksClient) ListByVpnSite(resourceGroupName string, vpnSit
 }
 
 // ListByVpnSiteCreateRequest creates the ListByVpnSite request.
-func (client *VpnSiteLinksClient) ListByVpnSiteCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+func (client *VpnSiteLinksClient) ListByVpnSiteCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSiteLinksListByVpnSiteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -18,21 +18,21 @@ import (
 // VpnSitesOperations contains the methods for the VpnSites group.
 type VpnSitesOperations interface {
 	// BeginCreateOrUpdate - Creates a VpnSite resource if it doesn't exist else updates the existing VpnSite.
-	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite) (*VpnSitePollerResponse, error)
+	BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite, options *VpnSitesCreateOrUpdateOptions) (*VpnSitePollerResponse, error)
 	// ResumeCreateOrUpdate - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeCreateOrUpdate(token string) (VpnSitePoller, error)
 	// BeginDelete - Deletes a VpnSite.
-	BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieves the details of a VPN site.
-	Get(ctx context.Context, resourceGroupName string, vpnSiteName string) (*VpnSiteResponse, error)
+	Get(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesGetOptions) (*VpnSiteResponse, error)
 	// List - Lists all the VpnSites in a subscription.
-	List() ListVpnSitesResultPager
+	List(options *VpnSitesListOptions) ListVpnSitesResultPager
 	// ListByResourceGroup - Lists all the vpnSites in a resource group.
-	ListByResourceGroup(resourceGroupName string) ListVpnSitesResultPager
+	ListByResourceGroup(resourceGroupName string, options *VpnSitesListByResourceGroupOptions) ListVpnSitesResultPager
 	// UpdateTags - Updates VpnSite tags.
-	UpdateTags(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject) (*VpnSiteResponse, error)
+	UpdateTags(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject, options *VpnSitesUpdateTagsOptions) (*VpnSiteResponse, error)
 }
 
 // VpnSitesClient implements the VpnSitesOperations interface.
@@ -52,8 +52,8 @@ func (client *VpnSitesClient) Do(req *azcore.Request) (*azcore.Response, error) 
 	return client.p.Do(req)
 }
 
-func (client *VpnSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite) (*VpnSitePollerResponse, error) {
-	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters)
+func (client *VpnSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite, options *VpnSitesCreateOrUpdateOptions) (*VpnSitePollerResponse, error) {
+	resp, err := client.CreateOrUpdate(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +87,8 @@ func (client *VpnSitesClient) ResumeCreateOrUpdate(token string) (VpnSitePoller,
 }
 
 // CreateOrUpdate - Creates a VpnSite resource if it doesn't exist else updates the existing VpnSite.
-func (client *VpnSitesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters)
+func (client *VpnSitesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite, options *VpnSitesCreateOrUpdateOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func (client *VpnSitesClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *VpnSitesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite) (*azcore.Request, error) {
+func (client *VpnSitesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters VpnSite, options *VpnSitesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -134,8 +134,8 @@ func (client *VpnSitesClient) CreateOrUpdateHandleError(resp *azcore.Response) e
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *VpnSitesClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, vpnSiteName)
+func (client *VpnSitesClient) BeginDelete(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, vpnSiteName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -169,8 +169,8 @@ func (client *VpnSitesClient) ResumeDelete(token string) (HTTPPoller, error) {
 }
 
 // Delete - Deletes a VpnSite.
-func (client *VpnSitesClient) Delete(ctx context.Context, resourceGroupName string, vpnSiteName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vpnSiteName)
+func (client *VpnSitesClient) Delete(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, vpnSiteName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (client *VpnSitesClient) Delete(ctx context.Context, resourceGroupName stri
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *VpnSitesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+func (client *VpnSitesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -211,8 +211,8 @@ func (client *VpnSitesClient) DeleteHandleError(resp *azcore.Response) error {
 }
 
 // Get - Retrieves the details of a VPN site.
-func (client *VpnSitesClient) Get(ctx context.Context, resourceGroupName string, vpnSiteName string) (*VpnSiteResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnSiteName)
+func (client *VpnSitesClient) Get(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesGetOptions) (*VpnSiteResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, vpnSiteName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (client *VpnSitesClient) Get(ctx context.Context, resourceGroupName string,
 }
 
 // GetCreateRequest creates the Get request.
-func (client *VpnSitesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string) (*azcore.Request, error) {
+func (client *VpnSitesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, options *VpnSitesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -263,11 +263,11 @@ func (client *VpnSitesClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - Lists all the VpnSites in a subscription.
-func (client *VpnSitesClient) List() ListVpnSitesResultPager {
+func (client *VpnSitesClient) List(options *VpnSitesListOptions) ListVpnSitesResultPager {
 	return &listVpnSitesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx)
+			return client.ListCreateRequest(ctx, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -278,7 +278,7 @@ func (client *VpnSitesClient) List() ListVpnSitesResultPager {
 }
 
 // ListCreateRequest creates the List request.
-func (client *VpnSitesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *VpnSitesClient) ListCreateRequest(ctx context.Context, options *VpnSitesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -308,11 +308,11 @@ func (client *VpnSitesClient) ListHandleError(resp *azcore.Response) error {
 }
 
 // ListByResourceGroup - Lists all the vpnSites in a resource group.
-func (client *VpnSitesClient) ListByResourceGroup(resourceGroupName string) ListVpnSitesResultPager {
+func (client *VpnSitesClient) ListByResourceGroup(resourceGroupName string, options *VpnSitesListByResourceGroupOptions) ListVpnSitesResultPager {
 	return &listVpnSitesResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName)
+			return client.ListByResourceGroupCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListByResourceGroupHandleResponse,
 		errorer:   client.ListByResourceGroupHandleError,
@@ -323,7 +323,7 @@ func (client *VpnSitesClient) ListByResourceGroup(resourceGroupName string) List
 }
 
 // ListByResourceGroupCreateRequest creates the ListByResourceGroup request.
-func (client *VpnSitesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *VpnSitesClient) ListByResourceGroupCreateRequest(ctx context.Context, resourceGroupName string, options *VpnSitesListByResourceGroupOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
@@ -354,8 +354,8 @@ func (client *VpnSitesClient) ListByResourceGroupHandleError(resp *azcore.Respon
 }
 
 // UpdateTags - Updates VpnSite tags.
-func (client *VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject) (*VpnSiteResponse, error) {
-	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters)
+func (client *VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject, options *VpnSitesUpdateTagsOptions) (*VpnSiteResponse, error) {
+	req, err := client.UpdateTagsCreateRequest(ctx, resourceGroupName, vpnSiteName, vpnSiteParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (client *VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName 
 }
 
 // UpdateTagsCreateRequest creates the UpdateTags request.
-func (client *VpnSitesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject) (*azcore.Request, error) {
+func (client *VpnSitesClient) UpdateTagsCreateRequest(ctx context.Context, resourceGroupName string, vpnSiteName string, vpnSiteParameters TagsObject, options *VpnSitesUpdateTagsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration.go
@@ -18,7 +18,7 @@ import (
 // VpnSitesConfigurationOperations contains the methods for the VpnSitesConfiguration group.
 type VpnSitesConfigurationOperations interface {
 	// BeginDownload - Gives the sas-url to download the configurations for vpn-sites in a resource group.
-	BeginDownload(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest) (*HTTPPollerResponse, error)
+	BeginDownload(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest, options *VpnSitesConfigurationDownloadOptions) (*HTTPPollerResponse, error)
 	// ResumeDownload - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDownload(token string) (HTTPPoller, error)
 }
@@ -40,8 +40,8 @@ func (client *VpnSitesConfigurationClient) Do(req *azcore.Request) (*azcore.Resp
 	return client.p.Do(req)
 }
 
-func (client *VpnSitesConfigurationClient) BeginDownload(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest) (*HTTPPollerResponse, error) {
-	resp, err := client.Download(ctx, resourceGroupName, virtualWanName, request)
+func (client *VpnSitesConfigurationClient) BeginDownload(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest, options *VpnSitesConfigurationDownloadOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Download(ctx, resourceGroupName, virtualWanName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func (client *VpnSitesConfigurationClient) ResumeDownload(token string) (HTTPPol
 }
 
 // Download - Gives the sas-url to download the configurations for vpn-sites in a resource group.
-func (client *VpnSitesConfigurationClient) Download(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest) (*azcore.Response, error) {
-	req, err := client.DownloadCreateRequest(ctx, resourceGroupName, virtualWanName, request)
+func (client *VpnSitesConfigurationClient) Download(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest, options *VpnSitesConfigurationDownloadOptions) (*azcore.Response, error) {
+	req, err := client.DownloadCreateRequest(ctx, resourceGroupName, virtualWanName, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (client *VpnSitesConfigurationClient) Download(ctx context.Context, resourc
 }
 
 // DownloadCreateRequest creates the Download request.
-func (client *VpnSitesConfigurationClient) DownloadCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest) (*azcore.Request, error) {
+func (client *VpnSitesConfigurationClient) DownloadCreateRequest(ctx context.Context, resourceGroupName string, virtualWanName string, request GetVpnSitesConfigurationRequest, options *VpnSitesConfigurationDownloadOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnConfiguration"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -18,17 +18,17 @@ import (
 // WebApplicationFirewallPoliciesOperations contains the methods for the WebApplicationFirewallPolicies group.
 type WebApplicationFirewallPoliciesOperations interface {
 	// CreateOrUpdate - Creates or update policy with specified rule set name within a resource group.
-	CreateOrUpdate(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy) (*WebApplicationFirewallPolicyResponse, error)
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy, options *WebApplicationFirewallPoliciesCreateOrUpdateOptions) (*WebApplicationFirewallPolicyResponse, error)
 	// BeginDelete - Deletes Policy.
-	BeginDelete(ctx context.Context, resourceGroupName string, policyName string) (*HTTPPollerResponse, error)
+	BeginDelete(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesDeleteOptions) (*HTTPPollerResponse, error)
 	// ResumeDelete - Used to create a new instance of this poller from the resume token of a previous instance of this poller type.
 	ResumeDelete(token string) (HTTPPoller, error)
 	// Get - Retrieve protection policy with specified name within a resource group.
-	Get(ctx context.Context, resourceGroupName string, policyName string) (*WebApplicationFirewallPolicyResponse, error)
+	Get(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesGetOptions) (*WebApplicationFirewallPolicyResponse, error)
 	// List - Lists all of the protection policies within a resource group.
-	List(resourceGroupName string) WebApplicationFirewallPolicyListResultPager
+	List(resourceGroupName string, options *WebApplicationFirewallPoliciesListOptions) WebApplicationFirewallPolicyListResultPager
 	// ListAll - Gets all the WAF policies in a subscription.
-	ListAll() WebApplicationFirewallPolicyListResultPager
+	ListAll(options *WebApplicationFirewallPoliciesListAllOptions) WebApplicationFirewallPolicyListResultPager
 }
 
 // WebApplicationFirewallPoliciesClient implements the WebApplicationFirewallPoliciesOperations interface.
@@ -49,8 +49,8 @@ func (client *WebApplicationFirewallPoliciesClient) Do(req *azcore.Request) (*az
 }
 
 // CreateOrUpdate - Creates or update policy with specified rule set name within a resource group.
-func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy) (*WebApplicationFirewallPolicyResponse, error) {
-	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, policyName, parameters)
+func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy, options *WebApplicationFirewallPoliciesCreateOrUpdateOptions) (*WebApplicationFirewallPolicyResponse, error) {
+	req, err := client.CreateOrUpdateCreateRequest(ctx, resourceGroupName, policyName, parameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.C
 }
 
 // CreateOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy) (*azcore.Request, error) {
+func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateCreateRequest(ctx context.Context, resourceGroupName string, policyName string, parameters WebApplicationFirewallPolicy, options *WebApplicationFirewallPoliciesCreateOrUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
@@ -100,8 +100,8 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdateHandleError(re
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
-func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, policyName string) (*HTTPPollerResponse, error) {
-	resp, err := client.Delete(ctx, resourceGroupName, policyName)
+func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesDeleteOptions) (*HTTPPollerResponse, error) {
+	resp, err := client.Delete(ctx, resourceGroupName, policyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +135,8 @@ func (client *WebApplicationFirewallPoliciesClient) ResumeDelete(token string) (
 }
 
 // Delete - Deletes Policy.
-func (client *WebApplicationFirewallPoliciesClient) Delete(ctx context.Context, resourceGroupName string, policyName string) (*azcore.Response, error) {
-	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, policyName)
+func (client *WebApplicationFirewallPoliciesClient) Delete(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesDeleteOptions) (*azcore.Response, error) {
+	req, err := client.DeleteCreateRequest(ctx, resourceGroupName, policyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (client *WebApplicationFirewallPoliciesClient) Delete(ctx context.Context, 
 }
 
 // DeleteCreateRequest creates the Delete request.
-func (client *WebApplicationFirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, policyName string) (*azcore.Request, error) {
+func (client *WebApplicationFirewallPoliciesClient) DeleteCreateRequest(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesDeleteOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
@@ -177,8 +177,8 @@ func (client *WebApplicationFirewallPoliciesClient) DeleteHandleError(resp *azco
 }
 
 // Get - Retrieve protection policy with specified name within a resource group.
-func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, resourceGroupName string, policyName string) (*WebApplicationFirewallPolicyResponse, error) {
-	req, err := client.GetCreateRequest(ctx, resourceGroupName, policyName)
+func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesGetOptions) (*WebApplicationFirewallPolicyResponse, error) {
+	req, err := client.GetCreateRequest(ctx, resourceGroupName, policyName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, res
 }
 
 // GetCreateRequest creates the Get request.
-func (client *WebApplicationFirewallPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, policyName string) (*azcore.Request, error) {
+func (client *WebApplicationFirewallPoliciesClient) GetCreateRequest(ctx context.Context, resourceGroupName string, policyName string, options *WebApplicationFirewallPoliciesGetOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{policyName}", url.PathEscape(policyName))
@@ -229,11 +229,11 @@ func (client *WebApplicationFirewallPoliciesClient) GetHandleError(resp *azcore.
 }
 
 // List - Lists all of the protection policies within a resource group.
-func (client *WebApplicationFirewallPoliciesClient) List(resourceGroupName string) WebApplicationFirewallPolicyListResultPager {
+func (client *WebApplicationFirewallPoliciesClient) List(resourceGroupName string, options *WebApplicationFirewallPoliciesListOptions) WebApplicationFirewallPolicyListResultPager {
 	return &webApplicationFirewallPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListCreateRequest(ctx, resourceGroupName)
+			return client.ListCreateRequest(ctx, resourceGroupName, options)
 		},
 		responder: client.ListHandleResponse,
 		errorer:   client.ListHandleError,
@@ -244,7 +244,7 @@ func (client *WebApplicationFirewallPoliciesClient) List(resourceGroupName strin
 }
 
 // ListCreateRequest creates the List request.
-func (client *WebApplicationFirewallPoliciesClient) ListCreateRequest(ctx context.Context, resourceGroupName string) (*azcore.Request, error) {
+func (client *WebApplicationFirewallPoliciesClient) ListCreateRequest(ctx context.Context, resourceGroupName string, options *WebApplicationFirewallPoliciesListOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
@@ -275,11 +275,11 @@ func (client *WebApplicationFirewallPoliciesClient) ListHandleError(resp *azcore
 }
 
 // ListAll - Gets all the WAF policies in a subscription.
-func (client *WebApplicationFirewallPoliciesClient) ListAll() WebApplicationFirewallPolicyListResultPager {
+func (client *WebApplicationFirewallPoliciesClient) ListAll(options *WebApplicationFirewallPoliciesListAllOptions) WebApplicationFirewallPolicyListResultPager {
 	return &webApplicationFirewallPolicyListResultPager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListAllCreateRequest(ctx)
+			return client.ListAllCreateRequest(ctx, options)
 		},
 		responder: client.ListAllHandleResponse,
 		errorer:   client.ListAllHandleError,
@@ -290,7 +290,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListAll() WebApplicationFire
 }
 
 // ListAllCreateRequest creates the ListAll request.
-func (client *WebApplicationFirewallPoliciesClient) ListAllCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *WebApplicationFirewallPoliciesClient) ListAllCreateRequest(ctx context.Context, options *WebApplicationFirewallPoliciesListAllOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies"
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -1108,8 +1108,8 @@ func (client *blobClient) GetAccessControlHandleError(resp *azcore.Response) err
 }
 
 // GetAccountInfo - Returns the sku name and account kind
-func (client *blobClient) GetAccountInfo(ctx context.Context) (*BlobGetAccountInfoResponse, error) {
-	req, err := client.GetAccountInfoCreateRequest(ctx)
+func (client *blobClient) GetAccountInfo(ctx context.Context, options *BlobGetAccountInfoOptions) (*BlobGetAccountInfoResponse, error) {
+	req, err := client.GetAccountInfoCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1128,7 +1128,7 @@ func (client *blobClient) GetAccountInfo(ctx context.Context) (*BlobGetAccountIn
 }
 
 // GetAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *blobClient) GetAccountInfoCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *blobClient) GetAccountInfoCreateRequest(ctx context.Context, options *BlobGetAccountInfoOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -2312,8 +2312,8 @@ func (client *blobClient) StartCopyFromURLHandleError(resp *azcore.Response) err
 }
 
 // Undelete - Undelete a blob that was previously soft deleted
-func (client *blobClient) Undelete(ctx context.Context, blobUndeleteOptions *BlobUndeleteOptions) (*BlobUndeleteResponse, error) {
-	req, err := client.UndeleteCreateRequest(ctx, blobUndeleteOptions)
+func (client *blobClient) Undelete(ctx context.Context, options *BlobUndeleteOptions) (*BlobUndeleteResponse, error) {
+	req, err := client.UndeleteCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -2332,20 +2332,20 @@ func (client *blobClient) Undelete(ctx context.Context, blobUndeleteOptions *Blo
 }
 
 // UndeleteCreateRequest creates the Undelete request.
-func (client *blobClient) UndeleteCreateRequest(ctx context.Context, blobUndeleteOptions *BlobUndeleteOptions) (*azcore.Request, error) {
+func (client *blobClient) UndeleteCreateRequest(ctx context.Context, options *BlobUndeleteOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodPut, client.u)
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
 	query.Set("comp", "undelete")
-	if blobUndeleteOptions != nil && blobUndeleteOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*blobUndeleteOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if blobUndeleteOptions != nil && blobUndeleteOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *blobUndeleteOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -581,8 +581,8 @@ func (client *containerClient) GetAccessPolicyHandleError(resp *azcore.Response)
 }
 
 // GetAccountInfo - Returns the sku name and account kind
-func (client *containerClient) GetAccountInfo(ctx context.Context) (*ContainerGetAccountInfoResponse, error) {
-	req, err := client.GetAccountInfoCreateRequest(ctx)
+func (client *containerClient) GetAccountInfo(ctx context.Context, options *ContainerGetAccountInfoOptions) (*ContainerGetAccountInfoResponse, error) {
+	req, err := client.GetAccountInfoCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func (client *containerClient) GetAccountInfo(ctx context.Context) (*ContainerGe
 }
 
 // GetAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *containerClient) GetAccountInfoCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *containerClient) GetAccountInfoCreateRequest(ctx context.Context, options *ContainerGetAccountInfoOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -781,11 +781,11 @@ func (client *containerClient) GetPropertiesHandleError(resp *azcore.Response) e
 }
 
 // ListBlobFlatSegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
-func (client *containerClient) ListBlobFlatSegment(containerListBlobFlatSegmentOptions *ContainerListBlobFlatSegmentOptions) ListBlobsFlatSegmentResponsePager {
+func (client *containerClient) ListBlobFlatSegment(options *ContainerListBlobFlatSegmentOptions) ListBlobsFlatSegmentResponsePager {
 	return &listBlobsFlatSegmentResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBlobFlatSegmentCreateRequest(ctx, containerListBlobFlatSegmentOptions)
+			return client.ListBlobFlatSegmentCreateRequest(ctx, options)
 		},
 		responder: client.ListBlobFlatSegmentHandleResponse,
 		errorer:   client.ListBlobFlatSegmentHandleError,
@@ -796,7 +796,7 @@ func (client *containerClient) ListBlobFlatSegment(containerListBlobFlatSegmentO
 }
 
 // ListBlobFlatSegmentCreateRequest creates the ListBlobFlatSegment request.
-func (client *containerClient) ListBlobFlatSegmentCreateRequest(ctx context.Context, containerListBlobFlatSegmentOptions *ContainerListBlobFlatSegmentOptions) (*azcore.Request, error) {
+func (client *containerClient) ListBlobFlatSegmentCreateRequest(ctx context.Context, options *ContainerListBlobFlatSegmentOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -804,25 +804,25 @@ func (client *containerClient) ListBlobFlatSegmentCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.Prefix != nil {
-		query.Set("prefix", *containerListBlobFlatSegmentOptions.Prefix)
+	if options != nil && options.Prefix != nil {
+		query.Set("prefix", *options.Prefix)
 	}
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.Marker != nil {
-		query.Set("marker", *containerListBlobFlatSegmentOptions.Marker)
+	if options != nil && options.Marker != nil {
+		query.Set("marker", *options.Marker)
 	}
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.Maxresults != nil {
-		query.Set("maxresults", strconv.FormatInt(int64(*containerListBlobFlatSegmentOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		query.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.Include != nil {
-		query.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(*containerListBlobFlatSegmentOptions.Include), "[]")), ","))
+	if options != nil && options.Include != nil {
+		query.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(*options.Include), "[]")), ","))
 	}
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*containerListBlobFlatSegmentOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if containerListBlobFlatSegmentOptions != nil && containerListBlobFlatSegmentOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *containerListBlobFlatSegmentOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil
@@ -863,11 +863,11 @@ func (client *containerClient) ListBlobFlatSegmentHandleError(resp *azcore.Respo
 }
 
 // ListBlobHierarchySegment - [Update] The List Blobs operation returns a list of the blobs under the specified container
-func (client *containerClient) ListBlobHierarchySegment(delimiter string, containerListBlobHierarchySegmentOptions *ContainerListBlobHierarchySegmentOptions) ListBlobsHierarchySegmentResponsePager {
+func (client *containerClient) ListBlobHierarchySegment(delimiter string, options *ContainerListBlobHierarchySegmentOptions) ListBlobsHierarchySegmentResponsePager {
 	return &listBlobsHierarchySegmentResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListBlobHierarchySegmentCreateRequest(ctx, delimiter, containerListBlobHierarchySegmentOptions)
+			return client.ListBlobHierarchySegmentCreateRequest(ctx, delimiter, options)
 		},
 		responder: client.ListBlobHierarchySegmentHandleResponse,
 		errorer:   client.ListBlobHierarchySegmentHandleError,
@@ -878,7 +878,7 @@ func (client *containerClient) ListBlobHierarchySegment(delimiter string, contai
 }
 
 // ListBlobHierarchySegmentCreateRequest creates the ListBlobHierarchySegment request.
-func (client *containerClient) ListBlobHierarchySegmentCreateRequest(ctx context.Context, delimiter string, containerListBlobHierarchySegmentOptions *ContainerListBlobHierarchySegmentOptions) (*azcore.Request, error) {
+func (client *containerClient) ListBlobHierarchySegmentCreateRequest(ctx context.Context, delimiter string, options *ContainerListBlobHierarchySegmentOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -886,26 +886,26 @@ func (client *containerClient) ListBlobHierarchySegmentCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("restype", "container")
 	query.Set("comp", "list")
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.Prefix != nil {
-		query.Set("prefix", *containerListBlobHierarchySegmentOptions.Prefix)
+	if options != nil && options.Prefix != nil {
+		query.Set("prefix", *options.Prefix)
 	}
 	query.Set("delimiter", delimiter)
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.Marker != nil {
-		query.Set("marker", *containerListBlobHierarchySegmentOptions.Marker)
+	if options != nil && options.Marker != nil {
+		query.Set("marker", *options.Marker)
 	}
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.Maxresults != nil {
-		query.Set("maxresults", strconv.FormatInt(int64(*containerListBlobHierarchySegmentOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		query.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.Include != nil {
-		query.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(*containerListBlobHierarchySegmentOptions.Include), "[]")), ","))
+	if options != nil && options.Include != nil {
+		query.Set("include", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(*options.Include), "[]")), ","))
 	}
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*containerListBlobHierarchySegmentOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if containerListBlobHierarchySegmentOptions != nil && containerListBlobHierarchySegmentOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *containerListBlobHierarchySegmentOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -708,6 +708,11 @@ type BlobGetAccessControlResponse struct {
 	Version *string
 }
 
+// BlobGetAccountInfoOptions contains the optional parameters for the Blob.GetAccountInfo method.
+type BlobGetAccountInfoOptions struct {
+	// placeholder for future optional parameters
+}
+
 // BlobGetAccountInfoResponse contains the response from method Blob.GetAccountInfo.
 type BlobGetAccountInfoResponse struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
@@ -1855,6 +1860,11 @@ type ContainerGetAccessPolicyOptions struct {
 	// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
 	// Timeouts for Blob Service Operations.</a>
 	Timeout *int32
+}
+
+// ContainerGetAccountInfoOptions contains the optional parameters for the Container.GetAccountInfo method.
+type ContainerGetAccountInfoOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ContainerGetAccountInfoResponse contains the response from method Container.GetAccountInfo.
@@ -3156,6 +3166,11 @@ type SequenceNumberAccessConditions struct {
 	IfSequenceNumberLessThan *int64
 	// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
 	IfSequenceNumberLessThanOrEqualTo *int64
+}
+
+// ServiceGetAccountInfoOptions contains the optional parameters for the Service.GetAccountInfo method.
+type ServiceGetAccountInfoOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ServiceGetAccountInfoResponse contains the response from method Service.GetAccountInfo.

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -23,8 +23,8 @@ func (client *serviceClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // GetAccountInfo - Returns the sku name and account kind
-func (client *serviceClient) GetAccountInfo(ctx context.Context) (*ServiceGetAccountInfoResponse, error) {
-	req, err := client.GetAccountInfoCreateRequest(ctx)
+func (client *serviceClient) GetAccountInfo(ctx context.Context, options *ServiceGetAccountInfoOptions) (*ServiceGetAccountInfoResponse, error) {
+	req, err := client.GetAccountInfoCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *serviceClient) GetAccountInfo(ctx context.Context) (*ServiceGetAcc
 }
 
 // GetAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *serviceClient) GetAccountInfoCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *serviceClient) GetAccountInfoCreateRequest(ctx context.Context, options *ServiceGetAccountInfoOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -95,8 +95,8 @@ func (client *serviceClient) GetAccountInfoHandleError(resp *azcore.Response) er
 }
 
 // GetProperties - gets the properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
-func (client *serviceClient) GetProperties(ctx context.Context, serviceGetPropertiesOptions *ServiceGetPropertiesOptions) (*StorageServicePropertiesResponse, error) {
-	req, err := client.GetPropertiesCreateRequest(ctx, serviceGetPropertiesOptions)
+func (client *serviceClient) GetProperties(ctx context.Context, options *ServiceGetPropertiesOptions) (*StorageServicePropertiesResponse, error) {
+	req, err := client.GetPropertiesCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (client *serviceClient) GetProperties(ctx context.Context, serviceGetProper
 }
 
 // GetPropertiesCreateRequest creates the GetProperties request.
-func (client *serviceClient) GetPropertiesCreateRequest(ctx context.Context, serviceGetPropertiesOptions *ServiceGetPropertiesOptions) (*azcore.Request, error) {
+func (client *serviceClient) GetPropertiesCreateRequest(ctx context.Context, options *ServiceGetPropertiesOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -123,13 +123,13 @@ func (client *serviceClient) GetPropertiesCreateRequest(ctx context.Context, ser
 	query := req.URL.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
-	if serviceGetPropertiesOptions != nil && serviceGetPropertiesOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceGetPropertiesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceGetPropertiesOptions != nil && serviceGetPropertiesOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceGetPropertiesOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil
@@ -160,8 +160,8 @@ func (client *serviceClient) GetPropertiesHandleError(resp *azcore.Response) err
 }
 
 // GetStatistics - Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
-func (client *serviceClient) GetStatistics(ctx context.Context, serviceGetStatisticsOptions *ServiceGetStatisticsOptions) (*StorageServiceStatsResponse, error) {
-	req, err := client.GetStatisticsCreateRequest(ctx, serviceGetStatisticsOptions)
+func (client *serviceClient) GetStatistics(ctx context.Context, options *ServiceGetStatisticsOptions) (*StorageServiceStatsResponse, error) {
+	req, err := client.GetStatisticsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (client *serviceClient) GetStatistics(ctx context.Context, serviceGetStatis
 }
 
 // GetStatisticsCreateRequest creates the GetStatistics request.
-func (client *serviceClient) GetStatisticsCreateRequest(ctx context.Context, serviceGetStatisticsOptions *ServiceGetStatisticsOptions) (*azcore.Request, error) {
+func (client *serviceClient) GetStatisticsCreateRequest(ctx context.Context, options *ServiceGetStatisticsOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
@@ -188,13 +188,13 @@ func (client *serviceClient) GetStatisticsCreateRequest(ctx context.Context, ser
 	query := req.URL.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "stats")
-	if serviceGetStatisticsOptions != nil && serviceGetStatisticsOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceGetStatisticsOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceGetStatisticsOptions != nil && serviceGetStatisticsOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceGetStatisticsOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil
@@ -232,8 +232,8 @@ func (client *serviceClient) GetStatisticsHandleError(resp *azcore.Response) err
 }
 
 // GetUserDelegationKey - Retrieves a user delegation key for the Blob service. This is only a valid operation when using bearer token authentication.
-func (client *serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo KeyInfo, serviceGetUserDelegationKeyOptions *ServiceGetUserDelegationKeyOptions) (*UserDelegationKeyResponse, error) {
-	req, err := client.GetUserDelegationKeyCreateRequest(ctx, keyInfo, serviceGetUserDelegationKeyOptions)
+func (client *serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo KeyInfo, options *ServiceGetUserDelegationKeyOptions) (*UserDelegationKeyResponse, error) {
+	req, err := client.GetUserDelegationKeyCreateRequest(ctx, keyInfo, options)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func (client *serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo K
 }
 
 // GetUserDelegationKeyCreateRequest creates the GetUserDelegationKey request.
-func (client *serviceClient) GetUserDelegationKeyCreateRequest(ctx context.Context, keyInfo KeyInfo, serviceGetUserDelegationKeyOptions *ServiceGetUserDelegationKeyOptions) (*azcore.Request, error) {
+func (client *serviceClient) GetUserDelegationKeyCreateRequest(ctx context.Context, keyInfo KeyInfo, options *ServiceGetUserDelegationKeyOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodPost, client.u)
 	if err != nil {
 		return nil, err
@@ -260,13 +260,13 @@ func (client *serviceClient) GetUserDelegationKeyCreateRequest(ctx context.Conte
 	query := req.URL.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "userdelegationkey")
-	if serviceGetUserDelegationKeyOptions != nil && serviceGetUserDelegationKeyOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceGetUserDelegationKeyOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceGetUserDelegationKeyOptions != nil && serviceGetUserDelegationKeyOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceGetUserDelegationKeyOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(keyInfo)
@@ -304,11 +304,11 @@ func (client *serviceClient) GetUserDelegationKeyHandleError(resp *azcore.Respon
 }
 
 // ListContainersSegment - The List Containers Segment operation returns a list of the containers under the specified account
-func (client *serviceClient) ListContainersSegment(serviceListContainersSegmentOptions *ServiceListContainersSegmentOptions) ListContainersSegmentResponsePager {
+func (client *serviceClient) ListContainersSegment(options *ServiceListContainersSegmentOptions) ListContainersSegmentResponsePager {
 	return &listContainersSegmentResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.ListContainersSegmentCreateRequest(ctx, serviceListContainersSegmentOptions)
+			return client.ListContainersSegmentCreateRequest(ctx, options)
 		},
 		responder: client.ListContainersSegmentHandleResponse,
 		errorer:   client.ListContainersSegmentHandleError,
@@ -319,32 +319,32 @@ func (client *serviceClient) ListContainersSegment(serviceListContainersSegmentO
 }
 
 // ListContainersSegmentCreateRequest creates the ListContainersSegment request.
-func (client *serviceClient) ListContainersSegmentCreateRequest(ctx context.Context, serviceListContainersSegmentOptions *ServiceListContainersSegmentOptions) (*azcore.Request, error) {
+func (client *serviceClient) ListContainersSegmentCreateRequest(ctx context.Context, options *ServiceListContainersSegmentOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodGet, client.u)
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
 	query.Set("comp", "list")
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Prefix != nil {
-		query.Set("prefix", *serviceListContainersSegmentOptions.Prefix)
+	if options != nil && options.Prefix != nil {
+		query.Set("prefix", *options.Prefix)
 	}
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Marker != nil {
-		query.Set("marker", *serviceListContainersSegmentOptions.Marker)
+	if options != nil && options.Marker != nil {
+		query.Set("marker", *options.Marker)
 	}
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Maxresults != nil {
-		query.Set("maxresults", strconv.FormatInt(int64(*serviceListContainersSegmentOptions.Maxresults), 10))
+	if options != nil && options.Maxresults != nil {
+		query.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Include != nil {
+	if options != nil && options.Include != nil {
 		query.Set("include", "metadata")
 	}
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceListContainersSegmentOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceListContainersSegmentOptions != nil && serviceListContainersSegmentOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceListContainersSegmentOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, nil
@@ -375,8 +375,8 @@ func (client *serviceClient) ListContainersSegmentHandleError(resp *azcore.Respo
 }
 
 // SetProperties - Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
-func (client *serviceClient) SetProperties(ctx context.Context, storageServiceProperties StorageServiceProperties, serviceSetPropertiesOptions *ServiceSetPropertiesOptions) (*ServiceSetPropertiesResponse, error) {
-	req, err := client.SetPropertiesCreateRequest(ctx, storageServiceProperties, serviceSetPropertiesOptions)
+func (client *serviceClient) SetProperties(ctx context.Context, storageServiceProperties StorageServiceProperties, options *ServiceSetPropertiesOptions) (*ServiceSetPropertiesResponse, error) {
+	req, err := client.SetPropertiesCreateRequest(ctx, storageServiceProperties, options)
 	if err != nil {
 		return nil, err
 	}
@@ -395,7 +395,7 @@ func (client *serviceClient) SetProperties(ctx context.Context, storageServicePr
 }
 
 // SetPropertiesCreateRequest creates the SetProperties request.
-func (client *serviceClient) SetPropertiesCreateRequest(ctx context.Context, storageServiceProperties StorageServiceProperties, serviceSetPropertiesOptions *ServiceSetPropertiesOptions) (*azcore.Request, error) {
+func (client *serviceClient) SetPropertiesCreateRequest(ctx context.Context, storageServiceProperties StorageServiceProperties, options *ServiceSetPropertiesOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodPut, client.u)
 	if err != nil {
 		return nil, err
@@ -403,13 +403,13 @@ func (client *serviceClient) SetPropertiesCreateRequest(ctx context.Context, sto
 	query := req.URL.Query()
 	query.Set("restype", "service")
 	query.Set("comp", "properties")
-	if serviceSetPropertiesOptions != nil && serviceSetPropertiesOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceSetPropertiesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceSetPropertiesOptions != nil && serviceSetPropertiesOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceSetPropertiesOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(storageServiceProperties)
@@ -440,8 +440,8 @@ func (client *serviceClient) SetPropertiesHandleError(resp *azcore.Response) err
 }
 
 // SubmitBatch - The Batch operation allows multiple API calls to be embedded into a single HTTP request.
-func (client *serviceClient) SubmitBatch(ctx context.Context, contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, serviceSubmitBatchOptions *ServiceSubmitBatchOptions) (*ServiceSubmitBatchResponse, error) {
-	req, err := client.SubmitBatchCreateRequest(ctx, contentLength, multipartContentType, body, serviceSubmitBatchOptions)
+func (client *serviceClient) SubmitBatch(ctx context.Context, contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, options *ServiceSubmitBatchOptions) (*ServiceSubmitBatchResponse, error) {
+	req, err := client.SubmitBatchCreateRequest(ctx, contentLength, multipartContentType, body, options)
 	if err != nil {
 		return nil, err
 	}
@@ -460,23 +460,23 @@ func (client *serviceClient) SubmitBatch(ctx context.Context, contentLength int6
 }
 
 // SubmitBatchCreateRequest creates the SubmitBatch request.
-func (client *serviceClient) SubmitBatchCreateRequest(ctx context.Context, contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, serviceSubmitBatchOptions *ServiceSubmitBatchOptions) (*azcore.Request, error) {
+func (client *serviceClient) SubmitBatchCreateRequest(ctx context.Context, contentLength int64, multipartContentType string, body azcore.ReadSeekCloser, options *ServiceSubmitBatchOptions) (*azcore.Request, error) {
 	req, err := azcore.NewRequest(ctx, http.MethodPost, client.u)
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
 	query.Set("comp", "batch")
-	if serviceSubmitBatchOptions != nil && serviceSubmitBatchOptions.Timeout != nil {
-		query.Set("timeout", strconv.FormatInt(int64(*serviceSubmitBatchOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		query.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.SkipBodyDownload()
 	req.Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	req.Header.Set("Content-Type", multipartContentType)
 	req.Header.Set("x-ms-version", "2019-07-07")
-	if serviceSubmitBatchOptions != nil && serviceSubmitBatchOptions.RequestId != nil {
-		req.Header.Set("x-ms-client-request-id", *serviceSubmitBatchOptions.RequestId)
+	if options != nil && options.RequestId != nil {
+		req.Header.Set("x-ms-client-request-id", *options.RequestId)
 	}
 	req.Header.Set("Accept", "application/xml")
 	return req, req.MarshalAsXML(body)

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
@@ -23,8 +23,8 @@ func (client *bigDataPoolsClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // Get - Get Big Data Pool
-func (client *bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName string) (*BigDataPoolResourceInfoResponse, error) {
-	req, err := client.GetCreateRequest(ctx, bigDataPoolName)
+func (client *bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName string, options *BigDataPoolsGetOptions) (*BigDataPoolResourceInfoResponse, error) {
+	req, err := client.GetCreateRequest(ctx, bigDataPoolName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName strin
 }
 
 // GetCreateRequest creates the Get request.
-func (client *bigDataPoolsClient) GetCreateRequest(ctx context.Context, bigDataPoolName string) (*azcore.Request, error) {
+func (client *bigDataPoolsClient) GetCreateRequest(ctx context.Context, bigDataPoolName string, options *BigDataPoolsGetOptions) (*azcore.Request, error) {
 	urlPath := "/bigDataPools/{bigDataPoolName}"
 	urlPath = strings.ReplaceAll(urlPath, "{bigDataPoolName}", url.PathEscape(bigDataPoolName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -73,8 +73,8 @@ func (client *bigDataPoolsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - List Big Data Pools
-func (client *bigDataPoolsClient) List(ctx context.Context) (*BigDataPoolResourceInfoListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx)
+func (client *bigDataPoolsClient) List(ctx context.Context, options *BigDataPoolsListOptions) (*BigDataPoolResourceInfoListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (client *bigDataPoolsClient) List(ctx context.Context) (*BigDataPoolResourc
 }
 
 // ListCreateRequest creates the List request.
-func (client *bigDataPoolsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *bigDataPoolsClient) ListCreateRequest(ctx context.Context, options *BigDataPoolsListOptions) (*azcore.Request, error) {
 	urlPath := "/bigDataPools"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
@@ -23,8 +23,8 @@ func (client *dataFlowClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // CreateOrUpdateDataFlow - Creates or updates a data flow.
-func (client *dataFlowClient) CreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, dataFlowCreateOrUpdateDataFlowOptions *DataFlowCreateOrUpdateDataFlowOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateDataFlowCreateRequest(ctx, dataFlowName, dataFlow, dataFlowCreateOrUpdateDataFlowOptions)
+func (client *dataFlowClient) CreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowCreateOrUpdateDataFlowOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateDataFlowCreateRequest(ctx, dataFlowName, dataFlow, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *dataFlowClient) CreateOrUpdateDataFlow(ctx context.Context, dataFl
 }
 
 // CreateOrUpdateDataFlowCreateRequest creates the CreateOrUpdateDataFlow request.
-func (client *dataFlowClient) CreateOrUpdateDataFlowCreateRequest(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, dataFlowCreateOrUpdateDataFlowOptions *DataFlowCreateOrUpdateDataFlowOptions) (*azcore.Request, error) {
+func (client *dataFlowClient) CreateOrUpdateDataFlowCreateRequest(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowCreateOrUpdateDataFlowOptions) (*azcore.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	urlPath = strings.ReplaceAll(urlPath, "{dataFlowName}", url.PathEscape(dataFlowName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -49,8 +49,8 @@ func (client *dataFlowClient) CreateOrUpdateDataFlowCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if dataFlowCreateOrUpdateDataFlowOptions != nil && dataFlowCreateOrUpdateDataFlowOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *dataFlowCreateOrUpdateDataFlowOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(dataFlow)
@@ -72,8 +72,8 @@ func (client *dataFlowClient) CreateOrUpdateDataFlowHandleError(resp *azcore.Res
 }
 
 // DeleteDataFlow - Deletes a data flow.
-func (client *dataFlowClient) DeleteDataFlow(ctx context.Context, dataFlowName string) (*azcore.Response, error) {
-	req, err := client.DeleteDataFlowCreateRequest(ctx, dataFlowName)
+func (client *dataFlowClient) DeleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowDeleteDataFlowOptions) (*azcore.Response, error) {
+	req, err := client.DeleteDataFlowCreateRequest(ctx, dataFlowName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (client *dataFlowClient) DeleteDataFlow(ctx context.Context, dataFlowName s
 }
 
 // DeleteDataFlowCreateRequest creates the DeleteDataFlow request.
-func (client *dataFlowClient) DeleteDataFlowCreateRequest(ctx context.Context, dataFlowName string) (*azcore.Request, error) {
+func (client *dataFlowClient) DeleteDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowDeleteDataFlowOptions) (*azcore.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	urlPath = strings.ReplaceAll(urlPath, "{dataFlowName}", url.PathEscape(dataFlowName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -112,8 +112,8 @@ func (client *dataFlowClient) DeleteDataFlowHandleError(resp *azcore.Response) e
 }
 
 // GetDataFlow - Gets a data flow.
-func (client *dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName string, dataFlowGetDataFlowOptions *DataFlowGetDataFlowOptions) (*DataFlowResourceResponse, error) {
-	req, err := client.GetDataFlowCreateRequest(ctx, dataFlowName, dataFlowGetDataFlowOptions)
+func (client *dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName string, options *DataFlowGetDataFlowOptions) (*DataFlowResourceResponse, error) {
+	req, err := client.GetDataFlowCreateRequest(ctx, dataFlowName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName stri
 }
 
 // GetDataFlowCreateRequest creates the GetDataFlow request.
-func (client *dataFlowClient) GetDataFlowCreateRequest(ctx context.Context, dataFlowName string, dataFlowGetDataFlowOptions *DataFlowGetDataFlowOptions) (*azcore.Request, error) {
+func (client *dataFlowClient) GetDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowGetDataFlowOptions) (*azcore.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	urlPath = strings.ReplaceAll(urlPath, "{dataFlowName}", url.PathEscape(dataFlowName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -142,8 +142,8 @@ func (client *dataFlowClient) GetDataFlowCreateRequest(ctx context.Context, data
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if dataFlowGetDataFlowOptions != nil && dataFlowGetDataFlowOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *dataFlowGetDataFlowOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -165,11 +165,11 @@ func (client *dataFlowClient) GetDataFlowHandleError(resp *azcore.Response) erro
 }
 
 // GetDataFlowsByWorkspace - Lists data flows.
-func (client *dataFlowClient) GetDataFlowsByWorkspace() DataFlowListResponsePager {
+func (client *dataFlowClient) GetDataFlowsByWorkspace(options *DataFlowGetDataFlowsByWorkspaceOptions) DataFlowListResponsePager {
 	return &dataFlowListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetDataFlowsByWorkspaceCreateRequest(ctx)
+			return client.GetDataFlowsByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetDataFlowsByWorkspaceHandleResponse,
 		errorer:   client.GetDataFlowsByWorkspaceHandleError,
@@ -180,7 +180,7 @@ func (client *dataFlowClient) GetDataFlowsByWorkspace() DataFlowListResponsePage
 }
 
 // GetDataFlowsByWorkspaceCreateRequest creates the GetDataFlowsByWorkspace request.
-func (client *dataFlowClient) GetDataFlowsByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *dataFlowClient) GetDataFlowsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowGetDataFlowsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/dataflows"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
@@ -21,8 +21,8 @@ func (client *dataFlowDebugSessionClient) Do(req *azcore.Request) (*azcore.Respo
 }
 
 // AddDataFlow - Add a data flow into debug session.
-func (client *dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, request DataFlowDebugPackage) (*AddDataFlowToDebugSessionResponseResponse, error) {
-	req, err := client.AddDataFlowCreateRequest(ctx, request)
+func (client *dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionAddDataFlowOptions) (*AddDataFlowToDebugSessionResponseResponse, error) {
+	req, err := client.AddDataFlowCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (client *dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, reque
 }
 
 // AddDataFlowCreateRequest creates the AddDataFlow request.
-func (client *dataFlowDebugSessionClient) AddDataFlowCreateRequest(ctx context.Context, request DataFlowDebugPackage) (*azcore.Request, error) {
+func (client *dataFlowDebugSessionClient) AddDataFlowCreateRequest(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionAddDataFlowOptions) (*azcore.Request, error) {
 	urlPath := "/addDataFlowToDebugSession"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -70,8 +70,8 @@ func (client *dataFlowDebugSessionClient) AddDataFlowHandleError(resp *azcore.Re
 }
 
 // CreateDataFlowDebugSession - Creates a data flow debug session.
-func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest) (*azcore.Response, error) {
-	req, err := client.CreateDataFlowDebugSessionCreateRequest(ctx, request)
+func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionCreateDataFlowDebugSessionOptions) (*azcore.Response, error) {
+	req, err := client.CreateDataFlowDebugSessionCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSession(ctx context
 }
 
 // CreateDataFlowDebugSessionCreateRequest creates the CreateDataFlowDebugSession request.
-func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSessionCreateRequest(ctx context.Context, request CreateDataFlowDebugSessionRequest) (*azcore.Request, error) {
+func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSessionCreateRequest(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionCreateDataFlowDebugSessionOptions) (*azcore.Request, error) {
 	urlPath := "/createDataFlowDebugSession"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -115,8 +115,8 @@ func (client *dataFlowDebugSessionClient) CreateDataFlowDebugSessionHandleError(
 }
 
 // DeleteDataFlowDebugSession - Deletes a data flow debug session.
-func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context.Context, request DeleteDataFlowDebugSessionRequest) (*http.Response, error) {
-	req, err := client.DeleteDataFlowDebugSessionCreateRequest(ctx, request)
+func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionDeleteDataFlowDebugSessionOptions) (*http.Response, error) {
+	req, err := client.DeleteDataFlowDebugSessionCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context
 }
 
 // DeleteDataFlowDebugSessionCreateRequest creates the DeleteDataFlowDebugSession request.
-func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSessionCreateRequest(ctx context.Context, request DeleteDataFlowDebugSessionRequest) (*azcore.Request, error) {
+func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSessionCreateRequest(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionDeleteDataFlowDebugSessionOptions) (*azcore.Request, error) {
 	urlPath := "/deleteDataFlowDebugSession"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -154,8 +154,8 @@ func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSessionHandleError(
 }
 
 // ExecuteCommand - Execute a data flow debug command.
-func (client *dataFlowDebugSessionClient) ExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest) (*azcore.Response, error) {
-	req, err := client.ExecuteCommandCreateRequest(ctx, request)
+func (client *dataFlowDebugSessionClient) ExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionExecuteCommandOptions) (*azcore.Response, error) {
+	req, err := client.ExecuteCommandCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (client *dataFlowDebugSessionClient) ExecuteCommand(ctx context.Context, re
 }
 
 // ExecuteCommandCreateRequest creates the ExecuteCommand request.
-func (client *dataFlowDebugSessionClient) ExecuteCommandCreateRequest(ctx context.Context, request DataFlowDebugCommandRequest) (*azcore.Request, error) {
+func (client *dataFlowDebugSessionClient) ExecuteCommandCreateRequest(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionExecuteCommandOptions) (*azcore.Request, error) {
 	urlPath := "/executeDataFlowDebugCommand"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -199,11 +199,11 @@ func (client *dataFlowDebugSessionClient) ExecuteCommandHandleError(resp *azcore
 }
 
 // QueryDataFlowDebugSessionsByWorkspace - Query all active data flow debug sessions.
-func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspace() QueryDataFlowDebugSessionsResponsePager {
+func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspace(options *DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions) QueryDataFlowDebugSessionsResponsePager {
 	return &queryDataFlowDebugSessionsResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.QueryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx)
+			return client.QueryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.QueryDataFlowDebugSessionsByWorkspaceHandleResponse,
 		errorer:   client.QueryDataFlowDebugSessionsByWorkspaceHandleError,
@@ -214,7 +214,7 @@ func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspace(
 }
 
 // QueryDataFlowDebugSessionsByWorkspaceCreateRequest creates the QueryDataFlowDebugSessionsByWorkspace request.
-func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/queryDataFlowDebugSessions"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
@@ -23,8 +23,8 @@ func (client *datasetClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // CreateOrUpdateDataset - Creates or updates a dataset.
-func (client *datasetClient) CreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, datasetCreateOrUpdateDatasetOptions *DatasetCreateOrUpdateDatasetOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateDatasetCreateRequest(ctx, datasetName, dataset, datasetCreateOrUpdateDatasetOptions)
+func (client *datasetClient) CreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetCreateOrUpdateDatasetOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateDatasetCreateRequest(ctx, datasetName, dataset, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *datasetClient) CreateOrUpdateDataset(ctx context.Context, datasetN
 }
 
 // CreateOrUpdateDatasetCreateRequest creates the CreateOrUpdateDataset request.
-func (client *datasetClient) CreateOrUpdateDatasetCreateRequest(ctx context.Context, datasetName string, dataset DatasetResource, datasetCreateOrUpdateDatasetOptions *DatasetCreateOrUpdateDatasetOptions) (*azcore.Request, error) {
+func (client *datasetClient) CreateOrUpdateDatasetCreateRequest(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetCreateOrUpdateDatasetOptions) (*azcore.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{datasetName}", url.PathEscape(datasetName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -49,8 +49,8 @@ func (client *datasetClient) CreateOrUpdateDatasetCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if datasetCreateOrUpdateDatasetOptions != nil && datasetCreateOrUpdateDatasetOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *datasetCreateOrUpdateDatasetOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(dataset)
@@ -72,8 +72,8 @@ func (client *datasetClient) CreateOrUpdateDatasetHandleError(resp *azcore.Respo
 }
 
 // DeleteDataset - Deletes a dataset.
-func (client *datasetClient) DeleteDataset(ctx context.Context, datasetName string) (*azcore.Response, error) {
-	req, err := client.DeleteDatasetCreateRequest(ctx, datasetName)
+func (client *datasetClient) DeleteDataset(ctx context.Context, datasetName string, options *DatasetDeleteDatasetOptions) (*azcore.Response, error) {
+	req, err := client.DeleteDatasetCreateRequest(ctx, datasetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (client *datasetClient) DeleteDataset(ctx context.Context, datasetName stri
 }
 
 // DeleteDatasetCreateRequest creates the DeleteDataset request.
-func (client *datasetClient) DeleteDatasetCreateRequest(ctx context.Context, datasetName string) (*azcore.Request, error) {
+func (client *datasetClient) DeleteDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetDeleteDatasetOptions) (*azcore.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{datasetName}", url.PathEscape(datasetName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -112,8 +112,8 @@ func (client *datasetClient) DeleteDatasetHandleError(resp *azcore.Response) err
 }
 
 // GetDataset - Gets a dataset.
-func (client *datasetClient) GetDataset(ctx context.Context, datasetName string, datasetGetDatasetOptions *DatasetGetDatasetOptions) (*DatasetResourceResponse, error) {
-	req, err := client.GetDatasetCreateRequest(ctx, datasetName, datasetGetDatasetOptions)
+func (client *datasetClient) GetDataset(ctx context.Context, datasetName string, options *DatasetGetDatasetOptions) (*DatasetResourceResponse, error) {
+	req, err := client.GetDatasetCreateRequest(ctx, datasetName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *datasetClient) GetDataset(ctx context.Context, datasetName string,
 }
 
 // GetDatasetCreateRequest creates the GetDataset request.
-func (client *datasetClient) GetDatasetCreateRequest(ctx context.Context, datasetName string, datasetGetDatasetOptions *DatasetGetDatasetOptions) (*azcore.Request, error) {
+func (client *datasetClient) GetDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetGetDatasetOptions) (*azcore.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	urlPath = strings.ReplaceAll(urlPath, "{datasetName}", url.PathEscape(datasetName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -142,8 +142,8 @@ func (client *datasetClient) GetDatasetCreateRequest(ctx context.Context, datase
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if datasetGetDatasetOptions != nil && datasetGetDatasetOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *datasetGetDatasetOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -165,11 +165,11 @@ func (client *datasetClient) GetDatasetHandleError(resp *azcore.Response) error 
 }
 
 // GetDatasetsByWorkspace - Lists datasets.
-func (client *datasetClient) GetDatasetsByWorkspace() DatasetListResponsePager {
+func (client *datasetClient) GetDatasetsByWorkspace(options *DatasetGetDatasetsByWorkspaceOptions) DatasetListResponsePager {
 	return &datasetListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetDatasetsByWorkspaceCreateRequest(ctx)
+			return client.GetDatasetsByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetDatasetsByWorkspaceHandleResponse,
 		errorer:   client.GetDatasetsByWorkspaceHandleError,
@@ -180,7 +180,7 @@ func (client *datasetClient) GetDatasetsByWorkspace() DatasetListResponsePager {
 }
 
 // GetDatasetsByWorkspaceCreateRequest creates the GetDatasetsByWorkspace request.
-func (client *datasetClient) GetDatasetsByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *datasetClient) GetDatasetsByWorkspaceCreateRequest(ctx context.Context, options *DatasetGetDatasetsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/datasets"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
@@ -23,8 +23,8 @@ func (client *integrationRuntimesClient) Do(req *azcore.Request) (*azcore.Respon
 }
 
 // Get - Get Integration Runtime
-func (client *integrationRuntimesClient) Get(ctx context.Context, integrationRuntimeName string) (*IntegrationRuntimeResourceResponse, error) {
-	req, err := client.GetCreateRequest(ctx, integrationRuntimeName)
+func (client *integrationRuntimesClient) Get(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesGetOptions) (*IntegrationRuntimeResourceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, integrationRuntimeName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *integrationRuntimesClient) Get(ctx context.Context, integrationRun
 }
 
 // GetCreateRequest creates the Get request.
-func (client *integrationRuntimesClient) GetCreateRequest(ctx context.Context, integrationRuntimeName string) (*azcore.Request, error) {
+func (client *integrationRuntimesClient) GetCreateRequest(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesGetOptions) (*azcore.Request, error) {
 	urlPath := "/integrationRuntimes/{integrationRuntimeName}"
 	urlPath = strings.ReplaceAll(urlPath, "{integrationRuntimeName}", url.PathEscape(integrationRuntimeName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -73,8 +73,8 @@ func (client *integrationRuntimesClient) GetHandleError(resp *azcore.Response) e
 }
 
 // List - List Integration Runtimes
-func (client *integrationRuntimesClient) List(ctx context.Context) (*IntegrationRuntimeListResponseResponse, error) {
-	req, err := client.ListCreateRequest(ctx)
+func (client *integrationRuntimesClient) List(ctx context.Context, options *IntegrationRuntimesListOptions) (*IntegrationRuntimeListResponseResponse, error) {
+	req, err := client.ListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (client *integrationRuntimesClient) List(ctx context.Context) (*Integration
 }
 
 // ListCreateRequest creates the List request.
-func (client *integrationRuntimesClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *integrationRuntimesClient) ListCreateRequest(ctx context.Context, options *IntegrationRuntimesListOptions) (*azcore.Request, error) {
 	urlPath := "/integrationRuntimes"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
@@ -23,8 +23,8 @@ func (client *linkedServiceClient) Do(req *azcore.Request) (*azcore.Response, er
 }
 
 // CreateOrUpdateLinkedService - Creates or updates a linked service.
-func (client *linkedServiceClient) CreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, linkedServiceCreateOrUpdateLinkedServiceOptions *LinkedServiceCreateOrUpdateLinkedServiceOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateLinkedServiceCreateRequest(ctx, linkedServiceName, linkedService, linkedServiceCreateOrUpdateLinkedServiceOptions)
+func (client *linkedServiceClient) CreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceCreateOrUpdateLinkedServiceOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateLinkedServiceCreateRequest(ctx, linkedServiceName, linkedService, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *linkedServiceClient) CreateOrUpdateLinkedService(ctx context.Conte
 }
 
 // CreateOrUpdateLinkedServiceCreateRequest creates the CreateOrUpdateLinkedService request.
-func (client *linkedServiceClient) CreateOrUpdateLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, linkedServiceCreateOrUpdateLinkedServiceOptions *LinkedServiceCreateOrUpdateLinkedServiceOptions) (*azcore.Request, error) {
+func (client *linkedServiceClient) CreateOrUpdateLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceCreateOrUpdateLinkedServiceOptions) (*azcore.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{linkedServiceName}", url.PathEscape(linkedServiceName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -49,8 +49,8 @@ func (client *linkedServiceClient) CreateOrUpdateLinkedServiceCreateRequest(ctx 
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if linkedServiceCreateOrUpdateLinkedServiceOptions != nil && linkedServiceCreateOrUpdateLinkedServiceOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *linkedServiceCreateOrUpdateLinkedServiceOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(linkedService)
@@ -72,8 +72,8 @@ func (client *linkedServiceClient) CreateOrUpdateLinkedServiceHandleError(resp *
 }
 
 // DeleteLinkedService - Deletes a linked service.
-func (client *linkedServiceClient) DeleteLinkedService(ctx context.Context, linkedServiceName string) (*azcore.Response, error) {
-	req, err := client.DeleteLinkedServiceCreateRequest(ctx, linkedServiceName)
+func (client *linkedServiceClient) DeleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceDeleteLinkedServiceOptions) (*azcore.Response, error) {
+	req, err := client.DeleteLinkedServiceCreateRequest(ctx, linkedServiceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (client *linkedServiceClient) DeleteLinkedService(ctx context.Context, link
 }
 
 // DeleteLinkedServiceCreateRequest creates the DeleteLinkedService request.
-func (client *linkedServiceClient) DeleteLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string) (*azcore.Request, error) {
+func (client *linkedServiceClient) DeleteLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceDeleteLinkedServiceOptions) (*azcore.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{linkedServiceName}", url.PathEscape(linkedServiceName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -112,8 +112,8 @@ func (client *linkedServiceClient) DeleteLinkedServiceHandleError(resp *azcore.R
 }
 
 // GetLinkedService - Gets a linked service.
-func (client *linkedServiceClient) GetLinkedService(ctx context.Context, linkedServiceName string, linkedServiceGetLinkedServiceOptions *LinkedServiceGetLinkedServiceOptions) (*LinkedServiceResourceResponse, error) {
-	req, err := client.GetLinkedServiceCreateRequest(ctx, linkedServiceName, linkedServiceGetLinkedServiceOptions)
+func (client *linkedServiceClient) GetLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceGetLinkedServiceOptions) (*LinkedServiceResourceResponse, error) {
+	req, err := client.GetLinkedServiceCreateRequest(ctx, linkedServiceName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *linkedServiceClient) GetLinkedService(ctx context.Context, linkedS
 }
 
 // GetLinkedServiceCreateRequest creates the GetLinkedService request.
-func (client *linkedServiceClient) GetLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, linkedServiceGetLinkedServiceOptions *LinkedServiceGetLinkedServiceOptions) (*azcore.Request, error) {
+func (client *linkedServiceClient) GetLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceGetLinkedServiceOptions) (*azcore.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	urlPath = strings.ReplaceAll(urlPath, "{linkedServiceName}", url.PathEscape(linkedServiceName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -142,8 +142,8 @@ func (client *linkedServiceClient) GetLinkedServiceCreateRequest(ctx context.Con
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if linkedServiceGetLinkedServiceOptions != nil && linkedServiceGetLinkedServiceOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *linkedServiceGetLinkedServiceOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -165,11 +165,11 @@ func (client *linkedServiceClient) GetLinkedServiceHandleError(resp *azcore.Resp
 }
 
 // GetLinkedServicesByWorkspace - Lists linked services.
-func (client *linkedServiceClient) GetLinkedServicesByWorkspace() LinkedServiceListResponsePager {
+func (client *linkedServiceClient) GetLinkedServicesByWorkspace(options *LinkedServiceGetLinkedServicesByWorkspaceOptions) LinkedServiceListResponsePager {
 	return &linkedServiceListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetLinkedServicesByWorkspaceCreateRequest(ctx)
+			return client.GetLinkedServicesByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetLinkedServicesByWorkspaceHandleResponse,
 		errorer:   client.GetLinkedServicesByWorkspaceHandleError,
@@ -180,7 +180,7 @@ func (client *linkedServiceClient) GetLinkedServicesByWorkspace() LinkedServiceL
 }
 
 // GetLinkedServicesByWorkspaceCreateRequest creates the GetLinkedServicesByWorkspace request.
-func (client *linkedServiceClient) GetLinkedServicesByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *linkedServiceClient) GetLinkedServicesByWorkspaceCreateRequest(ctx context.Context, options *LinkedServiceGetLinkedServicesByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/linkedservices"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -5841,6 +5841,16 @@ func (b *BigDataPoolResourceProperties) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// BigDataPoolsGetOptions contains the optional parameters for the BigDataPools.Get method.
+type BigDataPoolsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// BigDataPoolsListOptions contains the optional parameters for the BigDataPools.List method.
+type BigDataPoolsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Binary dataset.
 type BinaryDataset struct {
 	Dataset
@@ -8553,6 +8563,29 @@ type DataFlowDebugResultResponse struct {
 	Status *string `json:"status,omitempty"`
 }
 
+// DataFlowDebugSessionAddDataFlowOptions contains the optional parameters for the DataFlowDebugSession.AddDataFlow method.
+type DataFlowDebugSessionAddDataFlowOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DataFlowDebugSessionCreateDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSession.CreateDataFlowDebugSession
+// method.
+type DataFlowDebugSessionCreateDataFlowDebugSessionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DataFlowDebugSessionDeleteDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSession.DeleteDataFlowDebugSession
+// method.
+type DataFlowDebugSessionDeleteDataFlowDebugSessionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// DataFlowDebugSessionExecuteCommandOptions contains the optional parameters for the DataFlowDebugSession.ExecuteCommand
+// method.
+type DataFlowDebugSessionExecuteCommandOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Data flow debug session info.
 type DataFlowDebugSessionInfo struct {
 	// Contains additional key/value pairs not defined in the schema.
@@ -8696,6 +8729,12 @@ func (d *DataFlowDebugSessionInfo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the DataFlowDebugSession.QueryDataFlowDebugSessionsByWorkspace
+// method.
+type DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Request body structure for data flow statistics.
 type DataFlowDebugStatisticsRequest struct {
 	// List of column names.
@@ -8711,6 +8750,11 @@ type DataFlowDebugStatisticsRequest struct {
 	StreamName *string `json:"streamName,omitempty"`
 }
 
+// DataFlowDeleteDataFlowOptions contains the optional parameters for the DataFlow.DeleteDataFlow method.
+type DataFlowDeleteDataFlowOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The folder that this data flow is in. If not specified, Data flow will appear at the root level.
 type DataFlowFolder struct {
 	// The name of the folder that this data flow is in.
@@ -8722,6 +8766,11 @@ type DataFlowGetDataFlowOptions struct {
 	// ETag of the data flow entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// DataFlowGetDataFlowsByWorkspaceOptions contains the optional parameters for the DataFlow.GetDataFlowsByWorkspace method.
+type DataFlowGetDataFlowsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A list of data flow resources.
@@ -9444,6 +9493,11 @@ func (d *DatasetDeflateCompression) UnmarshalJSON(data []byte) error {
 	return d.DatasetCompression.unmarshalInternal(rawMsg)
 }
 
+// DatasetDeleteDatasetOptions contains the optional parameters for the Dataset.DeleteDataset method.
+type DatasetDeleteDatasetOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
 type DatasetFolder struct {
 	// The name of the folder that this Dataset is in.
@@ -9493,6 +9547,11 @@ type DatasetGetDatasetOptions struct {
 	// ETag of the dataset entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// DatasetGetDatasetsByWorkspaceOptions contains the optional parameters for the Dataset.GetDatasetsByWorkspace method.
+type DatasetGetDatasetsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A list of dataset resources.
@@ -16824,6 +16883,16 @@ func (i *IntegrationRuntimeVNetProperties) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// IntegrationRuntimesGetOptions contains the optional parameters for the IntegrationRuntimes.Get method.
+type IntegrationRuntimesGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// IntegrationRuntimesListOptions contains the optional parameters for the IntegrationRuntimes.List method.
+type IntegrationRuntimesListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Json dataset.
 type JSONDataset struct {
 	Dataset
@@ -17637,11 +17706,22 @@ type LinkedServiceDebugResource struct {
 	Properties LinkedServiceClassification `json:"properties,omitempty"`
 }
 
+// LinkedServiceDeleteLinkedServiceOptions contains the optional parameters for the LinkedService.DeleteLinkedService method.
+type LinkedServiceDeleteLinkedServiceOptions struct {
+	// placeholder for future optional parameters
+}
+
 // LinkedServiceGetLinkedServiceOptions contains the optional parameters for the LinkedService.GetLinkedService method.
 type LinkedServiceGetLinkedServiceOptions struct {
 	// ETag of the linked service entity. Should only be specified for get. If the ETag matches the existing entity tag, or if
 	// * was provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// LinkedServiceGetLinkedServicesByWorkspaceOptions contains the optional parameters for the LinkedService.GetLinkedServicesByWorkspace
+// method.
+type LinkedServiceGetLinkedServicesByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A list of linked service resources.
@@ -19769,11 +19849,27 @@ type NotebookCreateOrUpdateNotebookOptions struct {
 	IfMatch *string
 }
 
+// NotebookDeleteNotebookOptions contains the optional parameters for the Notebook.DeleteNotebook method.
+type NotebookDeleteNotebookOptions struct {
+	// placeholder for future optional parameters
+}
+
 // NotebookGetNotebookOptions contains the optional parameters for the Notebook.GetNotebook method.
 type NotebookGetNotebookOptions struct {
 	// ETag of the Notebook entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// NotebookGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the Notebook.GetNotebookSummaryByWorkSpace
+// method.
+type NotebookGetNotebookSummaryByWorkSpaceOptions struct {
+	// placeholder for future optional parameters
+}
+
+// NotebookGetNotebooksByWorkspaceOptions contains the optional parameters for the Notebook.GetNotebooksByWorkspace method.
+type NotebookGetNotebooksByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Kernel information.
@@ -21989,6 +22085,11 @@ type PipelineCreatePipelineRunOptions struct {
 	StartActivityName *string
 }
 
+// PipelineDeletePipelineOptions contains the optional parameters for the Pipeline.DeletePipeline method.
+type PipelineDeletePipelineOptions struct {
+	// placeholder for future optional parameters
+}
+
 // The folder that this Pipeline is in. If not specified, Pipeline will appear at the root level.
 type PipelineFolder struct {
 	// The name of the folder that this Pipeline is in.
@@ -22000,6 +22101,11 @@ type PipelineGetPipelineOptions struct {
 	// ETag of the pipeline entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// PipelineGetPipelinesByWorkspaceOptions contains the optional parameters for the Pipeline.GetPipelinesByWorkspace method.
+type PipelineGetPipelinesByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A list of pipeline resources.
@@ -22305,6 +22411,11 @@ type PipelineRunCancelPipelineRunOptions struct {
 	IsRecursive *bool
 }
 
+// PipelineRunGetPipelineRunOptions contains the optional parameters for the PipelineRun.GetPipelineRun method.
+type PipelineRunGetPipelineRunOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Provides entity name and id that started the pipeline run.
 type PipelineRunInvokedBy struct {
 	// The ID of the entity that started the run.
@@ -22315,6 +22426,17 @@ type PipelineRunInvokedBy struct {
 
 	// Name of the entity that started the pipeline run.
 	Name *string `json:"name,omitempty" azure:"ro"`
+}
+
+// PipelineRunQueryActivityRunsOptions contains the optional parameters for the PipelineRun.QueryActivityRuns method.
+type PipelineRunQueryActivityRunsOptions struct {
+	// placeholder for future optional parameters
+}
+
+// PipelineRunQueryPipelineRunsByWorkspaceOptions contains the optional parameters for the PipelineRun.QueryPipelineRunsByWorkspace
+// method.
+type PipelineRunQueryPipelineRunsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // PipelineRunResponse is the response envelope for operations that return a PipelineRun type.
@@ -24907,6 +25029,16 @@ type SQLPoolStoredProcedureActivityTypeProperties struct {
 	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
+// SQLPoolsGetOptions contains the optional parameters for the SQLPools.Get method.
+type SQLPoolsGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SQLPoolsListOptions contains the optional parameters for the SQLPools.List method.
+type SQLPoolsListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SQL script.
 type SQLScript struct {
 	// Contains additional key/value pairs not defined in the schema.
@@ -25068,11 +25200,21 @@ type SQLScriptCreateOrUpdateSQLScriptOptions struct {
 	IfMatch *string
 }
 
+// SQLScriptDeleteSQLScriptOptions contains the optional parameters for the SQLScript.DeleteSQLScript method.
+type SQLScriptDeleteSQLScriptOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SQLScriptGetSQLScriptOptions contains the optional parameters for the SQLScript.GetSQLScript method.
 type SQLScriptGetSQLScriptOptions struct {
 	// ETag of the sql compute entity. Should only be specified for get. If the ETag matches the existing entity tag, or if *
 	// was provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// SQLScriptGetSQLScriptsByWorkspaceOptions contains the optional parameters for the SQLScript.GetSQLScriptsByWorkspace method.
+type SQLScriptGetSQLScriptsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // The metadata of the SQL script.
@@ -29194,12 +29336,36 @@ type SparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions struct {
 	IfMatch *string
 }
 
+// SparkJobDefinitionDebugSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinition.DebugSparkJobDefinition
+// method.
+type SparkJobDefinitionDebugSparkJobDefinitionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkJobDefinitionDeleteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinition.DeleteSparkJobDefinition
+// method.
+type SparkJobDefinitionDeleteSparkJobDefinitionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkJobDefinitionExecuteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinition.ExecuteSparkJobDefinition
+// method.
+type SparkJobDefinitionExecuteSparkJobDefinitionOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SparkJobDefinitionGetSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinition.GetSparkJobDefinition
 // method.
 type SparkJobDefinitionGetSparkJobDefinitionOptions struct {
 	// ETag of the Spark Job Definition entity. Should only be specified for get. If the ETag matches the existing entity tag,
 	// or if * was provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the SparkJobDefinition.GetSparkJobDefinitionsByWorkspace
+// method.
+type SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Spark job definition resource type.
@@ -31600,6 +31766,11 @@ type TriggerCreateOrUpdateTriggerOptions struct {
 	IfMatch *string
 }
 
+// TriggerDeleteTriggerOptions contains the optional parameters for the Trigger.DeleteTrigger method.
+type TriggerDeleteTriggerOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Defines the response of a provision trigger dependency operation.
 type TriggerDependencyProvisioningStatus struct {
 	// Provisioning status.
@@ -31667,11 +31838,21 @@ func (t *TriggerDependencyReference) unmarshalInternal(rawMsg map[string]*json.R
 	return t.DependencyReference.unmarshalInternal(rawMsg)
 }
 
+// TriggerGetEventSubscriptionStatusOptions contains the optional parameters for the Trigger.GetEventSubscriptionStatus method.
+type TriggerGetEventSubscriptionStatusOptions struct {
+	// placeholder for future optional parameters
+}
+
 // TriggerGetTriggerOptions contains the optional parameters for the Trigger.GetTrigger method.
 type TriggerGetTriggerOptions struct {
 	// ETag of the trigger entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
+}
+
+// TriggerGetTriggersByWorkspaceOptions contains the optional parameters for the Trigger.GetTriggersByWorkspace method.
+type TriggerGetTriggersByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // A list of trigger resources.
@@ -31872,6 +32053,22 @@ func (t *TriggerRun) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// TriggerRunCancelTriggerInstanceOptions contains the optional parameters for the TriggerRun.CancelTriggerInstance method.
+type TriggerRunCancelTriggerInstanceOptions struct {
+	// placeholder for future optional parameters
+}
+
+// TriggerRunQueryTriggerRunsByWorkspaceOptions contains the optional parameters for the TriggerRun.QueryTriggerRunsByWorkspace
+// method.
+type TriggerRunQueryTriggerRunsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
+}
+
+// TriggerRunRerunTriggerInstanceOptions contains the optional parameters for the TriggerRun.RerunTriggerInstance method.
+type TriggerRunRerunTriggerInstanceOptions struct {
+	// placeholder for future optional parameters
+}
+
 // A list of trigger runs.
 type TriggerRunsQueryResponse struct {
 	// The continuation token for getting the next page of results, if any remaining results exist, null otherwise.
@@ -31888,6 +32085,21 @@ type TriggerRunsQueryResponseResponse struct {
 
 	// A list of trigger runs.
 	TriggerRunsQueryResponse *TriggerRunsQueryResponse
+}
+
+// TriggerStartTriggerOptions contains the optional parameters for the Trigger.StartTrigger method.
+type TriggerStartTriggerOptions struct {
+	// placeholder for future optional parameters
+}
+
+// TriggerStopTriggerOptions contains the optional parameters for the Trigger.StopTrigger method.
+type TriggerStopTriggerOptions struct {
+	// placeholder for future optional parameters
+}
+
+// TriggerSubscribeTriggerToEventsOptions contains the optional parameters for the Trigger.SubscribeTriggerToEvents method.
+type TriggerSubscribeTriggerToEventsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Defines the response of a trigger subscription operation.
@@ -31920,6 +32132,12 @@ type TriggerSubscriptionOperationStatusResponse struct {
 
 	// Defines the response of a trigger subscription operation.
 	TriggerSubscriptionOperationStatus *TriggerSubscriptionOperationStatus
+}
+
+// TriggerUnsubscribeTriggerFromEventsOptions contains the optional parameters for the Trigger.UnsubscribeTriggerFromEvents
+// method.
+type TriggerUnsubscribeTriggerFromEventsOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Trigger that schedules pipeline runs for all fixed time interval windows from a start time without gaps and also supports
@@ -32963,6 +33181,11 @@ type Workspace struct {
 
 	// Workspace resource properties
 	Properties *WorkspaceProperties `json:"properties,omitempty"`
+}
+
+// WorkspaceGetOptions contains the optional parameters for the Workspace.Get method.
+type WorkspaceGetOptions struct {
+	// placeholder for future optional parameters
 }
 
 // Identity properties of the workspace resource.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
@@ -23,8 +23,8 @@ func (client *notebookClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // CreateOrUpdateNotebook - Creates or updates a Note Book.
-func (client *notebookClient) CreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, notebookCreateOrUpdateNotebookOptions *NotebookCreateOrUpdateNotebookOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateNotebookCreateRequest(ctx, notebookName, notebook, notebookCreateOrUpdateNotebookOptions)
+func (client *notebookClient) CreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookCreateOrUpdateNotebookOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateNotebookCreateRequest(ctx, notebookName, notebook, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *notebookClient) CreateOrUpdateNotebook(ctx context.Context, notebo
 }
 
 // CreateOrUpdateNotebookCreateRequest creates the CreateOrUpdateNotebook request.
-func (client *notebookClient) CreateOrUpdateNotebookCreateRequest(ctx context.Context, notebookName string, notebook NotebookResource, notebookCreateOrUpdateNotebookOptions *NotebookCreateOrUpdateNotebookOptions) (*azcore.Request, error) {
+func (client *notebookClient) CreateOrUpdateNotebookCreateRequest(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookCreateOrUpdateNotebookOptions) (*azcore.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	urlPath = strings.ReplaceAll(urlPath, "{notebookName}", url.PathEscape(notebookName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -49,8 +49,8 @@ func (client *notebookClient) CreateOrUpdateNotebookCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if notebookCreateOrUpdateNotebookOptions != nil && notebookCreateOrUpdateNotebookOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *notebookCreateOrUpdateNotebookOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(notebook)
@@ -72,8 +72,8 @@ func (client *notebookClient) CreateOrUpdateNotebookHandleError(resp *azcore.Res
 }
 
 // DeleteNotebook - Deletes a Note book.
-func (client *notebookClient) DeleteNotebook(ctx context.Context, notebookName string) (*azcore.Response, error) {
-	req, err := client.DeleteNotebookCreateRequest(ctx, notebookName)
+func (client *notebookClient) DeleteNotebook(ctx context.Context, notebookName string, options *NotebookDeleteNotebookOptions) (*azcore.Response, error) {
+	req, err := client.DeleteNotebookCreateRequest(ctx, notebookName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (client *notebookClient) DeleteNotebook(ctx context.Context, notebookName s
 }
 
 // DeleteNotebookCreateRequest creates the DeleteNotebook request.
-func (client *notebookClient) DeleteNotebookCreateRequest(ctx context.Context, notebookName string) (*azcore.Request, error) {
+func (client *notebookClient) DeleteNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookDeleteNotebookOptions) (*azcore.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	urlPath = strings.ReplaceAll(urlPath, "{notebookName}", url.PathEscape(notebookName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -112,8 +112,8 @@ func (client *notebookClient) DeleteNotebookHandleError(resp *azcore.Response) e
 }
 
 // GetNotebook - Gets a Note Book.
-func (client *notebookClient) GetNotebook(ctx context.Context, notebookName string, notebookGetNotebookOptions *NotebookGetNotebookOptions) (*NotebookResourceResponse, error) {
-	req, err := client.GetNotebookCreateRequest(ctx, notebookName, notebookGetNotebookOptions)
+func (client *notebookClient) GetNotebook(ctx context.Context, notebookName string, options *NotebookGetNotebookOptions) (*NotebookResourceResponse, error) {
+	req, err := client.GetNotebookCreateRequest(ctx, notebookName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *notebookClient) GetNotebook(ctx context.Context, notebookName stri
 }
 
 // GetNotebookCreateRequest creates the GetNotebook request.
-func (client *notebookClient) GetNotebookCreateRequest(ctx context.Context, notebookName string, notebookGetNotebookOptions *NotebookGetNotebookOptions) (*azcore.Request, error) {
+func (client *notebookClient) GetNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookGetNotebookOptions) (*azcore.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	urlPath = strings.ReplaceAll(urlPath, "{notebookName}", url.PathEscape(notebookName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -142,8 +142,8 @@ func (client *notebookClient) GetNotebookCreateRequest(ctx context.Context, note
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if notebookGetNotebookOptions != nil && notebookGetNotebookOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *notebookGetNotebookOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -165,11 +165,11 @@ func (client *notebookClient) GetNotebookHandleError(resp *azcore.Response) erro
 }
 
 // GetNotebookSummaryByWorkSpace - Lists a summary of Notebooks.
-func (client *notebookClient) GetNotebookSummaryByWorkSpace() NotebookListResponsePager {
+func (client *notebookClient) GetNotebookSummaryByWorkSpace(options *NotebookGetNotebookSummaryByWorkSpaceOptions) NotebookListResponsePager {
 	return &notebookListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetNotebookSummaryByWorkSpaceCreateRequest(ctx)
+			return client.GetNotebookSummaryByWorkSpaceCreateRequest(ctx, options)
 		},
 		responder: client.GetNotebookSummaryByWorkSpaceHandleResponse,
 		errorer:   client.GetNotebookSummaryByWorkSpaceHandleError,
@@ -180,7 +180,7 @@ func (client *notebookClient) GetNotebookSummaryByWorkSpace() NotebookListRespon
 }
 
 // GetNotebookSummaryByWorkSpaceCreateRequest creates the GetNotebookSummaryByWorkSpace request.
-func (client *notebookClient) GetNotebookSummaryByWorkSpaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *notebookClient) GetNotebookSummaryByWorkSpaceCreateRequest(ctx context.Context, options *NotebookGetNotebookSummaryByWorkSpaceOptions) (*azcore.Request, error) {
 	urlPath := "/notebooks/summary"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -209,11 +209,11 @@ func (client *notebookClient) GetNotebookSummaryByWorkSpaceHandleError(resp *azc
 }
 
 // GetNotebooksByWorkspace - Lists Notebooks.
-func (client *notebookClient) GetNotebooksByWorkspace() NotebookListResponsePager {
+func (client *notebookClient) GetNotebooksByWorkspace(options *NotebookGetNotebooksByWorkspaceOptions) NotebookListResponsePager {
 	return &notebookListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetNotebooksByWorkspaceCreateRequest(ctx)
+			return client.GetNotebooksByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetNotebooksByWorkspaceHandleResponse,
 		errorer:   client.GetNotebooksByWorkspaceHandleError,
@@ -224,7 +224,7 @@ func (client *notebookClient) GetNotebooksByWorkspace() NotebookListResponsePage
 }
 
 // GetNotebooksByWorkspaceCreateRequest creates the GetNotebooksByWorkspace request.
-func (client *notebookClient) GetNotebooksByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *notebookClient) GetNotebooksByWorkspaceCreateRequest(ctx context.Context, options *NotebookGetNotebooksByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/notebooks"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
@@ -24,8 +24,8 @@ func (client *pipelineClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // CreateOrUpdatePipeline - Creates or updates a pipeline.
-func (client *pipelineClient) CreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, pipelineCreateOrUpdatePipelineOptions *PipelineCreateOrUpdatePipelineOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdatePipelineCreateRequest(ctx, pipelineName, pipeline, pipelineCreateOrUpdatePipelineOptions)
+func (client *pipelineClient) CreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineCreateOrUpdatePipelineOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdatePipelineCreateRequest(ctx, pipelineName, pipeline, options)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (client *pipelineClient) CreateOrUpdatePipeline(ctx context.Context, pipeli
 }
 
 // CreateOrUpdatePipelineCreateRequest creates the CreateOrUpdatePipeline request.
-func (client *pipelineClient) CreateOrUpdatePipelineCreateRequest(ctx context.Context, pipelineName string, pipeline PipelineResource, pipelineCreateOrUpdatePipelineOptions *PipelineCreateOrUpdatePipelineOptions) (*azcore.Request, error) {
+func (client *pipelineClient) CreateOrUpdatePipelineCreateRequest(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineCreateOrUpdatePipelineOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	urlPath = strings.ReplaceAll(urlPath, "{pipelineName}", url.PathEscape(pipelineName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -50,8 +50,8 @@ func (client *pipelineClient) CreateOrUpdatePipelineCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if pipelineCreateOrUpdatePipelineOptions != nil && pipelineCreateOrUpdatePipelineOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *pipelineCreateOrUpdatePipelineOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(pipeline)
@@ -73,8 +73,8 @@ func (client *pipelineClient) CreateOrUpdatePipelineHandleError(resp *azcore.Res
 }
 
 // CreatePipelineRun - Creates a run of a pipeline.
-func (client *pipelineClient) CreatePipelineRun(ctx context.Context, pipelineName string, pipelineCreatePipelineRunOptions *PipelineCreatePipelineRunOptions) (*CreateRunResponseResponse, error) {
-	req, err := client.CreatePipelineRunCreateRequest(ctx, pipelineName, pipelineCreatePipelineRunOptions)
+func (client *pipelineClient) CreatePipelineRun(ctx context.Context, pipelineName string, options *PipelineCreatePipelineRunOptions) (*CreateRunResponseResponse, error) {
+	req, err := client.CreatePipelineRunCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (client *pipelineClient) CreatePipelineRun(ctx context.Context, pipelineNam
 }
 
 // CreatePipelineRunCreateRequest creates the CreatePipelineRun request.
-func (client *pipelineClient) CreatePipelineRunCreateRequest(ctx context.Context, pipelineName string, pipelineCreatePipelineRunOptions *PipelineCreatePipelineRunOptions) (*azcore.Request, error) {
+func (client *pipelineClient) CreatePipelineRunCreateRequest(ctx context.Context, pipelineName string, options *PipelineCreatePipelineRunOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines/{pipelineName}/createRun"
 	urlPath = strings.ReplaceAll(urlPath, "{pipelineName}", url.PathEscape(pipelineName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -102,19 +102,19 @@ func (client *pipelineClient) CreatePipelineRunCreateRequest(ctx context.Context
 	}
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
-	if pipelineCreatePipelineRunOptions != nil && pipelineCreatePipelineRunOptions.ReferencePipelineRunId != nil {
-		query.Set("referencePipelineRunId", *pipelineCreatePipelineRunOptions.ReferencePipelineRunId)
+	if options != nil && options.ReferencePipelineRunId != nil {
+		query.Set("referencePipelineRunId", *options.ReferencePipelineRunId)
 	}
-	if pipelineCreatePipelineRunOptions != nil && pipelineCreatePipelineRunOptions.IsRecovery != nil {
-		query.Set("isRecovery", strconv.FormatBool(*pipelineCreatePipelineRunOptions.IsRecovery))
+	if options != nil && options.IsRecovery != nil {
+		query.Set("isRecovery", strconv.FormatBool(*options.IsRecovery))
 	}
-	if pipelineCreatePipelineRunOptions != nil && pipelineCreatePipelineRunOptions.StartActivityName != nil {
-		query.Set("startActivityName", *pipelineCreatePipelineRunOptions.StartActivityName)
+	if options != nil && options.StartActivityName != nil {
+		query.Set("startActivityName", *options.StartActivityName)
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if pipelineCreatePipelineRunOptions != nil {
-		return req, req.MarshalAsJSON(pipelineCreatePipelineRunOptions.Parameters)
+	if options != nil {
+		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil
 }
@@ -135,8 +135,8 @@ func (client *pipelineClient) CreatePipelineRunHandleError(resp *azcore.Response
 }
 
 // DeletePipeline - Deletes a pipeline.
-func (client *pipelineClient) DeletePipeline(ctx context.Context, pipelineName string) (*azcore.Response, error) {
-	req, err := client.DeletePipelineCreateRequest(ctx, pipelineName)
+func (client *pipelineClient) DeletePipeline(ctx context.Context, pipelineName string, options *PipelineDeletePipelineOptions) (*azcore.Response, error) {
+	req, err := client.DeletePipelineCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (client *pipelineClient) DeletePipeline(ctx context.Context, pipelineName s
 }
 
 // DeletePipelineCreateRequest creates the DeletePipeline request.
-func (client *pipelineClient) DeletePipelineCreateRequest(ctx context.Context, pipelineName string) (*azcore.Request, error) {
+func (client *pipelineClient) DeletePipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineDeletePipelineOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	urlPath = strings.ReplaceAll(urlPath, "{pipelineName}", url.PathEscape(pipelineName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -175,8 +175,8 @@ func (client *pipelineClient) DeletePipelineHandleError(resp *azcore.Response) e
 }
 
 // GetPipeline - Gets a pipeline.
-func (client *pipelineClient) GetPipeline(ctx context.Context, pipelineName string, pipelineGetPipelineOptions *PipelineGetPipelineOptions) (*PipelineResourceResponse, error) {
-	req, err := client.GetPipelineCreateRequest(ctx, pipelineName, pipelineGetPipelineOptions)
+func (client *pipelineClient) GetPipeline(ctx context.Context, pipelineName string, options *PipelineGetPipelineOptions) (*PipelineResourceResponse, error) {
+	req, err := client.GetPipelineCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (client *pipelineClient) GetPipeline(ctx context.Context, pipelineName stri
 }
 
 // GetPipelineCreateRequest creates the GetPipeline request.
-func (client *pipelineClient) GetPipelineCreateRequest(ctx context.Context, pipelineName string, pipelineGetPipelineOptions *PipelineGetPipelineOptions) (*azcore.Request, error) {
+func (client *pipelineClient) GetPipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineGetPipelineOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	urlPath = strings.ReplaceAll(urlPath, "{pipelineName}", url.PathEscape(pipelineName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -205,8 +205,8 @@ func (client *pipelineClient) GetPipelineCreateRequest(ctx context.Context, pipe
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if pipelineGetPipelineOptions != nil && pipelineGetPipelineOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *pipelineGetPipelineOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -228,11 +228,11 @@ func (client *pipelineClient) GetPipelineHandleError(resp *azcore.Response) erro
 }
 
 // GetPipelinesByWorkspace - Lists pipelines.
-func (client *pipelineClient) GetPipelinesByWorkspace() PipelineListResponsePager {
+func (client *pipelineClient) GetPipelinesByWorkspace(options *PipelineGetPipelinesByWorkspaceOptions) PipelineListResponsePager {
 	return &pipelineListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetPipelinesByWorkspaceCreateRequest(ctx)
+			return client.GetPipelinesByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetPipelinesByWorkspaceHandleResponse,
 		errorer:   client.GetPipelinesByWorkspaceHandleError,
@@ -243,7 +243,7 @@ func (client *pipelineClient) GetPipelinesByWorkspace() PipelineListResponsePage
 }
 
 // GetPipelinesByWorkspaceCreateRequest creates the GetPipelinesByWorkspace request.
-func (client *pipelineClient) GetPipelinesByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *pipelineClient) GetPipelinesByWorkspaceCreateRequest(ctx context.Context, options *PipelineGetPipelinesByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
@@ -24,8 +24,8 @@ func (client *pipelineRunClient) Do(req *azcore.Request) (*azcore.Response, erro
 }
 
 // CancelPipelineRun - Cancel a pipeline run by its run ID.
-func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runId string, pipelineRunCancelPipelineRunOptions *PipelineRunCancelPipelineRunOptions) (*http.Response, error) {
-	req, err := client.CancelPipelineRunCreateRequest(ctx, runId, pipelineRunCancelPipelineRunOptions)
+func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runId string, options *PipelineRunCancelPipelineRunOptions) (*http.Response, error) {
+	req, err := client.CancelPipelineRunCreateRequest(ctx, runId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runId st
 }
 
 // CancelPipelineRunCreateRequest creates the CancelPipelineRun request.
-func (client *pipelineRunClient) CancelPipelineRunCreateRequest(ctx context.Context, runId string, pipelineRunCancelPipelineRunOptions *PipelineRunCancelPipelineRunOptions) (*azcore.Request, error) {
+func (client *pipelineRunClient) CancelPipelineRunCreateRequest(ctx context.Context, runId string, options *PipelineRunCancelPipelineRunOptions) (*azcore.Request, error) {
 	urlPath := "/pipelineruns/{runId}/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{runId}", url.PathEscape(runId))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -48,8 +48,8 @@ func (client *pipelineRunClient) CancelPipelineRunCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	query := req.URL.Query()
-	if pipelineRunCancelPipelineRunOptions != nil && pipelineRunCancelPipelineRunOptions.IsRecursive != nil {
-		query.Set("isRecursive", strconv.FormatBool(*pipelineRunCancelPipelineRunOptions.IsRecursive))
+	if options != nil && options.IsRecursive != nil {
+		query.Set("isRecursive", strconv.FormatBool(*options.IsRecursive))
 	}
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
@@ -67,8 +67,8 @@ func (client *pipelineRunClient) CancelPipelineRunHandleError(resp *azcore.Respo
 }
 
 // GetPipelineRun - Get a pipeline run by its run ID.
-func (client *pipelineRunClient) GetPipelineRun(ctx context.Context, runId string) (*PipelineRunResponse, error) {
-	req, err := client.GetPipelineRunCreateRequest(ctx, runId)
+func (client *pipelineRunClient) GetPipelineRun(ctx context.Context, runId string, options *PipelineRunGetPipelineRunOptions) (*PipelineRunResponse, error) {
+	req, err := client.GetPipelineRunCreateRequest(ctx, runId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (client *pipelineRunClient) GetPipelineRun(ctx context.Context, runId strin
 }
 
 // GetPipelineRunCreateRequest creates the GetPipelineRun request.
-func (client *pipelineRunClient) GetPipelineRunCreateRequest(ctx context.Context, runId string) (*azcore.Request, error) {
+func (client *pipelineRunClient) GetPipelineRunCreateRequest(ctx context.Context, runId string, options *PipelineRunGetPipelineRunOptions) (*azcore.Request, error) {
 	urlPath := "/pipelineruns/{runId}"
 	urlPath = strings.ReplaceAll(urlPath, "{runId}", url.PathEscape(runId))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -117,8 +117,8 @@ func (client *pipelineRunClient) GetPipelineRunHandleError(resp *azcore.Response
 }
 
 // QueryActivityRuns - Query activity runs based on input filter conditions.
-func (client *pipelineRunClient) QueryActivityRuns(ctx context.Context, pipelineName string, runId string, filterParameters RunFilterParameters) (*ActivityRunsQueryResponseResponse, error) {
-	req, err := client.QueryActivityRunsCreateRequest(ctx, pipelineName, runId, filterParameters)
+func (client *pipelineRunClient) QueryActivityRuns(ctx context.Context, pipelineName string, runId string, filterParameters RunFilterParameters, options *PipelineRunQueryActivityRunsOptions) (*ActivityRunsQueryResponseResponse, error) {
+	req, err := client.QueryActivityRunsCreateRequest(ctx, pipelineName, runId, filterParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (client *pipelineRunClient) QueryActivityRuns(ctx context.Context, pipeline
 }
 
 // QueryActivityRunsCreateRequest creates the QueryActivityRuns request.
-func (client *pipelineRunClient) QueryActivityRunsCreateRequest(ctx context.Context, pipelineName string, runId string, filterParameters RunFilterParameters) (*azcore.Request, error) {
+func (client *pipelineRunClient) QueryActivityRunsCreateRequest(ctx context.Context, pipelineName string, runId string, filterParameters RunFilterParameters, options *PipelineRunQueryActivityRunsOptions) (*azcore.Request, error) {
 	urlPath := "/pipelines/{pipelineName}/pipelineruns/{runId}/queryActivityruns"
 	urlPath = strings.ReplaceAll(urlPath, "{pipelineName}", url.PathEscape(pipelineName))
 	urlPath = strings.ReplaceAll(urlPath, "{runId}", url.PathEscape(runId))
@@ -168,8 +168,8 @@ func (client *pipelineRunClient) QueryActivityRunsHandleError(resp *azcore.Respo
 }
 
 // QueryPipelineRunsByWorkspace - Query pipeline runs in the workspace based on input filter conditions.
-func (client *pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters) (*PipelineRunsQueryResponseResponse, error) {
-	req, err := client.QueryPipelineRunsByWorkspaceCreateRequest(ctx, filterParameters)
+func (client *pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunQueryPipelineRunsByWorkspaceOptions) (*PipelineRunsQueryResponseResponse, error) {
+	req, err := client.QueryPipelineRunsByWorkspaceCreateRequest(ctx, filterParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (client *pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Contex
 }
 
 // QueryPipelineRunsByWorkspaceCreateRequest creates the QueryPipelineRunsByWorkspace request.
-func (client *pipelineRunClient) QueryPipelineRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters) (*azcore.Request, error) {
+func (client *pipelineRunClient) QueryPipelineRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunQueryPipelineRunsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/queryPipelineRuns"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
@@ -23,8 +23,8 @@ func (client *sparkJobDefinitionClient) Do(req *azcore.Request) (*azcore.Respons
 }
 
 // CreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
-func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions *SparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions) (*SparkJobDefinitionResourceResponse, error) {
-	req, err := client.CreateOrUpdateSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, sparkJobDefinition, sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions)
+func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions) (*SparkJobDefinitionResourceResponse, error) {
+	req, err := client.CreateOrUpdateSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, sparkJobDefinition, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinition(ctx con
 }
 
 // CreateOrUpdateSparkJobDefinitionCreateRequest creates the CreateOrUpdateSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions *SparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions) (*azcore.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sparkJobDefinitionName}", url.PathEscape(sparkJobDefinitionName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -53,8 +53,8 @@ func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinitionCreateRe
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions != nil && sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *sparkJobDefinitionCreateOrUpdateSparkJobDefinitionOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(sparkJobDefinition)
@@ -76,8 +76,8 @@ func (client *sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinitionHandleEr
 }
 
 // DebugSparkJobDefinition - Debug the spark job definition.
-func (client *sparkJobDefinitionClient) DebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource) (*azcore.Response, error) {
-	req, err := client.DebugSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionAzureResource)
+func (client *sparkJobDefinitionClient) DebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionDebugSparkJobDefinitionOptions) (*azcore.Response, error) {
+	req, err := client.DebugSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionAzureResource, options)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (client *sparkJobDefinitionClient) DebugSparkJobDefinition(ctx context.Cont
 }
 
 // DebugSparkJobDefinitionCreateRequest creates the DebugSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) DebugSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) DebugSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionDebugSparkJobDefinitionOptions) (*azcore.Request, error) {
 	urlPath := "/debugSparkJobDefinition"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -121,8 +121,8 @@ func (client *sparkJobDefinitionClient) DebugSparkJobDefinitionHandleError(resp 
 }
 
 // DeleteSparkJobDefinition - Deletes a Spark Job Definition.
-func (client *sparkJobDefinitionClient) DeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string) (*http.Response, error) {
-	req, err := client.DeleteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName)
+func (client *sparkJobDefinitionClient) DeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionDeleteSparkJobDefinitionOptions) (*http.Response, error) {
+	req, err := client.DeleteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (client *sparkJobDefinitionClient) DeleteSparkJobDefinition(ctx context.Con
 }
 
 // DeleteSparkJobDefinitionCreateRequest creates the DeleteSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) DeleteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) DeleteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionDeleteSparkJobDefinitionOptions) (*azcore.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sparkJobDefinitionName}", url.PathEscape(sparkJobDefinitionName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -161,8 +161,8 @@ func (client *sparkJobDefinitionClient) DeleteSparkJobDefinitionHandleError(resp
 }
 
 // ExecuteSparkJobDefinition - Executes the spark job definition.
-func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string) (*azcore.Response, error) {
-	req, err := client.ExecuteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName)
+func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionExecuteSparkJobDefinitionOptions) (*azcore.Response, error) {
+	req, err := client.ExecuteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinition(ctx context.Co
 }
 
 // ExecuteSparkJobDefinitionCreateRequest creates the ExecuteSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionExecuteSparkJobDefinitionOptions) (*azcore.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}/execute"
 	urlPath = strings.ReplaceAll(urlPath, "{sparkJobDefinitionName}", url.PathEscape(sparkJobDefinitionName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -207,8 +207,8 @@ func (client *sparkJobDefinitionClient) ExecuteSparkJobDefinitionHandleError(res
 }
 
 // GetSparkJobDefinition - Gets a Spark Job Definition.
-func (client *sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinitionGetSparkJobDefinitionOptions *SparkJobDefinitionGetSparkJobDefinitionOptions) (*SparkJobDefinitionResourceResponse, error) {
-	req, err := client.GetSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, sparkJobDefinitionGetSparkJobDefinitionOptions)
+func (client *sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionGetSparkJobDefinitionOptions) (*SparkJobDefinitionResourceResponse, error) {
+	req, err := client.GetSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Contex
 }
 
 // GetSparkJobDefinitionCreateRequest creates the GetSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) GetSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinitionGetSparkJobDefinitionOptions *SparkJobDefinitionGetSparkJobDefinitionOptions) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) GetSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionGetSparkJobDefinitionOptions) (*azcore.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sparkJobDefinitionName}", url.PathEscape(sparkJobDefinitionName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -237,8 +237,8 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionCreateRequest(ctx c
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if sparkJobDefinitionGetSparkJobDefinitionOptions != nil && sparkJobDefinitionGetSparkJobDefinitionOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *sparkJobDefinitionGetSparkJobDefinitionOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -260,11 +260,11 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionHandleError(resp *a
 }
 
 // GetSparkJobDefinitionsByWorkspace - Lists spark job definitions.
-func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspace() SparkJobDefinitionsListResponsePager {
+func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspace(options *SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceOptions) SparkJobDefinitionsListResponsePager {
 	return &sparkJobDefinitionsListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetSparkJobDefinitionsByWorkspaceCreateRequest(ctx)
+			return client.GetSparkJobDefinitionsByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetSparkJobDefinitionsByWorkspaceHandleResponse,
 		errorer:   client.GetSparkJobDefinitionsByWorkspaceHandleError,
@@ -275,7 +275,7 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspace() Spar
 }
 
 // GetSparkJobDefinitionsByWorkspaceCreateRequest creates the GetSparkJobDefinitionsByWorkspace request.
-func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspaceCreateRequest(ctx context.Context, options *SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/sparkJobDefinitions"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
@@ -23,8 +23,8 @@ func (client *sqlPoolsClient) Do(req *azcore.Request) (*azcore.Response, error) 
 }
 
 // Get - Get Sql Pool
-func (client *sqlPoolsClient) Get(ctx context.Context, sqlPoolName string) (*SQLPoolResponse, error) {
-	req, err := client.GetCreateRequest(ctx, sqlPoolName)
+func (client *sqlPoolsClient) Get(ctx context.Context, sqlPoolName string, options *SQLPoolsGetOptions) (*SQLPoolResponse, error) {
+	req, err := client.GetCreateRequest(ctx, sqlPoolName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *sqlPoolsClient) Get(ctx context.Context, sqlPoolName string) (*SQL
 }
 
 // GetCreateRequest creates the Get request.
-func (client *sqlPoolsClient) GetCreateRequest(ctx context.Context, sqlPoolName string) (*azcore.Request, error) {
+func (client *sqlPoolsClient) GetCreateRequest(ctx context.Context, sqlPoolName string, options *SQLPoolsGetOptions) (*azcore.Request, error) {
 	urlPath := "/sqlPools/{sqlPoolName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sqlPoolName}", url.PathEscape(sqlPoolName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -73,8 +73,8 @@ func (client *sqlPoolsClient) GetHandleError(resp *azcore.Response) error {
 }
 
 // List - List Sql Pools
-func (client *sqlPoolsClient) List(ctx context.Context) (*SQLPoolInfoListResultResponse, error) {
-	req, err := client.ListCreateRequest(ctx)
+func (client *sqlPoolsClient) List(ctx context.Context, options *SQLPoolsListOptions) (*SQLPoolInfoListResultResponse, error) {
+	req, err := client.ListCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (client *sqlPoolsClient) List(ctx context.Context) (*SQLPoolInfoListResultR
 }
 
 // ListCreateRequest creates the List request.
-func (client *sqlPoolsClient) ListCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *sqlPoolsClient) ListCreateRequest(ctx context.Context, options *SQLPoolsListOptions) (*azcore.Request, error) {
 	urlPath := "/sqlPools"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
@@ -23,8 +23,8 @@ func (client *sqlScriptClient) Do(req *azcore.Request) (*azcore.Response, error)
 }
 
 // CreateOrUpdateSQLScript - Creates or updates a Sql Script.
-func (client *sqlScriptClient) CreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, sqlScriptCreateOrUpdateSqlscriptOptions *SQLScriptCreateOrUpdateSQLScriptOptions) (*SQLScriptResourceResponse, error) {
-	req, err := client.CreateOrUpdateSQLScriptCreateRequest(ctx, sqlScriptName, sqlScript, sqlScriptCreateOrUpdateSqlscriptOptions)
+func (client *sqlScriptClient) CreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptCreateOrUpdateSQLScriptOptions) (*SQLScriptResourceResponse, error) {
+	req, err := client.CreateOrUpdateSQLScriptCreateRequest(ctx, sqlScriptName, sqlScript, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *sqlScriptClient) CreateOrUpdateSQLScript(ctx context.Context, sqlS
 }
 
 // CreateOrUpdateSQLScriptCreateRequest creates the CreateOrUpdateSQLScript request.
-func (client *sqlScriptClient) CreateOrUpdateSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, sqlScriptCreateOrUpdateSqlscriptOptions *SQLScriptCreateOrUpdateSQLScriptOptions) (*azcore.Request, error) {
+func (client *sqlScriptClient) CreateOrUpdateSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptCreateOrUpdateSQLScriptOptions) (*azcore.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sqlScriptName}", url.PathEscape(sqlScriptName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -53,8 +53,8 @@ func (client *sqlScriptClient) CreateOrUpdateSQLScriptCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if sqlScriptCreateOrUpdateSqlscriptOptions != nil && sqlScriptCreateOrUpdateSqlscriptOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *sqlScriptCreateOrUpdateSqlscriptOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(sqlScript)
@@ -76,8 +76,8 @@ func (client *sqlScriptClient) CreateOrUpdateSQLScriptHandleError(resp *azcore.R
 }
 
 // DeleteSQLScript - Deletes a Sql Script.
-func (client *sqlScriptClient) DeleteSQLScript(ctx context.Context, sqlScriptName string) (*http.Response, error) {
-	req, err := client.DeleteSQLScriptCreateRequest(ctx, sqlScriptName)
+func (client *sqlScriptClient) DeleteSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptDeleteSQLScriptOptions) (*http.Response, error) {
+	req, err := client.DeleteSQLScriptCreateRequest(ctx, sqlScriptName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (client *sqlScriptClient) DeleteSQLScript(ctx context.Context, sqlScriptNam
 }
 
 // DeleteSQLScriptCreateRequest creates the DeleteSQLScript request.
-func (client *sqlScriptClient) DeleteSQLScriptCreateRequest(ctx context.Context, sqlScriptName string) (*azcore.Request, error) {
+func (client *sqlScriptClient) DeleteSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SQLScriptDeleteSQLScriptOptions) (*azcore.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sqlScriptName}", url.PathEscape(sqlScriptName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -116,8 +116,8 @@ func (client *sqlScriptClient) DeleteSQLScriptHandleError(resp *azcore.Response)
 }
 
 // GetSQLScript - Gets a sql script.
-func (client *sqlScriptClient) GetSQLScript(ctx context.Context, sqlScriptName string, sqlScriptGetSqlscriptOptions *SQLScriptGetSQLScriptOptions) (*SQLScriptResourceResponse, error) {
-	req, err := client.GetSQLScriptCreateRequest(ctx, sqlScriptName, sqlScriptGetSqlscriptOptions)
+func (client *sqlScriptClient) GetSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptGetSQLScriptOptions) (*SQLScriptResourceResponse, error) {
+	req, err := client.GetSQLScriptCreateRequest(ctx, sqlScriptName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (client *sqlScriptClient) GetSQLScript(ctx context.Context, sqlScriptName s
 }
 
 // GetSQLScriptCreateRequest creates the GetSQLScript request.
-func (client *sqlScriptClient) GetSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, sqlScriptGetSqlscriptOptions *SQLScriptGetSQLScriptOptions) (*azcore.Request, error) {
+func (client *sqlScriptClient) GetSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SQLScriptGetSQLScriptOptions) (*azcore.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	urlPath = strings.ReplaceAll(urlPath, "{sqlScriptName}", url.PathEscape(sqlScriptName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -146,8 +146,8 @@ func (client *sqlScriptClient) GetSQLScriptCreateRequest(ctx context.Context, sq
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if sqlScriptGetSqlscriptOptions != nil && sqlScriptGetSqlscriptOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *sqlScriptGetSqlscriptOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -169,11 +169,11 @@ func (client *sqlScriptClient) GetSQLScriptHandleError(resp *azcore.Response) er
 }
 
 // GetSQLScriptsByWorkspace - Lists sql scripts.
-func (client *sqlScriptClient) GetSQLScriptsByWorkspace() SQLScriptsListResponsePager {
+func (client *sqlScriptClient) GetSQLScriptsByWorkspace(options *SQLScriptGetSQLScriptsByWorkspaceOptions) SQLScriptsListResponsePager {
 	return &sqlScriptsListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetSQLScriptsByWorkspaceCreateRequest(ctx)
+			return client.GetSQLScriptsByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetSQLScriptsByWorkspaceHandleResponse,
 		errorer:   client.GetSQLScriptsByWorkspaceHandleError,
@@ -184,7 +184,7 @@ func (client *sqlScriptClient) GetSQLScriptsByWorkspace() SQLScriptsListResponse
 }
 
 // GetSQLScriptsByWorkspaceCreateRequest creates the GetSQLScriptsByWorkspace request.
-func (client *sqlScriptClient) GetSQLScriptsByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *sqlScriptClient) GetSQLScriptsByWorkspaceCreateRequest(ctx context.Context, options *SQLScriptGetSQLScriptsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/sqlScripts"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
@@ -23,8 +23,8 @@ func (client *triggerClient) Do(req *azcore.Request) (*azcore.Response, error) {
 }
 
 // CreateOrUpdateTrigger - Creates or updates a trigger.
-func (client *triggerClient) CreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, triggerCreateOrUpdateTriggerOptions *TriggerCreateOrUpdateTriggerOptions) (*azcore.Response, error) {
-	req, err := client.CreateOrUpdateTriggerCreateRequest(ctx, triggerName, trigger, triggerCreateOrUpdateTriggerOptions)
+func (client *triggerClient) CreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerCreateOrUpdateTriggerOptions) (*azcore.Response, error) {
+	req, err := client.CreateOrUpdateTriggerCreateRequest(ctx, triggerName, trigger, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *triggerClient) CreateOrUpdateTrigger(ctx context.Context, triggerN
 }
 
 // CreateOrUpdateTriggerCreateRequest creates the CreateOrUpdateTrigger request.
-func (client *triggerClient) CreateOrUpdateTriggerCreateRequest(ctx context.Context, triggerName string, trigger TriggerResource, triggerCreateOrUpdateTriggerOptions *TriggerCreateOrUpdateTriggerOptions) (*azcore.Request, error) {
+func (client *triggerClient) CreateOrUpdateTriggerCreateRequest(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerCreateOrUpdateTriggerOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))
@@ -49,8 +49,8 @@ func (client *triggerClient) CreateOrUpdateTriggerCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if triggerCreateOrUpdateTriggerOptions != nil && triggerCreateOrUpdateTriggerOptions.IfMatch != nil {
-		req.Header.Set("If-Match", *triggerCreateOrUpdateTriggerOptions.IfMatch)
+	if options != nil && options.IfMatch != nil {
+		req.Header.Set("If-Match", *options.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(trigger)
@@ -72,8 +72,8 @@ func (client *triggerClient) CreateOrUpdateTriggerHandleError(resp *azcore.Respo
 }
 
 // DeleteTrigger - Deletes a trigger.
-func (client *triggerClient) DeleteTrigger(ctx context.Context, triggerName string) (*azcore.Response, error) {
-	req, err := client.DeleteTriggerCreateRequest(ctx, triggerName)
+func (client *triggerClient) DeleteTrigger(ctx context.Context, triggerName string, options *TriggerDeleteTriggerOptions) (*azcore.Response, error) {
+	req, err := client.DeleteTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (client *triggerClient) DeleteTrigger(ctx context.Context, triggerName stri
 }
 
 // DeleteTriggerCreateRequest creates the DeleteTrigger request.
-func (client *triggerClient) DeleteTriggerCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) DeleteTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerDeleteTriggerOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -112,8 +112,8 @@ func (client *triggerClient) DeleteTriggerHandleError(resp *azcore.Response) err
 }
 
 // GetEventSubscriptionStatus - Get a trigger's event subscription status.
-func (client *triggerClient) GetEventSubscriptionStatus(ctx context.Context, triggerName string) (*TriggerSubscriptionOperationStatusResponse, error) {
-	req, err := client.GetEventSubscriptionStatusCreateRequest(ctx, triggerName)
+func (client *triggerClient) GetEventSubscriptionStatus(ctx context.Context, triggerName string, options *TriggerGetEventSubscriptionStatusOptions) (*TriggerSubscriptionOperationStatusResponse, error) {
+	req, err := client.GetEventSubscriptionStatusCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (client *triggerClient) GetEventSubscriptionStatus(ctx context.Context, tri
 }
 
 // GetEventSubscriptionStatusCreateRequest creates the GetEventSubscriptionStatus request.
-func (client *triggerClient) GetEventSubscriptionStatusCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) GetEventSubscriptionStatusCreateRequest(ctx context.Context, triggerName string, options *TriggerGetEventSubscriptionStatusOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/getEventSubscriptionStatus"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -162,8 +162,8 @@ func (client *triggerClient) GetEventSubscriptionStatusHandleError(resp *azcore.
 }
 
 // GetTrigger - Gets a trigger.
-func (client *triggerClient) GetTrigger(ctx context.Context, triggerName string, triggerGetTriggerOptions *TriggerGetTriggerOptions) (*TriggerResourceResponse, error) {
-	req, err := client.GetTriggerCreateRequest(ctx, triggerName, triggerGetTriggerOptions)
+func (client *triggerClient) GetTrigger(ctx context.Context, triggerName string, options *TriggerGetTriggerOptions) (*TriggerResourceResponse, error) {
+	req, err := client.GetTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (client *triggerClient) GetTrigger(ctx context.Context, triggerName string,
 }
 
 // GetTriggerCreateRequest creates the GetTrigger request.
-func (client *triggerClient) GetTriggerCreateRequest(ctx context.Context, triggerName string, triggerGetTriggerOptions *TriggerGetTriggerOptions) (*azcore.Request, error) {
+func (client *triggerClient) GetTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerGetTriggerOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -192,8 +192,8 @@ func (client *triggerClient) GetTriggerCreateRequest(ctx context.Context, trigge
 	query := req.URL.Query()
 	query.Set("api-version", "2019-06-01-preview")
 	req.URL.RawQuery = query.Encode()
-	if triggerGetTriggerOptions != nil && triggerGetTriggerOptions.IfNoneMatch != nil {
-		req.Header.Set("If-None-Match", *triggerGetTriggerOptions.IfNoneMatch)
+	if options != nil && options.IfNoneMatch != nil {
+		req.Header.Set("If-None-Match", *options.IfNoneMatch)
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
@@ -215,11 +215,11 @@ func (client *triggerClient) GetTriggerHandleError(resp *azcore.Response) error 
 }
 
 // GetTriggersByWorkspace - Lists triggers.
-func (client *triggerClient) GetTriggersByWorkspace() TriggerListResponsePager {
+func (client *triggerClient) GetTriggersByWorkspace(options *TriggerGetTriggersByWorkspaceOptions) TriggerListResponsePager {
 	return &triggerListResponsePager{
 		pipeline: client.p,
 		requester: func(ctx context.Context) (*azcore.Request, error) {
-			return client.GetTriggersByWorkspaceCreateRequest(ctx)
+			return client.GetTriggersByWorkspaceCreateRequest(ctx, options)
 		},
 		responder: client.GetTriggersByWorkspaceHandleResponse,
 		errorer:   client.GetTriggersByWorkspaceHandleError,
@@ -230,7 +230,7 @@ func (client *triggerClient) GetTriggersByWorkspace() TriggerListResponsePager {
 }
 
 // GetTriggersByWorkspaceCreateRequest creates the GetTriggersByWorkspace request.
-func (client *triggerClient) GetTriggersByWorkspaceCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *triggerClient) GetTriggersByWorkspaceCreateRequest(ctx context.Context, options *TriggerGetTriggersByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/triggers"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -259,8 +259,8 @@ func (client *triggerClient) GetTriggersByWorkspaceHandleError(resp *azcore.Resp
 }
 
 // StartTrigger - Starts a trigger.
-func (client *triggerClient) StartTrigger(ctx context.Context, triggerName string) (*azcore.Response, error) {
-	req, err := client.StartTriggerCreateRequest(ctx, triggerName)
+func (client *triggerClient) StartTrigger(ctx context.Context, triggerName string, options *TriggerStartTriggerOptions) (*azcore.Response, error) {
+	req, err := client.StartTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (client *triggerClient) StartTrigger(ctx context.Context, triggerName strin
 }
 
 // StartTriggerCreateRequest creates the StartTrigger request.
-func (client *triggerClient) StartTriggerCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) StartTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerStartTriggerOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/start"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -299,8 +299,8 @@ func (client *triggerClient) StartTriggerHandleError(resp *azcore.Response) erro
 }
 
 // StopTrigger - Stops a trigger.
-func (client *triggerClient) StopTrigger(ctx context.Context, triggerName string) (*azcore.Response, error) {
-	req, err := client.StopTriggerCreateRequest(ctx, triggerName)
+func (client *triggerClient) StopTrigger(ctx context.Context, triggerName string, options *TriggerStopTriggerOptions) (*azcore.Response, error) {
+	req, err := client.StopTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (client *triggerClient) StopTrigger(ctx context.Context, triggerName string
 }
 
 // StopTriggerCreateRequest creates the StopTrigger request.
-func (client *triggerClient) StopTriggerCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) StopTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerStopTriggerOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/stop"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -339,8 +339,8 @@ func (client *triggerClient) StopTriggerHandleError(resp *azcore.Response) error
 }
 
 // SubscribeTriggerToEvents - Subscribe event trigger to events.
-func (client *triggerClient) SubscribeTriggerToEvents(ctx context.Context, triggerName string) (*azcore.Response, error) {
-	req, err := client.SubscribeTriggerToEventsCreateRequest(ctx, triggerName)
+func (client *triggerClient) SubscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerSubscribeTriggerToEventsOptions) (*azcore.Response, error) {
+	req, err := client.SubscribeTriggerToEventsCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (client *triggerClient) SubscribeTriggerToEvents(ctx context.Context, trigg
 }
 
 // SubscribeTriggerToEventsCreateRequest creates the SubscribeTriggerToEvents request.
-func (client *triggerClient) SubscribeTriggerToEventsCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) SubscribeTriggerToEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerSubscribeTriggerToEventsOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/subscribeToEvents"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -385,8 +385,8 @@ func (client *triggerClient) SubscribeTriggerToEventsHandleError(resp *azcore.Re
 }
 
 // UnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.
-func (client *triggerClient) UnsubscribeTriggerFromEvents(ctx context.Context, triggerName string) (*azcore.Response, error) {
-	req, err := client.UnsubscribeTriggerFromEventsCreateRequest(ctx, triggerName)
+func (client *triggerClient) UnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerUnsubscribeTriggerFromEventsOptions) (*azcore.Response, error) {
+	req, err := client.UnsubscribeTriggerFromEventsCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +401,7 @@ func (client *triggerClient) UnsubscribeTriggerFromEvents(ctx context.Context, t
 }
 
 // UnsubscribeTriggerFromEventsCreateRequest creates the UnsubscribeTriggerFromEvents request.
-func (client *triggerClient) UnsubscribeTriggerFromEventsCreateRequest(ctx context.Context, triggerName string) (*azcore.Request, error) {
+func (client *triggerClient) UnsubscribeTriggerFromEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerUnsubscribeTriggerFromEventsOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/unsubscribeFromEvents"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
@@ -23,8 +23,8 @@ func (client *triggerRunClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // CancelTriggerInstance - Cancel single trigger instance by runId.
-func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, triggerName string, runId string) (*http.Response, error) {
-	req, err := client.CancelTriggerInstanceCreateRequest(ctx, triggerName, runId)
+func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, triggerName string, runId string, options *TriggerRunCancelTriggerInstanceOptions) (*http.Response, error) {
+	req, err := client.CancelTriggerInstanceCreateRequest(ctx, triggerName, runId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, trigg
 }
 
 // CancelTriggerInstanceCreateRequest creates the CancelTriggerInstance request.
-func (client *triggerRunClient) CancelTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runId string) (*azcore.Request, error) {
+func (client *triggerRunClient) CancelTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runId string, options *TriggerRunCancelTriggerInstanceOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/triggerRuns/{runId}/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	urlPath = strings.ReplaceAll(urlPath, "{runId}", url.PathEscape(runId))
@@ -64,8 +64,8 @@ func (client *triggerRunClient) CancelTriggerInstanceHandleError(resp *azcore.Re
 }
 
 // QueryTriggerRunsByWorkspace - Query trigger runs.
-func (client *triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters) (*TriggerRunsQueryResponseResponse, error) {
-	req, err := client.QueryTriggerRunsByWorkspaceCreateRequest(ctx, filterParameters)
+func (client *triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunQueryTriggerRunsByWorkspaceOptions) (*TriggerRunsQueryResponseResponse, error) {
+	req, err := client.QueryTriggerRunsByWorkspaceCreateRequest(ctx, filterParameters, options)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (client *triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context,
 }
 
 // QueryTriggerRunsByWorkspaceCreateRequest creates the QueryTriggerRunsByWorkspace request.
-func (client *triggerRunClient) QueryTriggerRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters) (*azcore.Request, error) {
+func (client *triggerRunClient) QueryTriggerRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunQueryTriggerRunsByWorkspaceOptions) (*azcore.Request, error) {
 	urlPath := "/queryTriggerRuns"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
@@ -113,8 +113,8 @@ func (client *triggerRunClient) QueryTriggerRunsByWorkspaceHandleError(resp *azc
 }
 
 // RerunTriggerInstance - Rerun single trigger instance by runId.
-func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, triggerName string, runId string) (*http.Response, error) {
-	req, err := client.RerunTriggerInstanceCreateRequest(ctx, triggerName, runId)
+func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, triggerName string, runId string, options *TriggerRunRerunTriggerInstanceOptions) (*http.Response, error) {
+	req, err := client.RerunTriggerInstanceCreateRequest(ctx, triggerName, runId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, trigge
 }
 
 // RerunTriggerInstanceCreateRequest creates the RerunTriggerInstance request.
-func (client *triggerRunClient) RerunTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runId string) (*azcore.Request, error) {
+func (client *triggerRunClient) RerunTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runId string, options *TriggerRunRerunTriggerInstanceOptions) (*azcore.Request, error) {
 	urlPath := "/triggers/{triggerName}/triggerRuns/{runId}/rerun"
 	urlPath = strings.ReplaceAll(urlPath, "{triggerName}", url.PathEscape(triggerName))
 	urlPath = strings.ReplaceAll(urlPath, "{runId}", url.PathEscape(runId))

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
@@ -21,8 +21,8 @@ func (client *workspaceClient) Do(req *azcore.Request) (*azcore.Response, error)
 }
 
 // Get - Get Workspace
-func (client *workspaceClient) Get(ctx context.Context) (*WorkspaceResponse, error) {
-	req, err := client.GetCreateRequest(ctx)
+func (client *workspaceClient) Get(ctx context.Context, options *WorkspaceGetOptions) (*WorkspaceResponse, error) {
+	req, err := client.GetCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (client *workspaceClient) Get(ctx context.Context) (*WorkspaceResponse, err
 }
 
 // GetCreateRequest creates the Get request.
-func (client *workspaceClient) GetCreateRequest(ctx context.Context) (*azcore.Request, error) {
+func (client *workspaceClient) GetCreateRequest(ctx context.Context, options *WorkspaceGetOptions) (*azcore.Request, error) {
 	urlPath := "/workspace"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -11,6 +11,11 @@ import (
 	"time"
 )
 
+// SparkBatchCancelSparkBatchJobOptions contains the optional parameters for the SparkBatch.CancelSparkBatchJob method.
+type SparkBatchCancelSparkBatchJobOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SparkBatchCreateSparkBatchJobOptions contains the optional parameters for the SparkBatch.CreateSparkBatchJob method.
 type SparkBatchCreateSparkBatchJobOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
@@ -498,6 +503,16 @@ type SparkSession struct {
 	WorkspaceName *string            `json:"workspaceName,omitempty"`
 }
 
+// SparkSessionCancelSparkSessionOptions contains the optional parameters for the SparkSession.CancelSparkSession method.
+type SparkSessionCancelSparkSessionOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionCancelSparkStatementOptions contains the optional parameters for the SparkSession.CancelSparkStatement method.
+type SparkSessionCancelSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
 type SparkSessionCollection struct {
 	From     *int32          `json:"from,omitempty"`
 	Sessions *[]SparkSession `json:"sessions,omitempty"`
@@ -517,6 +532,11 @@ type SparkSessionCreateSparkSessionOptions struct {
 	Detailed *bool
 }
 
+// SparkSessionCreateSparkStatementOptions contains the optional parameters for the SparkSession.CreateSparkStatement method.
+type SparkSessionCreateSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SparkSessionGetSparkSessionOptions contains the optional parameters for the SparkSession.GetSparkSession method.
 type SparkSessionGetSparkSessionOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
@@ -532,6 +552,16 @@ type SparkSessionGetSparkSessionsOptions struct {
 	// Optional param specifying the size of the returned list.
 	// By default it is 20 and that is the maximum.
 	Size *int32
+}
+
+// SparkSessionGetSparkStatementOptions contains the optional parameters for the SparkSession.GetSparkStatement method.
+type SparkSessionGetSparkStatementOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SparkSessionGetSparkStatementsOptions contains the optional parameters for the SparkSession.GetSparkStatements method.
+type SparkSessionGetSparkStatementsOptions struct {
+	// placeholder for future optional parameters
 }
 
 type SparkSessionOptions struct {
@@ -555,6 +585,12 @@ type SparkSessionOptions struct {
 
 	// Dictionary of <string>
 	Tags *map[string]string `json:"tags,omitempty"`
+}
+
+// SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the SparkSession.ResetSparkSessionTimeout
+// method.
+type SparkSessionResetSparkSessionTimeoutOptions struct {
+	// placeholder for future optional parameters
 }
 
 // SparkSessionResponse is the response envelope for operations that return a SparkSession type.

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
@@ -27,8 +27,8 @@ func (client *sparkBatchClient) Do(req *azcore.Request) (*azcore.Response, error
 }
 
 // CancelSparkBatchJob - Cancels a running spark batch job.
-func (client *sparkBatchClient) CancelSparkBatchJob(ctx context.Context, batchId int32) (*http.Response, error) {
-	req, err := client.CancelSparkBatchJobCreateRequest(ctx, batchId)
+func (client *sparkBatchClient) CancelSparkBatchJob(ctx context.Context, batchId int32, options *SparkBatchCancelSparkBatchJobOptions) (*http.Response, error) {
+	req, err := client.CancelSparkBatchJobCreateRequest(ctx, batchId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *sparkBatchClient) CancelSparkBatchJob(ctx context.Context, batchId
 }
 
 // CancelSparkBatchJobCreateRequest creates the CancelSparkBatchJob request.
-func (client *sparkBatchClient) CancelSparkBatchJobCreateRequest(ctx context.Context, batchId int32) (*azcore.Request, error) {
+func (client *sparkBatchClient) CancelSparkBatchJobCreateRequest(ctx context.Context, batchId int32, options *SparkBatchCancelSparkBatchJobOptions) (*azcore.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -66,8 +66,8 @@ func (client *sparkBatchClient) CancelSparkBatchJobHandleError(resp *azcore.Resp
 }
 
 // CreateSparkBatchJob - Create new spark batch job.
-func (client *sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, sparkBatchCreateSparkBatchJobOptions *SparkBatchCreateSparkBatchJobOptions) (*SparkBatchJobResponse, error) {
-	req, err := client.CreateSparkBatchJobCreateRequest(ctx, sparkBatchJobOptions, sparkBatchCreateSparkBatchJobOptions)
+func (client *sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (*SparkBatchJobResponse, error) {
+	req, err := client.CreateSparkBatchJobCreateRequest(ctx, sparkBatchJobOptions, options)
 	if err != nil {
 		return nil, err
 	}
@@ -86,15 +86,15 @@ func (client *sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBa
 }
 
 // CreateSparkBatchJobCreateRequest creates the CreateSparkBatchJob request.
-func (client *sparkBatchClient) CreateSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, sparkBatchCreateSparkBatchJobOptions *SparkBatchCreateSparkBatchJobOptions) (*azcore.Request, error) {
+func (client *sparkBatchClient) CreateSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions SparkBatchJobOptions, options *SparkBatchCreateSparkBatchJobOptions) (*azcore.Request, error) {
 	urlPath := "/batches"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkBatchCreateSparkBatchJobOptions != nil && sparkBatchCreateSparkBatchJobOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkBatchCreateSparkBatchJobOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -120,8 +120,8 @@ func (client *sparkBatchClient) CreateSparkBatchJobHandleError(resp *azcore.Resp
 }
 
 // GetSparkBatchJob - Gets a single spark batch job.
-func (client *sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchId int32, sparkBatchGetSparkBatchJobOptions *SparkBatchGetSparkBatchJobOptions) (*SparkBatchJobResponse, error) {
-	req, err := client.GetSparkBatchJobCreateRequest(ctx, batchId, sparkBatchGetSparkBatchJobOptions)
+func (client *sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchId int32, options *SparkBatchGetSparkBatchJobOptions) (*SparkBatchJobResponse, error) {
+	req, err := client.GetSparkBatchJobCreateRequest(ctx, batchId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (client *sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchId in
 }
 
 // GetSparkBatchJobCreateRequest creates the GetSparkBatchJob request.
-func (client *sparkBatchClient) GetSparkBatchJobCreateRequest(ctx context.Context, batchId int32, sparkBatchGetSparkBatchJobOptions *SparkBatchGetSparkBatchJobOptions) (*azcore.Request, error) {
+func (client *sparkBatchClient) GetSparkBatchJobCreateRequest(ctx context.Context, batchId int32, options *SparkBatchGetSparkBatchJobOptions) (*azcore.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -148,8 +148,8 @@ func (client *sparkBatchClient) GetSparkBatchJobCreateRequest(ctx context.Contex
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkBatchGetSparkBatchJobOptions != nil && sparkBatchGetSparkBatchJobOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkBatchGetSparkBatchJobOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -175,8 +175,8 @@ func (client *sparkBatchClient) GetSparkBatchJobHandleError(resp *azcore.Respons
 }
 
 // GetSparkBatchJobs - List all spark batch jobs which are running under a particular spark pool.
-func (client *sparkBatchClient) GetSparkBatchJobs(ctx context.Context, sparkBatchGetSparkBatchJobsOptions *SparkBatchGetSparkBatchJobsOptions) (*SparkBatchJobCollectionResponse, error) {
-	req, err := client.GetSparkBatchJobsCreateRequest(ctx, sparkBatchGetSparkBatchJobsOptions)
+func (client *sparkBatchClient) GetSparkBatchJobs(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (*SparkBatchJobCollectionResponse, error) {
+	req, err := client.GetSparkBatchJobsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -195,21 +195,21 @@ func (client *sparkBatchClient) GetSparkBatchJobs(ctx context.Context, sparkBatc
 }
 
 // GetSparkBatchJobsCreateRequest creates the GetSparkBatchJobs request.
-func (client *sparkBatchClient) GetSparkBatchJobsCreateRequest(ctx context.Context, sparkBatchGetSparkBatchJobsOptions *SparkBatchGetSparkBatchJobsOptions) (*azcore.Request, error) {
+func (client *sparkBatchClient) GetSparkBatchJobsCreateRequest(ctx context.Context, options *SparkBatchGetSparkBatchJobsOptions) (*azcore.Request, error) {
 	urlPath := "/batches"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkBatchGetSparkBatchJobsOptions != nil && sparkBatchGetSparkBatchJobsOptions.From != nil {
-		query.Set("from", strconv.FormatInt(int64(*sparkBatchGetSparkBatchJobsOptions.From), 10))
+	if options != nil && options.From != nil {
+		query.Set("from", strconv.FormatInt(int64(*options.From), 10))
 	}
-	if sparkBatchGetSparkBatchJobsOptions != nil && sparkBatchGetSparkBatchJobsOptions.Size != nil {
-		query.Set("size", strconv.FormatInt(int64(*sparkBatchGetSparkBatchJobsOptions.Size), 10))
+	if options != nil && options.Size != nil {
+		query.Set("size", strconv.FormatInt(int64(*options.Size), 10))
 	}
-	if sparkBatchGetSparkBatchJobsOptions != nil && sparkBatchGetSparkBatchJobsOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkBatchGetSparkBatchJobsOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
@@ -27,8 +27,8 @@ func (client *sparkSessionClient) Do(req *azcore.Request) (*azcore.Response, err
 }
 
 // CancelSparkSession - Cancels a running spark session.
-func (client *sparkSessionClient) CancelSparkSession(ctx context.Context, sessionId int32) (*http.Response, error) {
-	req, err := client.CancelSparkSessionCreateRequest(ctx, sessionId)
+func (client *sparkSessionClient) CancelSparkSession(ctx context.Context, sessionId int32, options *SparkSessionCancelSparkSessionOptions) (*http.Response, error) {
+	req, err := client.CancelSparkSessionCreateRequest(ctx, sessionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (client *sparkSessionClient) CancelSparkSession(ctx context.Context, sessio
 }
 
 // CancelSparkSessionCreateRequest creates the CancelSparkSession request.
-func (client *sparkSessionClient) CancelSparkSessionCreateRequest(ctx context.Context, sessionId int32) (*azcore.Request, error) {
+func (client *sparkSessionClient) CancelSparkSessionCreateRequest(ctx context.Context, sessionId int32, options *SparkSessionCancelSparkSessionOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodDelete, azcore.JoinPaths(client.u, urlPath))
@@ -66,8 +66,8 @@ func (client *sparkSessionClient) CancelSparkSessionHandleError(resp *azcore.Res
 }
 
 // CancelSparkStatement - Kill a statement within a session.
-func (client *sparkSessionClient) CancelSparkStatement(ctx context.Context, sessionId int32, statementId int32) (*SparkStatementCancellationResultResponse, error) {
-	req, err := client.CancelSparkStatementCreateRequest(ctx, sessionId, statementId)
+func (client *sparkSessionClient) CancelSparkStatement(ctx context.Context, sessionId int32, statementId int32, options *SparkSessionCancelSparkStatementOptions) (*SparkStatementCancellationResultResponse, error) {
+	req, err := client.CancelSparkStatementCreateRequest(ctx, sessionId, statementId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (client *sparkSessionClient) CancelSparkStatement(ctx context.Context, sess
 }
 
 // CancelSparkStatementCreateRequest creates the CancelSparkStatement request.
-func (client *sparkSessionClient) CancelSparkStatementCreateRequest(ctx context.Context, sessionId int32, statementId int32) (*azcore.Request, error) {
+func (client *sparkSessionClient) CancelSparkStatementCreateRequest(ctx context.Context, sessionId int32, statementId int32, options *SparkSessionCancelSparkStatementOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementId), 10)))
@@ -117,8 +117,8 @@ func (client *sparkSessionClient) CancelSparkStatementHandleError(resp *azcore.R
 }
 
 // CreateSparkSession - Create new spark session.
-func (client *sparkSessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SparkSessionOptions, sparkSessionCreateSparkSessionOptions *SparkSessionCreateSparkSessionOptions) (*SparkSessionResponse, error) {
-	req, err := client.CreateSparkSessionCreateRequest(ctx, sparkSessionOptions, sparkSessionCreateSparkSessionOptions)
+func (client *sparkSessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SparkSessionOptions, options *SparkSessionCreateSparkSessionOptions) (*SparkSessionResponse, error) {
+	req, err := client.CreateSparkSessionCreateRequest(ctx, sparkSessionOptions, options)
 	if err != nil {
 		return nil, err
 	}
@@ -137,15 +137,15 @@ func (client *sparkSessionClient) CreateSparkSession(ctx context.Context, sparkS
 }
 
 // CreateSparkSessionCreateRequest creates the CreateSparkSession request.
-func (client *sparkSessionClient) CreateSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SparkSessionOptions, sparkSessionCreateSparkSessionOptions *SparkSessionCreateSparkSessionOptions) (*azcore.Request, error) {
+func (client *sparkSessionClient) CreateSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SparkSessionOptions, options *SparkSessionCreateSparkSessionOptions) (*azcore.Request, error) {
 	urlPath := "/sessions"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkSessionCreateSparkSessionOptions != nil && sparkSessionCreateSparkSessionOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkSessionCreateSparkSessionOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -171,8 +171,8 @@ func (client *sparkSessionClient) CreateSparkSessionHandleError(resp *azcore.Res
 }
 
 // CreateSparkStatement - Create statement within a spark session.
-func (client *sparkSessionClient) CreateSparkStatement(ctx context.Context, sessionId int32, sparkStatementOptions SparkStatementOptions) (*SparkStatementResponse, error) {
-	req, err := client.CreateSparkStatementCreateRequest(ctx, sessionId, sparkStatementOptions)
+func (client *sparkSessionClient) CreateSparkStatement(ctx context.Context, sessionId int32, sparkStatementOptions SparkStatementOptions, options *SparkSessionCreateSparkStatementOptions) (*SparkStatementResponse, error) {
+	req, err := client.CreateSparkStatementCreateRequest(ctx, sessionId, sparkStatementOptions, options)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (client *sparkSessionClient) CreateSparkStatement(ctx context.Context, sess
 }
 
 // CreateSparkStatementCreateRequest creates the CreateSparkStatement request.
-func (client *sparkSessionClient) CreateSparkStatementCreateRequest(ctx context.Context, sessionId int32, sparkStatementOptions SparkStatementOptions) (*azcore.Request, error) {
+func (client *sparkSessionClient) CreateSparkStatementCreateRequest(ctx context.Context, sessionId int32, sparkStatementOptions SparkStatementOptions, options *SparkSessionCreateSparkStatementOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.u, urlPath))
@@ -221,8 +221,8 @@ func (client *sparkSessionClient) CreateSparkStatementHandleError(resp *azcore.R
 }
 
 // GetSparkSession - Gets a single spark session.
-func (client *sparkSessionClient) GetSparkSession(ctx context.Context, sessionId int32, sparkSessionGetSparkSessionOptions *SparkSessionGetSparkSessionOptions) (*SparkSessionResponse, error) {
-	req, err := client.GetSparkSessionCreateRequest(ctx, sessionId, sparkSessionGetSparkSessionOptions)
+func (client *sparkSessionClient) GetSparkSession(ctx context.Context, sessionId int32, options *SparkSessionGetSparkSessionOptions) (*SparkSessionResponse, error) {
+	req, err := client.GetSparkSessionCreateRequest(ctx, sessionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (client *sparkSessionClient) GetSparkSession(ctx context.Context, sessionId
 }
 
 // GetSparkSessionCreateRequest creates the GetSparkSession request.
-func (client *sparkSessionClient) GetSparkSessionCreateRequest(ctx context.Context, sessionId int32, sparkSessionGetSparkSessionOptions *SparkSessionGetSparkSessionOptions) (*azcore.Request, error) {
+func (client *sparkSessionClient) GetSparkSessionCreateRequest(ctx context.Context, sessionId int32, options *SparkSessionGetSparkSessionOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -249,8 +249,8 @@ func (client *sparkSessionClient) GetSparkSessionCreateRequest(ctx context.Conte
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkSessionGetSparkSessionOptions != nil && sparkSessionGetSparkSessionOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkSessionGetSparkSessionOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -276,8 +276,8 @@ func (client *sparkSessionClient) GetSparkSessionHandleError(resp *azcore.Respon
 }
 
 // GetSparkSessions - List all spark sessions which are running under a particular spark pool.
-func (client *sparkSessionClient) GetSparkSessions(ctx context.Context, sparkSessionGetSparkSessionsOptions *SparkSessionGetSparkSessionsOptions) (*SparkSessionCollectionResponse, error) {
-	req, err := client.GetSparkSessionsCreateRequest(ctx, sparkSessionGetSparkSessionsOptions)
+func (client *sparkSessionClient) GetSparkSessions(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (*SparkSessionCollectionResponse, error) {
+	req, err := client.GetSparkSessionsCreateRequest(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -296,21 +296,21 @@ func (client *sparkSessionClient) GetSparkSessions(ctx context.Context, sparkSes
 }
 
 // GetSparkSessionsCreateRequest creates the GetSparkSessions request.
-func (client *sparkSessionClient) GetSparkSessionsCreateRequest(ctx context.Context, sparkSessionGetSparkSessionsOptions *SparkSessionGetSparkSessionsOptions) (*azcore.Request, error) {
+func (client *sparkSessionClient) GetSparkSessionsCreateRequest(ctx context.Context, options *SparkSessionGetSparkSessionsOptions) (*azcore.Request, error) {
 	urlPath := "/sessions"
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	query := req.URL.Query()
-	if sparkSessionGetSparkSessionsOptions != nil && sparkSessionGetSparkSessionsOptions.From != nil {
-		query.Set("from", strconv.FormatInt(int64(*sparkSessionGetSparkSessionsOptions.From), 10))
+	if options != nil && options.From != nil {
+		query.Set("from", strconv.FormatInt(int64(*options.From), 10))
 	}
-	if sparkSessionGetSparkSessionsOptions != nil && sparkSessionGetSparkSessionsOptions.Size != nil {
-		query.Set("size", strconv.FormatInt(int64(*sparkSessionGetSparkSessionsOptions.Size), 10))
+	if options != nil && options.Size != nil {
+		query.Set("size", strconv.FormatInt(int64(*options.Size), 10))
 	}
-	if sparkSessionGetSparkSessionsOptions != nil && sparkSessionGetSparkSessionsOptions.Detailed != nil {
-		query.Set("detailed", strconv.FormatBool(*sparkSessionGetSparkSessionsOptions.Detailed))
+	if options != nil && options.Detailed != nil {
+		query.Set("detailed", strconv.FormatBool(*options.Detailed))
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
@@ -336,8 +336,8 @@ func (client *sparkSessionClient) GetSparkSessionsHandleError(resp *azcore.Respo
 }
 
 // GetSparkStatement - Gets a single statement within a spark session.
-func (client *sparkSessionClient) GetSparkStatement(ctx context.Context, sessionId int32, statementId int32) (*SparkStatementResponse, error) {
-	req, err := client.GetSparkStatementCreateRequest(ctx, sessionId, statementId)
+func (client *sparkSessionClient) GetSparkStatement(ctx context.Context, sessionId int32, statementId int32, options *SparkSessionGetSparkStatementOptions) (*SparkStatementResponse, error) {
+	req, err := client.GetSparkStatementCreateRequest(ctx, sessionId, statementId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func (client *sparkSessionClient) GetSparkStatement(ctx context.Context, session
 }
 
 // GetSparkStatementCreateRequest creates the GetSparkStatement request.
-func (client *sparkSessionClient) GetSparkStatementCreateRequest(ctx context.Context, sessionId int32, statementId int32) (*azcore.Request, error) {
+func (client *sparkSessionClient) GetSparkStatementCreateRequest(ctx context.Context, sessionId int32, statementId int32, options *SparkSessionGetSparkStatementOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementId), 10)))
@@ -387,8 +387,8 @@ func (client *sparkSessionClient) GetSparkStatementHandleError(resp *azcore.Resp
 }
 
 // GetSparkStatements - Gets a list of statements within a spark session.
-func (client *sparkSessionClient) GetSparkStatements(ctx context.Context, sessionId int32) (*SparkStatementCollectionResponse, error) {
-	req, err := client.GetSparkStatementsCreateRequest(ctx, sessionId)
+func (client *sparkSessionClient) GetSparkStatements(ctx context.Context, sessionId int32, options *SparkSessionGetSparkStatementsOptions) (*SparkStatementCollectionResponse, error) {
+	req, err := client.GetSparkStatementsCreateRequest(ctx, sessionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (client *sparkSessionClient) GetSparkStatements(ctx context.Context, sessio
 }
 
 // GetSparkStatementsCreateRequest creates the GetSparkStatements request.
-func (client *sparkSessionClient) GetSparkStatementsCreateRequest(ctx context.Context, sessionId int32) (*azcore.Request, error) {
+func (client *sparkSessionClient) GetSparkStatementsCreateRequest(ctx context.Context, sessionId int32, options *SparkSessionGetSparkStatementsOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodGet, azcore.JoinPaths(client.u, urlPath))
@@ -437,8 +437,8 @@ func (client *sparkSessionClient) GetSparkStatementsHandleError(resp *azcore.Res
 }
 
 // ResetSparkSessionTimeout - Sends a keep alive call to the current session to reset the session timeout.
-func (client *sparkSessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionId int32) (*http.Response, error) {
-	req, err := client.ResetSparkSessionTimeoutCreateRequest(ctx, sessionId)
+func (client *sparkSessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionId int32, options *SparkSessionResetSparkSessionTimeoutOptions) (*http.Response, error) {
+	req, err := client.ResetSparkSessionTimeoutCreateRequest(ctx, sessionId, options)
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +453,7 @@ func (client *sparkSessionClient) ResetSparkSessionTimeout(ctx context.Context, 
 }
 
 // ResetSparkSessionTimeoutCreateRequest creates the ResetSparkSessionTimeout request.
-func (client *sparkSessionClient) ResetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionId int32) (*azcore.Request, error) {
+func (client *sparkSessionClient) ResetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionId int32, options *SparkSessionResetSparkSessionTimeoutOptions) (*azcore.Request, error) {
 	urlPath := "/sessions/{sessionId}/reset-timeout"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionId), 10)))
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.u, urlPath))


### PR DESCRIPTION
Always add an optional params struct to an operation even if it doesn't
contain any optional params.  This is to prevent future addition of
optional params from being a breaking change.
Use the param name 'options' for singular, optional params arg.