### PR TITLE
Add npm publishing pipeline

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -21,10 +21,10 @@ jobs:
       matrix:
         Linux_Go113:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.13'
+          go.version: '1.14.10'
         Linux_Go114:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.14'
+          go.version: '1.15.3'
 
     pool:
       vmImage: '$(vm.image)'

--- a/eng/pipelines/publish-dev-release.yml
+++ b/eng/pipelines/publish-dev-release.yml
@@ -35,7 +35,7 @@ steps:
 
   - task: GoTool@0
     inputs:
-      version: '1.14'
+      version: '1.15.3'
     displayName: "Select Go Version"
 
   - script: |

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -39,7 +39,7 @@ steps:
 
   - task: GoTool@0
     inputs:
-      version: '1.14'
+      version: '1.15.3'
     displayName: "Select Go Version"
 
   - script: |

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -1,0 +1,107 @@
+trigger: none
+pr: none
+
+variables:
+  NodeVersion: '12.x'
+  goTestPath: '$(system.defaultWorkingDirectory)/test'
+  GOBIN: '$(system.defaultWorkingDirectory)/bin/go'
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  NodeVersion: '12.x'
+  TestFolder: '$(Build.SourcesDirectory)/test/'
+
+steps:
+  - task: NodeTool@0
+    displayName: 'Install Node $(NodeVersion)'
+    inputs:
+      versionSpec: '$(NodeVersion)'
+
+  - script: |
+      cd $(Build.SourcesDirectory)
+      npm install -g "@microsoft/rush"
+      rush update --debug
+      npm install -g autorest
+    displayName: 'Prepare Generator Environment'
+
+  - script: |
+      rush rebuild -v
+    displayName: 'Build Generator Sources'
+
+  - script: |
+      rush regenerate
+      git add -A ./test/.
+      git diff --staged -w 1>&2
+    displayName: 'Regenerate Autorest Tests'
+    failOnStderr: true
+
+  - task: GoTool@0
+    inputs:
+      version: '1.14'
+    displayName: "Select Go Version"
+
+  - script: |
+      set -e
+      go version
+      go get github.com/jstemmer/go-junit-report
+    displayName: 'Install Dependencies'
+    workingDirectory: '$(goTestPath)'
+
+  - pwsh: |
+      $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(goTestPath))
+      foreach ($md in $modDirs) {
+        pushd $md
+        Write-Host "##[command]Executing go build -v ./... in $md"
+        go build -v ./...
+      }
+    displayName: 'Build'
+
+  - pwsh: |
+      $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(goTestPath))
+      foreach ($md in $modDirs) {
+        pushd $md
+        Write-Host "##[command]Executing go vet ./... in $md"
+        go vet ./...
+      }
+    displayName: 'Vet'
+
+  - pwsh: |
+      pushd ./src/node_modules/@microsoft.azure/autorest.testserver
+      npm start&
+      popd
+      $testDirs = (./eng/scripts/get_test_dirs.ps1 -serviceDir $(goTestPath))
+      foreach ($td in $testDirs) {
+        pushd $td
+        Write-Host "##[command]Executing go test -run "^Test" -v $td | $(GOBIN)/go-junit-report -set-exit-code > report.xml"
+        go test -run "^Test" -v | $(GOBIN)/go-junit-report -set-exit-code > report.xml
+        popd
+      }
+      pushd test
+      go run ./autorest/covreport/main.go
+      popd
+      pushd ./src/node_modules/@microsoft.azure/autorest.testserver
+      npm stop
+      popd
+    displayName: 'Run Acceptance Tests'
+
+  - task: PublishTestResults@2
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: $(goTestPath)/**/report.xml
+      failTaskOnFailedTests: true
+
+  - pwsh: |
+      $currentVersion = node -p -e "require('./src/package.json').version";
+      $currentVersion="$currentVersion-$(Build.BuildNumber)";
+      cd src
+      npm version --no-git-tag-version $currentVersion
+      npm pack;
+      npx publish-release --token $(package-write-token) --repo autorest.go --owner azure --name "Autorest for Go v$currentVersion" --tag v$currentVersion --notes='Preview version of Autorest for Go track 2' --prerelease --editRelease false --assets autorest-go-$currentVersion.tgz --target_commitish $(Build.SourceBranchName);
+    displayName: 'Publish GitHub Release'
+
+  - script: |
+      echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
+      npm publish --access public
+    displayName: 'Publish to npm'

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -94,11 +94,10 @@ steps:
 
   - pwsh: |
       $currentVersion = node -p -e "require('./src/package.json').version";
-      $currentVersion="$currentVersion-$(Build.BuildNumber)";
       cd src
       npm version --no-git-tag-version $currentVersion
       npm pack;
-      npx publish-release --token $(package-write-token) --repo autorest.go --owner azure --name "Autorest for Go v$currentVersion" --tag v$currentVersion --notes='Preview version of Autorest for Go track 2' --prerelease --editRelease false --assets autorest-go-$currentVersion.tgz --target_commitish $(Build.SourceBranchName);
+      npx publish-release --token $(package-write-token) --repo autorest.go --owner azure --name "Autorest for Go v$currentVersion" --tag v$currentVersion --notes='Autorest for Go track 2' --prerelease --editRelease false --assets autorest-go-$currentVersion.tgz --target_commitish $(Build.SourceBranchName);
     displayName: 'Publish GitHub Release'
 
   - script: |

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0",
+  "version": "4.0.0-preview.1",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",


### PR DESCRIPTION
This basically copies the `publish-dev-release.yml` that you've already defined to add an `npm` publishing step.  Once this looks good I can create an Azure DevOps pipeline definition that uses it so that you can publish your first release.