### PR TITLE
Remove hard-coded status codes for NextPage()

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -37,7 +37,7 @@ export function isSchemaResponse(resp?: Response): resp is SchemaResponse {
 export interface PagerInfo {
   name: string;
   op: Operation;
-  respField: boolean;
+  hasLRO: boolean;
 }
 
 // returns true if the operation is pageable

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -222,6 +222,7 @@ function generateOperation(op: Operation, imports: ImportManager): string {
   }
   text += `func (client *${clientName}) ${op.language.go!.name}(${params}) (${returns.join(', ')}) {\n`;
   const reqParams = getCreateRequestParameters(op);
+  const statusCodes = getStatusCodes(op);
   if (isPageableOperation(op) && !isLROOperation(op)) {
     imports.add('context');
     text += `\treturn &${camelCase(op.language.go!.pageableType.name)}{\n`;
@@ -257,6 +258,7 @@ function generateOperation(op: Operation, imports: ImportManager): string {
       text += `\t\t\treturn azcore.NewRequest(ctx, http.MethodGet, *resp.${resultTypeName}.${nextLink})\n`;
     }
     text += `\t\t},\n`;
+    text += `\t\tstatusCodes: []int{${formatStatusCodes(statusCodes)}},\n`;
     text += `\t}\n`;
     text += '}\n\n';
     return text;
@@ -269,7 +271,6 @@ function generateOperation(op: Operation, imports: ImportManager): string {
   text += `\tif err != nil {\n`;
   text += `\t\treturn nil, err\n`;
   text += `\t}\n`;
-  const statusCodes = getStatusCodes(op);
   text += `\tif !resp.HasStatusCode(${formatStatusCodes(statusCodes)}) {\n`;
   text += `\t\treturn nil, client.${info.protocolNaming.errorMethod}(resp)\n`;
   text += '\t}\n';

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -665,10 +665,9 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
       const pagers = <Array<PagerInfo>>codeModel.language.go!.pageableTypes;
       for (const pager of values(pagers)) {
         if (pager.name === name) {
-          // this LRO check is necessary for operations that synchronously and asynchronously return a pager
-          // this will ensure that pagers that are used with pollers will have the response field included
+          // set when a pager is used in an LRO, or is shared between LRO and no-LRO operations
           if (isLROOperation(op)) {
-            pager.respField = true;
+            pager.hasLRO = true;
           }
           // found a match, hook it up to the method
           op.language.go!.pageableType = pager;
@@ -681,7 +680,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
         const pager = {
           name: name,
           op: op,
-          respField: isLROOperation(op),
+          hasLRO: isLROOperation(op),
         };
         pagers.push(pager);
         op.language.go!.pageableType = pager;

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -8,7 +8,6 @@ package paginggroup
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 // OdataProductResultPager provides iteration over OdataProductResult pages.
@@ -45,6 +44,8 @@ type odataProductResultPager struct {
 	advancer odataProductResultAdvancePage
 	// contains the current response
 	current *OdataProductResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -73,7 +74,7 @@ func (p *odataProductResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -124,6 +125,8 @@ type productResultPager struct {
 	advancer productResultAdvancePage
 	// contains the current response
 	current *ProductResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 	// previous response from the endpoint (LRO case)
@@ -159,7 +162,7 @@ func (p *productResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -210,6 +213,8 @@ type productResultValuePager struct {
 	advancer productResultValueAdvancePage
 	// contains the current response
 	current *ProductResultValueResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -238,7 +243,7 @@ func (p *productResultValuePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -289,6 +294,8 @@ type productResultValueWithXmsClientNamePager struct {
 	advancer productResultValueWithXmsClientNameAdvancePage
 	// contains the current response
 	current *ProductResultValueWithXmsClientNameResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -317,7 +324,7 @@ func (p *productResultValueWithXmsClientNamePager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -85,6 +85,7 @@ func (client *PagingClient) GetMultiplePages(options *PagingGetMultiplePagesOpti
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -138,6 +139,7 @@ func (client *PagingClient) GetMultiplePagesFailure(options *PagingGetMultiplePa
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -182,6 +184,7 @@ func (client *PagingClient) GetMultiplePagesFailureURI(options *PagingGetMultipl
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -226,6 +229,7 @@ func (client *PagingClient) GetMultiplePagesFragmentNextLink(apiVersion string, 
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return client.NextFragmentCreateRequest(ctx, apiVersion, tenant, *resp.OdataProductResult.OdataNextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -274,6 +278,7 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(customP
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return client.NextFragmentWithGroupingCreateRequest(ctx, *resp.OdataProductResult.OdataNextLink, customParameterGroup)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -420,6 +425,7 @@ func (client *PagingClient) GetMultiplePagesRetryFirst(options *PagingGetMultipl
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -464,6 +470,7 @@ func (client *PagingClient) GetMultiplePagesRetrySecond(options *PagingGetMultip
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -508,6 +515,7 @@ func (client *PagingClient) GetMultiplePagesWithOffset(pagingGetMultiplePagesWit
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -562,6 +570,7 @@ func (client *PagingClient) GetNoItemNamePages(options *PagingGetNoItemNamePages
 		advancer: func(ctx context.Context, resp *ProductResultValueResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResultValue.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -655,6 +664,7 @@ func (client *PagingClient) GetOdataMultiplePages(options *PagingGetOdataMultipl
 		advancer: func(ctx context.Context, resp *OdataProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.OdataProductResult.OdataNextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -708,6 +718,7 @@ func (client *PagingClient) GetPagingModelWithItemNameWithXmsClientName(options 
 		advancer: func(ctx context.Context, resp *ProductResultValueWithXmsClientNameResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResultValueWithXmsClientName.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -752,6 +763,7 @@ func (client *PagingClient) GetSinglePages(options *PagingGetSinglePagesOptions)
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -796,6 +808,7 @@ func (client *PagingClient) GetSinglePagesFailure(options *PagingGetSinglePagesF
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -840,6 +853,7 @@ func (client *PagingClient) GetWithQueryParams(requiredQueryParameter int32, opt
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return client.NextOperationWithQueryParamsCreateRequest(ctx)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/autorest/paginggroup/zz_generated_pollers.go
+++ b/test/autorest/paginggroup/zz_generated_pollers.go
@@ -72,5 +72,6 @@ func (p *productResultPagerPoller) handleResponse(resp *azcore.Response) (Produc
 		advancer: func(ctx context.Context, resp *ProductResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
 		},
+		statusCodes: []int{http.StatusAccepted, http.StatusOK},
 	}, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
@@ -217,6 +217,7 @@ func (client *AvailabilitySetsClient) List(resourceGroupName string, options *Av
 		advancer: func(ctx context.Context, resp *AvailabilitySetListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailabilitySetListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *AvailabilitySetsClient) ListBySubscription(options *AvailabilitySe
 		advancer: func(ctx context.Context, resp *AvailabilitySetListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailabilitySetListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
@@ -283,6 +283,7 @@ func (client *ContainerServicesClient) List(options *ContainerServicesListOption
 		advancer: func(ctx context.Context, resp *ContainerServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ContainerServiceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -331,6 +332,7 @@ func (client *ContainerServicesClient) ListByResourceGroup(resourceGroupName str
 		advancer: func(ctx context.Context, resp *ContainerServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ContainerServiceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
@@ -215,6 +215,7 @@ func (client *DedicatedHostGroupsClient) ListByResourceGroup(resourceGroupName s
 		advancer: func(ctx context.Context, resp *DedicatedHostGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DedicatedHostGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -264,6 +265,7 @@ func (client *DedicatedHostGroupsClient) ListBySubscription(options *DedicatedHo
 		advancer: func(ctx context.Context, resp *DedicatedHostGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DedicatedHostGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
@@ -291,6 +291,7 @@ func (client *DedicatedHostsClient) ListByHostGroup(resourceGroupName string, ho
 		advancer: func(ctx context.Context, resp *DedicatedHostListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DedicatedHostListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
@@ -276,6 +276,7 @@ func (client *DiskEncryptionSetsClient) List(options *DiskEncryptionSetsListOpti
 		advancer: func(ctx context.Context, resp *DiskEncryptionSetListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DiskEncryptionSetList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *DiskEncryptionSetsClient) ListByResourceGroup(resourceGroupName st
 		advancer: func(ctx context.Context, resp *DiskEncryptionSetListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DiskEncryptionSetList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks.go
@@ -380,6 +380,7 @@ func (client *DisksClient) List(options *DisksListOptions) DiskListPager {
 		advancer: func(ctx context.Context, resp *DiskListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DiskList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -428,6 +429,7 @@ func (client *DisksClient) ListByResourceGroup(resourceGroupName string, options
 		advancer: func(ctx context.Context, resp *DiskListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DiskList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
@@ -276,6 +276,7 @@ func (client *GalleriesClient) List(options *GalleriesListOptions) GalleryListPa
 		advancer: func(ctx context.Context, resp *GalleryListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *GalleriesClient) ListByResourceGroup(resourceGroupName string, opt
 		advancer: func(ctx context.Context, resp *GalleryListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
@@ -277,6 +277,7 @@ func (client *GalleryApplicationsClient) ListByGallery(resourceGroupName string,
 		advancer: func(ctx context.Context, resp *GalleryApplicationListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryApplicationList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
@@ -283,6 +283,7 @@ func (client *GalleryApplicationVersionsClient) ListByGalleryApplication(resourc
 		advancer: func(ctx context.Context, resp *GalleryApplicationVersionListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryApplicationVersionList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
@@ -277,6 +277,7 @@ func (client *GalleryImagesClient) ListByGallery(resourceGroupName string, galle
 		advancer: func(ctx context.Context, resp *GalleryImageListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryImageList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
@@ -283,6 +283,7 @@ func (client *GalleryImageVersionsClient) ListByGalleryImage(resourceGroupName s
 		advancer: func(ctx context.Context, resp *GalleryImageVersionListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.GalleryImageVersionList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_images.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images.go
@@ -290,6 +290,7 @@ func (client *ImagesClient) List(options *ImagesListOptions) ImageListResultPage
 		advancer: func(ctx context.Context, resp *ImageListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ImageListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -338,6 +339,7 @@ func (client *ImagesClient) ListByResourceGroup(resourceGroupName string, option
 		advancer: func(ctx context.Context, resp *ImageListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ImageListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
@@ -8,7 +8,6 @@ package armcompute
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 // AvailabilitySetListResultPager provides iteration over AvailabilitySetListResult pages.
@@ -45,6 +44,8 @@ type availabilitySetListResultPager struct {
 	advancer availabilitySetListResultAdvancePage
 	// contains the current response
 	current *AvailabilitySetListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -73,7 +74,7 @@ func (p *availabilitySetListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -124,6 +125,8 @@ type containerServiceListResultPager struct {
 	advancer containerServiceListResultAdvancePage
 	// contains the current response
 	current *ContainerServiceListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -152,7 +155,7 @@ func (p *containerServiceListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -203,6 +206,8 @@ type dedicatedHostGroupListResultPager struct {
 	advancer dedicatedHostGroupListResultAdvancePage
 	// contains the current response
 	current *DedicatedHostGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -231,7 +236,7 @@ func (p *dedicatedHostGroupListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -282,6 +287,8 @@ type dedicatedHostListResultPager struct {
 	advancer dedicatedHostListResultAdvancePage
 	// contains the current response
 	current *DedicatedHostListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -310,7 +317,7 @@ func (p *dedicatedHostListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -361,6 +368,8 @@ type diskEncryptionSetListPager struct {
 	advancer diskEncryptionSetListAdvancePage
 	// contains the current response
 	current *DiskEncryptionSetListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -389,7 +398,7 @@ func (p *diskEncryptionSetListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -440,6 +449,8 @@ type diskListPager struct {
 	advancer diskListAdvancePage
 	// contains the current response
 	current *DiskListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -468,7 +479,7 @@ func (p *diskListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -519,6 +530,8 @@ type galleryApplicationListPager struct {
 	advancer galleryApplicationListAdvancePage
 	// contains the current response
 	current *GalleryApplicationListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -547,7 +560,7 @@ func (p *galleryApplicationListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -598,6 +611,8 @@ type galleryApplicationVersionListPager struct {
 	advancer galleryApplicationVersionListAdvancePage
 	// contains the current response
 	current *GalleryApplicationVersionListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -626,7 +641,7 @@ func (p *galleryApplicationVersionListPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -677,6 +692,8 @@ type galleryImageListPager struct {
 	advancer galleryImageListAdvancePage
 	// contains the current response
 	current *GalleryImageListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -705,7 +722,7 @@ func (p *galleryImageListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -756,6 +773,8 @@ type galleryImageVersionListPager struct {
 	advancer galleryImageVersionListAdvancePage
 	// contains the current response
 	current *GalleryImageVersionListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -784,7 +803,7 @@ func (p *galleryImageVersionListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -835,6 +854,8 @@ type galleryListPager struct {
 	advancer galleryListAdvancePage
 	// contains the current response
 	current *GalleryListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -863,7 +884,7 @@ func (p *galleryListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -914,6 +935,8 @@ type imageListResultPager struct {
 	advancer imageListResultAdvancePage
 	// contains the current response
 	current *ImageListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -942,7 +965,7 @@ func (p *imageListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -993,6 +1016,8 @@ type listUsagesResultPager struct {
 	advancer listUsagesResultAdvancePage
 	// contains the current response
 	current *ListUsagesResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1021,7 +1046,7 @@ func (p *listUsagesResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1072,6 +1097,8 @@ type proximityPlacementGroupListResultPager struct {
 	advancer proximityPlacementGroupListResultAdvancePage
 	// contains the current response
 	current *ProximityPlacementGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1100,7 +1127,7 @@ func (p *proximityPlacementGroupListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1151,6 +1178,8 @@ type resourceSkUsResultPager struct {
 	advancer resourceSkUsResultAdvancePage
 	// contains the current response
 	current *ResourceSKUsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1179,7 +1208,7 @@ func (p *resourceSkUsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1230,6 +1259,8 @@ type runCommandListResultPager struct {
 	advancer runCommandListResultAdvancePage
 	// contains the current response
 	current *RunCommandListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1258,7 +1289,7 @@ func (p *runCommandListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1309,6 +1340,8 @@ type sshPublicKeysGroupListResultPager struct {
 	advancer sshPublicKeysGroupListResultAdvancePage
 	// contains the current response
 	current *SSHPublicKeysGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1337,7 +1370,7 @@ func (p *sshPublicKeysGroupListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1388,6 +1421,8 @@ type snapshotListPager struct {
 	advancer snapshotListAdvancePage
 	// contains the current response
 	current *SnapshotListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1416,7 +1451,7 @@ func (p *snapshotListPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1467,6 +1502,8 @@ type virtualMachineListResultPager struct {
 	advancer virtualMachineListResultAdvancePage
 	// contains the current response
 	current *VirtualMachineListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1495,7 +1532,7 @@ func (p *virtualMachineListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1546,6 +1583,8 @@ type virtualMachineScaleSetExtensionListResultPager struct {
 	advancer virtualMachineScaleSetExtensionListResultAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetExtensionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1574,7 +1613,7 @@ func (p *virtualMachineScaleSetExtensionListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1625,6 +1664,8 @@ type virtualMachineScaleSetListOSUpgradeHistoryPager struct {
 	advancer virtualMachineScaleSetListOSUpgradeHistoryAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetListOSUpgradeHistoryResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1653,7 +1694,7 @@ func (p *virtualMachineScaleSetListOSUpgradeHistoryPager) NextPage(ctx context.C
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1704,6 +1745,8 @@ type virtualMachineScaleSetListResultPager struct {
 	advancer virtualMachineScaleSetListResultAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1732,7 +1775,7 @@ func (p *virtualMachineScaleSetListResultPager) NextPage(ctx context.Context) bo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1783,6 +1826,8 @@ type virtualMachineScaleSetListSkUsResultPager struct {
 	advancer virtualMachineScaleSetListSkUsResultAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetListSKUsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1811,7 +1856,7 @@ func (p *virtualMachineScaleSetListSkUsResultPager) NextPage(ctx context.Context
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1862,6 +1907,8 @@ type virtualMachineScaleSetListWithLinkResultPager struct {
 	advancer virtualMachineScaleSetListWithLinkResultAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetListWithLinkResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1890,7 +1937,7 @@ func (p *virtualMachineScaleSetListWithLinkResultPager) NextPage(ctx context.Con
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1941,6 +1988,8 @@ type virtualMachineScaleSetVMListResultPager struct {
 	advancer virtualMachineScaleSetVMListResultAdvancePage
 	// contains the current response
 	current *VirtualMachineScaleSetVMListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1969,7 +2018,7 @@ func (p *virtualMachineScaleSetVMListResultPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
@@ -218,6 +218,7 @@ func (client *ProximityPlacementGroupsClient) ListByResourceGroup(resourceGroupN
 		advancer: func(ctx context.Context, resp *ProximityPlacementGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProximityPlacementGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -267,6 +268,7 @@ func (client *ProximityPlacementGroupsClient) ListBySubscription(options *Proxim
 		advancer: func(ctx context.Context, resp *ProximityPlacementGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ProximityPlacementGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
@@ -51,6 +51,7 @@ func (client *ResourceSKUsClient) List(options *ResourceSKUsListOptions) Resourc
 		advancer: func(ctx context.Context, resp *ResourceSKUsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ResourceSKUsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
@@ -380,6 +380,7 @@ func (client *SnapshotsClient) List(options *SnapshotsListOptions) SnapshotListP
 		advancer: func(ctx context.Context, resp *SnapshotListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SnapshotList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -428,6 +429,7 @@ func (client *SnapshotsClient) ListByResourceGroup(resourceGroupName string, opt
 		advancer: func(ctx context.Context, resp *SnapshotListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SnapshotList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
@@ -272,6 +272,7 @@ func (client *SSHPublicKeysClient) ListByResourceGroup(resourceGroupName string,
 		advancer: func(ctx context.Context, resp *SSHPublicKeysGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SSHPublicKeysGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *SSHPublicKeysClient) ListBySubscription(options *SSHPublicKeysList
 		advancer: func(ctx context.Context, resp *SSHPublicKeysGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SSHPublicKeysGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage.go
@@ -51,6 +51,7 @@ func (client *UsageClient) List(location string, options *UsageListOptions) List
 		advancer: func(ctx context.Context, resp *ListUsagesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListUsagesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
@@ -108,6 +108,7 @@ func (client *VirtualMachineRunCommandsClient) List(location string, options *Vi
 		advancer: func(ctx context.Context, resp *RunCommandListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RunCommandListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -685,6 +685,7 @@ func (client *VirtualMachinesClient) List(resourceGroupName string, options *Vir
 		advancer: func(ctx context.Context, resp *VirtualMachineListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -734,6 +735,7 @@ func (client *VirtualMachinesClient) ListAll(options *VirtualMachinesListAllOpti
 		advancer: func(ctx context.Context, resp *VirtualMachineListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -840,6 +842,7 @@ func (client *VirtualMachinesClient) ListByLocation(location string, options *Vi
 		advancer: func(ctx context.Context, resp *VirtualMachineListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
@@ -291,6 +291,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) List(resourceGroupName str
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetExtensionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetExtensionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
@@ -656,6 +656,7 @@ func (client *VirtualMachineScaleSetsClient) GetOSUpgradeHistory(resourceGroupNa
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetListOSUpgradeHistoryResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetListOSUpgradeHistory.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -706,6 +707,7 @@ func (client *VirtualMachineScaleSetsClient) List(resourceGroupName string, opti
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -755,6 +757,7 @@ func (client *VirtualMachineScaleSetsClient) ListAll(options *VirtualMachineScal
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetListWithLinkResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetListWithLinkResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -803,6 +806,7 @@ func (client *VirtualMachineScaleSetsClient) ListSKUs(resourceGroupName string, 
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetListSKUsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetListSKUsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
@@ -377,6 +377,7 @@ func (client *VirtualMachineScaleSetVMSClient) List(resourceGroupName string, vi
 		advancer: func(ctx context.Context, resp *VirtualMachineScaleSetVMListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualMachineScaleSetVMListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -525,6 +525,7 @@ func (client *ApplicationGatewaysClient) List(resourceGroupName string, options 
 		advancer: func(ctx context.Context, resp *ApplicationGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -571,6 +572,7 @@ func (client *ApplicationGatewaysClient) ListAll(options *ApplicationGatewaysLis
 		advancer: func(ctx context.Context, resp *ApplicationGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -816,6 +818,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSslPredefinedPolicies(opti
 		advancer: func(ctx context.Context, resp *ApplicationGatewayAvailableSslPredefinedPoliciesResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationGatewayAvailableSslPredefinedPolicies.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -274,6 +274,7 @@ func (client *ApplicationSecurityGroupsClient) List(resourceGroupName string, op
 		advancer: func(ctx context.Context, resp *ApplicationSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationSecurityGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -320,6 +321,7 @@ func (client *ApplicationSecurityGroupsClient) ListAll(options *ApplicationSecur
 		advancer: func(ctx context.Context, resp *ApplicationSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ApplicationSecurityGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -48,6 +48,7 @@ func (client *AvailableDelegationsClient) List(location string, options *Availab
 		advancer: func(ctx context.Context, resp *AvailableDelegationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableDelegationsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -48,6 +48,7 @@ func (client *AvailableEndpointServicesClient) List(location string, options *Av
 		advancer: func(ctx context.Context, resp *EndpointServicesListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EndpointServicesListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -50,6 +50,7 @@ func (client *AvailablePrivateEndpointTypesClient) List(location string, options
 		advancer: func(ctx context.Context, resp *AvailablePrivateEndpointTypesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailablePrivateEndpointTypesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -96,6 +97,7 @@ func (client *AvailablePrivateEndpointTypesClient) ListByResourceGroup(location 
 		advancer: func(ctx context.Context, resp *AvailablePrivateEndpointTypesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailablePrivateEndpointTypesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -48,6 +48,7 @@ func (client *AvailableResourceGroupDelegationsClient) List(location string, res
 		advancer: func(ctx context.Context, resp *AvailableDelegationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableDelegationsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -50,6 +50,7 @@ func (client *AvailableServiceAliasesClient) List(location string, options *Avai
 		advancer: func(ctx context.Context, resp *AvailableServiceAliasesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableServiceAliasesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -96,6 +97,7 @@ func (client *AvailableServiceAliasesClient) ListByResourceGroup(resourceGroupNa
 		advancer: func(ctx context.Context, resp *AvailableServiceAliasesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AvailableServiceAliasesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -48,6 +48,7 @@ func (client *AzureFirewallFqdnTagsClient) ListAll(options *AzureFirewallFqdnTag
 		advancer: func(ctx context.Context, resp *AzureFirewallFqdnTagListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallFqdnTagListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -276,6 +276,7 @@ func (client *AzureFirewallsClient) List(resourceGroupName string, options *Azur
 		advancer: func(ctx context.Context, resp *AzureFirewallListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *AzureFirewallsClient) ListAll(options *AzureFirewallsListAllOption
 		advancer: func(ctx context.Context, resp *AzureFirewallListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AzureFirewallListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -272,6 +272,7 @@ func (client *BastionHostsClient) List(options *BastionHostsListOptions) Bastion
 		advancer: func(ctx context.Context, resp *BastionHostListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionHostListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -317,6 +318,7 @@ func (client *BastionHostsClient) ListByResourceGroup(resourceGroupName string, 
 		advancer: func(ctx context.Context, resp *BastionHostListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionHostListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -48,6 +48,7 @@ func (client *BgpServiceCommunitiesClient) List(options *BgpServiceCommunitiesLi
 		advancer: func(ctx context.Context, resp *BgpServiceCommunityListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BgpServiceCommunityListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -274,6 +274,7 @@ func (client *DdosProtectionPlansClient) List(options *DdosProtectionPlansListOp
 		advancer: func(ctx context.Context, resp *DdosProtectionPlanListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DdosProtectionPlanListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *DdosProtectionPlansClient) ListByResourceGroup(resourceGroupName s
 		advancer: func(ctx context.Context, resp *DdosProtectionPlanListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DdosProtectionPlanListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -103,6 +103,7 @@ func (client *DefaultSecurityRulesClient) List(resourceGroupName string, network
 		advancer: func(ctx context.Context, resp *SecurityRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -273,6 +273,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) List(resourceGroupName st
 		advancer: func(ctx context.Context, resp *AuthorizationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AuthorizationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -276,6 +276,7 @@ func (client *ExpressRouteCircuitConnectionsClient) List(resourceGroupName strin
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -273,6 +273,7 @@ func (client *ExpressRouteCircuitPeeringsClient) List(resourceGroupName string, 
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitPeeringListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -395,6 +395,7 @@ func (client *ExpressRouteCircuitsClient) List(resourceGroupName string, options
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -441,6 +442,7 @@ func (client *ExpressRouteCircuitsClient) ListAll(options *ExpressRouteCircuitsL
 		advancer: func(ctx context.Context, resp *ExpressRouteCircuitListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCircuitListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -273,6 +273,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) List(resourceGroupName 
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionPeeringListResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionPeeringList.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -206,6 +206,7 @@ func (client *ExpressRouteCrossConnectionsClient) List(options *ExpressRouteCros
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -335,6 +336,7 @@ func (client *ExpressRouteCrossConnectionsClient) ListByResourceGroup(resourceGr
 		advancer: func(ctx context.Context, resp *ExpressRouteCrossConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteCrossConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -103,6 +103,7 @@ func (client *ExpressRouteLinksClient) List(resourceGroupName string, expressRou
 		advancer: func(ctx context.Context, resp *ExpressRouteLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteLinkListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -274,6 +274,7 @@ func (client *ExpressRoutePortsClient) List(options *ExpressRoutePortsListOption
 		advancer: func(ctx context.Context, resp *ExpressRoutePortListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *ExpressRoutePortsClient) ListByResourceGroup(resourceGroupName str
 		advancer: func(ctx context.Context, resp *ExpressRoutePortListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -101,6 +101,7 @@ func (client *ExpressRoutePortsLocationsClient) List(options *ExpressRoutePortsL
 		advancer: func(ctx context.Context, resp *ExpressRoutePortsLocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRoutePortsLocationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -48,6 +48,7 @@ func (client *ExpressRouteServiceProvidersClient) List(options *ExpressRouteServ
 		advancer: func(ctx context.Context, resp *ExpressRouteServiceProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ExpressRouteServiceProviderListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -275,6 +275,7 @@ func (client *FirewallPoliciesClient) List(resourceGroupName string, options *Fi
 		advancer: func(ctx context.Context, resp *FirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *FirewallPoliciesClient) ListAll(options *FirewallPoliciesListAllOp
 		advancer: func(ctx context.Context, resp *FirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -273,6 +273,7 @@ func (client *FirewallPolicyRuleGroupsClient) List(resourceGroupName string, fir
 		advancer: func(ctx context.Context, resp *FirewallPolicyRuleGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FirewallPolicyRuleGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -273,6 +273,7 @@ func (client *FlowLogsClient) List(resourceGroupName string, networkWatcherName 
 		advancer: func(ctx context.Context, resp *FlowLogListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.FlowLogListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -103,6 +103,7 @@ func (client *HubVirtualNetworkConnectionsClient) List(resourceGroupName string,
 		advancer: func(ctx context.Context, resp *ListHubVirtualNetworkConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListHubVirtualNetworkConnectionsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -276,6 +276,7 @@ func (client *InboundNatRulesClient) List(resourceGroupName string, loadBalancer
 		advancer: func(ctx context.Context, resp *InboundNatRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.InboundNatRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -277,6 +277,7 @@ func (client *IPAllocationsClient) List(options *IPAllocationsListOptions) IPAll
 		advancer: func(ctx context.Context, resp *IPAllocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPAllocationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *IPAllocationsClient) ListByResourceGroup(resourceGroupName string,
 		advancer: func(ctx context.Context, resp *IPAllocationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPAllocationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -277,6 +277,7 @@ func (client *IPGroupsClient) List(options *IPGroupsListOptions) IPGroupListResu
 		advancer: func(ctx context.Context, resp *IPGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *IPGroupsClient) ListByResourceGroup(resourceGroupName string, opti
 		advancer: func(ctx context.Context, resp *IPGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.IPGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -103,6 +103,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) List(resourceGroupName stri
 		advancer: func(ctx context.Context, resp *LoadBalancerBackendAddressPoolListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerBackendAddressPoolListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -103,6 +103,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) List(resourceGroupName
 		advancer: func(ctx context.Context, resp *LoadBalancerFrontendIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerFrontendIPConfigurationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -103,6 +103,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) List(resourceGroupName strin
 		advancer: func(ctx context.Context, resp *LoadBalancerLoadBalancingRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerLoadBalancingRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -48,6 +48,7 @@ func (client *LoadBalancerNetworkInterfacesClient) List(resourceGroupName string
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -103,6 +103,7 @@ func (client *LoadBalancerOutboundRulesClient) List(resourceGroupName string, lo
 		advancer: func(ctx context.Context, resp *LoadBalancerOutboundRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerOutboundRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -103,6 +103,7 @@ func (client *LoadBalancerProbesClient) List(resourceGroupName string, loadBalan
 		advancer: func(ctx context.Context, resp *LoadBalancerProbeListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerProbeListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -277,6 +277,7 @@ func (client *LoadBalancersClient) List(resourceGroupName string, options *LoadB
 		advancer: func(ctx context.Context, resp *LoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *LoadBalancersClient) ListAll(options *LoadBalancersListAllOptions)
 		advancer: func(ctx context.Context, resp *LoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LoadBalancerListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -272,6 +272,7 @@ func (client *LocalNetworkGatewaysClient) List(resourceGroupName string, options
 		advancer: func(ctx context.Context, resp *LocalNetworkGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LocalNetworkGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -277,6 +277,7 @@ func (client *NatGatewaysClient) List(resourceGroupName string, options *NatGate
 		advancer: func(ctx context.Context, resp *NatGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NatGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *NatGatewaysClient) ListAll(options *NatGatewaysListAllOptions) Nat
 		advancer: func(ctx context.Context, resp *NatGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NatGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -103,6 +103,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) List(resourceGroupName str
 		advancer: func(ctx context.Context, resp *NetworkInterfaceIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -48,6 +48,7 @@ func (client *NetworkInterfaceLoadBalancersClient) List(resourceGroupName string
 		advancer: func(ctx context.Context, resp *NetworkInterfaceLoadBalancerListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceLoadBalancerListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -492,6 +492,7 @@ func (client *NetworkInterfacesClient) List(resourceGroupName string, options *N
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -538,6 +539,7 @@ func (client *NetworkInterfacesClient) ListAll(options *NetworkInterfacesListAll
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -665,6 +667,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfiguration
 		advancer: func(ctx context.Context, resp *NetworkInterfaceIPConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceIPConfigurationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -717,6 +720,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfac
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -764,6 +768,7 @@ func (client *NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterf
 		advancer: func(ctx context.Context, resp *NetworkInterfaceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -273,6 +273,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) List(resourceGroupName st
 		advancer: func(ctx context.Context, resp *NetworkInterfaceTapConfigurationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkInterfaceTapConfigurationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -200,6 +200,7 @@ func (client *NetworkManagementClient) DisconnectActiveSessions(resourceGroupNam
 		advancer: func(ctx context.Context, resp *BastionSessionDeleteResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionSessionDeleteResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -421,6 +422,7 @@ func (client *NetworkManagementClient) GetBastionShareableLink(resourceGroupName
 		advancer: func(ctx context.Context, resp *BastionShareableLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionShareableLinkListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -245,6 +245,7 @@ func (client *NetworkProfilesClient) List(resourceGroupName string, options *Net
 		advancer: func(ctx context.Context, resp *NetworkProfileListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -291,6 +292,7 @@ func (client *NetworkProfilesClient) ListAll(options *NetworkProfilesListAllOpti
 		advancer: func(ctx context.Context, resp *NetworkProfileListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkProfileListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -277,6 +277,7 @@ func (client *NetworkSecurityGroupsClient) List(resourceGroupName string, option
 		advancer: func(ctx context.Context, resp *NetworkSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *NetworkSecurityGroupsClient) ListAll(options *NetworkSecurityGroup
 		advancer: func(ctx context.Context, resp *NetworkSecurityGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkSecurityGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -277,6 +277,7 @@ func (client *NetworkVirtualAppliancesClient) List(options *NetworkVirtualApplia
 		advancer: func(ctx context.Context, resp *NetworkVirtualApplianceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *NetworkVirtualAppliancesClient) ListByResourceGroup(resourceGroupN
 		advancer: func(ctx context.Context, resp *NetworkVirtualApplianceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NetworkVirtualApplianceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -45,6 +45,7 @@ func (client *OperationsClient) List(options *OperationsListOptions) OperationLi
 		advancer: func(ctx context.Context, resp *OperationListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.OperationListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -612,6 +612,7 @@ func (client *P2SVpnGatewaysClient) List(options *P2SVpnGatewaysListOptions) Lis
 		advancer: func(ctx context.Context, resp *ListP2SVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListP2SVpnGatewaysResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -657,6 +658,7 @@ func (client *P2SVpnGatewaysClient) ListByResourceGroup(resourceGroupName string
 		advancer: func(ctx context.Context, resp *ListP2SVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListP2SVpnGatewaysResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -8,7 +8,6 @@ package armnetwork
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 // ApplicationGatewayAvailableSslPredefinedPoliciesPager provides iteration over ApplicationGatewayAvailableSslPredefinedPolicies pages.
@@ -45,6 +44,8 @@ type applicationGatewayAvailableSslPredefinedPoliciesPager struct {
 	advancer applicationGatewayAvailableSslPredefinedPoliciesAdvancePage
 	// contains the current response
 	current *ApplicationGatewayAvailableSslPredefinedPoliciesResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -73,7 +74,7 @@ func (p *applicationGatewayAvailableSslPredefinedPoliciesPager) NextPage(ctx con
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -124,6 +125,8 @@ type applicationGatewayListResultPager struct {
 	advancer applicationGatewayListResultAdvancePage
 	// contains the current response
 	current *ApplicationGatewayListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -152,7 +155,7 @@ func (p *applicationGatewayListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -203,6 +206,8 @@ type applicationSecurityGroupListResultPager struct {
 	advancer applicationSecurityGroupListResultAdvancePage
 	// contains the current response
 	current *ApplicationSecurityGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -231,7 +236,7 @@ func (p *applicationSecurityGroupListResultPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -282,6 +287,8 @@ type authorizationListResultPager struct {
 	advancer authorizationListResultAdvancePage
 	// contains the current response
 	current *AuthorizationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -310,7 +317,7 @@ func (p *authorizationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -361,6 +368,8 @@ type autoApprovedPrivateLinkServicesResultPager struct {
 	advancer autoApprovedPrivateLinkServicesResultAdvancePage
 	// contains the current response
 	current *AutoApprovedPrivateLinkServicesResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -389,7 +398,7 @@ func (p *autoApprovedPrivateLinkServicesResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -440,6 +449,8 @@ type availableDelegationsResultPager struct {
 	advancer availableDelegationsResultAdvancePage
 	// contains the current response
 	current *AvailableDelegationsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -468,7 +479,7 @@ func (p *availableDelegationsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -519,6 +530,8 @@ type availablePrivateEndpointTypesResultPager struct {
 	advancer availablePrivateEndpointTypesResultAdvancePage
 	// contains the current response
 	current *AvailablePrivateEndpointTypesResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -547,7 +560,7 @@ func (p *availablePrivateEndpointTypesResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -598,6 +611,8 @@ type availableServiceAliasesResultPager struct {
 	advancer availableServiceAliasesResultAdvancePage
 	// contains the current response
 	current *AvailableServiceAliasesResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -626,7 +641,7 @@ func (p *availableServiceAliasesResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -677,6 +692,8 @@ type azureFirewallFqdnTagListResultPager struct {
 	advancer azureFirewallFqdnTagListResultAdvancePage
 	// contains the current response
 	current *AzureFirewallFqdnTagListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -705,7 +722,7 @@ func (p *azureFirewallFqdnTagListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -756,6 +773,8 @@ type azureFirewallListResultPager struct {
 	advancer azureFirewallListResultAdvancePage
 	// contains the current response
 	current *AzureFirewallListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -784,7 +803,7 @@ func (p *azureFirewallListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -835,6 +854,8 @@ type bastionActiveSessionListResultPager struct {
 	advancer bastionActiveSessionListResultAdvancePage
 	// contains the current response
 	current *BastionActiveSessionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 	// previous response from the endpoint (LRO case)
@@ -870,7 +891,7 @@ func (p *bastionActiveSessionListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -921,6 +942,8 @@ type bastionHostListResultPager struct {
 	advancer bastionHostListResultAdvancePage
 	// contains the current response
 	current *BastionHostListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -949,7 +972,7 @@ func (p *bastionHostListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1000,6 +1023,8 @@ type bastionSessionDeleteResultPager struct {
 	advancer bastionSessionDeleteResultAdvancePage
 	// contains the current response
 	current *BastionSessionDeleteResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1028,7 +1053,7 @@ func (p *bastionSessionDeleteResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1079,6 +1104,8 @@ type bastionShareableLinkListResultPager struct {
 	advancer bastionShareableLinkListResultAdvancePage
 	// contains the current response
 	current *BastionShareableLinkListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 	// previous response from the endpoint (LRO case)
@@ -1114,7 +1141,7 @@ func (p *bastionShareableLinkListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1165,6 +1192,8 @@ type bgpServiceCommunityListResultPager struct {
 	advancer bgpServiceCommunityListResultAdvancePage
 	// contains the current response
 	current *BgpServiceCommunityListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1193,7 +1222,7 @@ func (p *bgpServiceCommunityListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1244,6 +1273,8 @@ type ddosProtectionPlanListResultPager struct {
 	advancer ddosProtectionPlanListResultAdvancePage
 	// contains the current response
 	current *DdosProtectionPlanListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1272,7 +1303,7 @@ func (p *ddosProtectionPlanListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1323,6 +1354,8 @@ type endpointServicesListResultPager struct {
 	advancer endpointServicesListResultAdvancePage
 	// contains the current response
 	current *EndpointServicesListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1351,7 +1384,7 @@ func (p *endpointServicesListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1402,6 +1435,8 @@ type expressRouteCircuitConnectionListResultPager struct {
 	advancer expressRouteCircuitConnectionListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteCircuitConnectionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1430,7 +1465,7 @@ func (p *expressRouteCircuitConnectionListResultPager) NextPage(ctx context.Cont
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1481,6 +1516,8 @@ type expressRouteCircuitListResultPager struct {
 	advancer expressRouteCircuitListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteCircuitListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1509,7 +1546,7 @@ func (p *expressRouteCircuitListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1560,6 +1597,8 @@ type expressRouteCircuitPeeringListResultPager struct {
 	advancer expressRouteCircuitPeeringListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteCircuitPeeringListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1588,7 +1627,7 @@ func (p *expressRouteCircuitPeeringListResultPager) NextPage(ctx context.Context
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1639,6 +1678,8 @@ type expressRouteCrossConnectionListResultPager struct {
 	advancer expressRouteCrossConnectionListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteCrossConnectionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1667,7 +1708,7 @@ func (p *expressRouteCrossConnectionListResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1718,6 +1759,8 @@ type expressRouteCrossConnectionPeeringListPager struct {
 	advancer expressRouteCrossConnectionPeeringListAdvancePage
 	// contains the current response
 	current *ExpressRouteCrossConnectionPeeringListResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1746,7 +1789,7 @@ func (p *expressRouteCrossConnectionPeeringListPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1797,6 +1840,8 @@ type expressRouteLinkListResultPager struct {
 	advancer expressRouteLinkListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteLinkListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1825,7 +1870,7 @@ func (p *expressRouteLinkListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1876,6 +1921,8 @@ type expressRoutePortListResultPager struct {
 	advancer expressRoutePortListResultAdvancePage
 	// contains the current response
 	current *ExpressRoutePortListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1904,7 +1951,7 @@ func (p *expressRoutePortListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -1955,6 +2002,8 @@ type expressRoutePortsLocationListResultPager struct {
 	advancer expressRoutePortsLocationListResultAdvancePage
 	// contains the current response
 	current *ExpressRoutePortsLocationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -1983,7 +2032,7 @@ func (p *expressRoutePortsLocationListResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2034,6 +2083,8 @@ type expressRouteServiceProviderListResultPager struct {
 	advancer expressRouteServiceProviderListResultAdvancePage
 	// contains the current response
 	current *ExpressRouteServiceProviderListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2062,7 +2113,7 @@ func (p *expressRouteServiceProviderListResultPager) NextPage(ctx context.Contex
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2113,6 +2164,8 @@ type firewallPolicyListResultPager struct {
 	advancer firewallPolicyListResultAdvancePage
 	// contains the current response
 	current *FirewallPolicyListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2141,7 +2194,7 @@ func (p *firewallPolicyListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2192,6 +2245,8 @@ type firewallPolicyRuleGroupListResultPager struct {
 	advancer firewallPolicyRuleGroupListResultAdvancePage
 	// contains the current response
 	current *FirewallPolicyRuleGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2220,7 +2275,7 @@ func (p *firewallPolicyRuleGroupListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2271,6 +2326,8 @@ type flowLogListResultPager struct {
 	advancer flowLogListResultAdvancePage
 	// contains the current response
 	current *FlowLogListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2299,7 +2356,7 @@ func (p *flowLogListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2350,6 +2407,8 @@ type ipAllocationListResultPager struct {
 	advancer ipAllocationListResultAdvancePage
 	// contains the current response
 	current *IPAllocationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2378,7 +2437,7 @@ func (p *ipAllocationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2429,6 +2488,8 @@ type ipGroupListResultPager struct {
 	advancer ipGroupListResultAdvancePage
 	// contains the current response
 	current *IPGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2457,7 +2518,7 @@ func (p *ipGroupListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2508,6 +2569,8 @@ type inboundNatRuleListResultPager struct {
 	advancer inboundNatRuleListResultAdvancePage
 	// contains the current response
 	current *InboundNatRuleListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2536,7 +2599,7 @@ func (p *inboundNatRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2587,6 +2650,8 @@ type listHubVirtualNetworkConnectionsResultPager struct {
 	advancer listHubVirtualNetworkConnectionsResultAdvancePage
 	// contains the current response
 	current *ListHubVirtualNetworkConnectionsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2615,7 +2680,7 @@ func (p *listHubVirtualNetworkConnectionsResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2666,6 +2731,8 @@ type listP2SVpnGatewaysResultPager struct {
 	advancer listP2SVpnGatewaysResultAdvancePage
 	// contains the current response
 	current *ListP2SVpnGatewaysResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2694,7 +2761,7 @@ func (p *listP2SVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2745,6 +2812,8 @@ type listVirtualHubRouteTableV2SResultPager struct {
 	advancer listVirtualHubRouteTableV2SResultAdvancePage
 	// contains the current response
 	current *ListVirtualHubRouteTableV2SResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2773,7 +2842,7 @@ func (p *listVirtualHubRouteTableV2SResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2824,6 +2893,8 @@ type listVirtualHubsResultPager struct {
 	advancer listVirtualHubsResultAdvancePage
 	// contains the current response
 	current *ListVirtualHubsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2852,7 +2923,7 @@ func (p *listVirtualHubsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2903,6 +2974,8 @@ type listVirtualWaNsResultPager struct {
 	advancer listVirtualWaNsResultAdvancePage
 	// contains the current response
 	current *ListVirtualWaNsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -2931,7 +3004,7 @@ func (p *listVirtualWaNsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -2982,6 +3055,8 @@ type listVpnConnectionsResultPager struct {
 	advancer listVpnConnectionsResultAdvancePage
 	// contains the current response
 	current *ListVpnConnectionsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3010,7 +3085,7 @@ func (p *listVpnConnectionsResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3061,6 +3136,8 @@ type listVpnGatewaysResultPager struct {
 	advancer listVpnGatewaysResultAdvancePage
 	// contains the current response
 	current *ListVpnGatewaysResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3089,7 +3166,7 @@ func (p *listVpnGatewaysResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3140,6 +3217,8 @@ type listVpnServerConfigurationsResultPager struct {
 	advancer listVpnServerConfigurationsResultAdvancePage
 	// contains the current response
 	current *ListVpnServerConfigurationsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3168,7 +3247,7 @@ func (p *listVpnServerConfigurationsResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3219,6 +3298,8 @@ type listVpnSiteLinkConnectionsResultPager struct {
 	advancer listVpnSiteLinkConnectionsResultAdvancePage
 	// contains the current response
 	current *ListVpnSiteLinkConnectionsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3247,7 +3328,7 @@ func (p *listVpnSiteLinkConnectionsResultPager) NextPage(ctx context.Context) bo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3298,6 +3379,8 @@ type listVpnSiteLinksResultPager struct {
 	advancer listVpnSiteLinksResultAdvancePage
 	// contains the current response
 	current *ListVpnSiteLinksResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3326,7 +3409,7 @@ func (p *listVpnSiteLinksResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3377,6 +3460,8 @@ type listVpnSitesResultPager struct {
 	advancer listVpnSitesResultAdvancePage
 	// contains the current response
 	current *ListVpnSitesResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3405,7 +3490,7 @@ func (p *listVpnSitesResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3456,6 +3541,8 @@ type loadBalancerBackendAddressPoolListResultPager struct {
 	advancer loadBalancerBackendAddressPoolListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerBackendAddressPoolListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3484,7 +3571,7 @@ func (p *loadBalancerBackendAddressPoolListResultPager) NextPage(ctx context.Con
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3535,6 +3622,8 @@ type loadBalancerFrontendIPConfigurationListResultPager struct {
 	advancer loadBalancerFrontendIPConfigurationListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerFrontendIPConfigurationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3563,7 +3652,7 @@ func (p *loadBalancerFrontendIPConfigurationListResultPager) NextPage(ctx contex
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3614,6 +3703,8 @@ type loadBalancerListResultPager struct {
 	advancer loadBalancerListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3642,7 +3733,7 @@ func (p *loadBalancerListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3693,6 +3784,8 @@ type loadBalancerLoadBalancingRuleListResultPager struct {
 	advancer loadBalancerLoadBalancingRuleListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerLoadBalancingRuleListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3721,7 +3814,7 @@ func (p *loadBalancerLoadBalancingRuleListResultPager) NextPage(ctx context.Cont
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3772,6 +3865,8 @@ type loadBalancerOutboundRuleListResultPager struct {
 	advancer loadBalancerOutboundRuleListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerOutboundRuleListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3800,7 +3895,7 @@ func (p *loadBalancerOutboundRuleListResultPager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3851,6 +3946,8 @@ type loadBalancerProbeListResultPager struct {
 	advancer loadBalancerProbeListResultAdvancePage
 	// contains the current response
 	current *LoadBalancerProbeListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3879,7 +3976,7 @@ func (p *loadBalancerProbeListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -3930,6 +4027,8 @@ type localNetworkGatewayListResultPager struct {
 	advancer localNetworkGatewayListResultAdvancePage
 	// contains the current response
 	current *LocalNetworkGatewayListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -3958,7 +4057,7 @@ func (p *localNetworkGatewayListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4009,6 +4108,8 @@ type natGatewayListResultPager struct {
 	advancer natGatewayListResultAdvancePage
 	// contains the current response
 	current *NatGatewayListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4037,7 +4138,7 @@ func (p *natGatewayListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4088,6 +4189,8 @@ type networkInterfaceIPConfigurationListResultPager struct {
 	advancer networkInterfaceIPConfigurationListResultAdvancePage
 	// contains the current response
 	current *NetworkInterfaceIPConfigurationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4116,7 +4219,7 @@ func (p *networkInterfaceIPConfigurationListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4167,6 +4270,8 @@ type networkInterfaceListResultPager struct {
 	advancer networkInterfaceListResultAdvancePage
 	// contains the current response
 	current *NetworkInterfaceListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4195,7 +4300,7 @@ func (p *networkInterfaceListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4246,6 +4351,8 @@ type networkInterfaceLoadBalancerListResultPager struct {
 	advancer networkInterfaceLoadBalancerListResultAdvancePage
 	// contains the current response
 	current *NetworkInterfaceLoadBalancerListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4274,7 +4381,7 @@ func (p *networkInterfaceLoadBalancerListResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4325,6 +4432,8 @@ type networkInterfaceTapConfigurationListResultPager struct {
 	advancer networkInterfaceTapConfigurationListResultAdvancePage
 	// contains the current response
 	current *NetworkInterfaceTapConfigurationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4353,7 +4462,7 @@ func (p *networkInterfaceTapConfigurationListResultPager) NextPage(ctx context.C
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4404,6 +4513,8 @@ type networkProfileListResultPager struct {
 	advancer networkProfileListResultAdvancePage
 	// contains the current response
 	current *NetworkProfileListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4432,7 +4543,7 @@ func (p *networkProfileListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4483,6 +4594,8 @@ type networkSecurityGroupListResultPager struct {
 	advancer networkSecurityGroupListResultAdvancePage
 	// contains the current response
 	current *NetworkSecurityGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4511,7 +4624,7 @@ func (p *networkSecurityGroupListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4562,6 +4675,8 @@ type networkVirtualApplianceListResultPager struct {
 	advancer networkVirtualApplianceListResultAdvancePage
 	// contains the current response
 	current *NetworkVirtualApplianceListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4590,7 +4705,7 @@ func (p *networkVirtualApplianceListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4641,6 +4756,8 @@ type operationListResultPager struct {
 	advancer operationListResultAdvancePage
 	// contains the current response
 	current *OperationListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4669,7 +4786,7 @@ func (p *operationListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4720,6 +4837,8 @@ type peerExpressRouteCircuitConnectionListResultPager struct {
 	advancer peerExpressRouteCircuitConnectionListResultAdvancePage
 	// contains the current response
 	current *PeerExpressRouteCircuitConnectionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4748,7 +4867,7 @@ func (p *peerExpressRouteCircuitConnectionListResultPager) NextPage(ctx context.
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4799,6 +4918,8 @@ type privateDnsZoneGroupListResultPager struct {
 	advancer privateDnsZoneGroupListResultAdvancePage
 	// contains the current response
 	current *PrivateDNSZoneGroupListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4827,7 +4948,7 @@ func (p *privateDnsZoneGroupListResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4878,6 +4999,8 @@ type privateEndpointConnectionListResultPager struct {
 	advancer privateEndpointConnectionListResultAdvancePage
 	// contains the current response
 	current *PrivateEndpointConnectionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4906,7 +5029,7 @@ func (p *privateEndpointConnectionListResultPager) NextPage(ctx context.Context)
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -4957,6 +5080,8 @@ type privateEndpointListResultPager struct {
 	advancer privateEndpointListResultAdvancePage
 	// contains the current response
 	current *PrivateEndpointListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -4985,7 +5110,7 @@ func (p *privateEndpointListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5036,6 +5161,8 @@ type privateLinkServiceListResultPager struct {
 	advancer privateLinkServiceListResultAdvancePage
 	// contains the current response
 	current *PrivateLinkServiceListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5064,7 +5191,7 @@ func (p *privateLinkServiceListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5115,6 +5242,8 @@ type publicIPAddressListResultPager struct {
 	advancer publicIPAddressListResultAdvancePage
 	// contains the current response
 	current *PublicIPAddressListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5143,7 +5272,7 @@ func (p *publicIPAddressListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5194,6 +5323,8 @@ type publicIPPrefixListResultPager struct {
 	advancer publicIPPrefixListResultAdvancePage
 	// contains the current response
 	current *PublicIPPrefixListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5222,7 +5353,7 @@ func (p *publicIPPrefixListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5273,6 +5404,8 @@ type routeFilterListResultPager struct {
 	advancer routeFilterListResultAdvancePage
 	// contains the current response
 	current *RouteFilterListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5301,7 +5434,7 @@ func (p *routeFilterListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5352,6 +5485,8 @@ type routeFilterRuleListResultPager struct {
 	advancer routeFilterRuleListResultAdvancePage
 	// contains the current response
 	current *RouteFilterRuleListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5380,7 +5515,7 @@ func (p *routeFilterRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5431,6 +5566,8 @@ type routeListResultPager struct {
 	advancer routeListResultAdvancePage
 	// contains the current response
 	current *RouteListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5459,7 +5596,7 @@ func (p *routeListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5510,6 +5647,8 @@ type routeTableListResultPager struct {
 	advancer routeTableListResultAdvancePage
 	// contains the current response
 	current *RouteTableListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5538,7 +5677,7 @@ func (p *routeTableListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5589,6 +5728,8 @@ type securityPartnerProviderListResultPager struct {
 	advancer securityPartnerProviderListResultAdvancePage
 	// contains the current response
 	current *SecurityPartnerProviderListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5617,7 +5758,7 @@ func (p *securityPartnerProviderListResultPager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5668,6 +5809,8 @@ type securityRuleListResultPager struct {
 	advancer securityRuleListResultAdvancePage
 	// contains the current response
 	current *SecurityRuleListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5696,7 +5839,7 @@ func (p *securityRuleListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5747,6 +5890,8 @@ type serviceEndpointPolicyDefinitionListResultPager struct {
 	advancer serviceEndpointPolicyDefinitionListResultAdvancePage
 	// contains the current response
 	current *ServiceEndpointPolicyDefinitionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5775,7 +5920,7 @@ func (p *serviceEndpointPolicyDefinitionListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5826,6 +5971,8 @@ type serviceEndpointPolicyListResultPager struct {
 	advancer serviceEndpointPolicyListResultAdvancePage
 	// contains the current response
 	current *ServiceEndpointPolicyListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5854,7 +6001,7 @@ func (p *serviceEndpointPolicyListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5905,6 +6052,8 @@ type subnetListResultPager struct {
 	advancer subnetListResultAdvancePage
 	// contains the current response
 	current *SubnetListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -5933,7 +6082,7 @@ func (p *subnetListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -5984,6 +6133,8 @@ type usagesListResultPager struct {
 	advancer usagesListResultAdvancePage
 	// contains the current response
 	current *UsagesListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6012,7 +6163,7 @@ func (p *usagesListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6063,6 +6214,8 @@ type virtualNetworkGatewayConnectionListResultPager struct {
 	advancer virtualNetworkGatewayConnectionListResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkGatewayConnectionListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6091,7 +6244,7 @@ func (p *virtualNetworkGatewayConnectionListResultPager) NextPage(ctx context.Co
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6142,6 +6295,8 @@ type virtualNetworkGatewayListConnectionsResultPager struct {
 	advancer virtualNetworkGatewayListConnectionsResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkGatewayListConnectionsResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6170,7 +6325,7 @@ func (p *virtualNetworkGatewayListConnectionsResultPager) NextPage(ctx context.C
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6221,6 +6376,8 @@ type virtualNetworkGatewayListResultPager struct {
 	advancer virtualNetworkGatewayListResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkGatewayListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6249,7 +6406,7 @@ func (p *virtualNetworkGatewayListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6300,6 +6457,8 @@ type virtualNetworkListResultPager struct {
 	advancer virtualNetworkListResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6328,7 +6487,7 @@ func (p *virtualNetworkListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6379,6 +6538,8 @@ type virtualNetworkListUsageResultPager struct {
 	advancer virtualNetworkListUsageResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkListUsageResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6407,7 +6568,7 @@ func (p *virtualNetworkListUsageResultPager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6458,6 +6619,8 @@ type virtualNetworkPeeringListResultPager struct {
 	advancer virtualNetworkPeeringListResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkPeeringListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6486,7 +6649,7 @@ func (p *virtualNetworkPeeringListResultPager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6537,6 +6700,8 @@ type virtualNetworkTapListResultPager struct {
 	advancer virtualNetworkTapListResultAdvancePage
 	// contains the current response
 	current *VirtualNetworkTapListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6565,7 +6730,7 @@ func (p *virtualNetworkTapListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6616,6 +6781,8 @@ type virtualRouterListResultPager struct {
 	advancer virtualRouterListResultAdvancePage
 	// contains the current response
 	current *VirtualRouterListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6644,7 +6811,7 @@ func (p *virtualRouterListResultPager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6695,6 +6862,8 @@ type virtualRouterPeeringListResultPager struct {
 	advancer virtualRouterPeeringListResultAdvancePage
 	// contains the current response
 	current *VirtualRouterPeeringListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6723,7 +6892,7 @@ func (p *virtualRouterPeeringListResultPager) NextPage(ctx context.Context) bool
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -6774,6 +6943,8 @@ type webApplicationFirewallPolicyListResultPager struct {
 	advancer webApplicationFirewallPolicyListResultAdvancePage
 	// contains the current response
 	current *WebApplicationFirewallPolicyListResultResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -6802,7 +6973,7 @@ func (p *webApplicationFirewallPolicyListResultPager) NextPage(ctx context.Conte
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -104,6 +104,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) List(resourceGroupName s
 		advancer: func(ctx context.Context, resp *PeerExpressRouteCircuitConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PeerExpressRouteCircuitConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -422,6 +422,7 @@ func (p *bastionActiveSessionListResultPagerPoller) handleResponse(resp *azcore.
 		advancer: func(ctx context.Context, resp *BastionActiveSessionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionActiveSessionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK, http.StatusAccepted},
 	}, nil
 }
 
@@ -534,6 +535,7 @@ func (p *bastionShareableLinkListResultPagerPoller) handleResponse(resp *azcore.
 		advancer: func(ctx context.Context, resp *BastionShareableLinkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.BastionShareableLinkListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK, http.StatusAccepted},
 	}, nil
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -273,6 +273,7 @@ func (client *PrivateDNSZoneGroupsClient) List(privateEndpointName string, resou
 		advancer: func(ctx context.Context, resp *PrivateDNSZoneGroupListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateDNSZoneGroupListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -275,6 +275,7 @@ func (client *PrivateEndpointsClient) List(resourceGroupName string, options *Pr
 		advancer: func(ctx context.Context, resp *PrivateEndpointListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -321,6 +322,7 @@ func (client *PrivateEndpointsClient) ListBySubscription(options *PrivateEndpoin
 		advancer: func(ctx context.Context, resp *PrivateEndpointListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -593,6 +593,7 @@ func (client *PrivateLinkServicesClient) List(resourceGroupName string, options 
 		advancer: func(ctx context.Context, resp *PrivateLinkServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateLinkServiceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -639,6 +640,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServices(loc
 		advancer: func(ctx context.Context, resp *AutoApprovedPrivateLinkServicesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AutoApprovedPrivateLinkServicesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -685,6 +687,7 @@ func (client *PrivateLinkServicesClient) ListAutoApprovedPrivateLinkServicesByRe
 		advancer: func(ctx context.Context, resp *AutoApprovedPrivateLinkServicesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.AutoApprovedPrivateLinkServicesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -732,6 +735,7 @@ func (client *PrivateLinkServicesClient) ListBySubscription(options *PrivateLink
 		advancer: func(ctx context.Context, resp *PrivateLinkServiceListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateLinkServiceListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -777,6 +781,7 @@ func (client *PrivateLinkServicesClient) ListPrivateEndpointConnections(resource
 		advancer: func(ctx context.Context, resp *PrivateEndpointConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PrivateEndpointConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -342,6 +342,7 @@ func (client *PublicIPAddressesClient) List(resourceGroupName string, options *P
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -388,6 +389,7 @@ func (client *PublicIPAddressesClient) ListAll(options *PublicIPAddressesListAll
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -433,6 +435,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetPublicIPAddress
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -480,6 +483,7 @@ func (client *PublicIPAddressesClient) ListVirtualMachineScaleSetVMPublicIPaddre
 		advancer: func(ctx context.Context, resp *PublicIPAddressListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPAddressListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -277,6 +277,7 @@ func (client *PublicIPPrefixesClient) List(resourceGroupName string, options *Pu
 		advancer: func(ctx context.Context, resp *PublicIPPrefixListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPPrefixListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *PublicIPPrefixesClient) ListAll(options *PublicIPPrefixesListAllOp
 		advancer: func(ctx context.Context, resp *PublicIPPrefixListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PublicIPPrefixListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -273,6 +273,7 @@ func (client *RouteFilterRulesClient) ListByRouteFilter(resourceGroupName string
 		advancer: func(ctx context.Context, resp *RouteFilterRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -277,6 +277,7 @@ func (client *RouteFiltersClient) List(options *RouteFiltersListOptions) RouteFi
 		advancer: func(ctx context.Context, resp *RouteFilterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *RouteFiltersClient) ListByResourceGroup(resourceGroupName string, 
 		advancer: func(ctx context.Context, resp *RouteFilterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteFilterListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -273,6 +273,7 @@ func (client *RoutesClient) List(resourceGroupName string, routeTableName string
 		advancer: func(ctx context.Context, resp *RouteListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -277,6 +277,7 @@ func (client *RouteTablesClient) List(resourceGroupName string, options *RouteTa
 		advancer: func(ctx context.Context, resp *RouteTableListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteTableListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *RouteTablesClient) ListAll(options *RouteTablesListAllOptions) Rou
 		advancer: func(ctx context.Context, resp *RouteTableListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.RouteTableListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -274,6 +274,7 @@ func (client *SecurityPartnerProvidersClient) List(options *SecurityPartnerProvi
 		advancer: func(ctx context.Context, resp *SecurityPartnerProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityPartnerProviderListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *SecurityPartnerProvidersClient) ListByResourceGroup(resourceGroupN
 		advancer: func(ctx context.Context, resp *SecurityPartnerProviderListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityPartnerProviderListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -273,6 +273,7 @@ func (client *SecurityRulesClient) List(resourceGroupName string, networkSecurit
 		advancer: func(ctx context.Context, resp *SecurityRuleListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SecurityRuleListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -277,6 +277,7 @@ func (client *ServiceEndpointPoliciesClient) List(options *ServiceEndpointPolici
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -322,6 +323,7 @@ func (client *ServiceEndpointPoliciesClient) ListByResourceGroup(resourceGroupNa
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -273,6 +273,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) ListByResourceGroup(resour
 		advancer: func(ctx context.Context, resp *ServiceEndpointPolicyDefinitionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ServiceEndpointPolicyDefinitionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -284,6 +284,7 @@ func (client *SubnetsClient) List(resourceGroupName string, virtualNetworkName s
 		advancer: func(ctx context.Context, resp *SubnetListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SubnetListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -48,6 +48,7 @@ func (client *UsagesClient) List(location string, options *UsagesListOptions) Us
 		advancer: func(ctx context.Context, resp *UsagesListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.UsagesListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -273,6 +273,7 @@ func (client *VirtualHubRouteTableV2SClient) List(resourceGroupName string, virt
 		advancer: func(ctx context.Context, resp *ListVirtualHubRouteTableV2SResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubRouteTableV2SResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -274,6 +274,7 @@ func (client *VirtualHubsClient) List(options *VirtualHubsListOptions) ListVirtu
 		advancer: func(ctx context.Context, resp *ListVirtualHubsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *VirtualHubsClient) ListByResourceGroup(resourceGroupName string, o
 		advancer: func(ctx context.Context, resp *ListVirtualHubsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualHubsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -344,6 +344,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) List(resourceGroupName str
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayConnectionListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayConnectionListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -1072,6 +1072,7 @@ func (client *VirtualNetworkGatewaysClient) List(resourceGroupName string, optio
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -1118,6 +1119,7 @@ func (client *VirtualNetworkGatewaysClient) ListConnections(resourceGroupName st
 		advancer: func(ctx context.Context, resp *VirtualNetworkGatewayListConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkGatewayListConnectionsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -273,6 +273,7 @@ func (client *VirtualNetworkPeeringsClient) List(resourceGroupName string, virtu
 		advancer: func(ctx context.Context, resp *VirtualNetworkPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkPeeringListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -334,6 +334,7 @@ func (client *VirtualNetworksClient) List(resourceGroupName string, options *Vir
 		advancer: func(ctx context.Context, resp *VirtualNetworkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -380,6 +381,7 @@ func (client *VirtualNetworksClient) ListAll(options *VirtualNetworksListAllOpti
 		advancer: func(ctx context.Context, resp *VirtualNetworkListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -425,6 +427,7 @@ func (client *VirtualNetworksClient) ListUsage(resourceGroupName string, virtual
 		advancer: func(ctx context.Context, resp *VirtualNetworkListUsageResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkListUsageResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -274,6 +274,7 @@ func (client *VirtualNetworkTapsClient) ListAll(options *VirtualNetworkTapsListA
 		advancer: func(ctx context.Context, resp *VirtualNetworkTapListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkTapListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *VirtualNetworkTapsClient) ListByResourceGroup(resourceGroupName st
 		advancer: func(ctx context.Context, resp *VirtualNetworkTapListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualNetworkTapListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -273,6 +273,7 @@ func (client *VirtualRouterPeeringsClient) List(resourceGroupName string, virtua
 		advancer: func(ctx context.Context, resp *VirtualRouterPeeringListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterPeeringListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -275,6 +275,7 @@ func (client *VirtualRoutersClient) List(options *VirtualRoutersListOptions) Vir
 		advancer: func(ctx context.Context, resp *VirtualRouterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -320,6 +321,7 @@ func (client *VirtualRoutersClient) ListByResourceGroup(resourceGroupName string
 		advancer: func(ctx context.Context, resp *VirtualRouterListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.VirtualRouterListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -274,6 +274,7 @@ func (client *VirtualWansClient) List(options *VirtualWansListOptions) ListVirtu
 		advancer: func(ctx context.Context, resp *ListVirtualWaNsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualWaNsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *VirtualWansClient) ListByResourceGroup(resourceGroupName string, o
 		advancer: func(ctx context.Context, resp *ListVirtualWaNsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVirtualWaNsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -273,6 +273,7 @@ func (client *VpnConnectionsClient) ListByVpnGateway(resourceGroupName string, g
 		advancer: func(ctx context.Context, resp *ListVpnConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnConnectionsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -278,6 +278,7 @@ func (client *VpnGatewaysClient) List(options *VpnGatewaysListOptions) ListVpnGa
 		advancer: func(ctx context.Context, resp *ListVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnGatewaysResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -323,6 +324,7 @@ func (client *VpnGatewaysClient) ListByResourceGroup(resourceGroupName string, o
 		advancer: func(ctx context.Context, resp *ListVpnGatewaysResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnGatewaysResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -48,6 +48,7 @@ func (client *VpnLinkConnectionsClient) ListByVpnConnection(resourceGroupName st
 		advancer: func(ctx context.Context, resp *ListVpnSiteLinkConnectionsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSiteLinkConnectionsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -274,6 +274,7 @@ func (client *VpnServerConfigurationsClient) List(options *VpnServerConfiguratio
 		advancer: func(ctx context.Context, resp *ListVpnServerConfigurationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnServerConfigurationsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *VpnServerConfigurationsClient) ListByResourceGroup(resourceGroupNa
 		advancer: func(ctx context.Context, resp *ListVpnServerConfigurationsResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnServerConfigurationsResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -103,6 +103,7 @@ func (client *VpnSiteLinksClient) ListByVpnSite(resourceGroupName string, vpnSit
 		advancer: func(ctx context.Context, resp *ListVpnSiteLinksResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSiteLinksResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -274,6 +274,7 @@ func (client *VpnSitesClient) List(options *VpnSitesListOptions) ListVpnSitesRes
 		advancer: func(ctx context.Context, resp *ListVpnSitesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSitesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -319,6 +320,7 @@ func (client *VpnSitesClient) ListByResourceGroup(resourceGroupName string, opti
 		advancer: func(ctx context.Context, resp *ListVpnSitesResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.ListVpnSitesResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -240,6 +240,7 @@ func (client *WebApplicationFirewallPoliciesClient) List(resourceGroupName strin
 		advancer: func(ctx context.Context, resp *WebApplicationFirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.WebApplicationFirewallPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -286,6 +287,7 @@ func (client *WebApplicationFirewallPoliciesClient) ListAll(options *WebApplicat
 		advancer: func(ctx context.Context, resp *WebApplicationFirewallPolicyListResultResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.WebApplicationFirewallPolicyListResult.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -792,6 +792,7 @@ func (client *containerClient) ListBlobFlatSegment(options *ContainerListBlobFla
 		advancer: func(ctx context.Context, resp *ListBlobsFlatSegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -874,6 +875,7 @@ func (client *containerClient) ListBlobHierarchySegment(delimiter string, option
 		advancer: func(ctx context.Context, resp *ListBlobsHierarchySegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_pagers.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pagers.go
@@ -8,7 +8,6 @@ package azblob
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 // ListBlobsFlatSegmentResponsePager provides iteration over ListBlobsFlatSegmentResponse pages.
@@ -45,6 +44,8 @@ type listBlobsFlatSegmentResponsePager struct {
 	advancer listBlobsFlatSegmentResponseAdvancePage
 	// contains the current response
 	current *ListBlobsFlatSegmentResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -73,7 +74,7 @@ func (p *listBlobsFlatSegmentResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -124,6 +125,8 @@ type listBlobsHierarchySegmentResponsePager struct {
 	advancer listBlobsHierarchySegmentResponseAdvancePage
 	// contains the current response
 	current *ListBlobsHierarchySegmentResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -152,7 +155,7 @@ func (p *listBlobsHierarchySegmentResponsePager) NextPage(ctx context.Context) b
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -203,6 +206,8 @@ type listContainersSegmentResponsePager struct {
 	advancer listContainersSegmentResponseAdvancePage
 	// contains the current response
 	current *ListContainersSegmentResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -231,7 +236,7 @@ func (p *listContainersSegmentResponsePager) NextPage(ctx context.Context) bool 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -315,6 +315,7 @@ func (client *serviceClient) ListContainersSegment(options *ServiceListContainer
 		advancer: func(ctx context.Context, resp *ListContainersSegmentResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.EnumerationResults.NextMarker)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
@@ -176,6 +176,7 @@ func (client *dataFlowClient) GetDataFlowsByWorkspace(options *DataFlowGetDataFl
 		advancer: func(ctx context.Context, resp *DataFlowListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DataFlowListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
@@ -210,6 +210,7 @@ func (client *dataFlowDebugSessionClient) QueryDataFlowDebugSessionsByWorkspace(
 		advancer: func(ctx context.Context, resp *QueryDataFlowDebugSessionsResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.QueryDataFlowDebugSessionsResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
@@ -176,6 +176,7 @@ func (client *datasetClient) GetDatasetsByWorkspace(options *DatasetGetDatasetsB
 		advancer: func(ctx context.Context, resp *DatasetListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.DatasetListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
@@ -176,6 +176,7 @@ func (client *linkedServiceClient) GetLinkedServicesByWorkspace(options *LinkedS
 		advancer: func(ctx context.Context, resp *LinkedServiceListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.LinkedServiceListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
@@ -176,6 +176,7 @@ func (client *notebookClient) GetNotebookSummaryByWorkSpace(options *NotebookGet
 		advancer: func(ctx context.Context, resp *NotebookListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NotebookListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 
@@ -220,6 +221,7 @@ func (client *notebookClient) GetNotebooksByWorkspace(options *NotebookGetNotebo
 		advancer: func(ctx context.Context, resp *NotebookListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.NotebookListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
@@ -8,7 +8,6 @@ package azartifacts
 import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"net/http"
 )
 
 // DataFlowListResponsePager provides iteration over DataFlowListResponse pages.
@@ -45,6 +44,8 @@ type dataFlowListResponsePager struct {
 	advancer dataFlowListResponseAdvancePage
 	// contains the current response
 	current *DataFlowListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -73,7 +74,7 @@ func (p *dataFlowListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -124,6 +125,8 @@ type datasetListResponsePager struct {
 	advancer datasetListResponseAdvancePage
 	// contains the current response
 	current *DatasetListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -152,7 +155,7 @@ func (p *datasetListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -203,6 +206,8 @@ type linkedServiceListResponsePager struct {
 	advancer linkedServiceListResponseAdvancePage
 	// contains the current response
 	current *LinkedServiceListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -231,7 +236,7 @@ func (p *linkedServiceListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -282,6 +287,8 @@ type notebookListResponsePager struct {
 	advancer notebookListResponseAdvancePage
 	// contains the current response
 	current *NotebookListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -310,7 +317,7 @@ func (p *notebookListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -361,6 +368,8 @@ type pipelineListResponsePager struct {
 	advancer pipelineListResponseAdvancePage
 	// contains the current response
 	current *PipelineListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -389,7 +398,7 @@ func (p *pipelineListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -440,6 +449,8 @@ type queryDataFlowDebugSessionsResponsePager struct {
 	advancer queryDataFlowDebugSessionsResponseAdvancePage
 	// contains the current response
 	current *QueryDataFlowDebugSessionsResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -468,7 +479,7 @@ func (p *queryDataFlowDebugSessionsResponsePager) NextPage(ctx context.Context) 
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -519,6 +530,8 @@ type sqlScriptsListResponsePager struct {
 	advancer sqlScriptsListResponseAdvancePage
 	// contains the current response
 	current *SQLScriptsListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -547,7 +560,7 @@ func (p *sqlScriptsListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -598,6 +611,8 @@ type sparkJobDefinitionsListResponsePager struct {
 	advancer sparkJobDefinitionsListResponseAdvancePage
 	// contains the current response
 	current *SparkJobDefinitionsListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -626,7 +641,7 @@ func (p *sparkJobDefinitionsListResponsePager) NextPage(ctx context.Context) boo
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}
@@ -677,6 +692,8 @@ type triggerListResponsePager struct {
 	advancer triggerListResponseAdvancePage
 	// contains the current response
 	current *TriggerListResponseResponse
+	// status codes for successful retrieval
+	statusCodes []int
 	// any error encountered
 	err error
 }
@@ -705,7 +722,7 @@ func (p *triggerListResponsePager) NextPage(ctx context.Context) bool {
 		p.err = err
 		return false
 	}
-	if !resp.HasStatusCode(http.StatusOK) {
+	if !resp.HasStatusCode(p.statusCodes...) {
 		p.err = p.errorer(resp)
 		return false
 	}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
@@ -239,6 +239,7 @@ func (client *pipelineClient) GetPipelinesByWorkspace(options *PipelineGetPipeli
 		advancer: func(ctx context.Context, resp *PipelineListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.PipelineListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
@@ -271,6 +271,7 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinitionsByWorkspace(option
 		advancer: func(ctx context.Context, resp *SparkJobDefinitionsListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SparkJobDefinitionsListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
@@ -180,6 +180,7 @@ func (client *sqlScriptClient) GetSQLScriptsByWorkspace(options *SQLScriptGetSQL
 		advancer: func(ctx context.Context, resp *SQLScriptsListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.SQLScriptsListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
@@ -226,6 +226,7 @@ func (client *triggerClient) GetTriggersByWorkspace(options *TriggerGetTriggersB
 		advancer: func(ctx context.Context, resp *TriggerListResponseResponse) (*azcore.Request, error) {
 			return azcore.NewRequest(ctx, http.MethodGet, *resp.TriggerListResponse.NextLink)
 		},
+		statusCodes: []int{http.StatusOK},
 	}
 }
 


### PR DESCRIPTION
Status codes for a successful page retrieval might vary depending on the
operation, so use the per-operation values.
Renamed a field in PagerInfo to clarify its usage.