### PR TITLE
normalize output folder before output it

### DIFF
--- a/src/CodeGeneratorGo.cs
+++ b/src/CodeGeneratorGo.cs
@@ -43,7 +43,7 @@ namespace AutoRest.Go
         /// <returns></returns>
         public override async Task Generate(CodeModel cm)
         {
-            var folder = Settings.Instance.Host.GetValue<string>("output-folder").Result;
+            var folder = Path.GetFullPath(Settings.Instance.Host.GetValue<string>("output-folder").Result).Replace('\\', '/');
             // check if the namespace contains illegal characters
             var ns = Settings.Instance.Host.GetValue<string>("namespace").Result;
             var r = new Regex(@"^[a-z][a-z0-9_]*[a-z0-9]?$");
@@ -134,11 +134,10 @@ namespace AutoRest.Go
             var modRoot = Settings.Instance.Host.GetValue<string>("gomod-root").Result;
             if (!string.IsNullOrWhiteSpace(modRoot))
             {
-                var normalized = Path.GetFullPath(Settings.Instance.Host.GetValue<string>("output-folder").Result).Replace('\\', '/');
-                var i = normalized.IndexOf(modRoot);
+                var i = folder.IndexOf(modRoot);
                 if (i == -1)
                 {
-                    throw new Exception($"didn't find module root '{modRoot}' in output path '{normalized}'");
+                    throw new Exception($"didn't find module root '{modRoot}' in output path '{folder}'");
                 }
                 var goVersion = Settings.Instance.Host.GetValue<string>("go-version").Result;
                 if (string.IsNullOrWhiteSpace(goVersion)) 
@@ -146,7 +145,7 @@ namespace AutoRest.Go
                     goVersion = defaultGoVersion;
                 }
                 // module name is everything to the right of the start of the module root
-                var gomodTemplate = new GoModTemplate { Model = new GoMod(normalized.Substring(i), goVersion) };
+                var gomodTemplate = new GoModTemplate { Model = new GoMod(folder.Substring(i), goVersion) };
                 await Write(gomodTemplate, $"{StagingDir()}go.mod");
             }
 


### PR DESCRIPTION
@jhendrixMSFT could you please have a review on this?

It turns out that the output folder is just concat together without normalization, therefore on windows platform, if we assign relative path to `go-sdk-folder`, the output folder will mix `/` and `\`. This might breaking the json generated.
