### PR TITLE
Don't unmarshall into response envelopes

### DIFF
--- a/test/autorest/additionalpropsgroup/zz_generated_pets.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets.go
@@ -42,11 +42,7 @@ func (client PetsClient) CreateApInProperties(ctx context.Context, createParamet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetApInPropertiesResponse{}, client.createApInPropertiesHandleError(resp)
 	}
-	result, err := client.createApInPropertiesHandleResponse(resp)
-	if err != nil {
-		return PetApInPropertiesResponse{}, err
-	}
-	return result, nil
+	return client.createApInPropertiesHandleResponse(resp)
 }
 
 // createApInPropertiesCreateRequest creates the CreateApInProperties request.
@@ -63,9 +59,11 @@ func (client PetsClient) createApInPropertiesCreateRequest(ctx context.Context, 
 
 // createApInPropertiesHandleResponse handles the CreateApInProperties response.
 func (client PetsClient) createApInPropertiesHandleResponse(resp *azcore.Response) (PetApInPropertiesResponse, error) {
-	result := PetApInPropertiesResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetApInProperties)
-	return result, err
+	var val *PetApInProperties
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetApInPropertiesResponse{}, err
+	}
+	return PetApInPropertiesResponse{RawResponse: resp.Response, PetApInProperties: val}, nil
 }
 
 // createApInPropertiesHandleError handles the CreateApInProperties error response.
@@ -90,11 +88,7 @@ func (client PetsClient) CreateApInPropertiesWithApstring(ctx context.Context, c
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetApInPropertiesWithApstringResponse{}, client.createApInPropertiesWithApstringHandleError(resp)
 	}
-	result, err := client.createApInPropertiesWithApstringHandleResponse(resp)
-	if err != nil {
-		return PetApInPropertiesWithApstringResponse{}, err
-	}
-	return result, nil
+	return client.createApInPropertiesWithApstringHandleResponse(resp)
 }
 
 // createApInPropertiesWithApstringCreateRequest creates the CreateApInPropertiesWithApstring request.
@@ -111,9 +105,11 @@ func (client PetsClient) createApInPropertiesWithApstringCreateRequest(ctx conte
 
 // createApInPropertiesWithApstringHandleResponse handles the CreateApInPropertiesWithApstring response.
 func (client PetsClient) createApInPropertiesWithApstringHandleResponse(resp *azcore.Response) (PetApInPropertiesWithApstringResponse, error) {
-	result := PetApInPropertiesWithApstringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetApInPropertiesWithApstring)
-	return result, err
+	var val *PetApInPropertiesWithApstring
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetApInPropertiesWithApstringResponse{}, err
+	}
+	return PetApInPropertiesWithApstringResponse{RawResponse: resp.Response, PetApInPropertiesWithApstring: val}, nil
 }
 
 // createApInPropertiesWithApstringHandleError handles the CreateApInPropertiesWithApstring error response.
@@ -138,11 +134,7 @@ func (client PetsClient) CreateApObject(ctx context.Context, createParameters Pe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetApObjectResponse{}, client.createApObjectHandleError(resp)
 	}
-	result, err := client.createApObjectHandleResponse(resp)
-	if err != nil {
-		return PetApObjectResponse{}, err
-	}
-	return result, nil
+	return client.createApObjectHandleResponse(resp)
 }
 
 // createApObjectCreateRequest creates the CreateApObject request.
@@ -159,9 +151,11 @@ func (client PetsClient) createApObjectCreateRequest(ctx context.Context, create
 
 // createApObjectHandleResponse handles the CreateApObject response.
 func (client PetsClient) createApObjectHandleResponse(resp *azcore.Response) (PetApObjectResponse, error) {
-	result := PetApObjectResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetApObject)
-	return result, err
+	var val *PetApObject
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetApObjectResponse{}, err
+	}
+	return PetApObjectResponse{RawResponse: resp.Response, PetApObject: val}, nil
 }
 
 // createApObjectHandleError handles the CreateApObject error response.
@@ -186,11 +180,7 @@ func (client PetsClient) CreateApString(ctx context.Context, createParameters Pe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetApStringResponse{}, client.createApStringHandleError(resp)
 	}
-	result, err := client.createApStringHandleResponse(resp)
-	if err != nil {
-		return PetApStringResponse{}, err
-	}
-	return result, nil
+	return client.createApStringHandleResponse(resp)
 }
 
 // createApStringCreateRequest creates the CreateApString request.
@@ -207,9 +197,11 @@ func (client PetsClient) createApStringCreateRequest(ctx context.Context, create
 
 // createApStringHandleResponse handles the CreateApString response.
 func (client PetsClient) createApStringHandleResponse(resp *azcore.Response) (PetApStringResponse, error) {
-	result := PetApStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetApString)
-	return result, err
+	var val *PetApString
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetApStringResponse{}, err
+	}
+	return PetApStringResponse{RawResponse: resp.Response, PetApString: val}, nil
 }
 
 // createApStringHandleError handles the CreateApString error response.
@@ -234,11 +226,7 @@ func (client PetsClient) CreateApTrue(ctx context.Context, createParameters PetA
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetApTrueResponse{}, client.createApTrueHandleError(resp)
 	}
-	result, err := client.createApTrueHandleResponse(resp)
-	if err != nil {
-		return PetApTrueResponse{}, err
-	}
-	return result, nil
+	return client.createApTrueHandleResponse(resp)
 }
 
 // createApTrueCreateRequest creates the CreateApTrue request.
@@ -255,9 +243,11 @@ func (client PetsClient) createApTrueCreateRequest(ctx context.Context, createPa
 
 // createApTrueHandleResponse handles the CreateApTrue response.
 func (client PetsClient) createApTrueHandleResponse(resp *azcore.Response) (PetApTrueResponse, error) {
-	result := PetApTrueResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetApTrue)
-	return result, err
+	var val *PetApTrue
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetApTrueResponse{}, err
+	}
+	return PetApTrueResponse{RawResponse: resp.Response, PetApTrue: val}, nil
 }
 
 // createApTrueHandleError handles the CreateApTrue error response.
@@ -282,11 +272,7 @@ func (client PetsClient) CreateCatApTrue(ctx context.Context, createParameters C
 	if !resp.HasStatusCode(http.StatusOK) {
 		return CatApTrueResponse{}, client.createCatApTrueHandleError(resp)
 	}
-	result, err := client.createCatApTrueHandleResponse(resp)
-	if err != nil {
-		return CatApTrueResponse{}, err
-	}
-	return result, nil
+	return client.createCatApTrueHandleResponse(resp)
 }
 
 // createCatApTrueCreateRequest creates the CreateCatApTrue request.
@@ -303,9 +289,11 @@ func (client PetsClient) createCatApTrueCreateRequest(ctx context.Context, creat
 
 // createCatApTrueHandleResponse handles the CreateCatApTrue response.
 func (client PetsClient) createCatApTrueHandleResponse(resp *azcore.Response) (CatApTrueResponse, error) {
-	result := CatApTrueResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CatApTrue)
-	return result, err
+	var val *CatApTrue
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CatApTrueResponse{}, err
+	}
+	return CatApTrueResponse{RawResponse: resp.Response, CatApTrue: val}, nil
 }
 
 // createCatApTrueHandleError handles the CreateCatApTrue error response.

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -43,11 +43,7 @@ func (client ArrayClient) GetArrayEmpty(ctx context.Context, options *ArrayGetAr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayArrayResponse{}, client.getArrayEmptyHandleError(resp)
 	}
-	result, err := client.getArrayEmptyHandleResponse(resp)
-	if err != nil {
-		return StringArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayEmptyHandleResponse(resp)
 }
 
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
@@ -64,9 +60,11 @@ func (client ArrayClient) getArrayEmptyCreateRequest(ctx context.Context, option
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client ArrayClient) getArrayEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	result := StringArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArrayArray)
-	return result, err
+	var val *[][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayArrayResponse{}, err
+	}
+	return StringArrayArrayResponse{RawResponse: resp.Response, StringArrayArray: val}, nil
 }
 
 // getArrayEmptyHandleError handles the GetArrayEmpty error response.
@@ -91,11 +89,7 @@ func (client ArrayClient) GetArrayItemEmpty(ctx context.Context, options *ArrayG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayArrayResponse{}, client.getArrayItemEmptyHandleError(resp)
 	}
-	result, err := client.getArrayItemEmptyHandleResponse(resp)
-	if err != nil {
-		return StringArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayItemEmptyHandleResponse(resp)
 }
 
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
@@ -112,9 +106,11 @@ func (client ArrayClient) getArrayItemEmptyCreateRequest(ctx context.Context, op
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client ArrayClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	result := StringArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArrayArray)
-	return result, err
+	var val *[][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayArrayResponse{}, err
+	}
+	return StringArrayArrayResponse{RawResponse: resp.Response, StringArrayArray: val}, nil
 }
 
 // getArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
@@ -139,11 +135,7 @@ func (client ArrayClient) GetArrayItemNull(ctx context.Context, options *ArrayGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayArrayResponse{}, client.getArrayItemNullHandleError(resp)
 	}
-	result, err := client.getArrayItemNullHandleResponse(resp)
-	if err != nil {
-		return StringArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayItemNullHandleResponse(resp)
 }
 
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
@@ -160,9 +152,11 @@ func (client ArrayClient) getArrayItemNullCreateRequest(ctx context.Context, opt
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client ArrayClient) getArrayItemNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	result := StringArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArrayArray)
-	return result, err
+	var val *[][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayArrayResponse{}, err
+	}
+	return StringArrayArrayResponse{RawResponse: resp.Response, StringArrayArray: val}, nil
 }
 
 // getArrayItemNullHandleError handles the GetArrayItemNull error response.
@@ -187,11 +181,7 @@ func (client ArrayClient) GetArrayNull(ctx context.Context, options *ArrayGetArr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayArrayResponse{}, client.getArrayNullHandleError(resp)
 	}
-	result, err := client.getArrayNullHandleResponse(resp)
-	if err != nil {
-		return StringArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayNullHandleResponse(resp)
 }
 
 // getArrayNullCreateRequest creates the GetArrayNull request.
@@ -208,9 +198,11 @@ func (client ArrayClient) getArrayNullCreateRequest(ctx context.Context, options
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client ArrayClient) getArrayNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	result := StringArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArrayArray)
-	return result, err
+	var val *[][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayArrayResponse{}, err
+	}
+	return StringArrayArrayResponse{RawResponse: resp.Response, StringArrayArray: val}, nil
 }
 
 // getArrayNullHandleError handles the GetArrayNull error response.
@@ -235,11 +227,7 @@ func (client ArrayClient) GetArrayValid(ctx context.Context, options *ArrayGetAr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayArrayResponse{}, client.getArrayValidHandleError(resp)
 	}
-	result, err := client.getArrayValidHandleResponse(resp)
-	if err != nil {
-		return StringArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayValidHandleResponse(resp)
 }
 
 // getArrayValidCreateRequest creates the GetArrayValid request.
@@ -256,9 +244,11 @@ func (client ArrayClient) getArrayValidCreateRequest(ctx context.Context, option
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client ArrayClient) getArrayValidHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	result := StringArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArrayArray)
-	return result, err
+	var val *[][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayArrayResponse{}, err
+	}
+	return StringArrayArrayResponse{RawResponse: resp.Response, StringArrayArray: val}, nil
 }
 
 // getArrayValidHandleError handles the GetArrayValid error response.
@@ -283,11 +273,7 @@ func (client ArrayClient) GetBase64URL(ctx context.Context, options *ArrayGetBas
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayArrayResponse{}, client.getBase64UrlHandleError(resp)
 	}
-	result, err := client.getBase64UrlHandleResponse(resp)
-	if err != nil {
-		return ByteArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBase64UrlHandleResponse(resp)
 }
 
 // getBase64UrlCreateRequest creates the GetBase64URL request.
@@ -304,9 +290,11 @@ func (client ArrayClient) getBase64UrlCreateRequest(ctx context.Context, options
 
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client ArrayClient) getBase64UrlHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	result := ByteArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ByteArrayArray)
-	return result, err
+	var val *[][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ByteArrayArrayResponse{}, err
+	}
+	return ByteArrayArrayResponse{RawResponse: resp.Response, ByteArrayArray: val}, nil
 }
 
 // getBase64UrlHandleError handles the GetBase64URL error response.
@@ -331,11 +319,7 @@ func (client ArrayClient) GetBooleanInvalidNull(ctx context.Context, options *Ar
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolArrayResponse{}, client.getBooleanInvalidNullHandleError(resp)
 	}
-	result, err := client.getBooleanInvalidNullHandleResponse(resp)
-	if err != nil {
-		return BoolArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanInvalidNullHandleResponse(resp)
 }
 
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
@@ -352,9 +336,11 @@ func (client ArrayClient) getBooleanInvalidNullCreateRequest(ctx context.Context
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client ArrayClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	result := BoolArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BoolArray)
-	return result, err
+	var val *[]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolArrayResponse{}, err
+	}
+	return BoolArrayResponse{RawResponse: resp.Response, BoolArray: val}, nil
 }
 
 // getBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
@@ -379,11 +365,7 @@ func (client ArrayClient) GetBooleanInvalidString(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolArrayResponse{}, client.getBooleanInvalidStringHandleError(resp)
 	}
-	result, err := client.getBooleanInvalidStringHandleResponse(resp)
-	if err != nil {
-		return BoolArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanInvalidStringHandleResponse(resp)
 }
 
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
@@ -400,9 +382,11 @@ func (client ArrayClient) getBooleanInvalidStringCreateRequest(ctx context.Conte
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client ArrayClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	result := BoolArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BoolArray)
-	return result, err
+	var val *[]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolArrayResponse{}, err
+	}
+	return BoolArrayResponse{RawResponse: resp.Response, BoolArray: val}, nil
 }
 
 // getBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
@@ -427,11 +411,7 @@ func (client ArrayClient) GetBooleanTfft(ctx context.Context, options *ArrayGetB
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolArrayResponse{}, client.getBooleanTfftHandleError(resp)
 	}
-	result, err := client.getBooleanTfftHandleResponse(resp)
-	if err != nil {
-		return BoolArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanTfftHandleResponse(resp)
 }
 
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
@@ -448,9 +428,11 @@ func (client ArrayClient) getBooleanTfftCreateRequest(ctx context.Context, optio
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client ArrayClient) getBooleanTfftHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	result := BoolArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BoolArray)
-	return result, err
+	var val *[]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolArrayResponse{}, err
+	}
+	return BoolArrayResponse{RawResponse: resp.Response, BoolArray: val}, nil
 }
 
 // getBooleanTfftHandleError handles the GetBooleanTfft error response.
@@ -475,11 +457,7 @@ func (client ArrayClient) GetByteInvalidNull(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayArrayResponse{}, client.getByteInvalidNullHandleError(resp)
 	}
-	result, err := client.getByteInvalidNullHandleResponse(resp)
-	if err != nil {
-		return ByteArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getByteInvalidNullHandleResponse(resp)
 }
 
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
@@ -496,9 +474,11 @@ func (client ArrayClient) getByteInvalidNullCreateRequest(ctx context.Context, o
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client ArrayClient) getByteInvalidNullHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	result := ByteArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ByteArrayArray)
-	return result, err
+	var val *[][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ByteArrayArrayResponse{}, err
+	}
+	return ByteArrayArrayResponse{RawResponse: resp.Response, ByteArrayArray: val}, nil
 }
 
 // getByteInvalidNullHandleError handles the GetByteInvalidNull error response.
@@ -523,11 +503,7 @@ func (client ArrayClient) GetByteValid(ctx context.Context, options *ArrayGetByt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayArrayResponse{}, client.getByteValidHandleError(resp)
 	}
-	result, err := client.getByteValidHandleResponse(resp)
-	if err != nil {
-		return ByteArrayArrayResponse{}, err
-	}
-	return result, nil
+	return client.getByteValidHandleResponse(resp)
 }
 
 // getByteValidCreateRequest creates the GetByteValid request.
@@ -544,9 +520,11 @@ func (client ArrayClient) getByteValidCreateRequest(ctx context.Context, options
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client ArrayClient) getByteValidHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	result := ByteArrayArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ByteArrayArray)
-	return result, err
+	var val *[][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ByteArrayArrayResponse{}, err
+	}
+	return ByteArrayArrayResponse{RawResponse: resp.Response, ByteArrayArray: val}, nil
 }
 
 // getByteValidHandleError handles the GetByteValid error response.
@@ -571,11 +549,7 @@ func (client ArrayClient) GetComplexEmpty(ctx context.Context, options *ArrayGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductArrayResponse{}, client.getComplexEmptyHandleError(resp)
 	}
-	result, err := client.getComplexEmptyHandleResponse(resp)
-	if err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return result, nil
+	return client.getComplexEmptyHandleResponse(resp)
 }
 
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
@@ -592,9 +566,11 @@ func (client ArrayClient) getComplexEmptyCreateRequest(ctx context.Context, opti
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client ArrayClient) getComplexEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // getComplexEmptyHandleError handles the GetComplexEmpty error response.
@@ -619,11 +595,7 @@ func (client ArrayClient) GetComplexItemEmpty(ctx context.Context, options *Arra
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductArrayResponse{}, client.getComplexItemEmptyHandleError(resp)
 	}
-	result, err := client.getComplexItemEmptyHandleResponse(resp)
-	if err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return result, nil
+	return client.getComplexItemEmptyHandleResponse(resp)
 }
 
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
@@ -640,9 +612,11 @@ func (client ArrayClient) getComplexItemEmptyCreateRequest(ctx context.Context, 
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client ArrayClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // getComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
@@ -667,11 +641,7 @@ func (client ArrayClient) GetComplexItemNull(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductArrayResponse{}, client.getComplexItemNullHandleError(resp)
 	}
-	result, err := client.getComplexItemNullHandleResponse(resp)
-	if err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return result, nil
+	return client.getComplexItemNullHandleResponse(resp)
 }
 
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
@@ -688,9 +658,11 @@ func (client ArrayClient) getComplexItemNullCreateRequest(ctx context.Context, o
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client ArrayClient) getComplexItemNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // getComplexItemNullHandleError handles the GetComplexItemNull error response.
@@ -715,11 +687,7 @@ func (client ArrayClient) GetComplexNull(ctx context.Context, options *ArrayGetC
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductArrayResponse{}, client.getComplexNullHandleError(resp)
 	}
-	result, err := client.getComplexNullHandleResponse(resp)
-	if err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return result, nil
+	return client.getComplexNullHandleResponse(resp)
 }
 
 // getComplexNullCreateRequest creates the GetComplexNull request.
@@ -736,9 +704,11 @@ func (client ArrayClient) getComplexNullCreateRequest(ctx context.Context, optio
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client ArrayClient) getComplexNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // getComplexNullHandleError handles the GetComplexNull error response.
@@ -763,11 +733,7 @@ func (client ArrayClient) GetComplexValid(ctx context.Context, options *ArrayGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductArrayResponse{}, client.getComplexValidHandleError(resp)
 	}
-	result, err := client.getComplexValidHandleResponse(resp)
-	if err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return result, nil
+	return client.getComplexValidHandleResponse(resp)
 }
 
 // getComplexValidCreateRequest creates the GetComplexValid request.
@@ -784,9 +750,11 @@ func (client ArrayClient) getComplexValidCreateRequest(ctx context.Context, opti
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client ArrayClient) getComplexValidHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // getComplexValidHandleError handles the GetComplexValid error response.
@@ -811,11 +779,7 @@ func (client ArrayClient) GetDateInvalidChars(ctx context.Context, options *Arra
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateInvalidCharsHandleError(resp)
 	}
-	result, err := client.getDateInvalidCharsHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateInvalidCharsHandleResponse(resp)
 }
 
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
@@ -865,11 +829,7 @@ func (client ArrayClient) GetDateInvalidNull(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateInvalidNullHandleError(resp)
 	}
-	result, err := client.getDateInvalidNullHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateInvalidNullHandleResponse(resp)
 }
 
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
@@ -919,11 +879,7 @@ func (client ArrayClient) GetDateTimeInvalidChars(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateTimeInvalidCharsHandleError(resp)
 	}
-	result, err := client.getDateTimeInvalidCharsHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeInvalidCharsHandleResponse(resp)
 }
 
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
@@ -973,11 +929,7 @@ func (client ArrayClient) GetDateTimeInvalidNull(ctx context.Context, options *A
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateTimeInvalidNullHandleError(resp)
 	}
-	result, err := client.getDateTimeInvalidNullHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeInvalidNullHandleResponse(resp)
 }
 
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
@@ -1027,11 +979,7 @@ func (client ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateTimeRfc1123ValidHandleError(resp)
 	}
-	result, err := client.getDateTimeRfc1123ValidHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeRfc1123ValidHandleResponse(resp)
 }
 
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
@@ -1081,11 +1029,7 @@ func (client ArrayClient) GetDateTimeValid(ctx context.Context, options *ArrayGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateTimeValidHandleError(resp)
 	}
-	result, err := client.getDateTimeValidHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeValidHandleResponse(resp)
 }
 
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
@@ -1135,11 +1079,7 @@ func (client ArrayClient) GetDateValid(ctx context.Context, options *ArrayGetDat
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeArrayResponse{}, client.getDateValidHandleError(resp)
 	}
-	result, err := client.getDateValidHandleResponse(resp)
-	if err != nil {
-		return TimeArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDateValidHandleResponse(resp)
 }
 
 // getDateValidCreateRequest creates the GetDateValid request.
@@ -1189,11 +1129,7 @@ func (client ArrayClient) GetDictionaryEmpty(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getDictionaryEmptyHandleError(resp)
 	}
-	result, err := client.getDictionaryEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryEmptyHandleResponse(resp)
 }
 
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
@@ -1210,9 +1146,11 @@ func (client ArrayClient) getDictionaryEmptyCreateRequest(ctx context.Context, o
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client ArrayClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MapOfStringArray)
-	return result, err
+	var val *[]map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, MapOfStringArray: val}, nil
 }
 
 // getDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
@@ -1238,11 +1176,7 @@ func (client ArrayClient) GetDictionaryItemEmpty(ctx context.Context, options *A
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getDictionaryItemEmptyHandleError(resp)
 	}
-	result, err := client.getDictionaryItemEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryItemEmptyHandleResponse(resp)
 }
 
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
@@ -1259,9 +1193,11 @@ func (client ArrayClient) getDictionaryItemEmptyCreateRequest(ctx context.Contex
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client ArrayClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MapOfStringArray)
-	return result, err
+	var val *[]map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, MapOfStringArray: val}, nil
 }
 
 // getDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
@@ -1287,11 +1223,7 @@ func (client ArrayClient) GetDictionaryItemNull(ctx context.Context, options *Ar
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getDictionaryItemNullHandleError(resp)
 	}
-	result, err := client.getDictionaryItemNullHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryItemNullHandleResponse(resp)
 }
 
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
@@ -1308,9 +1240,11 @@ func (client ArrayClient) getDictionaryItemNullCreateRequest(ctx context.Context
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client ArrayClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MapOfStringArray)
-	return result, err
+	var val *[]map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, MapOfStringArray: val}, nil
 }
 
 // getDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
@@ -1335,11 +1269,7 @@ func (client ArrayClient) GetDictionaryNull(ctx context.Context, options *ArrayG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getDictionaryNullHandleError(resp)
 	}
-	result, err := client.getDictionaryNullHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryNullHandleResponse(resp)
 }
 
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
@@ -1356,9 +1286,11 @@ func (client ArrayClient) getDictionaryNullCreateRequest(ctx context.Context, op
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client ArrayClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MapOfStringArray)
-	return result, err
+	var val *[]map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, MapOfStringArray: val}, nil
 }
 
 // getDictionaryNullHandleError handles the GetDictionaryNull error response.
@@ -1384,11 +1316,7 @@ func (client ArrayClient) GetDictionaryValid(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getDictionaryValidHandleError(resp)
 	}
-	result, err := client.getDictionaryValidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryValidHandleResponse(resp)
 }
 
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
@@ -1405,9 +1333,11 @@ func (client ArrayClient) getDictionaryValidCreateRequest(ctx context.Context, o
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client ArrayClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MapOfStringArray)
-	return result, err
+	var val *[]map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, MapOfStringArray: val}, nil
 }
 
 // getDictionaryValidHandleError handles the GetDictionaryValid error response.
@@ -1432,11 +1362,7 @@ func (client ArrayClient) GetDoubleInvalidNull(ctx context.Context, options *Arr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64ArrayResponse{}, client.getDoubleInvalidNullHandleError(resp)
 	}
-	result, err := client.getDoubleInvalidNullHandleResponse(resp)
-	if err != nil {
-		return Float64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDoubleInvalidNullHandleResponse(resp)
 }
 
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
@@ -1453,9 +1379,11 @@ func (client ArrayClient) getDoubleInvalidNullCreateRequest(ctx context.Context,
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client ArrayClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	result := Float64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float64Array)
-	return result, err
+	var val *[]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64ArrayResponse{}, err
+	}
+	return Float64ArrayResponse{RawResponse: resp.Response, Float64Array: val}, nil
 }
 
 // getDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
@@ -1480,11 +1408,7 @@ func (client ArrayClient) GetDoubleInvalidString(ctx context.Context, options *A
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64ArrayResponse{}, client.getDoubleInvalidStringHandleError(resp)
 	}
-	result, err := client.getDoubleInvalidStringHandleResponse(resp)
-	if err != nil {
-		return Float64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDoubleInvalidStringHandleResponse(resp)
 }
 
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
@@ -1501,9 +1425,11 @@ func (client ArrayClient) getDoubleInvalidStringCreateRequest(ctx context.Contex
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client ArrayClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	result := Float64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float64Array)
-	return result, err
+	var val *[]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64ArrayResponse{}, err
+	}
+	return Float64ArrayResponse{RawResponse: resp.Response, Float64Array: val}, nil
 }
 
 // getDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
@@ -1528,11 +1454,7 @@ func (client ArrayClient) GetDoubleValid(ctx context.Context, options *ArrayGetD
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64ArrayResponse{}, client.getDoubleValidHandleError(resp)
 	}
-	result, err := client.getDoubleValidHandleResponse(resp)
-	if err != nil {
-		return Float64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDoubleValidHandleResponse(resp)
 }
 
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
@@ -1549,9 +1471,11 @@ func (client ArrayClient) getDoubleValidCreateRequest(ctx context.Context, optio
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client ArrayClient) getDoubleValidHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	result := Float64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float64Array)
-	return result, err
+	var val *[]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64ArrayResponse{}, err
+	}
+	return Float64ArrayResponse{RawResponse: resp.Response, Float64Array: val}, nil
 }
 
 // getDoubleValidHandleError handles the GetDoubleValid error response.
@@ -1576,11 +1500,7 @@ func (client ArrayClient) GetDurationValid(ctx context.Context, options *ArrayGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getDurationValidHandleError(resp)
 	}
-	result, err := client.getDurationValidHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getDurationValidHandleResponse(resp)
 }
 
 // getDurationValidCreateRequest creates the GetDurationValid request.
@@ -1597,9 +1517,11 @@ func (client ArrayClient) getDurationValidCreateRequest(ctx context.Context, opt
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client ArrayClient) getDurationValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getDurationValidHandleError handles the GetDurationValid error response.
@@ -1624,11 +1546,7 @@ func (client ArrayClient) GetEmpty(ctx context.Context, options *ArrayGetEmptyOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -1645,9 +1563,11 @@ func (client ArrayClient) getEmptyCreateRequest(ctx context.Context, options *Ar
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client ArrayClient) getEmptyHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -1672,11 +1592,7 @@ func (client ArrayClient) GetEnumValid(ctx context.Context, options *ArrayGetEnu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FooEnumArrayResponse{}, client.getEnumValidHandleError(resp)
 	}
-	result, err := client.getEnumValidHandleResponse(resp)
-	if err != nil {
-		return FooEnumArrayResponse{}, err
-	}
-	return result, nil
+	return client.getEnumValidHandleResponse(resp)
 }
 
 // getEnumValidCreateRequest creates the GetEnumValid request.
@@ -1693,9 +1609,11 @@ func (client ArrayClient) getEnumValidCreateRequest(ctx context.Context, options
 
 // getEnumValidHandleResponse handles the GetEnumValid response.
 func (client ArrayClient) getEnumValidHandleResponse(resp *azcore.Response) (FooEnumArrayResponse, error) {
-	result := FooEnumArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FooEnumArray)
-	return result, err
+	var val *[]FooEnum
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FooEnumArrayResponse{}, err
+	}
+	return FooEnumArrayResponse{RawResponse: resp.Response, FooEnumArray: val}, nil
 }
 
 // getEnumValidHandleError handles the GetEnumValid error response.
@@ -1720,11 +1638,7 @@ func (client ArrayClient) GetFloatInvalidNull(ctx context.Context, options *Arra
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32ArrayResponse{}, client.getFloatInvalidNullHandleError(resp)
 	}
-	result, err := client.getFloatInvalidNullHandleResponse(resp)
-	if err != nil {
-		return Float32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getFloatInvalidNullHandleResponse(resp)
 }
 
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
@@ -1741,9 +1655,11 @@ func (client ArrayClient) getFloatInvalidNullCreateRequest(ctx context.Context, 
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client ArrayClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	result := Float32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float32Array)
-	return result, err
+	var val *[]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32ArrayResponse{}, err
+	}
+	return Float32ArrayResponse{RawResponse: resp.Response, Float32Array: val}, nil
 }
 
 // getFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
@@ -1768,11 +1684,7 @@ func (client ArrayClient) GetFloatInvalidString(ctx context.Context, options *Ar
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32ArrayResponse{}, client.getFloatInvalidStringHandleError(resp)
 	}
-	result, err := client.getFloatInvalidStringHandleResponse(resp)
-	if err != nil {
-		return Float32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getFloatInvalidStringHandleResponse(resp)
 }
 
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
@@ -1789,9 +1701,11 @@ func (client ArrayClient) getFloatInvalidStringCreateRequest(ctx context.Context
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client ArrayClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	result := Float32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float32Array)
-	return result, err
+	var val *[]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32ArrayResponse{}, err
+	}
+	return Float32ArrayResponse{RawResponse: resp.Response, Float32Array: val}, nil
 }
 
 // getFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
@@ -1816,11 +1730,7 @@ func (client ArrayClient) GetFloatValid(ctx context.Context, options *ArrayGetFl
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32ArrayResponse{}, client.getFloatValidHandleError(resp)
 	}
-	result, err := client.getFloatValidHandleResponse(resp)
-	if err != nil {
-		return Float32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getFloatValidHandleResponse(resp)
 }
 
 // getFloatValidCreateRequest creates the GetFloatValid request.
@@ -1837,9 +1747,11 @@ func (client ArrayClient) getFloatValidCreateRequest(ctx context.Context, option
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client ArrayClient) getFloatValidHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	result := Float32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Float32Array)
-	return result, err
+	var val *[]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32ArrayResponse{}, err
+	}
+	return Float32ArrayResponse{RawResponse: resp.Response, Float32Array: val}, nil
 }
 
 // getFloatValidHandleError handles the GetFloatValid error response.
@@ -1864,11 +1776,7 @@ func (client ArrayClient) GetIntInvalidNull(ctx context.Context, options *ArrayG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getIntInvalidNullHandleError(resp)
 	}
-	result, err := client.getIntInvalidNullHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getIntInvalidNullHandleResponse(resp)
 }
 
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
@@ -1885,9 +1793,11 @@ func (client ArrayClient) getIntInvalidNullCreateRequest(ctx context.Context, op
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client ArrayClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getIntInvalidNullHandleError handles the GetIntInvalidNull error response.
@@ -1912,11 +1822,7 @@ func (client ArrayClient) GetIntInvalidString(ctx context.Context, options *Arra
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getIntInvalidStringHandleError(resp)
 	}
-	result, err := client.getIntInvalidStringHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getIntInvalidStringHandleResponse(resp)
 }
 
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
@@ -1933,9 +1839,11 @@ func (client ArrayClient) getIntInvalidStringCreateRequest(ctx context.Context, 
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client ArrayClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getIntInvalidStringHandleError handles the GetIntInvalidString error response.
@@ -1960,11 +1868,7 @@ func (client ArrayClient) GetIntegerValid(ctx context.Context, options *ArrayGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getIntegerValidHandleError(resp)
 	}
-	result, err := client.getIntegerValidHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getIntegerValidHandleResponse(resp)
 }
 
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
@@ -1981,9 +1885,11 @@ func (client ArrayClient) getIntegerValidCreateRequest(ctx context.Context, opti
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client ArrayClient) getIntegerValidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getIntegerValidHandleError handles the GetIntegerValid error response.
@@ -2008,11 +1914,7 @@ func (client ArrayClient) GetInvalid(ctx context.Context, options *ArrayGetInval
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -2029,9 +1931,11 @@ func (client ArrayClient) getInvalidCreateRequest(ctx context.Context, options *
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client ArrayClient) getInvalidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -2056,11 +1960,7 @@ func (client ArrayClient) GetLongInvalidNull(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int64ArrayResponse{}, client.getLongInvalidNullHandleError(resp)
 	}
-	result, err := client.getLongInvalidNullHandleResponse(resp)
-	if err != nil {
-		return Int64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getLongInvalidNullHandleResponse(resp)
 }
 
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
@@ -2077,9 +1977,11 @@ func (client ArrayClient) getLongInvalidNullCreateRequest(ctx context.Context, o
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client ArrayClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	result := Int64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int64Array)
-	return result, err
+	var val *[]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int64ArrayResponse{}, err
+	}
+	return Int64ArrayResponse{RawResponse: resp.Response, Int64Array: val}, nil
 }
 
 // getLongInvalidNullHandleError handles the GetLongInvalidNull error response.
@@ -2104,11 +2006,7 @@ func (client ArrayClient) GetLongInvalidString(ctx context.Context, options *Arr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int64ArrayResponse{}, client.getLongInvalidStringHandleError(resp)
 	}
-	result, err := client.getLongInvalidStringHandleResponse(resp)
-	if err != nil {
-		return Int64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getLongInvalidStringHandleResponse(resp)
 }
 
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
@@ -2125,9 +2023,11 @@ func (client ArrayClient) getLongInvalidStringCreateRequest(ctx context.Context,
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client ArrayClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	result := Int64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int64Array)
-	return result, err
+	var val *[]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int64ArrayResponse{}, err
+	}
+	return Int64ArrayResponse{RawResponse: resp.Response, Int64Array: val}, nil
 }
 
 // getLongInvalidStringHandleError handles the GetLongInvalidString error response.
@@ -2152,11 +2052,7 @@ func (client ArrayClient) GetLongValid(ctx context.Context, options *ArrayGetLon
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int64ArrayResponse{}, client.getLongValidHandleError(resp)
 	}
-	result, err := client.getLongValidHandleResponse(resp)
-	if err != nil {
-		return Int64ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getLongValidHandleResponse(resp)
 }
 
 // getLongValidCreateRequest creates the GetLongValid request.
@@ -2173,9 +2069,11 @@ func (client ArrayClient) getLongValidCreateRequest(ctx context.Context, options
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client ArrayClient) getLongValidHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	result := Int64ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int64Array)
-	return result, err
+	var val *[]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int64ArrayResponse{}, err
+	}
+	return Int64ArrayResponse{RawResponse: resp.Response, Int64Array: val}, nil
 }
 
 // getLongValidHandleError handles the GetLongValid error response.
@@ -2200,11 +2098,7 @@ func (client ArrayClient) GetNull(ctx context.Context, options *ArrayGetNullOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32ArrayResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return Int32ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -2221,9 +2115,11 @@ func (client ArrayClient) getNullCreateRequest(ctx context.Context, options *Arr
 
 // getNullHandleResponse handles the GetNull response.
 func (client ArrayClient) getNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	result := Int32ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Int32Array)
-	return result, err
+	var val *[]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32ArrayResponse{}, err
+	}
+	return Int32ArrayResponse{RawResponse: resp.Response, Int32Array: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -2248,11 +2144,7 @@ func (client ArrayClient) GetStringEnumValid(ctx context.Context, options *Array
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Enum0ArrayResponse{}, client.getStringEnumValidHandleError(resp)
 	}
-	result, err := client.getStringEnumValidHandleResponse(resp)
-	if err != nil {
-		return Enum0ArrayResponse{}, err
-	}
-	return result, nil
+	return client.getStringEnumValidHandleResponse(resp)
 }
 
 // getStringEnumValidCreateRequest creates the GetStringEnumValid request.
@@ -2269,9 +2161,11 @@ func (client ArrayClient) getStringEnumValidCreateRequest(ctx context.Context, o
 
 // getStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client ArrayClient) getStringEnumValidHandleResponse(resp *azcore.Response) (Enum0ArrayResponse, error) {
-	result := Enum0ArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Enum0Array)
-	return result, err
+	var val *[]Enum0
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Enum0ArrayResponse{}, err
+	}
+	return Enum0ArrayResponse{RawResponse: resp.Response, Enum0Array: val}, nil
 }
 
 // getStringEnumValidHandleError handles the GetStringEnumValid error response.
@@ -2296,11 +2190,7 @@ func (client ArrayClient) GetStringValid(ctx context.Context, options *ArrayGetS
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getStringValidHandleError(resp)
 	}
-	result, err := client.getStringValidHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getStringValidHandleResponse(resp)
 }
 
 // getStringValidCreateRequest creates the GetStringValid request.
@@ -2317,9 +2207,11 @@ func (client ArrayClient) getStringValidCreateRequest(ctx context.Context, optio
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client ArrayClient) getStringValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getStringValidHandleError handles the GetStringValid error response.
@@ -2344,11 +2236,7 @@ func (client ArrayClient) GetStringWithInvalid(ctx context.Context, options *Arr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getStringWithInvalidHandleError(resp)
 	}
-	result, err := client.getStringWithInvalidHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getStringWithInvalidHandleResponse(resp)
 }
 
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
@@ -2365,9 +2253,11 @@ func (client ArrayClient) getStringWithInvalidCreateRequest(ctx context.Context,
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client ArrayClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getStringWithInvalidHandleError handles the GetStringWithInvalid error response.
@@ -2392,11 +2282,7 @@ func (client ArrayClient) GetStringWithNull(ctx context.Context, options *ArrayG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getStringWithNullHandleError(resp)
 	}
-	result, err := client.getStringWithNullHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getStringWithNullHandleResponse(resp)
 }
 
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
@@ -2413,9 +2299,11 @@ func (client ArrayClient) getStringWithNullCreateRequest(ctx context.Context, op
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client ArrayClient) getStringWithNullHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getStringWithNullHandleError handles the GetStringWithNull error response.
@@ -2440,11 +2328,7 @@ func (client ArrayClient) GetUUIDInvalidChars(ctx context.Context, options *Arra
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getUuidInvalidCharsHandleError(resp)
 	}
-	result, err := client.getUuidInvalidCharsHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getUuidInvalidCharsHandleResponse(resp)
 }
 
 // getUuidInvalidCharsCreateRequest creates the GetUUIDInvalidChars request.
@@ -2461,9 +2345,11 @@ func (client ArrayClient) getUuidInvalidCharsCreateRequest(ctx context.Context, 
 
 // getUuidInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client ArrayClient) getUuidInvalidCharsHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getUuidInvalidCharsHandleError handles the GetUUIDInvalidChars error response.
@@ -2488,11 +2374,7 @@ func (client ArrayClient) GetUUIDValid(ctx context.Context, options *ArrayGetUUI
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.getUuidValidHandleError(resp)
 	}
-	result, err := client.getUuidValidHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getUuidValidHandleResponse(resp)
 }
 
 // getUuidValidCreateRequest creates the GetUUIDValid request.
@@ -2509,9 +2391,11 @@ func (client ArrayClient) getUuidValidCreateRequest(ctx context.Context, options
 
 // getUuidValidHandleResponse handles the GetUUIDValid response.
 func (client ArrayClient) getUuidValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // getUuidValidHandleError handles the GetUUIDValid error response.

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -42,11 +42,7 @@ func (client AutoRestReportServiceForAzureClient) GetReport(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getReportHandleError(resp)
 	}
-	result, err := client.getReportHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getReportHandleResponse(resp)
 }
 
 // getReportCreateRequest creates the GetReport request.
@@ -68,9 +64,11 @@ func (client AutoRestReportServiceForAzureClient) getReportCreateRequest(ctx con
 
 // getReportHandleResponse handles the GetReport response.
 func (client AutoRestReportServiceForAzureClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getReportHandleError handles the GetReport error response.

--- a/test/autorest/azurespecialsgroup/zz_generated_header.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header.go
@@ -42,11 +42,7 @@ func (client HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientRe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderCustomNamedRequestIDResponse{}, client.customNamedRequestIdHandleError(resp)
 	}
-	result, err := client.customNamedRequestIdHandleResponse(resp)
-	if err != nil {
-		return HeaderCustomNamedRequestIDResponse{}, err
-	}
-	return result, nil
+	return client.customNamedRequestIdHandleResponse(resp)
 }
 
 // customNamedRequestIdCreateRequest creates the CustomNamedRequestID request.
@@ -93,11 +89,7 @@ func (client HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooClie
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotFound) {
 		return HeaderCustomNamedRequestIDHeadResponse{}, client.customNamedRequestIdHeadHandleError(resp)
 	}
-	result, err := client.customNamedRequestIdHeadHandleResponse(resp)
-	if err != nil {
-		return HeaderCustomNamedRequestIDHeadResponse{}, err
-	}
-	return result, nil
+	return client.customNamedRequestIdHeadHandleResponse(resp)
 }
 
 // customNamedRequestIdHeadCreateRequest creates the CustomNamedRequestIDHead request.
@@ -147,11 +139,7 @@ func (client HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderCustomNamedRequestIDParamGroupingResponse{}, client.customNamedRequestIdParamGroupingHandleError(resp)
 	}
-	result, err := client.customNamedRequestIdParamGroupingHandleResponse(resp)
-	if err != nil {
-		return HeaderCustomNamedRequestIDParamGroupingResponse{}, err
-	}
-	return result, nil
+	return client.customNamedRequestIdParamGroupingHandleResponse(resp)
 }
 
 // customNamedRequestIdParamGroupingCreateRequest creates the CustomNamedRequestIDParamGrouping request.

--- a/test/autorest/booleangroup/zz_generated_bool.go
+++ b/test/autorest/booleangroup/zz_generated_bool.go
@@ -42,11 +42,7 @@ func (client BoolClient) GetFalse(ctx context.Context, options *BoolGetFalseOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getFalseHandleError(resp)
 	}
-	result, err := client.getFalseHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getFalseHandleResponse(resp)
 }
 
 // getFalseCreateRequest creates the GetFalse request.
@@ -63,9 +59,11 @@ func (client BoolClient) getFalseCreateRequest(ctx context.Context, options *Boo
 
 // getFalseHandleResponse handles the GetFalse response.
 func (client BoolClient) getFalseHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getFalseHandleError handles the GetFalse error response.
@@ -90,11 +88,7 @@ func (client BoolClient) GetInvalid(ctx context.Context, options *BoolGetInvalid
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -111,9 +105,11 @@ func (client BoolClient) getInvalidCreateRequest(ctx context.Context, options *B
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client BoolClient) getInvalidHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -138,11 +134,7 @@ func (client BoolClient) GetNull(ctx context.Context, options *BoolGetNullOption
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -159,9 +151,11 @@ func (client BoolClient) getNullCreateRequest(ctx context.Context, options *Bool
 
 // getNullHandleResponse handles the GetNull response.
 func (client BoolClient) getNullHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -186,11 +180,7 @@ func (client BoolClient) GetTrue(ctx context.Context, options *BoolGetTrueOption
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getTrueHandleError(resp)
 	}
-	result, err := client.getTrueHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getTrueHandleResponse(resp)
 }
 
 // getTrueCreateRequest creates the GetTrue request.
@@ -207,9 +197,11 @@ func (client BoolClient) getTrueCreateRequest(ctx context.Context, options *Bool
 
 // getTrueHandleResponse handles the GetTrue response.
 func (client BoolClient) getTrueHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getTrueHandleError handles the GetTrue error response.

--- a/test/autorest/bytegroup/zz_generated_byte.go
+++ b/test/autorest/bytegroup/zz_generated_byte.go
@@ -42,11 +42,7 @@ func (client ByteClient) GetEmpty(ctx context.Context, options *ByteGetEmptyOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -63,9 +59,11 @@ func (client ByteClient) getEmptyCreateRequest(ctx context.Context, options *Byt
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client ByteClient) getEmptyHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64StdFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -90,11 +88,7 @@ func (client ByteClient) GetInvalid(ctx context.Context, options *ByteGetInvalid
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -111,9 +105,11 @@ func (client ByteClient) getInvalidCreateRequest(ctx context.Context, options *B
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client ByteClient) getInvalidHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64StdFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -138,11 +134,7 @@ func (client ByteClient) GetNonASCII(ctx context.Context, options *ByteGetNonASC
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getNonAsciiHandleError(resp)
 	}
-	result, err := client.getNonAsciiHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getNonAsciiHandleResponse(resp)
 }
 
 // getNonAsciiCreateRequest creates the GetNonASCII request.
@@ -159,9 +151,11 @@ func (client ByteClient) getNonAsciiCreateRequest(ctx context.Context, options *
 
 // getNonAsciiHandleResponse handles the GetNonASCII response.
 func (client ByteClient) getNonAsciiHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64StdFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNonAsciiHandleError handles the GetNonASCII error response.
@@ -186,11 +180,7 @@ func (client ByteClient) GetNull(ctx context.Context, options *ByteGetNullOption
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -207,9 +197,11 @@ func (client ByteClient) getNullCreateRequest(ctx context.Context, options *Byte
 
 // getNullHandleResponse handles the GetNull response.
 func (client ByteClient) getNullHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64StdFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.

--- a/test/autorest/complexgroup/zz_generated_array.go
+++ b/test/autorest/complexgroup/zz_generated_array.go
@@ -42,11 +42,7 @@ func (client ArrayClient) GetEmpty(ctx context.Context, options *ArrayGetEmptyOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ArrayWrapperResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return ArrayWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -63,9 +59,11 @@ func (client ArrayClient) getEmptyCreateRequest(ctx context.Context, options *Ar
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client ArrayClient) getEmptyHandleResponse(resp *azcore.Response) (ArrayWrapperResponse, error) {
-	result := ArrayWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ArrayWrapper)
-	return result, err
+	var val *ArrayWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ArrayWrapperResponse{}, err
+	}
+	return ArrayWrapperResponse{RawResponse: resp.Response, ArrayWrapper: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -90,11 +88,7 @@ func (client ArrayClient) GetNotProvided(ctx context.Context, options *ArrayGetN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ArrayWrapperResponse{}, client.getNotProvidedHandleError(resp)
 	}
-	result, err := client.getNotProvidedHandleResponse(resp)
-	if err != nil {
-		return ArrayWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getNotProvidedHandleResponse(resp)
 }
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
@@ -111,9 +105,11 @@ func (client ArrayClient) getNotProvidedCreateRequest(ctx context.Context, optio
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client ArrayClient) getNotProvidedHandleResponse(resp *azcore.Response) (ArrayWrapperResponse, error) {
-	result := ArrayWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ArrayWrapper)
-	return result, err
+	var val *ArrayWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ArrayWrapperResponse{}, err
+	}
+	return ArrayWrapperResponse{RawResponse: resp.Response, ArrayWrapper: val}, nil
 }
 
 // getNotProvidedHandleError handles the GetNotProvided error response.
@@ -138,11 +134,7 @@ func (client ArrayClient) GetValid(ctx context.Context, options *ArrayGetValidOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ArrayWrapperResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return ArrayWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -159,9 +151,11 @@ func (client ArrayClient) getValidCreateRequest(ctx context.Context, options *Ar
 
 // getValidHandleResponse handles the GetValid response.
 func (client ArrayClient) getValidHandleResponse(resp *azcore.Response) (ArrayWrapperResponse, error) {
-	result := ArrayWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ArrayWrapper)
-	return result, err
+	var val *ArrayWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ArrayWrapperResponse{}, err
+	}
+	return ArrayWrapperResponse{RawResponse: resp.Response, ArrayWrapper: val}, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_basic.go
+++ b/test/autorest/complexgroup/zz_generated_basic.go
@@ -42,11 +42,7 @@ func (client BasicClient) GetEmpty(ctx context.Context, options *BasicGetEmptyOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BasicResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return BasicResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -63,9 +59,11 @@ func (client BasicClient) getEmptyCreateRequest(ctx context.Context, options *Ba
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client BasicClient) getEmptyHandleResponse(resp *azcore.Response) (BasicResponse, error) {
-	result := BasicResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Basic)
-	return result, err
+	var val *Basic
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BasicResponse{}, err
+	}
+	return BasicResponse{RawResponse: resp.Response, Basic: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -90,11 +88,7 @@ func (client BasicClient) GetInvalid(ctx context.Context, options *BasicGetInval
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BasicResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return BasicResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -111,9 +105,11 @@ func (client BasicClient) getInvalidCreateRequest(ctx context.Context, options *
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client BasicClient) getInvalidHandleResponse(resp *azcore.Response) (BasicResponse, error) {
-	result := BasicResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Basic)
-	return result, err
+	var val *Basic
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BasicResponse{}, err
+	}
+	return BasicResponse{RawResponse: resp.Response, Basic: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -138,11 +134,7 @@ func (client BasicClient) GetNotProvided(ctx context.Context, options *BasicGetN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BasicResponse{}, client.getNotProvidedHandleError(resp)
 	}
-	result, err := client.getNotProvidedHandleResponse(resp)
-	if err != nil {
-		return BasicResponse{}, err
-	}
-	return result, nil
+	return client.getNotProvidedHandleResponse(resp)
 }
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
@@ -159,9 +151,11 @@ func (client BasicClient) getNotProvidedCreateRequest(ctx context.Context, optio
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client BasicClient) getNotProvidedHandleResponse(resp *azcore.Response) (BasicResponse, error) {
-	result := BasicResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Basic)
-	return result, err
+	var val *Basic
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BasicResponse{}, err
+	}
+	return BasicResponse{RawResponse: resp.Response, Basic: val}, nil
 }
 
 // getNotProvidedHandleError handles the GetNotProvided error response.
@@ -186,11 +180,7 @@ func (client BasicClient) GetNull(ctx context.Context, options *BasicGetNullOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BasicResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return BasicResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -207,9 +197,11 @@ func (client BasicClient) getNullCreateRequest(ctx context.Context, options *Bas
 
 // getNullHandleResponse handles the GetNull response.
 func (client BasicClient) getNullHandleResponse(resp *azcore.Response) (BasicResponse, error) {
-	result := BasicResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Basic)
-	return result, err
+	var val *Basic
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BasicResponse{}, err
+	}
+	return BasicResponse{RawResponse: resp.Response, Basic: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -234,11 +226,7 @@ func (client BasicClient) GetValid(ctx context.Context, options *BasicGetValidOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BasicResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return BasicResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -255,9 +243,11 @@ func (client BasicClient) getValidCreateRequest(ctx context.Context, options *Ba
 
 // getValidHandleResponse handles the GetValid response.
 func (client BasicClient) getValidHandleResponse(resp *azcore.Response) (BasicResponse, error) {
-	result := BasicResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Basic)
-	return result, err
+	var val *Basic
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BasicResponse{}, err
+	}
+	return BasicResponse{RawResponse: resp.Response, Basic: val}, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_dictionary.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary.go
@@ -42,11 +42,7 @@ func (client DictionaryClient) GetEmpty(ctx context.Context, options *Dictionary
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DictionaryWrapperResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return DictionaryWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -63,9 +59,11 @@ func (client DictionaryClient) getEmptyCreateRequest(ctx context.Context, option
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client DictionaryClient) getEmptyHandleResponse(resp *azcore.Response) (DictionaryWrapperResponse, error) {
-	result := DictionaryWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DictionaryWrapper)
-	return result, err
+	var val *DictionaryWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DictionaryWrapperResponse{}, err
+	}
+	return DictionaryWrapperResponse{RawResponse: resp.Response, DictionaryWrapper: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -90,11 +88,7 @@ func (client DictionaryClient) GetNotProvided(ctx context.Context, options *Dict
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DictionaryWrapperResponse{}, client.getNotProvidedHandleError(resp)
 	}
-	result, err := client.getNotProvidedHandleResponse(resp)
-	if err != nil {
-		return DictionaryWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getNotProvidedHandleResponse(resp)
 }
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
@@ -111,9 +105,11 @@ func (client DictionaryClient) getNotProvidedCreateRequest(ctx context.Context, 
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client DictionaryClient) getNotProvidedHandleResponse(resp *azcore.Response) (DictionaryWrapperResponse, error) {
-	result := DictionaryWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DictionaryWrapper)
-	return result, err
+	var val *DictionaryWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DictionaryWrapperResponse{}, err
+	}
+	return DictionaryWrapperResponse{RawResponse: resp.Response, DictionaryWrapper: val}, nil
 }
 
 // getNotProvidedHandleError handles the GetNotProvided error response.
@@ -138,11 +134,7 @@ func (client DictionaryClient) GetNull(ctx context.Context, options *DictionaryG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DictionaryWrapperResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return DictionaryWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -159,9 +151,11 @@ func (client DictionaryClient) getNullCreateRequest(ctx context.Context, options
 
 // getNullHandleResponse handles the GetNull response.
 func (client DictionaryClient) getNullHandleResponse(resp *azcore.Response) (DictionaryWrapperResponse, error) {
-	result := DictionaryWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DictionaryWrapper)
-	return result, err
+	var val *DictionaryWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DictionaryWrapperResponse{}, err
+	}
+	return DictionaryWrapperResponse{RawResponse: resp.Response, DictionaryWrapper: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -186,11 +180,7 @@ func (client DictionaryClient) GetValid(ctx context.Context, options *Dictionary
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DictionaryWrapperResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return DictionaryWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -207,9 +197,11 @@ func (client DictionaryClient) getValidCreateRequest(ctx context.Context, option
 
 // getValidHandleResponse handles the GetValid response.
 func (client DictionaryClient) getValidHandleResponse(resp *azcore.Response) (DictionaryWrapperResponse, error) {
-	result := DictionaryWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DictionaryWrapper)
-	return result, err
+	var val *DictionaryWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DictionaryWrapperResponse{}, err
+	}
+	return DictionaryWrapperResponse{RawResponse: resp.Response, DictionaryWrapper: val}, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_flattencomplex.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex.go
@@ -44,11 +44,7 @@ func (client FlattencomplexClient) GetValid(ctx context.Context, options *Flatte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyBaseTypeResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return MyBaseTypeResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -66,8 +62,10 @@ func (client FlattencomplexClient) getValidCreateRequest(ctx context.Context, op
 // getValidHandleResponse handles the GetValid response.
 func (client FlattencomplexClient) getValidHandleResponse(resp *azcore.Response) (MyBaseTypeResponse, error) {
 	result := MyBaseTypeResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return MyBaseTypeResponse{}, err
+	}
+	return result, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_inheritance.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance.go
@@ -42,11 +42,7 @@ func (client InheritanceClient) GetValid(ctx context.Context, options *Inheritan
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SiameseResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return SiameseResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -63,9 +59,11 @@ func (client InheritanceClient) getValidCreateRequest(ctx context.Context, optio
 
 // getValidHandleResponse handles the GetValid response.
 func (client InheritanceClient) getValidHandleResponse(resp *azcore.Response) (SiameseResponse, error) {
-	result := SiameseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Siamese)
-	return result, err
+	var val *Siamese
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SiameseResponse{}, err
+	}
+	return SiameseResponse{RawResponse: resp.Response, Siamese: val}, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive.go
@@ -42,11 +42,7 @@ func (client PolymorphicrecursiveClient) GetValid(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FishResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return FishResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -64,8 +60,10 @@ func (client PolymorphicrecursiveClient) getValidCreateRequest(ctx context.Conte
 // getValidHandleResponse handles the GetValid response.
 func (client PolymorphicrecursiveClient) getValidHandleResponse(resp *azcore.Response) (FishResponse, error) {
 	result := FishResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return FishResponse{}, err
+	}
+	return result, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexgroup/zz_generated_polymorphism.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism.go
@@ -42,11 +42,7 @@ func (client PolymorphismClient) GetComplicated(ctx context.Context, options *Po
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SalmonResponse{}, client.getComplicatedHandleError(resp)
 	}
-	result, err := client.getComplicatedHandleResponse(resp)
-	if err != nil {
-		return SalmonResponse{}, err
-	}
-	return result, nil
+	return client.getComplicatedHandleResponse(resp)
 }
 
 // getComplicatedCreateRequest creates the GetComplicated request.
@@ -64,8 +60,10 @@ func (client PolymorphismClient) getComplicatedCreateRequest(ctx context.Context
 // getComplicatedHandleResponse handles the GetComplicated response.
 func (client PolymorphismClient) getComplicatedHandleResponse(resp *azcore.Response) (SalmonResponse, error) {
 	result := SalmonResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return SalmonResponse{}, err
+	}
+	return result, nil
 }
 
 // getComplicatedHandleError handles the GetComplicated error response.
@@ -92,11 +90,7 @@ func (client PolymorphismClient) GetComposedWithDiscriminator(ctx context.Contex
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DotFishMarketResponse{}, client.getComposedWithDiscriminatorHandleError(resp)
 	}
-	result, err := client.getComposedWithDiscriminatorHandleResponse(resp)
-	if err != nil {
-		return DotFishMarketResponse{}, err
-	}
-	return result, nil
+	return client.getComposedWithDiscriminatorHandleResponse(resp)
 }
 
 // getComposedWithDiscriminatorCreateRequest creates the GetComposedWithDiscriminator request.
@@ -113,9 +107,11 @@ func (client PolymorphismClient) getComposedWithDiscriminatorCreateRequest(ctx c
 
 // getComposedWithDiscriminatorHandleResponse handles the GetComposedWithDiscriminator response.
 func (client PolymorphismClient) getComposedWithDiscriminatorHandleResponse(resp *azcore.Response) (DotFishMarketResponse, error) {
-	result := DotFishMarketResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DotFishMarket)
-	return result, err
+	var val *DotFishMarket
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DotFishMarketResponse{}, err
+	}
+	return DotFishMarketResponse{RawResponse: resp.Response, DotFishMarket: val}, nil
 }
 
 // getComposedWithDiscriminatorHandleError handles the GetComposedWithDiscriminator error response.
@@ -142,11 +138,7 @@ func (client PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Con
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DotFishMarketResponse{}, client.getComposedWithoutDiscriminatorHandleError(resp)
 	}
-	result, err := client.getComposedWithoutDiscriminatorHandleResponse(resp)
-	if err != nil {
-		return DotFishMarketResponse{}, err
-	}
-	return result, nil
+	return client.getComposedWithoutDiscriminatorHandleResponse(resp)
 }
 
 // getComposedWithoutDiscriminatorCreateRequest creates the GetComposedWithoutDiscriminator request.
@@ -163,9 +155,11 @@ func (client PolymorphismClient) getComposedWithoutDiscriminatorCreateRequest(ct
 
 // getComposedWithoutDiscriminatorHandleResponse handles the GetComposedWithoutDiscriminator response.
 func (client PolymorphismClient) getComposedWithoutDiscriminatorHandleResponse(resp *azcore.Response) (DotFishMarketResponse, error) {
-	result := DotFishMarketResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DotFishMarket)
-	return result, err
+	var val *DotFishMarket
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DotFishMarketResponse{}, err
+	}
+	return DotFishMarketResponse{RawResponse: resp.Response, DotFishMarket: val}, nil
 }
 
 // getComposedWithoutDiscriminatorHandleError handles the GetComposedWithoutDiscriminator error response.
@@ -190,11 +184,7 @@ func (client PolymorphismClient) GetDotSyntax(ctx context.Context, options *Poly
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DotFishResponse{}, client.getDotSyntaxHandleError(resp)
 	}
-	result, err := client.getDotSyntaxHandleResponse(resp)
-	if err != nil {
-		return DotFishResponse{}, err
-	}
-	return result, nil
+	return client.getDotSyntaxHandleResponse(resp)
 }
 
 // getDotSyntaxCreateRequest creates the GetDotSyntax request.
@@ -212,8 +202,10 @@ func (client PolymorphismClient) getDotSyntaxCreateRequest(ctx context.Context, 
 // getDotSyntaxHandleResponse handles the GetDotSyntax response.
 func (client PolymorphismClient) getDotSyntaxHandleResponse(resp *azcore.Response) (DotFishResponse, error) {
 	result := DotFishResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return DotFishResponse{}, err
+	}
+	return result, nil
 }
 
 // getDotSyntaxHandleError handles the GetDotSyntax error response.
@@ -238,11 +230,7 @@ func (client PolymorphismClient) GetValid(ctx context.Context, options *Polymorp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FishResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return FishResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -260,8 +248,10 @@ func (client PolymorphismClient) getValidCreateRequest(ctx context.Context, opti
 // getValidHandleResponse handles the GetValid response.
 func (client PolymorphismClient) getValidHandleResponse(resp *azcore.Response) (FishResponse, error) {
 	result := FishResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return FishResponse{}, err
+	}
+	return result, nil
 }
 
 // getValidHandleError handles the GetValid error response.
@@ -323,11 +313,7 @@ func (client PolymorphismClient) PutMissingDiscriminator(ctx context.Context, co
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SalmonResponse{}, client.putMissingDiscriminatorHandleError(resp)
 	}
-	result, err := client.putMissingDiscriminatorHandleResponse(resp)
-	if err != nil {
-		return SalmonResponse{}, err
-	}
-	return result, nil
+	return client.putMissingDiscriminatorHandleResponse(resp)
 }
 
 // putMissingDiscriminatorCreateRequest creates the PutMissingDiscriminator request.
@@ -345,8 +331,10 @@ func (client PolymorphismClient) putMissingDiscriminatorCreateRequest(ctx contex
 // putMissingDiscriminatorHandleResponse handles the PutMissingDiscriminator response.
 func (client PolymorphismClient) putMissingDiscriminatorHandleResponse(resp *azcore.Response) (SalmonResponse, error) {
 	result := SalmonResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result)
-	return result, err
+	if err := resp.UnmarshalAsJSON(&result); err != nil {
+		return SalmonResponse{}, err
+	}
+	return result, nil
 }
 
 // putMissingDiscriminatorHandleError handles the PutMissingDiscriminator error response.

--- a/test/autorest/complexgroup/zz_generated_primitive.go
+++ b/test/autorest/complexgroup/zz_generated_primitive.go
@@ -42,11 +42,7 @@ func (client PrimitiveClient) GetBool(ctx context.Context, options *PrimitiveGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BooleanWrapperResponse{}, client.getBoolHandleError(resp)
 	}
-	result, err := client.getBoolHandleResponse(resp)
-	if err != nil {
-		return BooleanWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getBoolHandleResponse(resp)
 }
 
 // getBoolCreateRequest creates the GetBool request.
@@ -63,9 +59,11 @@ func (client PrimitiveClient) getBoolCreateRequest(ctx context.Context, options 
 
 // getBoolHandleResponse handles the GetBool response.
 func (client PrimitiveClient) getBoolHandleResponse(resp *azcore.Response) (BooleanWrapperResponse, error) {
-	result := BooleanWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BooleanWrapper)
-	return result, err
+	var val *BooleanWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BooleanWrapperResponse{}, err
+	}
+	return BooleanWrapperResponse{RawResponse: resp.Response, BooleanWrapper: val}, nil
 }
 
 // getBoolHandleError handles the GetBool error response.
@@ -90,11 +88,7 @@ func (client PrimitiveClient) GetByte(ctx context.Context, options *PrimitiveGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteWrapperResponse{}, client.getByteHandleError(resp)
 	}
-	result, err := client.getByteHandleResponse(resp)
-	if err != nil {
-		return ByteWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getByteHandleResponse(resp)
 }
 
 // getByteCreateRequest creates the GetByte request.
@@ -111,9 +105,11 @@ func (client PrimitiveClient) getByteCreateRequest(ctx context.Context, options 
 
 // getByteHandleResponse handles the GetByte response.
 func (client PrimitiveClient) getByteHandleResponse(resp *azcore.Response) (ByteWrapperResponse, error) {
-	result := ByteWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ByteWrapper)
-	return result, err
+	var val *ByteWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ByteWrapperResponse{}, err
+	}
+	return ByteWrapperResponse{RawResponse: resp.Response, ByteWrapper: val}, nil
 }
 
 // getByteHandleError handles the GetByte error response.
@@ -138,11 +134,7 @@ func (client PrimitiveClient) GetDate(ctx context.Context, options *PrimitiveGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DateWrapperResponse{}, client.getDateHandleError(resp)
 	}
-	result, err := client.getDateHandleResponse(resp)
-	if err != nil {
-		return DateWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getDateHandleResponse(resp)
 }
 
 // getDateCreateRequest creates the GetDate request.
@@ -159,9 +151,11 @@ func (client PrimitiveClient) getDateCreateRequest(ctx context.Context, options 
 
 // getDateHandleResponse handles the GetDate response.
 func (client PrimitiveClient) getDateHandleResponse(resp *azcore.Response) (DateWrapperResponse, error) {
-	result := DateWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DateWrapper)
-	return result, err
+	var val *DateWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DateWrapperResponse{}, err
+	}
+	return DateWrapperResponse{RawResponse: resp.Response, DateWrapper: val}, nil
 }
 
 // getDateHandleError handles the GetDate error response.
@@ -186,11 +180,7 @@ func (client PrimitiveClient) GetDateTime(ctx context.Context, options *Primitiv
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DatetimeWrapperResponse{}, client.getDateTimeHandleError(resp)
 	}
-	result, err := client.getDateTimeHandleResponse(resp)
-	if err != nil {
-		return DatetimeWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeHandleResponse(resp)
 }
 
 // getDateTimeCreateRequest creates the GetDateTime request.
@@ -207,9 +197,11 @@ func (client PrimitiveClient) getDateTimeCreateRequest(ctx context.Context, opti
 
 // getDateTimeHandleResponse handles the GetDateTime response.
 func (client PrimitiveClient) getDateTimeHandleResponse(resp *azcore.Response) (DatetimeWrapperResponse, error) {
-	result := DatetimeWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DatetimeWrapper)
-	return result, err
+	var val *DatetimeWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DatetimeWrapperResponse{}, err
+	}
+	return DatetimeWrapperResponse{RawResponse: resp.Response, DatetimeWrapper: val}, nil
 }
 
 // getDateTimeHandleError handles the GetDateTime error response.
@@ -234,11 +226,7 @@ func (client PrimitiveClient) GetDateTimeRFC1123(ctx context.Context, options *P
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Datetimerfc1123WrapperResponse{}, client.getDateTimeRfc1123HandleError(resp)
 	}
-	result, err := client.getDateTimeRfc1123HandleResponse(resp)
-	if err != nil {
-		return Datetimerfc1123WrapperResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeRfc1123HandleResponse(resp)
 }
 
 // getDateTimeRfc1123CreateRequest creates the GetDateTimeRFC1123 request.
@@ -255,9 +243,11 @@ func (client PrimitiveClient) getDateTimeRfc1123CreateRequest(ctx context.Contex
 
 // getDateTimeRfc1123HandleResponse handles the GetDateTimeRFC1123 response.
 func (client PrimitiveClient) getDateTimeRfc1123HandleResponse(resp *azcore.Response) (Datetimerfc1123WrapperResponse, error) {
-	result := Datetimerfc1123WrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Datetimerfc1123Wrapper)
-	return result, err
+	var val *Datetimerfc1123Wrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Datetimerfc1123WrapperResponse{}, err
+	}
+	return Datetimerfc1123WrapperResponse{RawResponse: resp.Response, Datetimerfc1123Wrapper: val}, nil
 }
 
 // getDateTimeRfc1123HandleError handles the GetDateTimeRFC1123 error response.
@@ -282,11 +272,7 @@ func (client PrimitiveClient) GetDouble(ctx context.Context, options *PrimitiveG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DoubleWrapperResponse{}, client.getDoubleHandleError(resp)
 	}
-	result, err := client.getDoubleHandleResponse(resp)
-	if err != nil {
-		return DoubleWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getDoubleHandleResponse(resp)
 }
 
 // getDoubleCreateRequest creates the GetDouble request.
@@ -303,9 +289,11 @@ func (client PrimitiveClient) getDoubleCreateRequest(ctx context.Context, option
 
 // getDoubleHandleResponse handles the GetDouble response.
 func (client PrimitiveClient) getDoubleHandleResponse(resp *azcore.Response) (DoubleWrapperResponse, error) {
-	result := DoubleWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DoubleWrapper)
-	return result, err
+	var val *DoubleWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DoubleWrapperResponse{}, err
+	}
+	return DoubleWrapperResponse{RawResponse: resp.Response, DoubleWrapper: val}, nil
 }
 
 // getDoubleHandleError handles the GetDouble error response.
@@ -330,11 +318,7 @@ func (client PrimitiveClient) GetDuration(ctx context.Context, options *Primitiv
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DurationWrapperResponse{}, client.getDurationHandleError(resp)
 	}
-	result, err := client.getDurationHandleResponse(resp)
-	if err != nil {
-		return DurationWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getDurationHandleResponse(resp)
 }
 
 // getDurationCreateRequest creates the GetDuration request.
@@ -351,9 +335,11 @@ func (client PrimitiveClient) getDurationCreateRequest(ctx context.Context, opti
 
 // getDurationHandleResponse handles the GetDuration response.
 func (client PrimitiveClient) getDurationHandleResponse(resp *azcore.Response) (DurationWrapperResponse, error) {
-	result := DurationWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DurationWrapper)
-	return result, err
+	var val *DurationWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DurationWrapperResponse{}, err
+	}
+	return DurationWrapperResponse{RawResponse: resp.Response, DurationWrapper: val}, nil
 }
 
 // getDurationHandleError handles the GetDuration error response.
@@ -378,11 +364,7 @@ func (client PrimitiveClient) GetFloat(ctx context.Context, options *PrimitiveGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FloatWrapperResponse{}, client.getFloatHandleError(resp)
 	}
-	result, err := client.getFloatHandleResponse(resp)
-	if err != nil {
-		return FloatWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getFloatHandleResponse(resp)
 }
 
 // getFloatCreateRequest creates the GetFloat request.
@@ -399,9 +381,11 @@ func (client PrimitiveClient) getFloatCreateRequest(ctx context.Context, options
 
 // getFloatHandleResponse handles the GetFloat response.
 func (client PrimitiveClient) getFloatHandleResponse(resp *azcore.Response) (FloatWrapperResponse, error) {
-	result := FloatWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FloatWrapper)
-	return result, err
+	var val *FloatWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FloatWrapperResponse{}, err
+	}
+	return FloatWrapperResponse{RawResponse: resp.Response, FloatWrapper: val}, nil
 }
 
 // getFloatHandleError handles the GetFloat error response.
@@ -426,11 +410,7 @@ func (client PrimitiveClient) GetInt(ctx context.Context, options *PrimitiveGetI
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IntWrapperResponse{}, client.getIntHandleError(resp)
 	}
-	result, err := client.getIntHandleResponse(resp)
-	if err != nil {
-		return IntWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getIntHandleResponse(resp)
 }
 
 // getIntCreateRequest creates the GetInt request.
@@ -447,9 +427,11 @@ func (client PrimitiveClient) getIntCreateRequest(ctx context.Context, options *
 
 // getIntHandleResponse handles the GetInt response.
 func (client PrimitiveClient) getIntHandleResponse(resp *azcore.Response) (IntWrapperResponse, error) {
-	result := IntWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IntWrapper)
-	return result, err
+	var val *IntWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IntWrapperResponse{}, err
+	}
+	return IntWrapperResponse{RawResponse: resp.Response, IntWrapper: val}, nil
 }
 
 // getIntHandleError handles the GetInt error response.
@@ -474,11 +456,7 @@ func (client PrimitiveClient) GetLong(ctx context.Context, options *PrimitiveGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LongWrapperResponse{}, client.getLongHandleError(resp)
 	}
-	result, err := client.getLongHandleResponse(resp)
-	if err != nil {
-		return LongWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getLongHandleResponse(resp)
 }
 
 // getLongCreateRequest creates the GetLong request.
@@ -495,9 +473,11 @@ func (client PrimitiveClient) getLongCreateRequest(ctx context.Context, options 
 
 // getLongHandleResponse handles the GetLong response.
 func (client PrimitiveClient) getLongHandleResponse(resp *azcore.Response) (LongWrapperResponse, error) {
-	result := LongWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LongWrapper)
-	return result, err
+	var val *LongWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LongWrapperResponse{}, err
+	}
+	return LongWrapperResponse{RawResponse: resp.Response, LongWrapper: val}, nil
 }
 
 // getLongHandleError handles the GetLong error response.
@@ -522,11 +502,7 @@ func (client PrimitiveClient) GetString(ctx context.Context, options *PrimitiveG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringWrapperResponse{}, client.getStringHandleError(resp)
 	}
-	result, err := client.getStringHandleResponse(resp)
-	if err != nil {
-		return StringWrapperResponse{}, err
-	}
-	return result, nil
+	return client.getStringHandleResponse(resp)
 }
 
 // getStringCreateRequest creates the GetString request.
@@ -543,9 +519,11 @@ func (client PrimitiveClient) getStringCreateRequest(ctx context.Context, option
 
 // getStringHandleResponse handles the GetString response.
 func (client PrimitiveClient) getStringHandleResponse(resp *azcore.Response) (StringWrapperResponse, error) {
-	result := StringWrapperResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringWrapper)
-	return result, err
+	var val *StringWrapper
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringWrapperResponse{}, err
+	}
+	return StringWrapperResponse{RawResponse: resp.Response, StringWrapper: val}, nil
 }
 
 // getStringHandleError handles the GetString error response.

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty.go
@@ -42,11 +42,7 @@ func (client ReadonlypropertyClient) GetValid(ctx context.Context, options *Read
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ReadonlyObjResponse{}, client.getValidHandleError(resp)
 	}
-	result, err := client.getValidHandleResponse(resp)
-	if err != nil {
-		return ReadonlyObjResponse{}, err
-	}
-	return result, nil
+	return client.getValidHandleResponse(resp)
 }
 
 // getValidCreateRequest creates the GetValid request.
@@ -63,9 +59,11 @@ func (client ReadonlypropertyClient) getValidCreateRequest(ctx context.Context, 
 
 // getValidHandleResponse handles the GetValid response.
 func (client ReadonlypropertyClient) getValidHandleResponse(resp *azcore.Response) (ReadonlyObjResponse, error) {
-	result := ReadonlyObjResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ReadonlyObj)
-	return result, err
+	var val *ReadonlyObj
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ReadonlyObjResponse{}, err
+	}
+	return ReadonlyObjResponse{RawResponse: resp.Response, ReadonlyObj: val}, nil
 }
 
 // getValidHandleError handles the GetValid error response.

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient.go
@@ -44,11 +44,7 @@ func (client ComplexModelClient) Create(ctx context.Context, subscriptionId stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return CatalogDictionaryResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return CatalogDictionaryResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.
@@ -70,9 +66,11 @@ func (client ComplexModelClient) createCreateRequest(ctx context.Context, subscr
 
 // createHandleResponse handles the Create response.
 func (client ComplexModelClient) createHandleResponse(resp *azcore.Response) (CatalogDictionaryResponse, error) {
-	result := CatalogDictionaryResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CatalogDictionary)
-	return result, err
+	var val *CatalogDictionary
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CatalogDictionaryResponse{}, err
+	}
+	return CatalogDictionaryResponse{RawResponse: resp.Response, CatalogDictionary: val}, nil
 }
 
 // createHandleError handles the Create error response.
@@ -99,11 +97,7 @@ func (client ComplexModelClient) List(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return CatalogArrayResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return CatalogArrayResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -125,9 +119,11 @@ func (client ComplexModelClient) listCreateRequest(ctx context.Context, resource
 
 // listHandleResponse handles the List response.
 func (client ComplexModelClient) listHandleResponse(resp *azcore.Response) (CatalogArrayResponse, error) {
-	result := CatalogArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CatalogArray)
-	return result, err
+	var val *CatalogArray
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CatalogArrayResponse{}, err
+	}
+	return CatalogArrayResponse{RawResponse: resp.Response, CatalogArray: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -152,11 +148,7 @@ func (client ComplexModelClient) Update(ctx context.Context, subscriptionId stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return CatalogArrayResponse{}, client.updateHandleError(resp)
 	}
-	result, err := client.updateHandleResponse(resp)
-	if err != nil {
-		return CatalogArrayResponse{}, err
-	}
-	return result, nil
+	return client.updateHandleResponse(resp)
 }
 
 // updateCreateRequest creates the Update request.
@@ -178,9 +170,11 @@ func (client ComplexModelClient) updateCreateRequest(ctx context.Context, subscr
 
 // updateHandleResponse handles the Update response.
 func (client ComplexModelClient) updateHandleResponse(resp *azcore.Response) (CatalogArrayResponse, error) {
-	result := CatalogArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CatalogArray)
-	return result, err
+	var val *CatalogArray
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CatalogArrayResponse{}, err
+	}
+	return CatalogArrayResponse{RawResponse: resp.Response, CatalogArray: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/autorest/dategroup/zz_generated_date.go
+++ b/test/autorest/dategroup/zz_generated_date.go
@@ -43,11 +43,7 @@ func (client DateClient) GetInvalidDate(ctx context.Context, options *DateGetInv
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getInvalidDateHandleError(resp)
 	}
-	result, err := client.getInvalidDateHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidDateHandleResponse(resp)
 }
 
 // getInvalidDateCreateRequest creates the GetInvalidDate request.
@@ -65,8 +61,10 @@ func (client DateClient) getInvalidDateCreateRequest(ctx context.Context, option
 // getInvalidDateHandleResponse handles the GetInvalidDate response.
 func (client DateClient) getInvalidDateHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getInvalidDateHandleError handles the GetInvalidDate error response.
@@ -91,11 +89,7 @@ func (client DateClient) GetMaxDate(ctx context.Context, options *DateGetMaxDate
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getMaxDateHandleError(resp)
 	}
-	result, err := client.getMaxDateHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getMaxDateHandleResponse(resp)
 }
 
 // getMaxDateCreateRequest creates the GetMaxDate request.
@@ -113,8 +107,10 @@ func (client DateClient) getMaxDateCreateRequest(ctx context.Context, options *D
 // getMaxDateHandleResponse handles the GetMaxDate response.
 func (client DateClient) getMaxDateHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getMaxDateHandleError handles the GetMaxDate error response.
@@ -139,11 +135,7 @@ func (client DateClient) GetMinDate(ctx context.Context, options *DateGetMinDate
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getMinDateHandleError(resp)
 	}
-	result, err := client.getMinDateHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getMinDateHandleResponse(resp)
 }
 
 // getMinDateCreateRequest creates the GetMinDate request.
@@ -161,8 +153,10 @@ func (client DateClient) getMinDateCreateRequest(ctx context.Context, options *D
 // getMinDateHandleResponse handles the GetMinDate response.
 func (client DateClient) getMinDateHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getMinDateHandleError handles the GetMinDate error response.
@@ -187,11 +181,7 @@ func (client DateClient) GetNull(ctx context.Context, options *DateGetNullOption
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -209,8 +199,10 @@ func (client DateClient) getNullCreateRequest(ctx context.Context, options *Date
 // getNullHandleResponse handles the GetNull response.
 func (client DateClient) getNullHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -235,11 +227,7 @@ func (client DateClient) GetOverflowDate(ctx context.Context, options *DateGetOv
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getOverflowDateHandleError(resp)
 	}
-	result, err := client.getOverflowDateHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getOverflowDateHandleResponse(resp)
 }
 
 // getOverflowDateCreateRequest creates the GetOverflowDate request.
@@ -257,8 +245,10 @@ func (client DateClient) getOverflowDateCreateRequest(ctx context.Context, optio
 // getOverflowDateHandleResponse handles the GetOverflowDate response.
 func (client DateClient) getOverflowDateHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getOverflowDateHandleError handles the GetOverflowDate error response.
@@ -283,11 +273,7 @@ func (client DateClient) GetUnderflowDate(ctx context.Context, options *DateGetU
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUnderflowDateHandleError(resp)
 	}
-	result, err := client.getUnderflowDateHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUnderflowDateHandleResponse(resp)
 }
 
 // getUnderflowDateCreateRequest creates the GetUnderflowDate request.
@@ -305,8 +291,10 @@ func (client DateClient) getUnderflowDateCreateRequest(ctx context.Context, opti
 // getUnderflowDateHandleResponse handles the GetUnderflowDate response.
 func (client DateClient) getUnderflowDateHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *dateType
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUnderflowDateHandleError handles the GetUnderflowDate error response.

--- a/test/autorest/datetimegroup/zz_generated_datetime.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime.go
@@ -43,11 +43,7 @@ func (client DatetimeClient) GetInvalid(ctx context.Context, options *DatetimeGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -65,8 +61,10 @@ func (client DatetimeClient) getInvalidCreateRequest(ctx context.Context, option
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client DatetimeClient) getInvalidHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -91,11 +89,7 @@ func (client DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalNegativeOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetLowercaseMaxDateTime request.
@@ -113,8 +107,10 @@ func (client DatetimeClient) getLocalNegativeOffsetLowercaseMaxDateTimeCreateReq
 // getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetLowercaseMaxDateTime response.
 func (client DatetimeClient) getLocalNegativeOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalNegativeOffsetLowercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetLowercaseMaxDateTime error response.
@@ -139,11 +135,7 @@ func (client DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalNegativeOffsetMinDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalNegativeOffsetMinDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalNegativeOffsetMinDateTimeHandleResponse(resp)
 }
 
 // getLocalNegativeOffsetMinDateTimeCreateRequest creates the GetLocalNegativeOffsetMinDateTime request.
@@ -161,8 +153,10 @@ func (client DatetimeClient) getLocalNegativeOffsetMinDateTimeCreateRequest(ctx 
 // getLocalNegativeOffsetMinDateTimeHandleResponse handles the GetLocalNegativeOffsetMinDateTime response.
 func (client DatetimeClient) getLocalNegativeOffsetMinDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalNegativeOffsetMinDateTimeHandleError handles the GetLocalNegativeOffsetMinDateTime error response.
@@ -187,11 +181,7 @@ func (client DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalNegativeOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalNegativeOffsetUppercaseMaxDateTime request.
@@ -209,8 +199,10 @@ func (client DatetimeClient) getLocalNegativeOffsetUppercaseMaxDateTimeCreateReq
 // getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalNegativeOffsetUppercaseMaxDateTime response.
 func (client DatetimeClient) getLocalNegativeOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalNegativeOffsetUppercaseMaxDateTimeHandleError handles the GetLocalNegativeOffsetUppercaseMaxDateTime error response.
@@ -235,11 +227,7 @@ func (client DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalNoOffsetMinDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalNoOffsetMinDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalNoOffsetMinDateTimeHandleResponse(resp)
 }
 
 // getLocalNoOffsetMinDateTimeCreateRequest creates the GetLocalNoOffsetMinDateTime request.
@@ -257,8 +245,10 @@ func (client DatetimeClient) getLocalNoOffsetMinDateTimeCreateRequest(ctx contex
 // getLocalNoOffsetMinDateTimeHandleResponse handles the GetLocalNoOffsetMinDateTime response.
 func (client DatetimeClient) getLocalNoOffsetMinDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalNoOffsetMinDateTimeHandleError handles the GetLocalNoOffsetMinDateTime error response.
@@ -283,11 +273,7 @@ func (client DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalPositiveOffsetLowercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetLowercaseMaxDateTime request.
@@ -305,8 +291,10 @@ func (client DatetimeClient) getLocalPositiveOffsetLowercaseMaxDateTimeCreateReq
 // getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetLowercaseMaxDateTime response.
 func (client DatetimeClient) getLocalPositiveOffsetLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalPositiveOffsetLowercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetLowercaseMaxDateTime error response.
@@ -331,11 +319,7 @@ func (client DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalPositiveOffsetMinDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalPositiveOffsetMinDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalPositiveOffsetMinDateTimeHandleResponse(resp)
 }
 
 // getLocalPositiveOffsetMinDateTimeCreateRequest creates the GetLocalPositiveOffsetMinDateTime request.
@@ -353,8 +337,10 @@ func (client DatetimeClient) getLocalPositiveOffsetMinDateTimeCreateRequest(ctx 
 // getLocalPositiveOffsetMinDateTimeHandleResponse handles the GetLocalPositiveOffsetMinDateTime response.
 func (client DatetimeClient) getLocalPositiveOffsetMinDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalPositiveOffsetMinDateTimeHandleError handles the GetLocalPositiveOffsetMinDateTime error response.
@@ -379,11 +365,7 @@ func (client DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getLocalPositiveOffsetUppercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeCreateRequest creates the GetLocalPositiveOffsetUppercaseMaxDateTime request.
@@ -401,8 +383,10 @@ func (client DatetimeClient) getLocalPositiveOffsetUppercaseMaxDateTimeCreateReq
 // getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse handles the GetLocalPositiveOffsetUppercaseMaxDateTime response.
 func (client DatetimeClient) getLocalPositiveOffsetUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getLocalPositiveOffsetUppercaseMaxDateTimeHandleError handles the GetLocalPositiveOffsetUppercaseMaxDateTime error response.
@@ -427,11 +411,7 @@ func (client DatetimeClient) GetNull(ctx context.Context, options *DatetimeGetNu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -449,8 +429,10 @@ func (client DatetimeClient) getNullCreateRequest(ctx context.Context, options *
 // getNullHandleResponse handles the GetNull response.
 func (client DatetimeClient) getNullHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -475,11 +457,7 @@ func (client DatetimeClient) GetOverflow(ctx context.Context, options *DatetimeG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getOverflowHandleError(resp)
 	}
-	result, err := client.getOverflowHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getOverflowHandleResponse(resp)
 }
 
 // getOverflowCreateRequest creates the GetOverflow request.
@@ -497,8 +475,10 @@ func (client DatetimeClient) getOverflowCreateRequest(ctx context.Context, optio
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client DatetimeClient) getOverflowHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getOverflowHandleError handles the GetOverflow error response.
@@ -523,11 +503,7 @@ func (client DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context, opt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcLowercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcLowercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcLowercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
@@ -545,8 +521,10 @@ func (client DatetimeClient) getUtcLowercaseMaxDateTimeCreateRequest(ctx context
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client DatetimeClient) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
@@ -571,11 +549,7 @@ func (client DatetimeClient) GetUTCMinDateTime(ctx context.Context, options *Dat
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcMinDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcMinDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcMinDateTimeHandleResponse(resp)
 }
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
@@ -593,8 +567,10 @@ func (client DatetimeClient) getUtcMinDateTimeCreateRequest(ctx context.Context,
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client DatetimeClient) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcMinDateTimeHandleError handles the GetUTCMinDateTime error response.
@@ -619,11 +595,7 @@ func (client DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context, opt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcUppercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcUppercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcUppercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
@@ -641,8 +613,10 @@ func (client DatetimeClient) getUtcUppercaseMaxDateTimeCreateRequest(ctx context
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client DatetimeClient) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
@@ -667,11 +641,7 @@ func (client DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcUppercaseMaxDateTime7DigitsHandleError(resp)
 	}
-	result, err := client.getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp)
 }
 
 // getUtcUppercaseMaxDateTime7DigitsCreateRequest creates the GetUTCUppercaseMaxDateTime7Digits request.
@@ -689,8 +659,10 @@ func (client DatetimeClient) getUtcUppercaseMaxDateTime7DigitsCreateRequest(ctx 
 // getUtcUppercaseMaxDateTime7DigitsHandleResponse handles the GetUTCUppercaseMaxDateTime7Digits response.
 func (client DatetimeClient) getUtcUppercaseMaxDateTime7DigitsHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcUppercaseMaxDateTime7DigitsHandleError handles the GetUTCUppercaseMaxDateTime7Digits error response.
@@ -715,11 +687,7 @@ func (client DatetimeClient) GetUnderflow(ctx context.Context, options *Datetime
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUnderflowHandleError(resp)
 	}
-	result, err := client.getUnderflowHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUnderflowHandleResponse(resp)
 }
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
@@ -737,8 +705,10 @@ func (client DatetimeClient) getUnderflowCreateRequest(ctx context.Context, opti
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client DatetimeClient) getUnderflowHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC3339
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUnderflowHandleError handles the GetUnderflow error response.

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123.go
@@ -43,11 +43,7 @@ func (client Datetimerfc1123Client) GetInvalid(ctx context.Context, options *Dat
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -65,8 +61,10 @@ func (client Datetimerfc1123Client) getInvalidCreateRequest(ctx context.Context,
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client Datetimerfc1123Client) getInvalidHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -91,11 +89,7 @@ func (client Datetimerfc1123Client) GetNull(ctx context.Context, options *Dateti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -113,8 +107,10 @@ func (client Datetimerfc1123Client) getNullCreateRequest(ctx context.Context, op
 // getNullHandleResponse handles the GetNull response.
 func (client Datetimerfc1123Client) getNullHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -139,11 +135,7 @@ func (client Datetimerfc1123Client) GetOverflow(ctx context.Context, options *Da
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getOverflowHandleError(resp)
 	}
-	result, err := client.getOverflowHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getOverflowHandleResponse(resp)
 }
 
 // getOverflowCreateRequest creates the GetOverflow request.
@@ -161,8 +153,10 @@ func (client Datetimerfc1123Client) getOverflowCreateRequest(ctx context.Context
 // getOverflowHandleResponse handles the GetOverflow response.
 func (client Datetimerfc1123Client) getOverflowHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getOverflowHandleError handles the GetOverflow error response.
@@ -187,11 +181,7 @@ func (client Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcLowercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcLowercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcLowercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getUtcLowercaseMaxDateTimeCreateRequest creates the GetUTCLowercaseMaxDateTime request.
@@ -209,8 +199,10 @@ func (client Datetimerfc1123Client) getUtcLowercaseMaxDateTimeCreateRequest(ctx 
 // getUtcLowercaseMaxDateTimeHandleResponse handles the GetUTCLowercaseMaxDateTime response.
 func (client Datetimerfc1123Client) getUtcLowercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcLowercaseMaxDateTimeHandleError handles the GetUTCLowercaseMaxDateTime error response.
@@ -235,11 +227,7 @@ func (client Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcMinDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcMinDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcMinDateTimeHandleResponse(resp)
 }
 
 // getUtcMinDateTimeCreateRequest creates the GetUTCMinDateTime request.
@@ -257,8 +245,10 @@ func (client Datetimerfc1123Client) getUtcMinDateTimeCreateRequest(ctx context.C
 // getUtcMinDateTimeHandleResponse handles the GetUTCMinDateTime response.
 func (client Datetimerfc1123Client) getUtcMinDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcMinDateTimeHandleError handles the GetUTCMinDateTime error response.
@@ -283,11 +273,7 @@ func (client Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUtcUppercaseMaxDateTimeHandleError(resp)
 	}
-	result, err := client.getUtcUppercaseMaxDateTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUtcUppercaseMaxDateTimeHandleResponse(resp)
 }
 
 // getUtcUppercaseMaxDateTimeCreateRequest creates the GetUTCUppercaseMaxDateTime request.
@@ -305,8 +291,10 @@ func (client Datetimerfc1123Client) getUtcUppercaseMaxDateTimeCreateRequest(ctx 
 // getUtcUppercaseMaxDateTimeHandleResponse handles the GetUTCUppercaseMaxDateTime response.
 func (client Datetimerfc1123Client) getUtcUppercaseMaxDateTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUtcUppercaseMaxDateTimeHandleError handles the GetUTCUppercaseMaxDateTime error response.
@@ -331,11 +319,7 @@ func (client Datetimerfc1123Client) GetUnderflow(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUnderflowHandleError(resp)
 	}
-	result, err := client.getUnderflowHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUnderflowHandleResponse(resp)
 }
 
 // getUnderflowCreateRequest creates the GetUnderflow request.
@@ -353,8 +337,10 @@ func (client Datetimerfc1123Client) getUnderflowCreateRequest(ctx context.Contex
 // getUnderflowHandleResponse handles the GetUnderflow response.
 func (client Datetimerfc1123Client) getUnderflowHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeRFC1123
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUnderflowHandleError handles the GetUnderflow error response.

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -43,11 +43,7 @@ func (client DictionaryClient) GetArrayEmpty(ctx context.Context, options *Dicti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getArrayEmptyHandleError(resp)
 	}
-	result, err := client.getArrayEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayEmptyHandleResponse(resp)
 }
 
 // getArrayEmptyCreateRequest creates the GetArrayEmpty request.
@@ -64,9 +60,11 @@ func (client DictionaryClient) getArrayEmptyCreateRequest(ctx context.Context, o
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client DictionaryClient) getArrayEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getArrayEmptyHandleError handles the GetArrayEmpty error response.
@@ -91,11 +89,7 @@ func (client DictionaryClient) GetArrayItemEmpty(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getArrayItemEmptyHandleError(resp)
 	}
-	result, err := client.getArrayItemEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayItemEmptyHandleResponse(resp)
 }
 
 // getArrayItemEmptyCreateRequest creates the GetArrayItemEmpty request.
@@ -112,9 +106,11 @@ func (client DictionaryClient) getArrayItemEmptyCreateRequest(ctx context.Contex
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client DictionaryClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getArrayItemEmptyHandleError handles the GetArrayItemEmpty error response.
@@ -139,11 +135,7 @@ func (client DictionaryClient) GetArrayItemNull(ctx context.Context, options *Di
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getArrayItemNullHandleError(resp)
 	}
-	result, err := client.getArrayItemNullHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayItemNullHandleResponse(resp)
 }
 
 // getArrayItemNullCreateRequest creates the GetArrayItemNull request.
@@ -160,9 +152,11 @@ func (client DictionaryClient) getArrayItemNullCreateRequest(ctx context.Context
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client DictionaryClient) getArrayItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getArrayItemNullHandleError handles the GetArrayItemNull error response.
@@ -187,11 +181,7 @@ func (client DictionaryClient) GetArrayNull(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getArrayNullHandleError(resp)
 	}
-	result, err := client.getArrayNullHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayNullHandleResponse(resp)
 }
 
 // getArrayNullCreateRequest creates the GetArrayNull request.
@@ -208,9 +198,11 @@ func (client DictionaryClient) getArrayNullCreateRequest(ctx context.Context, op
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client DictionaryClient) getArrayNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getArrayNullHandleError handles the GetArrayNull error response.
@@ -235,11 +227,7 @@ func (client DictionaryClient) GetArrayValid(ctx context.Context, options *Dicti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringArrayResponse{}, client.getArrayValidHandleError(resp)
 	}
-	result, err := client.getArrayValidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringArrayResponse{}, err
-	}
-	return result, nil
+	return client.getArrayValidHandleResponse(resp)
 }
 
 // getArrayValidCreateRequest creates the GetArrayValid request.
@@ -256,9 +244,11 @@ func (client DictionaryClient) getArrayValidCreateRequest(ctx context.Context, o
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client DictionaryClient) getArrayValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	result := MapOfStringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringArrayResponse{}, err
+	}
+	return MapOfStringArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getArrayValidHandleError handles the GetArrayValid error response.
@@ -283,11 +273,7 @@ func (client DictionaryClient) GetBase64URL(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfByteArrayResponse{}, client.getBase64UrlHandleError(resp)
 	}
-	result, err := client.getBase64UrlHandleResponse(resp)
-	if err != nil {
-		return MapOfByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBase64UrlHandleResponse(resp)
 }
 
 // getBase64UrlCreateRequest creates the GetBase64URL request.
@@ -304,9 +290,11 @@ func (client DictionaryClient) getBase64UrlCreateRequest(ctx context.Context, op
 
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client DictionaryClient) getBase64UrlHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	result := MapOfByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfByteArrayResponse{}, err
+	}
+	return MapOfByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBase64UrlHandleError handles the GetBase64URL error response.
@@ -331,11 +319,7 @@ func (client DictionaryClient) GetBooleanInvalidNull(ctx context.Context, option
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfBoolResponse{}, client.getBooleanInvalidNullHandleError(resp)
 	}
-	result, err := client.getBooleanInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfBoolResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanInvalidNullHandleResponse(resp)
 }
 
 // getBooleanInvalidNullCreateRequest creates the GetBooleanInvalidNull request.
@@ -352,9 +336,11 @@ func (client DictionaryClient) getBooleanInvalidNullCreateRequest(ctx context.Co
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client DictionaryClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	result := MapOfBoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfBoolResponse{}, err
+	}
+	return MapOfBoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBooleanInvalidNullHandleError handles the GetBooleanInvalidNull error response.
@@ -379,11 +365,7 @@ func (client DictionaryClient) GetBooleanInvalidString(ctx context.Context, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfBoolResponse{}, client.getBooleanInvalidStringHandleError(resp)
 	}
-	result, err := client.getBooleanInvalidStringHandleResponse(resp)
-	if err != nil {
-		return MapOfBoolResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanInvalidStringHandleResponse(resp)
 }
 
 // getBooleanInvalidStringCreateRequest creates the GetBooleanInvalidString request.
@@ -400,9 +382,11 @@ func (client DictionaryClient) getBooleanInvalidStringCreateRequest(ctx context.
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client DictionaryClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	result := MapOfBoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfBoolResponse{}, err
+	}
+	return MapOfBoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBooleanInvalidStringHandleError handles the GetBooleanInvalidString error response.
@@ -427,11 +411,7 @@ func (client DictionaryClient) GetBooleanTfft(ctx context.Context, options *Dict
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfBoolResponse{}, client.getBooleanTfftHandleError(resp)
 	}
-	result, err := client.getBooleanTfftHandleResponse(resp)
-	if err != nil {
-		return MapOfBoolResponse{}, err
-	}
-	return result, nil
+	return client.getBooleanTfftHandleResponse(resp)
 }
 
 // getBooleanTfftCreateRequest creates the GetBooleanTfft request.
@@ -448,9 +428,11 @@ func (client DictionaryClient) getBooleanTfftCreateRequest(ctx context.Context, 
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client DictionaryClient) getBooleanTfftHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	result := MapOfBoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfBoolResponse{}, err
+	}
+	return MapOfBoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBooleanTfftHandleError handles the GetBooleanTfft error response.
@@ -475,11 +457,7 @@ func (client DictionaryClient) GetByteInvalidNull(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfByteArrayResponse{}, client.getByteInvalidNullHandleError(resp)
 	}
-	result, err := client.getByteInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getByteInvalidNullHandleResponse(resp)
 }
 
 // getByteInvalidNullCreateRequest creates the GetByteInvalidNull request.
@@ -496,9 +474,11 @@ func (client DictionaryClient) getByteInvalidNullCreateRequest(ctx context.Conte
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client DictionaryClient) getByteInvalidNullHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	result := MapOfByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfByteArrayResponse{}, err
+	}
+	return MapOfByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getByteInvalidNullHandleError handles the GetByteInvalidNull error response.
@@ -523,11 +503,7 @@ func (client DictionaryClient) GetByteValid(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfByteArrayResponse{}, client.getByteValidHandleError(resp)
 	}
-	result, err := client.getByteValidHandleResponse(resp)
-	if err != nil {
-		return MapOfByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getByteValidHandleResponse(resp)
 }
 
 // getByteValidCreateRequest creates the GetByteValid request.
@@ -544,9 +520,11 @@ func (client DictionaryClient) getByteValidCreateRequest(ctx context.Context, op
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client DictionaryClient) getByteValidHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	result := MapOfByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string][]byte
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfByteArrayResponse{}, err
+	}
+	return MapOfByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getByteValidHandleError handles the GetByteValid error response.
@@ -571,11 +549,7 @@ func (client DictionaryClient) GetComplexEmpty(ctx context.Context, options *Dic
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfWidgetResponse{}, client.getComplexEmptyHandleError(resp)
 	}
-	result, err := client.getComplexEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfWidgetResponse{}, err
-	}
-	return result, nil
+	return client.getComplexEmptyHandleResponse(resp)
 }
 
 // getComplexEmptyCreateRequest creates the GetComplexEmpty request.
@@ -592,9 +566,11 @@ func (client DictionaryClient) getComplexEmptyCreateRequest(ctx context.Context,
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client DictionaryClient) getComplexEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	result := MapOfWidgetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]Widget
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfWidgetResponse{}, err
+	}
+	return MapOfWidgetResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getComplexEmptyHandleError handles the GetComplexEmpty error response.
@@ -619,11 +595,7 @@ func (client DictionaryClient) GetComplexItemEmpty(ctx context.Context, options 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfWidgetResponse{}, client.getComplexItemEmptyHandleError(resp)
 	}
-	result, err := client.getComplexItemEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfWidgetResponse{}, err
-	}
-	return result, nil
+	return client.getComplexItemEmptyHandleResponse(resp)
 }
 
 // getComplexItemEmptyCreateRequest creates the GetComplexItemEmpty request.
@@ -640,9 +612,11 @@ func (client DictionaryClient) getComplexItemEmptyCreateRequest(ctx context.Cont
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client DictionaryClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	result := MapOfWidgetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]Widget
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfWidgetResponse{}, err
+	}
+	return MapOfWidgetResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getComplexItemEmptyHandleError handles the GetComplexItemEmpty error response.
@@ -667,11 +641,7 @@ func (client DictionaryClient) GetComplexItemNull(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfWidgetResponse{}, client.getComplexItemNullHandleError(resp)
 	}
-	result, err := client.getComplexItemNullHandleResponse(resp)
-	if err != nil {
-		return MapOfWidgetResponse{}, err
-	}
-	return result, nil
+	return client.getComplexItemNullHandleResponse(resp)
 }
 
 // getComplexItemNullCreateRequest creates the GetComplexItemNull request.
@@ -688,9 +658,11 @@ func (client DictionaryClient) getComplexItemNullCreateRequest(ctx context.Conte
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client DictionaryClient) getComplexItemNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	result := MapOfWidgetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]Widget
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfWidgetResponse{}, err
+	}
+	return MapOfWidgetResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getComplexItemNullHandleError handles the GetComplexItemNull error response.
@@ -715,11 +687,7 @@ func (client DictionaryClient) GetComplexNull(ctx context.Context, options *Dict
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfWidgetResponse{}, client.getComplexNullHandleError(resp)
 	}
-	result, err := client.getComplexNullHandleResponse(resp)
-	if err != nil {
-		return MapOfWidgetResponse{}, err
-	}
-	return result, nil
+	return client.getComplexNullHandleResponse(resp)
 }
 
 // getComplexNullCreateRequest creates the GetComplexNull request.
@@ -736,9 +704,11 @@ func (client DictionaryClient) getComplexNullCreateRequest(ctx context.Context, 
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client DictionaryClient) getComplexNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	result := MapOfWidgetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]Widget
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfWidgetResponse{}, err
+	}
+	return MapOfWidgetResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getComplexNullHandleError handles the GetComplexNull error response.
@@ -764,11 +734,7 @@ func (client DictionaryClient) GetComplexValid(ctx context.Context, options *Dic
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfWidgetResponse{}, client.getComplexValidHandleError(resp)
 	}
-	result, err := client.getComplexValidHandleResponse(resp)
-	if err != nil {
-		return MapOfWidgetResponse{}, err
-	}
-	return result, nil
+	return client.getComplexValidHandleResponse(resp)
 }
 
 // getComplexValidCreateRequest creates the GetComplexValid request.
@@ -785,9 +751,11 @@ func (client DictionaryClient) getComplexValidCreateRequest(ctx context.Context,
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client DictionaryClient) getComplexValidHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	result := MapOfWidgetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]Widget
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfWidgetResponse{}, err
+	}
+	return MapOfWidgetResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getComplexValidHandleError handles the GetComplexValid error response.
@@ -812,11 +780,7 @@ func (client DictionaryClient) GetDateInvalidChars(ctx context.Context, options 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateInvalidCharsHandleError(resp)
 	}
-	result, err := client.getDateInvalidCharsHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateInvalidCharsHandleResponse(resp)
 }
 
 // getDateInvalidCharsCreateRequest creates the GetDateInvalidChars request.
@@ -866,11 +830,7 @@ func (client DictionaryClient) GetDateInvalidNull(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateInvalidNullHandleError(resp)
 	}
-	result, err := client.getDateInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateInvalidNullHandleResponse(resp)
 }
 
 // getDateInvalidNullCreateRequest creates the GetDateInvalidNull request.
@@ -920,11 +880,7 @@ func (client DictionaryClient) GetDateTimeInvalidChars(ctx context.Context, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateTimeInvalidCharsHandleError(resp)
 	}
-	result, err := client.getDateTimeInvalidCharsHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeInvalidCharsHandleResponse(resp)
 }
 
 // getDateTimeInvalidCharsCreateRequest creates the GetDateTimeInvalidChars request.
@@ -974,11 +930,7 @@ func (client DictionaryClient) GetDateTimeInvalidNull(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateTimeInvalidNullHandleError(resp)
 	}
-	result, err := client.getDateTimeInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeInvalidNullHandleResponse(resp)
 }
 
 // getDateTimeInvalidNullCreateRequest creates the GetDateTimeInvalidNull request.
@@ -1029,11 +981,7 @@ func (client DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateTimeRfc1123ValidHandleError(resp)
 	}
-	result, err := client.getDateTimeRfc1123ValidHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeRfc1123ValidHandleResponse(resp)
 }
 
 // getDateTimeRfc1123ValidCreateRequest creates the GetDateTimeRFC1123Valid request.
@@ -1083,11 +1031,7 @@ func (client DictionaryClient) GetDateTimeValid(ctx context.Context, options *Di
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateTimeValidHandleError(resp)
 	}
-	result, err := client.getDateTimeValidHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateTimeValidHandleResponse(resp)
 }
 
 // getDateTimeValidCreateRequest creates the GetDateTimeValid request.
@@ -1137,11 +1081,7 @@ func (client DictionaryClient) GetDateValid(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfTimeResponse{}, client.getDateValidHandleError(resp)
 	}
-	result, err := client.getDateValidHandleResponse(resp)
-	if err != nil {
-		return MapOfTimeResponse{}, err
-	}
-	return result, nil
+	return client.getDateValidHandleResponse(resp)
 }
 
 // getDateValidCreateRequest creates the GetDateValid request.
@@ -1191,11 +1131,7 @@ func (client DictionaryClient) GetDictionaryEmpty(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInterfaceResponse{}, client.getDictionaryEmptyHandleError(resp)
 	}
-	result, err := client.getDictionaryEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryEmptyHandleResponse(resp)
 }
 
 // getDictionaryEmptyCreateRequest creates the GetDictionaryEmpty request.
@@ -1212,9 +1148,11 @@ func (client DictionaryClient) getDictionaryEmptyCreateRequest(ctx context.Conte
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client DictionaryClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfInterfaceResponse, error) {
-	result := MapOfInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]interface{}
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInterfaceResponse{}, err
+	}
+	return MapOfInterfaceResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDictionaryEmptyHandleError handles the GetDictionaryEmpty error response.
@@ -1240,11 +1178,7 @@ func (client DictionaryClient) GetDictionaryItemEmpty(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInterfaceResponse{}, client.getDictionaryItemEmptyHandleError(resp)
 	}
-	result, err := client.getDictionaryItemEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryItemEmptyHandleResponse(resp)
 }
 
 // getDictionaryItemEmptyCreateRequest creates the GetDictionaryItemEmpty request.
@@ -1261,9 +1195,11 @@ func (client DictionaryClient) getDictionaryItemEmptyCreateRequest(ctx context.C
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client DictionaryClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfInterfaceResponse, error) {
-	result := MapOfInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]interface{}
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInterfaceResponse{}, err
+	}
+	return MapOfInterfaceResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDictionaryItemEmptyHandleError handles the GetDictionaryItemEmpty error response.
@@ -1289,11 +1225,7 @@ func (client DictionaryClient) GetDictionaryItemNull(ctx context.Context, option
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInterfaceResponse{}, client.getDictionaryItemNullHandleError(resp)
 	}
-	result, err := client.getDictionaryItemNullHandleResponse(resp)
-	if err != nil {
-		return MapOfInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryItemNullHandleResponse(resp)
 }
 
 // getDictionaryItemNullCreateRequest creates the GetDictionaryItemNull request.
@@ -1310,9 +1242,11 @@ func (client DictionaryClient) getDictionaryItemNullCreateRequest(ctx context.Co
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client DictionaryClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfInterfaceResponse, error) {
-	result := MapOfInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]interface{}
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInterfaceResponse{}, err
+	}
+	return MapOfInterfaceResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDictionaryItemNullHandleError handles the GetDictionaryItemNull error response.
@@ -1337,11 +1271,7 @@ func (client DictionaryClient) GetDictionaryNull(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInterfaceResponse{}, client.getDictionaryNullHandleError(resp)
 	}
-	result, err := client.getDictionaryNullHandleResponse(resp)
-	if err != nil {
-		return MapOfInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryNullHandleResponse(resp)
 }
 
 // getDictionaryNullCreateRequest creates the GetDictionaryNull request.
@@ -1358,9 +1288,11 @@ func (client DictionaryClient) getDictionaryNullCreateRequest(ctx context.Contex
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client DictionaryClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfInterfaceResponse, error) {
-	result := MapOfInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]interface{}
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInterfaceResponse{}, err
+	}
+	return MapOfInterfaceResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDictionaryNullHandleError handles the GetDictionaryNull error response.
@@ -1386,11 +1318,7 @@ func (client DictionaryClient) GetDictionaryValid(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInterfaceResponse{}, client.getDictionaryValidHandleError(resp)
 	}
-	result, err := client.getDictionaryValidHandleResponse(resp)
-	if err != nil {
-		return MapOfInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getDictionaryValidHandleResponse(resp)
 }
 
 // getDictionaryValidCreateRequest creates the GetDictionaryValid request.
@@ -1407,9 +1335,11 @@ func (client DictionaryClient) getDictionaryValidCreateRequest(ctx context.Conte
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client DictionaryClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfInterfaceResponse, error) {
-	result := MapOfInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]interface{}
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInterfaceResponse{}, err
+	}
+	return MapOfInterfaceResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDictionaryValidHandleError handles the GetDictionaryValid error response.
@@ -1434,11 +1364,7 @@ func (client DictionaryClient) GetDoubleInvalidNull(ctx context.Context, options
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat64Response{}, client.getDoubleInvalidNullHandleError(resp)
 	}
-	result, err := client.getDoubleInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat64Response{}, err
-	}
-	return result, nil
+	return client.getDoubleInvalidNullHandleResponse(resp)
 }
 
 // getDoubleInvalidNullCreateRequest creates the GetDoubleInvalidNull request.
@@ -1455,9 +1381,11 @@ func (client DictionaryClient) getDoubleInvalidNullCreateRequest(ctx context.Con
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client DictionaryClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	result := MapOfFloat64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat64Response{}, err
+	}
+	return MapOfFloat64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDoubleInvalidNullHandleError handles the GetDoubleInvalidNull error response.
@@ -1482,11 +1410,7 @@ func (client DictionaryClient) GetDoubleInvalidString(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat64Response{}, client.getDoubleInvalidStringHandleError(resp)
 	}
-	result, err := client.getDoubleInvalidStringHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat64Response{}, err
-	}
-	return result, nil
+	return client.getDoubleInvalidStringHandleResponse(resp)
 }
 
 // getDoubleInvalidStringCreateRequest creates the GetDoubleInvalidString request.
@@ -1503,9 +1427,11 @@ func (client DictionaryClient) getDoubleInvalidStringCreateRequest(ctx context.C
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client DictionaryClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	result := MapOfFloat64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat64Response{}, err
+	}
+	return MapOfFloat64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDoubleInvalidStringHandleError handles the GetDoubleInvalidString error response.
@@ -1530,11 +1456,7 @@ func (client DictionaryClient) GetDoubleValid(ctx context.Context, options *Dict
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat64Response{}, client.getDoubleValidHandleError(resp)
 	}
-	result, err := client.getDoubleValidHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat64Response{}, err
-	}
-	return result, nil
+	return client.getDoubleValidHandleResponse(resp)
 }
 
 // getDoubleValidCreateRequest creates the GetDoubleValid request.
@@ -1551,9 +1473,11 @@ func (client DictionaryClient) getDoubleValidCreateRequest(ctx context.Context, 
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client DictionaryClient) getDoubleValidHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	result := MapOfFloat64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat64Response{}, err
+	}
+	return MapOfFloat64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDoubleValidHandleError handles the GetDoubleValid error response.
@@ -1578,11 +1502,7 @@ func (client DictionaryClient) GetDurationValid(ctx context.Context, options *Di
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getDurationValidHandleError(resp)
 	}
-	result, err := client.getDurationValidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getDurationValidHandleResponse(resp)
 }
 
 // getDurationValidCreateRequest creates the GetDurationValid request.
@@ -1599,9 +1519,11 @@ func (client DictionaryClient) getDurationValidCreateRequest(ctx context.Context
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client DictionaryClient) getDurationValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getDurationValidHandleError handles the GetDurationValid error response.
@@ -1626,11 +1548,7 @@ func (client DictionaryClient) GetEmpty(ctx context.Context, options *Dictionary
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -1647,9 +1565,11 @@ func (client DictionaryClient) getEmptyCreateRequest(ctx context.Context, option
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client DictionaryClient) getEmptyHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -1674,11 +1594,7 @@ func (client DictionaryClient) GetEmptyStringKey(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getEmptyStringKeyHandleError(resp)
 	}
-	result, err := client.getEmptyStringKeyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyStringKeyHandleResponse(resp)
 }
 
 // getEmptyStringKeyCreateRequest creates the GetEmptyStringKey request.
@@ -1695,9 +1611,11 @@ func (client DictionaryClient) getEmptyStringKeyCreateRequest(ctx context.Contex
 
 // getEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client DictionaryClient) getEmptyStringKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getEmptyStringKeyHandleError handles the GetEmptyStringKey error response.
@@ -1722,11 +1640,7 @@ func (client DictionaryClient) GetFloatInvalidNull(ctx context.Context, options 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat32Response{}, client.getFloatInvalidNullHandleError(resp)
 	}
-	result, err := client.getFloatInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat32Response{}, err
-	}
-	return result, nil
+	return client.getFloatInvalidNullHandleResponse(resp)
 }
 
 // getFloatInvalidNullCreateRequest creates the GetFloatInvalidNull request.
@@ -1743,9 +1657,11 @@ func (client DictionaryClient) getFloatInvalidNullCreateRequest(ctx context.Cont
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client DictionaryClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	result := MapOfFloat32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat32Response{}, err
+	}
+	return MapOfFloat32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getFloatInvalidNullHandleError handles the GetFloatInvalidNull error response.
@@ -1770,11 +1686,7 @@ func (client DictionaryClient) GetFloatInvalidString(ctx context.Context, option
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat32Response{}, client.getFloatInvalidStringHandleError(resp)
 	}
-	result, err := client.getFloatInvalidStringHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat32Response{}, err
-	}
-	return result, nil
+	return client.getFloatInvalidStringHandleResponse(resp)
 }
 
 // getFloatInvalidStringCreateRequest creates the GetFloatInvalidString request.
@@ -1791,9 +1703,11 @@ func (client DictionaryClient) getFloatInvalidStringCreateRequest(ctx context.Co
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client DictionaryClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	result := MapOfFloat32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat32Response{}, err
+	}
+	return MapOfFloat32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getFloatInvalidStringHandleError handles the GetFloatInvalidString error response.
@@ -1818,11 +1732,7 @@ func (client DictionaryClient) GetFloatValid(ctx context.Context, options *Dicti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfFloat32Response{}, client.getFloatValidHandleError(resp)
 	}
-	result, err := client.getFloatValidHandleResponse(resp)
-	if err != nil {
-		return MapOfFloat32Response{}, err
-	}
-	return result, nil
+	return client.getFloatValidHandleResponse(resp)
 }
 
 // getFloatValidCreateRequest creates the GetFloatValid request.
@@ -1839,9 +1749,11 @@ func (client DictionaryClient) getFloatValidCreateRequest(ctx context.Context, o
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client DictionaryClient) getFloatValidHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	result := MapOfFloat32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfFloat32Response{}, err
+	}
+	return MapOfFloat32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getFloatValidHandleError handles the GetFloatValid error response.
@@ -1866,11 +1778,7 @@ func (client DictionaryClient) GetIntInvalidNull(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getIntInvalidNullHandleError(resp)
 	}
-	result, err := client.getIntInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getIntInvalidNullHandleResponse(resp)
 }
 
 // getIntInvalidNullCreateRequest creates the GetIntInvalidNull request.
@@ -1887,9 +1795,11 @@ func (client DictionaryClient) getIntInvalidNullCreateRequest(ctx context.Contex
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client DictionaryClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getIntInvalidNullHandleError handles the GetIntInvalidNull error response.
@@ -1914,11 +1824,7 @@ func (client DictionaryClient) GetIntInvalidString(ctx context.Context, options 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getIntInvalidStringHandleError(resp)
 	}
-	result, err := client.getIntInvalidStringHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getIntInvalidStringHandleResponse(resp)
 }
 
 // getIntInvalidStringCreateRequest creates the GetIntInvalidString request.
@@ -1935,9 +1841,11 @@ func (client DictionaryClient) getIntInvalidStringCreateRequest(ctx context.Cont
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client DictionaryClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getIntInvalidStringHandleError handles the GetIntInvalidString error response.
@@ -1962,11 +1870,7 @@ func (client DictionaryClient) GetIntegerValid(ctx context.Context, options *Dic
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getIntegerValidHandleError(resp)
 	}
-	result, err := client.getIntegerValidHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getIntegerValidHandleResponse(resp)
 }
 
 // getIntegerValidCreateRequest creates the GetIntegerValid request.
@@ -1983,9 +1887,11 @@ func (client DictionaryClient) getIntegerValidCreateRequest(ctx context.Context,
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client DictionaryClient) getIntegerValidHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getIntegerValidHandleError handles the GetIntegerValid error response.
@@ -2010,11 +1916,7 @@ func (client DictionaryClient) GetInvalid(ctx context.Context, options *Dictiona
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -2031,9 +1933,11 @@ func (client DictionaryClient) getInvalidCreateRequest(ctx context.Context, opti
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client DictionaryClient) getInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -2058,11 +1962,7 @@ func (client DictionaryClient) GetLongInvalidNull(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt64Response{}, client.getLongInvalidNullHandleError(resp)
 	}
-	result, err := client.getLongInvalidNullHandleResponse(resp)
-	if err != nil {
-		return MapOfInt64Response{}, err
-	}
-	return result, nil
+	return client.getLongInvalidNullHandleResponse(resp)
 }
 
 // getLongInvalidNullCreateRequest creates the GetLongInvalidNull request.
@@ -2079,9 +1979,11 @@ func (client DictionaryClient) getLongInvalidNullCreateRequest(ctx context.Conte
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client DictionaryClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	result := MapOfInt64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt64Response{}, err
+	}
+	return MapOfInt64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getLongInvalidNullHandleError handles the GetLongInvalidNull error response.
@@ -2106,11 +2008,7 @@ func (client DictionaryClient) GetLongInvalidString(ctx context.Context, options
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt64Response{}, client.getLongInvalidStringHandleError(resp)
 	}
-	result, err := client.getLongInvalidStringHandleResponse(resp)
-	if err != nil {
-		return MapOfInt64Response{}, err
-	}
-	return result, nil
+	return client.getLongInvalidStringHandleResponse(resp)
 }
 
 // getLongInvalidStringCreateRequest creates the GetLongInvalidString request.
@@ -2127,9 +2025,11 @@ func (client DictionaryClient) getLongInvalidStringCreateRequest(ctx context.Con
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client DictionaryClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	result := MapOfInt64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt64Response{}, err
+	}
+	return MapOfInt64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getLongInvalidStringHandleError handles the GetLongInvalidString error response.
@@ -2154,11 +2054,7 @@ func (client DictionaryClient) GetLongValid(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt64Response{}, client.getLongValidHandleError(resp)
 	}
-	result, err := client.getLongValidHandleResponse(resp)
-	if err != nil {
-		return MapOfInt64Response{}, err
-	}
-	return result, nil
+	return client.getLongValidHandleResponse(resp)
 }
 
 // getLongValidCreateRequest creates the GetLongValid request.
@@ -2175,9 +2071,11 @@ func (client DictionaryClient) getLongValidCreateRequest(ctx context.Context, op
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client DictionaryClient) getLongValidHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	result := MapOfInt64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt64Response{}, err
+	}
+	return MapOfInt64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getLongValidHandleError handles the GetLongValid error response.
@@ -2202,11 +2100,7 @@ func (client DictionaryClient) GetNull(ctx context.Context, options *DictionaryG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -2223,9 +2117,11 @@ func (client DictionaryClient) getNullCreateRequest(ctx context.Context, options
 
 // getNullHandleResponse handles the GetNull response.
 func (client DictionaryClient) getNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -2250,11 +2146,7 @@ func (client DictionaryClient) GetNullKey(ctx context.Context, options *Dictiona
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getNullKeyHandleError(resp)
 	}
-	result, err := client.getNullKeyHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getNullKeyHandleResponse(resp)
 }
 
 // getNullKeyCreateRequest creates the GetNullKey request.
@@ -2271,9 +2163,11 @@ func (client DictionaryClient) getNullKeyCreateRequest(ctx context.Context, opti
 
 // getNullKeyHandleResponse handles the GetNullKey response.
 func (client DictionaryClient) getNullKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullKeyHandleError handles the GetNullKey error response.
@@ -2298,11 +2192,7 @@ func (client DictionaryClient) GetNullValue(ctx context.Context, options *Dictio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getNullValueHandleError(resp)
 	}
-	result, err := client.getNullValueHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getNullValueHandleResponse(resp)
 }
 
 // getNullValueCreateRequest creates the GetNullValue request.
@@ -2319,9 +2209,11 @@ func (client DictionaryClient) getNullValueCreateRequest(ctx context.Context, op
 
 // getNullValueHandleResponse handles the GetNullValue response.
 func (client DictionaryClient) getNullValueHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullValueHandleError handles the GetNullValue error response.
@@ -2346,11 +2238,7 @@ func (client DictionaryClient) GetStringValid(ctx context.Context, options *Dict
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getStringValidHandleError(resp)
 	}
-	result, err := client.getStringValidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getStringValidHandleResponse(resp)
 }
 
 // getStringValidCreateRequest creates the GetStringValid request.
@@ -2367,9 +2255,11 @@ func (client DictionaryClient) getStringValidCreateRequest(ctx context.Context, 
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client DictionaryClient) getStringValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getStringValidHandleError handles the GetStringValid error response.
@@ -2394,11 +2284,7 @@ func (client DictionaryClient) GetStringWithInvalid(ctx context.Context, options
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getStringWithInvalidHandleError(resp)
 	}
-	result, err := client.getStringWithInvalidHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getStringWithInvalidHandleResponse(resp)
 }
 
 // getStringWithInvalidCreateRequest creates the GetStringWithInvalid request.
@@ -2415,9 +2301,11 @@ func (client DictionaryClient) getStringWithInvalidCreateRequest(ctx context.Con
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client DictionaryClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getStringWithInvalidHandleError handles the GetStringWithInvalid error response.
@@ -2442,11 +2330,7 @@ func (client DictionaryClient) GetStringWithNull(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfStringResponse{}, client.getStringWithNullHandleError(resp)
 	}
-	result, err := client.getStringWithNullHandleResponse(resp)
-	if err != nil {
-		return MapOfStringResponse{}, err
-	}
-	return result, nil
+	return client.getStringWithNullHandleResponse(resp)
 }
 
 // getStringWithNullCreateRequest creates the GetStringWithNull request.
@@ -2463,9 +2347,11 @@ func (client DictionaryClient) getStringWithNullCreateRequest(ctx context.Contex
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client DictionaryClient) getStringWithNullHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	result := MapOfStringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfStringResponse{}, err
+	}
+	return MapOfStringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getStringWithNullHandleError handles the GetStringWithNull error response.

--- a/test/autorest/durationgroup/zz_generated_duration.go
+++ b/test/autorest/durationgroup/zz_generated_duration.go
@@ -42,11 +42,7 @@ func (client DurationClient) GetInvalid(ctx context.Context, options *DurationGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -63,9 +59,11 @@ func (client DurationClient) getInvalidCreateRequest(ctx context.Context, option
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client DurationClient) getInvalidHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -90,11 +88,7 @@ func (client DurationClient) GetNull(ctx context.Context, options *DurationGetNu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -111,9 +105,11 @@ func (client DurationClient) getNullCreateRequest(ctx context.Context, options *
 
 // getNullHandleResponse handles the GetNull response.
 func (client DurationClient) getNullHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -138,11 +134,7 @@ func (client DurationClient) GetPositiveDuration(ctx context.Context, options *D
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getPositiveDurationHandleError(resp)
 	}
-	result, err := client.getPositiveDurationHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getPositiveDurationHandleResponse(resp)
 }
 
 // getPositiveDurationCreateRequest creates the GetPositiveDuration request.
@@ -159,9 +151,11 @@ func (client DurationClient) getPositiveDurationCreateRequest(ctx context.Contex
 
 // getPositiveDurationHandleResponse handles the GetPositiveDuration response.
 func (client DurationClient) getPositiveDurationHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getPositiveDurationHandleError handles the GetPositiveDuration error response.

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -47,11 +47,7 @@ func (client PetClient) DoSomething(ctx context.Context, whatAction string, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetActionResponse{}, client.doSomethingHandleError(resp)
 	}
-	result, err := client.doSomethingHandleResponse(resp)
-	if err != nil {
-		return PetActionResponse{}, err
-	}
-	return result, nil
+	return client.doSomethingHandleResponse(resp)
 }
 
 // doSomethingCreateRequest creates the DoSomething request.
@@ -69,9 +65,11 @@ func (client PetClient) doSomethingCreateRequest(ctx context.Context, whatAction
 
 // doSomethingHandleResponse handles the DoSomething response.
 func (client PetClient) doSomethingHandleResponse(resp *azcore.Response) (PetActionResponse, error) {
-	result := PetActionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PetAction)
-	return result, err
+	var val *PetAction
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetActionResponse{}, err
+	}
+	return PetActionResponse{RawResponse: resp.Response, PetAction: val}, nil
 }
 
 // doSomethingHandleError handles the DoSomething error response.
@@ -105,11 +103,7 @@ func (client PetClient) GetPetByID(ctx context.Context, petId string, options *P
 	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return PetResponse{}, client.getPetByIdHandleError(resp)
 	}
-	result, err := client.getPetByIdHandleResponse(resp)
-	if err != nil {
-		return PetResponse{}, err
-	}
-	return result, nil
+	return client.getPetByIdHandleResponse(resp)
 }
 
 // getPetByIdCreateRequest creates the GetPetByID request.
@@ -127,9 +121,11 @@ func (client PetClient) getPetByIdCreateRequest(ctx context.Context, petId strin
 
 // getPetByIdHandleResponse handles the GetPetByID response.
 func (client PetClient) getPetByIdHandleResponse(resp *azcore.Response) (PetResponse, error) {
-	result := PetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Pet)
-	return result, err
+	var val *Pet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetResponse{}, err
+	}
+	return PetResponse{RawResponse: resp.Response, Pet: val}, nil
 }
 
 // getPetByIdHandleError handles the GetPetByID error response.

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -47,11 +47,7 @@ func (client PetClient) AddPet(ctx context.Context, options *PetAddPetOptions) (
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetResponse{}, client.addPetHandleError(resp)
 	}
-	result, err := client.addPetHandleResponse(resp)
-	if err != nil {
-		return PetResponse{}, err
-	}
-	return result, nil
+	return client.addPetHandleResponse(resp)
 }
 
 // addPetCreateRequest creates the AddPet request.
@@ -71,9 +67,11 @@ func (client PetClient) addPetCreateRequest(ctx context.Context, options *PetAdd
 
 // addPetHandleResponse handles the AddPet response.
 func (client PetClient) addPetHandleResponse(resp *azcore.Response) (PetResponse, error) {
-	result := PetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Pet)
-	return result, err
+	var val *Pet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetResponse{}, err
+	}
+	return PetResponse{RawResponse: resp.Response, Pet: val}, nil
 }
 
 // addPetHandleError handles the AddPet error response.
@@ -101,11 +99,7 @@ func (client PetClient) GetByPetID(ctx context.Context, petId string, options *P
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetResponse{}, client.getByPetIdHandleError(resp)
 	}
-	result, err := client.getByPetIdHandleResponse(resp)
-	if err != nil {
-		return PetResponse{}, err
-	}
-	return result, nil
+	return client.getByPetIdHandleResponse(resp)
 }
 
 // getByPetIdCreateRequest creates the GetByPetID request.
@@ -123,9 +117,11 @@ func (client PetClient) getByPetIdCreateRequest(ctx context.Context, petId strin
 
 // getByPetIdHandleResponse handles the GetByPetID response.
 func (client PetClient) getByPetIdHandleResponse(resp *azcore.Response) (PetResponse, error) {
-	result := PetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Pet)
-	return result, err
+	var val *Pet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetResponse{}, err
+	}
+	return PetResponse{RawResponse: resp.Response, Pet: val}, nil
 }
 
 // getByPetIdHandleError handles the GetByPetID error response.

--- a/test/autorest/headergroup/zz_generated_header.go
+++ b/test/autorest/headergroup/zz_generated_header.go
@@ -634,11 +634,7 @@ func (client HeaderClient) ResponseBool(ctx context.Context, scenario string, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseBoolResponse{}, client.responseBoolHandleError(resp)
 	}
-	result, err := client.responseBoolHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseBoolResponse{}, err
-	}
-	return result, nil
+	return client.responseBoolHandleResponse(resp)
 }
 
 // responseBoolCreateRequest creates the ResponseBool request.
@@ -689,11 +685,7 @@ func (client HeaderClient) ResponseByte(ctx context.Context, scenario string, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseByteResponse{}, client.responseByteHandleError(resp)
 	}
-	result, err := client.responseByteHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseByteResponse{}, err
-	}
-	return result, nil
+	return client.responseByteHandleResponse(resp)
 }
 
 // responseByteCreateRequest creates the ResponseByte request.
@@ -744,11 +736,7 @@ func (client HeaderClient) ResponseDate(ctx context.Context, scenario string, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseDateResponse{}, client.responseDateHandleError(resp)
 	}
-	result, err := client.responseDateHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseDateResponse{}, err
-	}
-	return result, nil
+	return client.responseDateHandleResponse(resp)
 }
 
 // responseDateCreateRequest creates the ResponseDate request.
@@ -799,11 +787,7 @@ func (client HeaderClient) ResponseDatetime(ctx context.Context, scenario string
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseDatetimeResponse{}, client.responseDatetimeHandleError(resp)
 	}
-	result, err := client.responseDatetimeHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseDatetimeResponse{}, err
-	}
-	return result, nil
+	return client.responseDatetimeHandleResponse(resp)
 }
 
 // responseDatetimeCreateRequest creates the ResponseDatetime request.
@@ -854,11 +838,7 @@ func (client HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenario
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseDatetimeRFC1123Response{}, client.responseDatetimeRfc1123HandleError(resp)
 	}
-	result, err := client.responseDatetimeRfc1123HandleResponse(resp)
-	if err != nil {
-		return HeaderResponseDatetimeRFC1123Response{}, err
-	}
-	return result, nil
+	return client.responseDatetimeRfc1123HandleResponse(resp)
 }
 
 // responseDatetimeRfc1123CreateRequest creates the ResponseDatetimeRFC1123 request.
@@ -909,11 +889,7 @@ func (client HeaderClient) ResponseDouble(ctx context.Context, scenario string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseDoubleResponse{}, client.responseDoubleHandleError(resp)
 	}
-	result, err := client.responseDoubleHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseDoubleResponse{}, err
-	}
-	return result, nil
+	return client.responseDoubleHandleResponse(resp)
 }
 
 // responseDoubleCreateRequest creates the ResponseDouble request.
@@ -964,11 +940,7 @@ func (client HeaderClient) ResponseDuration(ctx context.Context, scenario string
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseDurationResponse{}, client.responseDurationHandleError(resp)
 	}
-	result, err := client.responseDurationHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseDurationResponse{}, err
-	}
-	return result, nil
+	return client.responseDurationHandleResponse(resp)
 }
 
 // responseDurationCreateRequest creates the ResponseDuration request.
@@ -1015,11 +987,7 @@ func (client HeaderClient) ResponseEnum(ctx context.Context, scenario string, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseEnumResponse{}, client.responseEnumHandleError(resp)
 	}
-	result, err := client.responseEnumHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseEnumResponse{}, err
-	}
-	return result, nil
+	return client.responseEnumHandleResponse(resp)
 }
 
 // responseEnumCreateRequest creates the ResponseEnum request.
@@ -1066,11 +1034,7 @@ func (client HeaderClient) ResponseExistingKey(ctx context.Context, options *Hea
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseExistingKeyResponse{}, client.responseExistingKeyHandleError(resp)
 	}
-	result, err := client.responseExistingKeyHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseExistingKeyResponse{}, err
-	}
-	return result, nil
+	return client.responseExistingKeyHandleResponse(resp)
 }
 
 // responseExistingKeyCreateRequest creates the ResponseExistingKey request.
@@ -1116,11 +1080,7 @@ func (client HeaderClient) ResponseFloat(ctx context.Context, scenario string, o
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseFloatResponse{}, client.responseFloatHandleError(resp)
 	}
-	result, err := client.responseFloatHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseFloatResponse{}, err
-	}
-	return result, nil
+	return client.responseFloatHandleResponse(resp)
 }
 
 // responseFloatCreateRequest creates the ResponseFloat request.
@@ -1172,11 +1132,7 @@ func (client HeaderClient) ResponseInteger(ctx context.Context, scenario string,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseIntegerResponse{}, client.responseIntegerHandleError(resp)
 	}
-	result, err := client.responseIntegerHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseIntegerResponse{}, err
-	}
-	return result, nil
+	return client.responseIntegerHandleResponse(resp)
 }
 
 // responseIntegerCreateRequest creates the ResponseInteger request.
@@ -1228,11 +1184,7 @@ func (client HeaderClient) ResponseLong(ctx context.Context, scenario string, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseLongResponse{}, client.responseLongHandleError(resp)
 	}
-	result, err := client.responseLongHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseLongResponse{}, err
-	}
-	return result, nil
+	return client.responseLongHandleResponse(resp)
 }
 
 // responseLongCreateRequest creates the ResponseLong request.
@@ -1283,11 +1235,7 @@ func (client HeaderClient) ResponseProtectedKey(ctx context.Context, options *He
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseProtectedKeyResponse{}, client.responseProtectedKeyHandleError(resp)
 	}
-	result, err := client.responseProtectedKeyHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseProtectedKeyResponse{}, err
-	}
-	return result, nil
+	return client.responseProtectedKeyHandleResponse(resp)
 }
 
 // responseProtectedKeyCreateRequest creates the ResponseProtectedKey request.
@@ -1333,11 +1281,7 @@ func (client HeaderClient) ResponseString(ctx context.Context, scenario string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HeaderResponseStringResponse{}, client.responseStringHandleError(resp)
 	}
-	result, err := client.responseStringHandleResponse(resp)
-	if err != nil {
-		return HeaderResponseStringResponse{}, err
-	}
-	return result, nil
+	return client.responseStringHandleResponse(resp)
 }
 
 // responseStringCreateRequest creates the ResponseString request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure.go
@@ -45,11 +45,7 @@ func (client HTTPFailureClient) GetEmptyError(ctx context.Context, options *HTTP
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getEmptyErrorHandleError(resp)
 	}
-	result, err := client.getEmptyErrorHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyErrorHandleResponse(resp)
 }
 
 // getEmptyErrorCreateRequest creates the GetEmptyError request.
@@ -66,9 +62,11 @@ func (client HTTPFailureClient) getEmptyErrorCreateRequest(ctx context.Context, 
 
 // getEmptyErrorHandleResponse handles the GetEmptyError response.
 func (client HTTPFailureClient) getEmptyErrorHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getEmptyErrorHandleError handles the GetEmptyError error response.
@@ -93,11 +91,7 @@ func (client HTTPFailureClient) GetNoModelEmpty(ctx context.Context, options *HT
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getNoModelEmptyHandleError(resp)
 	}
-	result, err := client.getNoModelEmptyHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getNoModelEmptyHandleResponse(resp)
 }
 
 // getNoModelEmptyCreateRequest creates the GetNoModelEmpty request.
@@ -114,9 +108,11 @@ func (client HTTPFailureClient) getNoModelEmptyCreateRequest(ctx context.Context
 
 // getNoModelEmptyHandleResponse handles the GetNoModelEmpty response.
 func (client HTTPFailureClient) getNoModelEmptyHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNoModelEmptyHandleError handles the GetNoModelEmpty error response.
@@ -144,11 +140,7 @@ func (client HTTPFailureClient) GetNoModelError(ctx context.Context, options *HT
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.getNoModelErrorHandleError(resp)
 	}
-	result, err := client.getNoModelErrorHandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.getNoModelErrorHandleResponse(resp)
 }
 
 // getNoModelErrorCreateRequest creates the GetNoModelError request.
@@ -165,9 +157,11 @@ func (client HTTPFailureClient) getNoModelErrorCreateRequest(ctx context.Context
 
 // getNoModelErrorHandleResponse handles the GetNoModelError response.
 func (client HTTPFailureClient) getNoModelErrorHandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNoModelErrorHandleError handles the GetNoModelError error response.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -81,11 +81,7 @@ func (client HTTPRedirectsClient) Get300(ctx context.Context, options *HTTPRedir
 	if !resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
 		return nil, client.get300HandleError(resp)
 	}
-	result, err := client.get300HandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get300HandleResponse(resp)
 }
 
 // get300CreateRequest creates the Get300 request.
@@ -110,12 +106,15 @@ func (client HTTPRedirectsClient) get300HandleResponse(resp *azcore.Response) (i
 		}
 		return result, nil
 	case http.StatusMultipleChoices:
-		result := StringArrayResponse{RawResponse: resp.Response}
+		var val *[]string
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		result := StringArrayResponse{RawResponse: resp.Response, StringArray: val}
 		if val := resp.Header.Get("Location"); val != "" {
 			result.Location = &val
 		}
-		err := resp.UnmarshalAsJSON(&result.StringArray)
-		return result, err
+		return result, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -254,11 +253,7 @@ func (client HTTPRedirectsClient) Head300(ctx context.Context, options *HTTPRedi
 	if !resp.HasStatusCode(http.StatusOK, http.StatusMultipleChoices) {
 		return HTTPRedirectsHead300Response{}, client.head300HandleError(resp)
 	}
-	result, err := client.head300HandleResponse(resp)
-	if err != nil {
-		return HTTPRedirectsHead300Response{}, err
-	}
-	return result, nil
+	return client.head300HandleResponse(resp)
 }
 
 // head300CreateRequest creates the Head300 request.
@@ -465,11 +460,7 @@ func (client HTTPRedirectsClient) Patch302(ctx context.Context, options *HTTPRed
 	if !resp.HasStatusCode(http.StatusFound) {
 		return HTTPRedirectsPatch302Response{}, client.patch302HandleError(resp)
 	}
-	result, err := client.patch302HandleResponse(resp)
-	if err != nil {
-		return HTTPRedirectsPatch302Response{}, err
-	}
-	return result, nil
+	return client.patch302HandleResponse(resp)
 }
 
 // patch302CreateRequest creates the Patch302 request.
@@ -553,11 +544,7 @@ func (client HTTPRedirectsClient) Post303(ctx context.Context, options *HTTPRedi
 	if !resp.HasStatusCode(http.StatusOK, http.StatusSeeOther) {
 		return HTTPRedirectsPost303Response{}, client.post303HandleError(resp)
 	}
-	result, err := client.post303HandleResponse(resp)
-	if err != nil {
-		return HTTPRedirectsPost303Response{}, err
-	}
-	return result, nil
+	return client.post303HandleResponse(resp)
 }
 
 // post303CreateRequest creates the Post303 request.
@@ -641,11 +628,7 @@ func (client HTTPRedirectsClient) Put301(ctx context.Context, options *HTTPRedir
 	if !resp.HasStatusCode(http.StatusMovedPermanently) {
 		return HTTPRedirectsPut301Response{}, client.put301HandleError(resp)
 	}
-	result, err := client.put301HandleResponse(resp)
-	if err != nil {
-		return HTTPRedirectsPut301Response{}, err
-	}
-	return result, nil
+	return client.put301HandleResponse(resp)
 }
 
 // put301CreateRequest creates the Put301 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry.go
@@ -156,11 +156,7 @@ func (client HTTPRetryClient) Options502(ctx context.Context, options *HTTPRetry
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.options502HandleError(resp)
 	}
-	result, err := client.options502HandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.options502HandleResponse(resp)
 }
 
 // options502CreateRequest creates the Options502 request.
@@ -177,9 +173,11 @@ func (client HTTPRetryClient) options502CreateRequest(ctx context.Context, optio
 
 // options502HandleResponse handles the Options502 response.
 func (client HTTPRetryClient) options502HandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // options502HandleError handles the Options502 error response.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess.go
@@ -153,11 +153,7 @@ func (client HTTPSuccessClient) Get200(ctx context.Context, options *HTTPSuccess
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.get200HandleError(resp)
 	}
-	result, err := client.get200HandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.get200HandleResponse(resp)
 }
 
 // get200CreateRequest creates the Get200 request.
@@ -174,9 +170,11 @@ func (client HTTPSuccessClient) get200CreateRequest(ctx context.Context, options
 
 // get200HandleResponse handles the Get200 response.
 func (client HTTPSuccessClient) get200HandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // get200HandleError handles the Get200 error response.
@@ -321,11 +319,7 @@ func (client HTTPSuccessClient) Options200(ctx context.Context, options *HTTPSuc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BoolResponse{}, client.options200HandleError(resp)
 	}
-	result, err := client.options200HandleResponse(resp)
-	if err != nil {
-		return BoolResponse{}, err
-	}
-	return result, nil
+	return client.options200HandleResponse(resp)
 }
 
 // options200CreateRequest creates the Options200 request.
@@ -342,9 +336,11 @@ func (client HTTPSuccessClient) options200CreateRequest(ctx context.Context, opt
 
 // options200HandleResponse handles the Options200 response.
 func (client HTTPSuccessClient) options200HandleResponse(resp *azcore.Response) (BoolResponse, error) {
-	result := BoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *bool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BoolResponse{}, err
+	}
+	return BoolResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // options200HandleError handles the Options200 error response.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses.go
@@ -46,11 +46,7 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(ct
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, client.get200Model201ModelDefaultError200ValidHandleError(resp)
 	}
-	result, err := client.get200Model201ModelDefaultError200ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200Model201ModelDefaultError200ValidHandleResponse(resp)
 }
 
 // get200Model201ModelDefaultError200ValidCreateRequest creates the Get200Model201ModelDefaultError200Valid request.
@@ -69,13 +65,17 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError200ValidCre
 func (client MultipleResponsesClient) get200Model201ModelDefaultError200ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := BResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.B)
-		return result, err
+		var val *B
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return BResponse{RawResponse: resp.Response, B: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -104,11 +104,7 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(ct
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, client.get200Model201ModelDefaultError201ValidHandleError(resp)
 	}
-	result, err := client.get200Model201ModelDefaultError201ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200Model201ModelDefaultError201ValidHandleResponse(resp)
 }
 
 // get200Model201ModelDefaultError201ValidCreateRequest creates the Get200Model201ModelDefaultError201Valid request.
@@ -127,13 +123,17 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError201ValidCre
 func (client MultipleResponsesClient) get200Model201ModelDefaultError201ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := BResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.B)
-		return result, err
+		var val *B
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return BResponse{RawResponse: resp.Response, B: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -162,11 +162,7 @@ func (client MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(ct
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return nil, client.get200Model201ModelDefaultError400ValidHandleError(resp)
 	}
-	result, err := client.get200Model201ModelDefaultError400ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200Model201ModelDefaultError400ValidHandleResponse(resp)
 }
 
 // get200Model201ModelDefaultError400ValidCreateRequest creates the Get200Model201ModelDefaultError400Valid request.
@@ -185,13 +181,17 @@ func (client MultipleResponsesClient) get200Model201ModelDefaultError400ValidCre
 func (client MultipleResponsesClient) get200Model201ModelDefaultError400ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := BResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.B)
-		return result, err
+		var val *B
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return BResponse{RawResponse: resp.Response, B: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -219,11 +219,7 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid(
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return MyExceptionResponse{}, client.get200Model204NoModelDefaultError200ValidHandleError(resp)
 	}
-	result, err := client.get200Model204NoModelDefaultError200ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200Model204NoModelDefaultError200ValidHandleResponse(resp)
 }
 
 // get200Model204NoModelDefaultError200ValidCreateRequest creates the Get200Model204NoModelDefaultError200Valid request.
@@ -240,9 +236,11 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError200ValidC
 
 // get200Model204NoModelDefaultError200ValidHandleResponse handles the Get200Model204NoModelDefaultError200Valid response.
 func (client MultipleResponsesClient) get200Model204NoModelDefaultError200ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200Model204NoModelDefaultError200ValidHandleError handles the Get200Model204NoModelDefaultError200Valid error response.
@@ -267,11 +265,7 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError201Invali
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return MyExceptionResponse{}, client.get200Model204NoModelDefaultError201InvalidHandleError(resp)
 	}
-	result, err := client.get200Model204NoModelDefaultError201InvalidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200Model204NoModelDefaultError201InvalidHandleResponse(resp)
 }
 
 // get200Model204NoModelDefaultError201InvalidCreateRequest creates the Get200Model204NoModelDefaultError201Invalid request.
@@ -288,9 +282,11 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError201Invali
 
 // get200Model204NoModelDefaultError201InvalidHandleResponse handles the Get200Model204NoModelDefaultError201Invalid response.
 func (client MultipleResponsesClient) get200Model204NoModelDefaultError201InvalidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200Model204NoModelDefaultError201InvalidHandleError handles the Get200Model204NoModelDefaultError201Invalid error response.
@@ -315,11 +311,7 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError202None(c
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return MyExceptionResponse{}, client.get200Model204NoModelDefaultError202NoneHandleError(resp)
 	}
-	result, err := client.get200Model204NoModelDefaultError202NoneHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200Model204NoModelDefaultError202NoneHandleResponse(resp)
 }
 
 // get200Model204NoModelDefaultError202NoneCreateRequest creates the Get200Model204NoModelDefaultError202None request.
@@ -336,9 +328,11 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError202NoneCr
 
 // get200Model204NoModelDefaultError202NoneHandleResponse handles the Get200Model204NoModelDefaultError202None response.
 func (client MultipleResponsesClient) get200Model204NoModelDefaultError202NoneHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200Model204NoModelDefaultError202NoneHandleError handles the Get200Model204NoModelDefaultError202None error response.
@@ -363,11 +357,7 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid(
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return MyExceptionResponse{}, client.get200Model204NoModelDefaultError204ValidHandleError(resp)
 	}
-	result, err := client.get200Model204NoModelDefaultError204ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200Model204NoModelDefaultError204ValidHandleResponse(resp)
 }
 
 // get200Model204NoModelDefaultError204ValidCreateRequest creates the Get200Model204NoModelDefaultError204Valid request.
@@ -384,9 +374,11 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError204ValidC
 
 // get200Model204NoModelDefaultError204ValidHandleResponse handles the Get200Model204NoModelDefaultError204Valid response.
 func (client MultipleResponsesClient) get200Model204NoModelDefaultError204ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200Model204NoModelDefaultError204ValidHandleError handles the Get200Model204NoModelDefaultError204Valid error response.
@@ -411,11 +403,7 @@ func (client MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid(
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNoContent) {
 		return MyExceptionResponse{}, client.get200Model204NoModelDefaultError400ValidHandleError(resp)
 	}
-	result, err := client.get200Model204NoModelDefaultError400ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200Model204NoModelDefaultError400ValidHandleResponse(resp)
 }
 
 // get200Model204NoModelDefaultError400ValidCreateRequest creates the Get200Model204NoModelDefaultError400Valid request.
@@ -432,9 +420,11 @@ func (client MultipleResponsesClient) get200Model204NoModelDefaultError400ValidC
 
 // get200Model204NoModelDefaultError400ValidHandleResponse handles the Get200Model204NoModelDefaultError400Valid response.
 func (client MultipleResponsesClient) get200Model204NoModelDefaultError400ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200Model204NoModelDefaultError400ValidHandleError handles the Get200Model204NoModelDefaultError400Valid error response.
@@ -459,11 +449,7 @@ func (client MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA200InvalidHandleError(resp)
 	}
-	result, err := client.get200ModelA200InvalidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA200InvalidHandleResponse(resp)
 }
 
 // get200ModelA200InvalidCreateRequest creates the Get200ModelA200Invalid request.
@@ -480,9 +466,11 @@ func (client MultipleResponsesClient) get200ModelA200InvalidCreateRequest(ctx co
 
 // get200ModelA200InvalidHandleResponse handles the Get200ModelA200Invalid response.
 func (client MultipleResponsesClient) get200ModelA200InvalidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA200InvalidHandleError handles the Get200ModelA200Invalid error response.
@@ -510,11 +498,7 @@ func (client MultipleResponsesClient) Get200ModelA200None(ctx context.Context, o
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA200NoneHandleError(resp)
 	}
-	result, err := client.get200ModelA200NoneHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA200NoneHandleResponse(resp)
 }
 
 // get200ModelA200NoneCreateRequest creates the Get200ModelA200None request.
@@ -531,9 +515,11 @@ func (client MultipleResponsesClient) get200ModelA200NoneCreateRequest(ctx conte
 
 // get200ModelA200NoneHandleResponse handles the Get200ModelA200None response.
 func (client MultipleResponsesClient) get200ModelA200NoneHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA200NoneHandleError handles the Get200ModelA200None error response.
@@ -561,11 +547,7 @@ func (client MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA200ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA200ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA200ValidHandleResponse(resp)
 }
 
 // get200ModelA200ValidCreateRequest creates the Get200ModelA200Valid request.
@@ -582,9 +564,11 @@ func (client MultipleResponsesClient) get200ModelA200ValidCreateRequest(ctx cont
 
 // get200ModelA200ValidHandleResponse handles the Get200ModelA200Valid response.
 func (client MultipleResponsesClient) get200ModelA200ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA200ValidHandleError handles the Get200ModelA200Valid error response.
@@ -613,11 +597,7 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError200ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError200ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError200Valid request.
@@ -636,17 +616,23 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError200ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := CResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.C)
-		return result, err
+		var val *C
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return CResponse{RawResponse: resp.Response, C: val}, nil
 	case http.StatusNotFound:
-		result := DResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.D)
-		return result, err
+		var val *D
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return DResponse{RawResponse: resp.Response, D: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -675,11 +661,7 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError201ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError201ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError201Valid request.
@@ -698,17 +680,23 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError201ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := CResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.C)
-		return result, err
+		var val *C
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return CResponse{RawResponse: resp.Response, C: val}, nil
 	case http.StatusNotFound:
-		result := DResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.D)
-		return result, err
+		var val *D
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return DResponse{RawResponse: resp.Response, D: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -737,11 +725,7 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError400ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError400ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError400Valid request.
@@ -760,17 +744,23 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError400ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := CResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.C)
-		return result, err
+		var val *C
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return CResponse{RawResponse: resp.Response, C: val}, nil
 	case http.StatusNotFound:
-		result := DResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.D)
-		return result, err
+		var val *D
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return DResponse{RawResponse: resp.Response, D: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -799,11 +789,7 @@ func (client MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultError
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated, http.StatusNotFound) {
 		return nil, client.get200ModelA201ModelC404ModelDDefaultError404ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return client.get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp)
 }
 
 // get200ModelA201ModelC404ModelDDefaultError404ValidCreateRequest creates the Get200ModelA201ModelC404ModelDDefaultError404Valid request.
@@ -822,17 +808,23 @@ func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError
 func (client MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultError404ValidHandleResponse(resp *azcore.Response) (interface{}, error) {
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := MyExceptionResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.MyException)
-		return result, err
+		var val *MyException
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 	case http.StatusCreated:
-		result := CResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.C)
-		return result, err
+		var val *C
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return CResponse{RawResponse: resp.Response, C: val}, nil
 	case http.StatusNotFound:
-		result := DResponse{RawResponse: resp.Response}
-		err := resp.UnmarshalAsJSON(&result.D)
-		return result, err
+		var val *D
+		if err := resp.UnmarshalAsJSON(&val); err != nil {
+			return nil, err
+		}
+		return DResponse{RawResponse: resp.Response, D: val}, nil
 	default:
 		return nil, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)
 	}
@@ -860,11 +852,7 @@ func (client MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA202ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA202ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA202ValidHandleResponse(resp)
 }
 
 // get200ModelA202ValidCreateRequest creates the Get200ModelA202Valid request.
@@ -881,9 +869,11 @@ func (client MultipleResponsesClient) get200ModelA202ValidCreateRequest(ctx cont
 
 // get200ModelA202ValidHandleResponse handles the Get200ModelA202Valid response.
 func (client MultipleResponsesClient) get200ModelA202ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA202ValidHandleError handles the Get200ModelA202Valid error response.
@@ -911,11 +901,7 @@ func (client MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA400InvalidHandleError(resp)
 	}
-	result, err := client.get200ModelA400InvalidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA400InvalidHandleResponse(resp)
 }
 
 // get200ModelA400InvalidCreateRequest creates the Get200ModelA400Invalid request.
@@ -932,9 +918,11 @@ func (client MultipleResponsesClient) get200ModelA400InvalidCreateRequest(ctx co
 
 // get200ModelA400InvalidHandleResponse handles the Get200ModelA400Invalid response.
 func (client MultipleResponsesClient) get200ModelA400InvalidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA400InvalidHandleError handles the Get200ModelA400Invalid error response.
@@ -962,11 +950,7 @@ func (client MultipleResponsesClient) Get200ModelA400None(ctx context.Context, o
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA400NoneHandleError(resp)
 	}
-	result, err := client.get200ModelA400NoneHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA400NoneHandleResponse(resp)
 }
 
 // get200ModelA400NoneCreateRequest creates the Get200ModelA400None request.
@@ -983,9 +967,11 @@ func (client MultipleResponsesClient) get200ModelA400NoneCreateRequest(ctx conte
 
 // get200ModelA400NoneHandleResponse handles the Get200ModelA400None response.
 func (client MultipleResponsesClient) get200ModelA400NoneHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA400NoneHandleError handles the Get200ModelA400None error response.
@@ -1013,11 +999,7 @@ func (client MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.get200ModelA400ValidHandleError(resp)
 	}
-	result, err := client.get200ModelA400ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.get200ModelA400ValidHandleResponse(resp)
 }
 
 // get200ModelA400ValidCreateRequest creates the Get200ModelA400Valid request.
@@ -1034,9 +1016,11 @@ func (client MultipleResponsesClient) get200ModelA400ValidCreateRequest(ctx cont
 
 // get200ModelA400ValidHandleResponse handles the Get200ModelA400Valid response.
 func (client MultipleResponsesClient) get200ModelA400ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // get200ModelA400ValidHandleError handles the Get200ModelA400Valid error response.
@@ -1331,11 +1315,7 @@ func (client MultipleResponsesClient) GetDefaultModelA200None(ctx context.Contex
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.getDefaultModelA200NoneHandleError(resp)
 	}
-	result, err := client.getDefaultModelA200NoneHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.getDefaultModelA200NoneHandleResponse(resp)
 }
 
 // getDefaultModelA200NoneCreateRequest creates the GetDefaultModelA200None request.
@@ -1352,9 +1332,11 @@ func (client MultipleResponsesClient) getDefaultModelA200NoneCreateRequest(ctx c
 
 // getDefaultModelA200NoneHandleResponse handles the GetDefaultModelA200None response.
 func (client MultipleResponsesClient) getDefaultModelA200NoneHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // getDefaultModelA200NoneHandleError handles the GetDefaultModelA200None error response.
@@ -1382,11 +1364,7 @@ func (client MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MyExceptionResponse{}, client.getDefaultModelA200ValidHandleError(resp)
 	}
-	result, err := client.getDefaultModelA200ValidHandleResponse(resp)
-	if err != nil {
-		return MyExceptionResponse{}, err
-	}
-	return result, nil
+	return client.getDefaultModelA200ValidHandleResponse(resp)
 }
 
 // getDefaultModelA200ValidCreateRequest creates the GetDefaultModelA200Valid request.
@@ -1403,9 +1381,11 @@ func (client MultipleResponsesClient) getDefaultModelA200ValidCreateRequest(ctx 
 
 // getDefaultModelA200ValidHandleResponse handles the GetDefaultModelA200Valid response.
 func (client MultipleResponsesClient) getDefaultModelA200ValidHandleResponse(resp *azcore.Response) (MyExceptionResponse, error) {
-	result := MyExceptionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.MyException)
-	return result, err
+	var val *MyException
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MyExceptionResponse{}, err
+	}
+	return MyExceptionResponse{RawResponse: resp.Response, MyException: val}, nil
 }
 
 // getDefaultModelA200ValidHandleError handles the GetDefaultModelA200Valid error response.

--- a/test/autorest/integergroup/zz_generated_int.go
+++ b/test/autorest/integergroup/zz_generated_int.go
@@ -43,11 +43,7 @@ func (client IntClient) GetInvalid(ctx context.Context, options *IntGetInvalidOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32Response{}, client.getInvalidHandleError(resp)
 	}
-	result, err := client.getInvalidHandleResponse(resp)
-	if err != nil {
-		return Int32Response{}, err
-	}
-	return result, nil
+	return client.getInvalidHandleResponse(resp)
 }
 
 // getInvalidCreateRequest creates the GetInvalid request.
@@ -64,9 +60,11 @@ func (client IntClient) getInvalidCreateRequest(ctx context.Context, options *In
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client IntClient) getInvalidHandleResponse(resp *azcore.Response) (Int32Response, error) {
-	result := Int32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32Response{}, err
+	}
+	return Int32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidHandleError handles the GetInvalid error response.
@@ -91,11 +89,7 @@ func (client IntClient) GetInvalidUnixTime(ctx context.Context, options *IntGetI
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getInvalidUnixTimeHandleError(resp)
 	}
-	result, err := client.getInvalidUnixTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getInvalidUnixTimeHandleResponse(resp)
 }
 
 // getInvalidUnixTimeCreateRequest creates the GetInvalidUnixTime request.
@@ -113,8 +107,10 @@ func (client IntClient) getInvalidUnixTimeCreateRequest(ctx context.Context, opt
 // getInvalidUnixTimeHandleResponse handles the GetInvalidUnixTime response.
 func (client IntClient) getInvalidUnixTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeUnix
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getInvalidUnixTimeHandleError handles the GetInvalidUnixTime error response.
@@ -139,11 +135,7 @@ func (client IntClient) GetNull(ctx context.Context, options *IntGetNullOptions)
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32Response{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return Int32Response{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -160,9 +152,11 @@ func (client IntClient) getNullCreateRequest(ctx context.Context, options *IntGe
 
 // getNullHandleResponse handles the GetNull response.
 func (client IntClient) getNullHandleResponse(resp *azcore.Response) (Int32Response, error) {
-	result := Int32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32Response{}, err
+	}
+	return Int32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -187,11 +181,7 @@ func (client IntClient) GetNullUnixTime(ctx context.Context, options *IntGetNull
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getNullUnixTimeHandleError(resp)
 	}
-	result, err := client.getNullUnixTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getNullUnixTimeHandleResponse(resp)
 }
 
 // getNullUnixTimeCreateRequest creates the GetNullUnixTime request.
@@ -209,8 +199,10 @@ func (client IntClient) getNullUnixTimeCreateRequest(ctx context.Context, option
 // getNullUnixTimeHandleResponse handles the GetNullUnixTime response.
 func (client IntClient) getNullUnixTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeUnix
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getNullUnixTimeHandleError handles the GetNullUnixTime error response.
@@ -235,11 +227,7 @@ func (client IntClient) GetOverflowInt32(ctx context.Context, options *IntGetOve
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32Response{}, client.getOverflowInt32HandleError(resp)
 	}
-	result, err := client.getOverflowInt32HandleResponse(resp)
-	if err != nil {
-		return Int32Response{}, err
-	}
-	return result, nil
+	return client.getOverflowInt32HandleResponse(resp)
 }
 
 // getOverflowInt32CreateRequest creates the GetOverflowInt32 request.
@@ -256,9 +244,11 @@ func (client IntClient) getOverflowInt32CreateRequest(ctx context.Context, optio
 
 // getOverflowInt32HandleResponse handles the GetOverflowInt32 response.
 func (client IntClient) getOverflowInt32HandleResponse(resp *azcore.Response) (Int32Response, error) {
-	result := Int32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32Response{}, err
+	}
+	return Int32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getOverflowInt32HandleError handles the GetOverflowInt32 error response.
@@ -283,11 +273,7 @@ func (client IntClient) GetOverflowInt64(ctx context.Context, options *IntGetOve
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int64Response{}, client.getOverflowInt64HandleError(resp)
 	}
-	result, err := client.getOverflowInt64HandleResponse(resp)
-	if err != nil {
-		return Int64Response{}, err
-	}
-	return result, nil
+	return client.getOverflowInt64HandleResponse(resp)
 }
 
 // getOverflowInt64CreateRequest creates the GetOverflowInt64 request.
@@ -304,9 +290,11 @@ func (client IntClient) getOverflowInt64CreateRequest(ctx context.Context, optio
 
 // getOverflowInt64HandleResponse handles the GetOverflowInt64 response.
 func (client IntClient) getOverflowInt64HandleResponse(resp *azcore.Response) (Int64Response, error) {
-	result := Int64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int64Response{}, err
+	}
+	return Int64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getOverflowInt64HandleError handles the GetOverflowInt64 error response.
@@ -331,11 +319,7 @@ func (client IntClient) GetUnderflowInt32(ctx context.Context, options *IntGetUn
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int32Response{}, client.getUnderflowInt32HandleError(resp)
 	}
-	result, err := client.getUnderflowInt32HandleResponse(resp)
-	if err != nil {
-		return Int32Response{}, err
-	}
-	return result, nil
+	return client.getUnderflowInt32HandleResponse(resp)
 }
 
 // getUnderflowInt32CreateRequest creates the GetUnderflowInt32 request.
@@ -352,9 +336,11 @@ func (client IntClient) getUnderflowInt32CreateRequest(ctx context.Context, opti
 
 // getUnderflowInt32HandleResponse handles the GetUnderflowInt32 response.
 func (client IntClient) getUnderflowInt32HandleResponse(resp *azcore.Response) (Int32Response, error) {
-	result := Int32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int32Response{}, err
+	}
+	return Int32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getUnderflowInt32HandleError handles the GetUnderflowInt32 error response.
@@ -379,11 +365,7 @@ func (client IntClient) GetUnderflowInt64(ctx context.Context, options *IntGetUn
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Int64Response{}, client.getUnderflowInt64HandleError(resp)
 	}
-	result, err := client.getUnderflowInt64HandleResponse(resp)
-	if err != nil {
-		return Int64Response{}, err
-	}
-	return result, nil
+	return client.getUnderflowInt64HandleResponse(resp)
 }
 
 // getUnderflowInt64CreateRequest creates the GetUnderflowInt64 request.
@@ -400,9 +382,11 @@ func (client IntClient) getUnderflowInt64CreateRequest(ctx context.Context, opti
 
 // getUnderflowInt64HandleResponse handles the GetUnderflowInt64 response.
 func (client IntClient) getUnderflowInt64HandleResponse(resp *azcore.Response) (Int64Response, error) {
-	result := Int64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *int64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Int64Response{}, err
+	}
+	return Int64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getUnderflowInt64HandleError handles the GetUnderflowInt64 error response.
@@ -427,11 +411,7 @@ func (client IntClient) GetUnixTime(ctx context.Context, options *IntGetUnixTime
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TimeResponse{}, client.getUnixTimeHandleError(resp)
 	}
-	result, err := client.getUnixTimeHandleResponse(resp)
-	if err != nil {
-		return TimeResponse{}, err
-	}
-	return result, nil
+	return client.getUnixTimeHandleResponse(resp)
 }
 
 // getUnixTimeCreateRequest creates the GetUnixTime request.
@@ -449,8 +429,10 @@ func (client IntClient) getUnixTimeCreateRequest(ctx context.Context, options *I
 // getUnixTimeHandleResponse handles the GetUnixTime response.
 func (client IntClient) getUnixTimeHandleResponse(resp *azcore.Response) (TimeResponse, error) {
 	var aux *timeUnix
-	err := resp.UnmarshalAsJSON(&aux)
-	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, err
+	if err := resp.UnmarshalAsJSON(&aux); err != nil {
+		return TimeResponse{}, err
+	}
+	return TimeResponse{RawResponse: resp.Response, Value: (*time.Time)(aux)}, nil
 }
 
 // getUnixTimeHandleError handles the GetUnixTime error response.

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -254,9 +254,11 @@ func (client LroRetrysClient) deleteProvisioning202Accepted200SucceededCreateReq
 
 // deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client LroRetrysClient) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
@@ -502,9 +504,11 @@ func (client LroRetrysClient) put201CreatingSucceeded200CreateRequest(ctx contex
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client LroRetrysClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
@@ -590,9 +594,11 @@ func (client LroRetrysClient) putAsyncRelativeRetrySucceededCreateRequest(ctx co
 
 // putAsyncRelativeRetrySucceededHandleResponse handles the PutAsyncRelativeRetrySucceeded response.
 func (client LroRetrysClient) putAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetrySucceededHandleError handles the PutAsyncRelativeRetrySucceeded error response.

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -100,9 +100,11 @@ func (client LrOSClient) delete202NoRetry204CreateRequest(ctx context.Context, o
 
 // delete202NoRetry204HandleResponse handles the Delete202NoRetry204 response.
 func (client LrOSClient) delete202NoRetry204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // delete202NoRetry204HandleError handles the Delete202NoRetry204 error response.
@@ -183,9 +185,11 @@ func (client LrOSClient) delete202Retry200CreateRequest(ctx context.Context, opt
 
 // delete202Retry200HandleResponse handles the Delete202Retry200 response.
 func (client LrOSClient) delete202Retry200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // delete202Retry200HandleError handles the Delete202Retry200 error response.
@@ -798,9 +802,11 @@ func (client LrOSClient) deleteProvisioning202Accepted200SucceededCreateRequest(
 
 // deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
 func (client LrOSClient) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
@@ -883,9 +889,11 @@ func (client LrOSClient) deleteProvisioning202DeletingFailed200CreateRequest(ctx
 
 // deleteProvisioning202DeletingFailed200HandleResponse handles the DeleteProvisioning202DeletingFailed200 response.
 func (client LrOSClient) deleteProvisioning202DeletingFailed200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // deleteProvisioning202DeletingFailed200HandleError handles the DeleteProvisioning202DeletingFailed200 error response.
@@ -968,9 +976,11 @@ func (client LrOSClient) deleteProvisioning202Deletingcanceled200CreateRequest(c
 
 // deleteProvisioning202Deletingcanceled200HandleResponse handles the DeleteProvisioning202Deletingcanceled200 response.
 func (client LrOSClient) deleteProvisioning202Deletingcanceled200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // deleteProvisioning202Deletingcanceled200HandleError handles the DeleteProvisioning202Deletingcanceled200 error response.
@@ -1051,9 +1061,11 @@ func (client LrOSClient) post200WithPayloadCreateRequest(ctx context.Context, op
 
 // post200WithPayloadHandleResponse handles the Post200WithPayload response.
 func (client LrOSClient) post200WithPayloadHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	result := SKUResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SKU)
-	return result, err
+	var val *SKU
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SKUResponse{}, err
+	}
+	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
 }
 
 // post200WithPayloadHandleError handles the Post200WithPayload error response.
@@ -1134,9 +1146,11 @@ func (client LrOSClient) post202ListCreateRequest(ctx context.Context, options *
 
 // post202ListHandleResponse handles the Post202List response.
 func (client LrOSClient) post202ListHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	result := ProductArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductArray)
-	return result, err
+	var val *[]Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductArrayResponse{}, err
+	}
+	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
 }
 
 // post202ListHandleError handles the Post202List error response.
@@ -1219,9 +1233,11 @@ func (client LrOSClient) post202NoRetry204CreateRequest(ctx context.Context, opt
 
 // post202NoRetry204HandleResponse handles the Post202NoRetry204 response.
 func (client LrOSClient) post202NoRetry204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // post202NoRetry204HandleError handles the Post202NoRetry204 error response.
@@ -1386,9 +1402,11 @@ func (client LrOSClient) postAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 
 // postAsyncNoRetrySucceededHandleResponse handles the PostAsyncNoRetrySucceeded response.
 func (client LrOSClient) postAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postAsyncNoRetrySucceededHandleError handles the PostAsyncNoRetrySucceeded error response.
@@ -1555,9 +1573,11 @@ func (client LrOSClient) postAsyncRetrySucceededCreateRequest(ctx context.Contex
 
 // postAsyncRetrySucceededHandleResponse handles the PostAsyncRetrySucceeded response.
 func (client LrOSClient) postAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
@@ -1719,9 +1739,11 @@ func (client LrOSClient) postDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx c
 
 // postDoubleHeadersFinalAzureHeaderGetHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGet response.
 func (client LrOSClient) postDoubleHeadersFinalAzureHeaderGetHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postDoubleHeadersFinalAzureHeaderGetHandleError handles the PostDoubleHeadersFinalAzureHeaderGet error response.
@@ -1804,9 +1826,11 @@ func (client LrOSClient) postDoubleHeadersFinalAzureHeaderGetDefaultCreateReques
 
 // postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGetDefault response.
 func (client LrOSClient) postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postDoubleHeadersFinalAzureHeaderGetDefaultHandleError handles the PostDoubleHeadersFinalAzureHeaderGetDefault error response.
@@ -1887,9 +1911,11 @@ func (client LrOSClient) postDoubleHeadersFinalLocationGetCreateRequest(ctx cont
 
 // postDoubleHeadersFinalLocationGetHandleResponse handles the PostDoubleHeadersFinalLocationGet response.
 func (client LrOSClient) postDoubleHeadersFinalLocationGetHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postDoubleHeadersFinalLocationGetHandleError handles the PostDoubleHeadersFinalLocationGet error response.
@@ -1975,9 +2001,11 @@ func (client LrOSClient) put200Acceptedcanceled200CreateRequest(ctx context.Cont
 
 // put200Acceptedcanceled200HandleResponse handles the Put200Acceptedcanceled200 response.
 func (client LrOSClient) put200Acceptedcanceled200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200Acceptedcanceled200HandleError handles the Put200Acceptedcanceled200 error response.
@@ -2059,9 +2087,11 @@ func (client LrOSClient) put200SucceededCreateRequest(ctx context.Context, optio
 
 // put200SucceededHandleResponse handles the Put200Succeeded response.
 func (client LrOSClient) put200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200SucceededHandleError handles the Put200Succeeded error response.
@@ -2143,9 +2173,11 @@ func (client LrOSClient) put200SucceededNoStateCreateRequest(ctx context.Context
 
 // put200SucceededNoStateHandleResponse handles the Put200SucceededNoState response.
 func (client LrOSClient) put200SucceededNoStateHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200SucceededNoStateHandleError handles the Put200SucceededNoState error response.
@@ -2231,9 +2263,11 @@ func (client LrOSClient) put200UpdatingSucceeded204CreateRequest(ctx context.Con
 
 // put200UpdatingSucceeded204HandleResponse handles the Put200UpdatingSucceeded204 response.
 func (client LrOSClient) put200UpdatingSucceeded204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200UpdatingSucceeded204HandleError handles the Put200UpdatingSucceeded204 error response.
@@ -2319,9 +2353,11 @@ func (client LrOSClient) put201CreatingFailed200CreateRequest(ctx context.Contex
 
 // put201CreatingFailed200HandleResponse handles the Put201CreatingFailed200 response.
 func (client LrOSClient) put201CreatingFailed200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201CreatingFailed200HandleError handles the Put201CreatingFailed200 error response.
@@ -2407,9 +2443,11 @@ func (client LrOSClient) put201CreatingSucceeded200CreateRequest(ctx context.Con
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client LrOSClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
@@ -2491,9 +2529,11 @@ func (client LrOSClient) put201SucceededCreateRequest(ctx context.Context, optio
 
 // put201SucceededHandleResponse handles the Put201Succeeded response.
 func (client LrOSClient) put201SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201SucceededHandleError handles the Put201Succeeded error response.
@@ -2577,9 +2617,11 @@ func (client LrOSClient) put202Retry200CreateRequest(ctx context.Context, option
 
 // put202Retry200HandleResponse handles the Put202Retry200 response.
 func (client LrOSClient) put202Retry200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put202Retry200HandleError handles the Put202Retry200 error response.
@@ -2663,9 +2705,11 @@ func (client LrOSClient) putAsyncNoHeaderInRetryCreateRequest(ctx context.Contex
 
 // putAsyncNoHeaderInRetryHandleResponse handles the PutAsyncNoHeaderInRetry response.
 func (client LrOSClient) putAsyncNoHeaderInRetryHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncNoHeaderInRetryHandleError handles the PutAsyncNoHeaderInRetry error response.
@@ -2751,9 +2795,11 @@ func (client LrOSClient) putAsyncNoRetrySucceededCreateRequest(ctx context.Conte
 
 // putAsyncNoRetrySucceededHandleResponse handles the PutAsyncNoRetrySucceeded response.
 func (client LrOSClient) putAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncNoRetrySucceededHandleError handles the PutAsyncNoRetrySucceeded error response.
@@ -2839,9 +2885,11 @@ func (client LrOSClient) putAsyncNoRetrycanceledCreateRequest(ctx context.Contex
 
 // putAsyncNoRetrycanceledHandleResponse handles the PutAsyncNoRetrycanceled response.
 func (client LrOSClient) putAsyncNoRetrycanceledHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncNoRetrycanceledHandleError handles the PutAsyncNoRetrycanceled error response.
@@ -2923,9 +2971,11 @@ func (client LrOSClient) putAsyncNonResourceCreateRequest(ctx context.Context, o
 
 // putAsyncNonResourceHandleResponse handles the PutAsyncNonResource response.
 func (client LrOSClient) putAsyncNonResourceHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	result := SKUResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SKU)
-	return result, err
+	var val *SKU
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SKUResponse{}, err
+	}
+	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
 }
 
 // putAsyncNonResourceHandleError handles the PutAsyncNonResource error response.
@@ -3011,9 +3061,11 @@ func (client LrOSClient) putAsyncRetryFailedCreateRequest(ctx context.Context, o
 
 // putAsyncRetryFailedHandleResponse handles the PutAsyncRetryFailed response.
 func (client LrOSClient) putAsyncRetryFailedHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRetryFailedHandleError handles the PutAsyncRetryFailed error response.
@@ -3099,9 +3151,11 @@ func (client LrOSClient) putAsyncRetrySucceededCreateRequest(ctx context.Context
 
 // putAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
 func (client LrOSClient) putAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
@@ -3183,9 +3237,11 @@ func (client LrOSClient) putAsyncSubResourceCreateRequest(ctx context.Context, o
 
 // putAsyncSubResourceHandleResponse handles the PutAsyncSubResource response.
 func (client LrOSClient) putAsyncSubResourceHandleResponse(resp *azcore.Response) (SubProductResponse, error) {
-	result := SubProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SubProduct)
-	return result, err
+	var val *SubProduct
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SubProductResponse{}, err
+	}
+	return SubProductResponse{RawResponse: resp.Response, SubProduct: val}, nil
 }
 
 // putAsyncSubResourceHandleError handles the PutAsyncSubResource error response.
@@ -3269,9 +3325,11 @@ func (client LrOSClient) putNoHeaderInRetryCreateRequest(ctx context.Context, op
 
 // putNoHeaderInRetryHandleResponse handles the PutNoHeaderInRetry response.
 func (client LrOSClient) putNoHeaderInRetryHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNoHeaderInRetryHandleError handles the PutNoHeaderInRetry error response.
@@ -3353,9 +3411,11 @@ func (client LrOSClient) putNonResourceCreateRequest(ctx context.Context, option
 
 // putNonResourceHandleResponse handles the PutNonResource response.
 func (client LrOSClient) putNonResourceHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	result := SKUResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SKU)
-	return result, err
+	var val *SKU
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SKUResponse{}, err
+	}
+	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
 }
 
 // putNonResourceHandleError handles the PutNonResource error response.
@@ -3437,9 +3497,11 @@ func (client LrOSClient) putSubResourceCreateRequest(ctx context.Context, option
 
 // putSubResourceHandleResponse handles the PutSubResource response.
 func (client LrOSClient) putSubResourceHandleResponse(resp *azcore.Response) (SubProductResponse, error) {
-	result := SubProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SubProduct)
-	return result, err
+	var val *SubProduct
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SubProductResponse{}, err
+	}
+	return SubProductResponse{RawResponse: resp.Response, SubProduct: val}, nil
 }
 
 // putSubResourceHandleError handles the PutSubResource error response.

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -1333,9 +1333,11 @@ func (client LrosaDsClient) put200InvalidJsonCreateRequest(ctx context.Context, 
 
 // put200InvalidJsonHandleResponse handles the Put200InvalidJSON response.
 func (client LrosaDsClient) put200InvalidJsonHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200InvalidJsonHandleError handles the Put200InvalidJSON error response.
@@ -1419,9 +1421,11 @@ func (client LrosaDsClient) putAsyncRelativeRetry400CreateRequest(ctx context.Co
 
 // putAsyncRelativeRetry400HandleResponse handles the PutAsyncRelativeRetry400 response.
 func (client LrosaDsClient) putAsyncRelativeRetry400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetry400HandleError handles the PutAsyncRelativeRetry400 error response.
@@ -1505,9 +1509,11 @@ func (client LrosaDsClient) putAsyncRelativeRetryInvalidHeaderCreateRequest(ctx 
 
 // putAsyncRelativeRetryInvalidHeaderHandleResponse handles the PutAsyncRelativeRetryInvalidHeader response.
 func (client LrosaDsClient) putAsyncRelativeRetryInvalidHeaderHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryInvalidHeaderHandleError handles the PutAsyncRelativeRetryInvalidHeader error response.
@@ -1593,9 +1599,11 @@ func (client LrosaDsClient) putAsyncRelativeRetryInvalidJsonPollingCreateRequest
 
 // putAsyncRelativeRetryInvalidJsonPollingHandleResponse handles the PutAsyncRelativeRetryInvalidJSONPolling response.
 func (client LrosaDsClient) putAsyncRelativeRetryInvalidJsonPollingHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryInvalidJsonPollingHandleError handles the PutAsyncRelativeRetryInvalidJSONPolling error response.
@@ -1681,9 +1689,11 @@ func (client LrosaDsClient) putAsyncRelativeRetryNoStatusCreateRequest(ctx conte
 
 // putAsyncRelativeRetryNoStatusHandleResponse handles the PutAsyncRelativeRetryNoStatus response.
 func (client LrosaDsClient) putAsyncRelativeRetryNoStatusHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryNoStatusHandleError handles the PutAsyncRelativeRetryNoStatus error response.
@@ -1769,9 +1779,11 @@ func (client LrosaDsClient) putAsyncRelativeRetryNoStatusPayloadCreateRequest(ct
 
 // putAsyncRelativeRetryNoStatusPayloadHandleResponse handles the PutAsyncRelativeRetryNoStatusPayload response.
 func (client LrosaDsClient) putAsyncRelativeRetryNoStatusPayloadHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryNoStatusPayloadHandleError handles the PutAsyncRelativeRetryNoStatusPayload error response.
@@ -1853,9 +1865,11 @@ func (client LrosaDsClient) putError201NoProvisioningStatePayloadCreateRequest(c
 
 // putError201NoProvisioningStatePayloadHandleResponse handles the PutError201NoProvisioningStatePayload response.
 func (client LrosaDsClient) putError201NoProvisioningStatePayloadHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putError201NoProvisioningStatePayloadHandleError handles the PutError201NoProvisioningStatePayload error response.
@@ -1937,9 +1951,11 @@ func (client LrosaDsClient) putNonRetry201Creating400CreateRequest(ctx context.C
 
 // putNonRetry201Creating400HandleResponse handles the PutNonRetry201Creating400 response.
 func (client LrosaDsClient) putNonRetry201Creating400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNonRetry201Creating400HandleError handles the PutNonRetry201Creating400 error response.
@@ -2022,9 +2038,11 @@ func (client LrosaDsClient) putNonRetry201Creating400InvalidJsonCreateRequest(ct
 
 // putNonRetry201Creating400InvalidJsonHandleResponse handles the PutNonRetry201Creating400InvalidJSON response.
 func (client LrosaDsClient) putNonRetry201Creating400InvalidJsonHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNonRetry201Creating400InvalidJsonHandleError handles the PutNonRetry201Creating400InvalidJSON error response.
@@ -2106,9 +2124,11 @@ func (client LrosaDsClient) putNonRetry400CreateRequest(ctx context.Context, opt
 
 // putNonRetry400HandleResponse handles the PutNonRetry400 response.
 func (client LrosaDsClient) putNonRetry400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNonRetry400HandleError handles the PutNonRetry400 error response.

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -267,9 +267,11 @@ func (client LrOSCustomHeaderClient) put201CreatingSucceeded200CreateRequest(ctx
 
 // put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
 func (client LrOSCustomHeaderClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
@@ -355,9 +357,11 @@ func (client LrOSCustomHeaderClient) putAsyncRetrySucceededCreateRequest(ctx con
 
 // putAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
 func (client LrOSCustomHeaderClient) putAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -46,11 +46,7 @@ func (client MediaTypesClient) AnalyzeBody(ctx context.Context, contentType Cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.analyzeBodyHandleError(resp)
 	}
-	result, err := client.analyzeBodyHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.analyzeBodyHandleResponse(resp)
 }
 
 // analyzeBodyCreateRequest creates the AnalyzeBody request.
@@ -68,9 +64,11 @@ func (client MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, con
 
 // analyzeBodyHandleResponse handles the AnalyzeBody response.
 func (client MediaTypesClient) analyzeBodyHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // analyzeBodyHandleError handles the AnalyzeBody error response.
@@ -98,11 +96,7 @@ func (client MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.analyzeBodyWithSourcePathHandleError(resp)
 	}
-	result, err := client.analyzeBodyWithSourcePathHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.analyzeBodyWithSourcePathHandleResponse(resp)
 }
 
 // analyzeBodyWithSourcePathCreateRequest creates the AnalyzeBodyWithSourcePath request.
@@ -122,9 +116,11 @@ func (client MediaTypesClient) analyzeBodyWithSourcePathCreateRequest(ctx contex
 
 // analyzeBodyWithSourcePathHandleResponse handles the AnalyzeBodyWithSourcePath response.
 func (client MediaTypesClient) analyzeBodyWithSourcePathHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // analyzeBodyWithSourcePathHandleError handles the AnalyzeBodyWithSourcePath error response.
@@ -152,11 +148,7 @@ func (client MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, inpu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.contentTypeWithEncodingHandleError(resp)
 	}
-	result, err := client.contentTypeWithEncodingHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.contentTypeWithEncodingHandleResponse(resp)
 }
 
 // contentTypeWithEncodingCreateRequest creates the ContentTypeWithEncoding request.
@@ -174,9 +166,11 @@ func (client MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context.
 
 // contentTypeWithEncodingHandleResponse handles the ContentTypeWithEncoding response.
 func (client MediaTypesClient) contentTypeWithEncodingHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // contentTypeWithEncodingHandleError handles the ContentTypeWithEncoding error response.

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient.go
@@ -45,11 +45,7 @@ func (client MultipleInheritanceServiceClient) GetCat(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return CatResponse{}, client.getCatHandleError(resp)
 	}
-	result, err := client.getCatHandleResponse(resp)
-	if err != nil {
-		return CatResponse{}, err
-	}
-	return result, nil
+	return client.getCatHandleResponse(resp)
 }
 
 // getCatCreateRequest creates the GetCat request.
@@ -66,9 +62,11 @@ func (client MultipleInheritanceServiceClient) getCatCreateRequest(ctx context.C
 
 // getCatHandleResponse handles the GetCat response.
 func (client MultipleInheritanceServiceClient) getCatHandleResponse(resp *azcore.Response) (CatResponse, error) {
-	result := CatResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Cat)
-	return result, err
+	var val *Cat
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CatResponse{}, err
+	}
+	return CatResponse{RawResponse: resp.Response, Cat: val}, nil
 }
 
 // getCatHandleError handles the GetCat error response.
@@ -93,11 +91,7 @@ func (client MultipleInheritanceServiceClient) GetFeline(ctx context.Context, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FelineResponse{}, client.getFelineHandleError(resp)
 	}
-	result, err := client.getFelineHandleResponse(resp)
-	if err != nil {
-		return FelineResponse{}, err
-	}
-	return result, nil
+	return client.getFelineHandleResponse(resp)
 }
 
 // getFelineCreateRequest creates the GetFeline request.
@@ -114,9 +108,11 @@ func (client MultipleInheritanceServiceClient) getFelineCreateRequest(ctx contex
 
 // getFelineHandleResponse handles the GetFeline response.
 func (client MultipleInheritanceServiceClient) getFelineHandleResponse(resp *azcore.Response) (FelineResponse, error) {
-	result := FelineResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Feline)
-	return result, err
+	var val *Feline
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FelineResponse{}, err
+	}
+	return FelineResponse{RawResponse: resp.Response, Feline: val}, nil
 }
 
 // getFelineHandleError handles the GetFeline error response.
@@ -141,11 +137,7 @@ func (client MultipleInheritanceServiceClient) GetHorse(ctx context.Context, opt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HorseResponse{}, client.getHorseHandleError(resp)
 	}
-	result, err := client.getHorseHandleResponse(resp)
-	if err != nil {
-		return HorseResponse{}, err
-	}
-	return result, nil
+	return client.getHorseHandleResponse(resp)
 }
 
 // getHorseCreateRequest creates the GetHorse request.
@@ -162,9 +154,11 @@ func (client MultipleInheritanceServiceClient) getHorseCreateRequest(ctx context
 
 // getHorseHandleResponse handles the GetHorse response.
 func (client MultipleInheritanceServiceClient) getHorseHandleResponse(resp *azcore.Response) (HorseResponse, error) {
-	result := HorseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Horse)
-	return result, err
+	var val *Horse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return HorseResponse{}, err
+	}
+	return HorseResponse{RawResponse: resp.Response, Horse: val}, nil
 }
 
 // getHorseHandleError handles the GetHorse error response.
@@ -189,11 +183,7 @@ func (client MultipleInheritanceServiceClient) GetKitten(ctx context.Context, op
 	if !resp.HasStatusCode(http.StatusOK) {
 		return KittenResponse{}, client.getKittenHandleError(resp)
 	}
-	result, err := client.getKittenHandleResponse(resp)
-	if err != nil {
-		return KittenResponse{}, err
-	}
-	return result, nil
+	return client.getKittenHandleResponse(resp)
 }
 
 // getKittenCreateRequest creates the GetKitten request.
@@ -210,9 +200,11 @@ func (client MultipleInheritanceServiceClient) getKittenCreateRequest(ctx contex
 
 // getKittenHandleResponse handles the GetKitten response.
 func (client MultipleInheritanceServiceClient) getKittenHandleResponse(resp *azcore.Response) (KittenResponse, error) {
-	result := KittenResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Kitten)
-	return result, err
+	var val *Kitten
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return KittenResponse{}, err
+	}
+	return KittenResponse{RawResponse: resp.Response, Kitten: val}, nil
 }
 
 // getKittenHandleError handles the GetKitten error response.
@@ -237,11 +229,7 @@ func (client MultipleInheritanceServiceClient) GetPet(ctx context.Context, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PetResponse{}, client.getPetHandleError(resp)
 	}
-	result, err := client.getPetHandleResponse(resp)
-	if err != nil {
-		return PetResponse{}, err
-	}
-	return result, nil
+	return client.getPetHandleResponse(resp)
 }
 
 // getPetCreateRequest creates the GetPet request.
@@ -258,9 +246,11 @@ func (client MultipleInheritanceServiceClient) getPetCreateRequest(ctx context.C
 
 // getPetHandleResponse handles the GetPet response.
 func (client MultipleInheritanceServiceClient) getPetHandleResponse(resp *azcore.Response) (PetResponse, error) {
-	result := PetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Pet)
-	return result, err
+	var val *Pet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PetResponse{}, err
+	}
+	return PetResponse{RawResponse: resp.Response, Pet: val}, nil
 }
 
 // getPetHandleError handles the GetPet error response.
@@ -285,11 +275,7 @@ func (client MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat C
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putCatHandleError(resp)
 	}
-	result, err := client.putCatHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putCatHandleResponse(resp)
 }
 
 // putCatCreateRequest creates the PutCat request.
@@ -306,9 +292,11 @@ func (client MultipleInheritanceServiceClient) putCatCreateRequest(ctx context.C
 
 // putCatHandleResponse handles the PutCat response.
 func (client MultipleInheritanceServiceClient) putCatHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putCatHandleError handles the PutCat error response.
@@ -336,11 +324,7 @@ func (client MultipleInheritanceServiceClient) PutFeline(ctx context.Context, fe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putFelineHandleError(resp)
 	}
-	result, err := client.putFelineHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putFelineHandleResponse(resp)
 }
 
 // putFelineCreateRequest creates the PutFeline request.
@@ -357,9 +341,11 @@ func (client MultipleInheritanceServiceClient) putFelineCreateRequest(ctx contex
 
 // putFelineHandleResponse handles the PutFeline response.
 func (client MultipleInheritanceServiceClient) putFelineHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putFelineHandleError handles the PutFeline error response.
@@ -387,11 +373,7 @@ func (client MultipleInheritanceServiceClient) PutHorse(ctx context.Context, hor
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putHorseHandleError(resp)
 	}
-	result, err := client.putHorseHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putHorseHandleResponse(resp)
 }
 
 // putHorseCreateRequest creates the PutHorse request.
@@ -408,9 +390,11 @@ func (client MultipleInheritanceServiceClient) putHorseCreateRequest(ctx context
 
 // putHorseHandleResponse handles the PutHorse response.
 func (client MultipleInheritanceServiceClient) putHorseHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putHorseHandleError handles the PutHorse error response.
@@ -438,11 +422,7 @@ func (client MultipleInheritanceServiceClient) PutKitten(ctx context.Context, ki
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putKittenHandleError(resp)
 	}
-	result, err := client.putKittenHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putKittenHandleResponse(resp)
 }
 
 // putKittenCreateRequest creates the PutKitten request.
@@ -459,9 +439,11 @@ func (client MultipleInheritanceServiceClient) putKittenCreateRequest(ctx contex
 
 // putKittenHandleResponse handles the PutKitten response.
 func (client MultipleInheritanceServiceClient) putKittenHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putKittenHandleError handles the PutKitten error response.
@@ -489,11 +471,7 @@ func (client MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet P
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putPetHandleError(resp)
 	}
-	result, err := client.putPetHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putPetHandleResponse(resp)
 }
 
 // putPetCreateRequest creates the PutPet request.
@@ -510,9 +488,11 @@ func (client MultipleInheritanceServiceClient) putPetCreateRequest(ctx context.C
 
 // putPetHandleResponse handles the PutPet response.
 func (client MultipleInheritanceServiceClient) putPetHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putPetHandleError handles the PutPet error response.

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -45,11 +45,7 @@ func (client FloatClient) Get(ctx context.Context, options *FloatGetOptions) (Fl
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FloatEnumResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return FloatEnumResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -66,9 +62,11 @@ func (client FloatClient) getCreateRequest(ctx context.Context, options *FloatGe
 
 // getHandleResponse handles the Get response.
 func (client FloatClient) getHandleResponse(resp *azcore.Response) (FloatEnumResponse, error) {
-	result := FloatEnumResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *FloatEnum
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FloatEnumResponse{}, err
+	}
+	return FloatEnumResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -96,11 +94,7 @@ func (client FloatClient) Put(ctx context.Context, options *FloatPutOptions) (St
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putHandleError(resp)
 	}
-	result, err := client.putHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putHandleResponse(resp)
 }
 
 // putCreateRequest creates the Put request.
@@ -120,9 +114,11 @@ func (client FloatClient) putCreateRequest(ctx context.Context, options *FloatPu
 
 // putHandleResponse handles the Put response.
 func (client FloatClient) putHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putHandleError handles the Put error response.

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -45,11 +45,7 @@ func (client IntClient) Get(ctx context.Context, options *IntGetOptions) (IntEnu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IntEnumResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return IntEnumResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -66,9 +62,11 @@ func (client IntClient) getCreateRequest(ctx context.Context, options *IntGetOpt
 
 // getHandleResponse handles the Get response.
 func (client IntClient) getHandleResponse(resp *azcore.Response) (IntEnumResponse, error) {
-	result := IntEnumResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *IntEnum
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IntEnumResponse{}, err
+	}
+	return IntEnumResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -96,11 +94,7 @@ func (client IntClient) Put(ctx context.Context, options *IntPutOptions) (String
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.putHandleError(resp)
 	}
-	result, err := client.putHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.putHandleResponse(resp)
 }
 
 // putCreateRequest creates the Put request.
@@ -120,9 +114,11 @@ func (client IntClient) putCreateRequest(ctx context.Context, options *IntPutOpt
 
 // putHandleResponse handles the Put response.
 func (client IntClient) putHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // putHandleError handles the Put error response.

--- a/test/autorest/numbergroup/zz_generated_number.go
+++ b/test/autorest/numbergroup/zz_generated_number.go
@@ -42,11 +42,7 @@ func (client NumberClient) GetBigDecimal(ctx context.Context, options *NumberGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDecimalHandleError(resp)
 	}
-	result, err := client.getBigDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDecimalHandleResponse(resp)
 }
 
 // getBigDecimalCreateRequest creates the GetBigDecimal request.
@@ -63,9 +59,11 @@ func (client NumberClient) getBigDecimalCreateRequest(ctx context.Context, optio
 
 // getBigDecimalHandleResponse handles the GetBigDecimal response.
 func (client NumberClient) getBigDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDecimalHandleError handles the GetBigDecimal error response.
@@ -90,11 +88,7 @@ func (client NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context, opt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDecimalNegativeDecimalHandleError(resp)
 	}
-	result, err := client.getBigDecimalNegativeDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDecimalNegativeDecimalHandleResponse(resp)
 }
 
 // getBigDecimalNegativeDecimalCreateRequest creates the GetBigDecimalNegativeDecimal request.
@@ -111,9 +105,11 @@ func (client NumberClient) getBigDecimalNegativeDecimalCreateRequest(ctx context
 
 // getBigDecimalNegativeDecimalHandleResponse handles the GetBigDecimalNegativeDecimal response.
 func (client NumberClient) getBigDecimalNegativeDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDecimalNegativeDecimalHandleError handles the GetBigDecimalNegativeDecimal error response.
@@ -138,11 +134,7 @@ func (client NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context, opt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDecimalPositiveDecimalHandleError(resp)
 	}
-	result, err := client.getBigDecimalPositiveDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDecimalPositiveDecimalHandleResponse(resp)
 }
 
 // getBigDecimalPositiveDecimalCreateRequest creates the GetBigDecimalPositiveDecimal request.
@@ -159,9 +151,11 @@ func (client NumberClient) getBigDecimalPositiveDecimalCreateRequest(ctx context
 
 // getBigDecimalPositiveDecimalHandleResponse handles the GetBigDecimalPositiveDecimal response.
 func (client NumberClient) getBigDecimalPositiveDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDecimalPositiveDecimalHandleError handles the GetBigDecimalPositiveDecimal error response.
@@ -186,11 +180,7 @@ func (client NumberClient) GetBigDouble(ctx context.Context, options *NumberGetB
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDoubleHandleError(resp)
 	}
-	result, err := client.getBigDoubleHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDoubleHandleResponse(resp)
 }
 
 // getBigDoubleCreateRequest creates the GetBigDouble request.
@@ -207,9 +197,11 @@ func (client NumberClient) getBigDoubleCreateRequest(ctx context.Context, option
 
 // getBigDoubleHandleResponse handles the GetBigDouble response.
 func (client NumberClient) getBigDoubleHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDoubleHandleError handles the GetBigDouble error response.
@@ -234,11 +226,7 @@ func (client NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDoubleNegativeDecimalHandleError(resp)
 	}
-	result, err := client.getBigDoubleNegativeDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDoubleNegativeDecimalHandleResponse(resp)
 }
 
 // getBigDoubleNegativeDecimalCreateRequest creates the GetBigDoubleNegativeDecimal request.
@@ -255,9 +243,11 @@ func (client NumberClient) getBigDoubleNegativeDecimalCreateRequest(ctx context.
 
 // getBigDoubleNegativeDecimalHandleResponse handles the GetBigDoubleNegativeDecimal response.
 func (client NumberClient) getBigDoubleNegativeDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDoubleNegativeDecimalHandleError handles the GetBigDoubleNegativeDecimal error response.
@@ -282,11 +272,7 @@ func (client NumberClient) GetBigDoublePositiveDecimal(ctx context.Context, opti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getBigDoublePositiveDecimalHandleError(resp)
 	}
-	result, err := client.getBigDoublePositiveDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getBigDoublePositiveDecimalHandleResponse(resp)
 }
 
 // getBigDoublePositiveDecimalCreateRequest creates the GetBigDoublePositiveDecimal request.
@@ -303,9 +289,11 @@ func (client NumberClient) getBigDoublePositiveDecimalCreateRequest(ctx context.
 
 // getBigDoublePositiveDecimalHandleResponse handles the GetBigDoublePositiveDecimal response.
 func (client NumberClient) getBigDoublePositiveDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigDoublePositiveDecimalHandleError handles the GetBigDoublePositiveDecimal error response.
@@ -330,11 +318,7 @@ func (client NumberClient) GetBigFloat(ctx context.Context, options *NumberGetBi
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32Response{}, client.getBigFloatHandleError(resp)
 	}
-	result, err := client.getBigFloatHandleResponse(resp)
-	if err != nil {
-		return Float32Response{}, err
-	}
-	return result, nil
+	return client.getBigFloatHandleResponse(resp)
 }
 
 // getBigFloatCreateRequest creates the GetBigFloat request.
@@ -351,9 +335,11 @@ func (client NumberClient) getBigFloatCreateRequest(ctx context.Context, options
 
 // getBigFloatHandleResponse handles the GetBigFloat response.
 func (client NumberClient) getBigFloatHandleResponse(resp *azcore.Response) (Float32Response, error) {
-	result := Float32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32Response{}, err
+	}
+	return Float32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBigFloatHandleError handles the GetBigFloat error response.
@@ -378,11 +364,7 @@ func (client NumberClient) GetInvalidDecimal(ctx context.Context, options *Numbe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getInvalidDecimalHandleError(resp)
 	}
-	result, err := client.getInvalidDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getInvalidDecimalHandleResponse(resp)
 }
 
 // getInvalidDecimalCreateRequest creates the GetInvalidDecimal request.
@@ -399,9 +381,11 @@ func (client NumberClient) getInvalidDecimalCreateRequest(ctx context.Context, o
 
 // getInvalidDecimalHandleResponse handles the GetInvalidDecimal response.
 func (client NumberClient) getInvalidDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidDecimalHandleError handles the GetInvalidDecimal error response.
@@ -426,11 +410,7 @@ func (client NumberClient) GetInvalidDouble(ctx context.Context, options *Number
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getInvalidDoubleHandleError(resp)
 	}
-	result, err := client.getInvalidDoubleHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getInvalidDoubleHandleResponse(resp)
 }
 
 // getInvalidDoubleCreateRequest creates the GetInvalidDouble request.
@@ -447,9 +427,11 @@ func (client NumberClient) getInvalidDoubleCreateRequest(ctx context.Context, op
 
 // getInvalidDoubleHandleResponse handles the GetInvalidDouble response.
 func (client NumberClient) getInvalidDoubleHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidDoubleHandleError handles the GetInvalidDouble error response.
@@ -474,11 +456,7 @@ func (client NumberClient) GetInvalidFloat(ctx context.Context, options *NumberG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32Response{}, client.getInvalidFloatHandleError(resp)
 	}
-	result, err := client.getInvalidFloatHandleResponse(resp)
-	if err != nil {
-		return Float32Response{}, err
-	}
-	return result, nil
+	return client.getInvalidFloatHandleResponse(resp)
 }
 
 // getInvalidFloatCreateRequest creates the GetInvalidFloat request.
@@ -495,9 +473,11 @@ func (client NumberClient) getInvalidFloatCreateRequest(ctx context.Context, opt
 
 // getInvalidFloatHandleResponse handles the GetInvalidFloat response.
 func (client NumberClient) getInvalidFloatHandleResponse(resp *azcore.Response) (Float32Response, error) {
-	result := Float32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32Response{}, err
+	}
+	return Float32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getInvalidFloatHandleError handles the GetInvalidFloat error response.
@@ -522,11 +502,7 @@ func (client NumberClient) GetNull(ctx context.Context, options *NumberGetNullOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float32Response{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return Float32Response{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -543,9 +519,11 @@ func (client NumberClient) getNullCreateRequest(ctx context.Context, options *Nu
 
 // getNullHandleResponse handles the GetNull response.
 func (client NumberClient) getNullHandleResponse(resp *azcore.Response) (Float32Response, error) {
-	result := Float32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float32Response{}, err
+	}
+	return Float32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -570,11 +548,7 @@ func (client NumberClient) GetSmallDecimal(ctx context.Context, options *NumberG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getSmallDecimalHandleError(resp)
 	}
-	result, err := client.getSmallDecimalHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getSmallDecimalHandleResponse(resp)
 }
 
 // getSmallDecimalCreateRequest creates the GetSmallDecimal request.
@@ -591,9 +565,11 @@ func (client NumberClient) getSmallDecimalCreateRequest(ctx context.Context, opt
 
 // getSmallDecimalHandleResponse handles the GetSmallDecimal response.
 func (client NumberClient) getSmallDecimalHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getSmallDecimalHandleError handles the GetSmallDecimal error response.
@@ -618,11 +594,7 @@ func (client NumberClient) GetSmallDouble(ctx context.Context, options *NumberGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getSmallDoubleHandleError(resp)
 	}
-	result, err := client.getSmallDoubleHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getSmallDoubleHandleResponse(resp)
 }
 
 // getSmallDoubleCreateRequest creates the GetSmallDouble request.
@@ -639,9 +611,11 @@ func (client NumberClient) getSmallDoubleCreateRequest(ctx context.Context, opti
 
 // getSmallDoubleHandleResponse handles the GetSmallDouble response.
 func (client NumberClient) getSmallDoubleHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getSmallDoubleHandleError handles the GetSmallDouble error response.
@@ -666,11 +640,7 @@ func (client NumberClient) GetSmallFloat(ctx context.Context, options *NumberGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return Float64Response{}, client.getSmallFloatHandleError(resp)
 	}
-	result, err := client.getSmallFloatHandleResponse(resp)
-	if err != nil {
-		return Float64Response{}, err
-	}
-	return result, nil
+	return client.getSmallFloatHandleResponse(resp)
 }
 
 // getSmallFloatCreateRequest creates the GetSmallFloat request.
@@ -687,9 +657,11 @@ func (client NumberClient) getSmallFloatCreateRequest(ctx context.Context, optio
 
 // getSmallFloatHandleResponse handles the GetSmallFloat response.
 func (client NumberClient) getSmallFloatHandleResponse(resp *azcore.Response) (Float64Response, error) {
-	result := Float64Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *float64
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return Float64Response{}, err
+	}
+	return Float64Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getSmallFloatHandleError handles the GetSmallFloat error response.

--- a/test/autorest/paginggroup/zz_generated_paging.go
+++ b/test/autorest/paginggroup/zz_generated_paging.go
@@ -76,9 +76,11 @@ func (client PagingClient) getMultiplePagesCreateRequest(ctx context.Context, op
 
 // getMultiplePagesHandleResponse handles the GetMultiplePages response.
 func (client PagingClient) getMultiplePagesHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesHandleError handles the GetMultiplePages error response.
@@ -123,9 +125,11 @@ func (client PagingClient) getMultiplePagesFailureCreateRequest(ctx context.Cont
 
 // getMultiplePagesFailureHandleResponse handles the GetMultiplePagesFailure response.
 func (client PagingClient) getMultiplePagesFailureHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesFailureHandleError handles the GetMultiplePagesFailure error response.
@@ -170,9 +174,11 @@ func (client PagingClient) getMultiplePagesFailureUriCreateRequest(ctx context.C
 
 // getMultiplePagesFailureUriHandleResponse handles the GetMultiplePagesFailureURI response.
 func (client PagingClient) getMultiplePagesFailureUriHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesFailureUriHandleError handles the GetMultiplePagesFailureURI error response.
@@ -221,9 +227,11 @@ func (client PagingClient) getMultiplePagesFragmentNextLinkCreateRequest(ctx con
 
 // getMultiplePagesFragmentNextLinkHandleResponse handles the GetMultiplePagesFragmentNextLink response.
 func (client PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp *azcore.Response) (OdataProductResultResponse, error) {
-	result := OdataProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OdataProductResult)
-	return result, err
+	var val *OdataProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OdataProductResultResponse{}, err
+	}
+	return OdataProductResultResponse{RawResponse: resp.Response, OdataProductResult: val}, nil
 }
 
 // getMultiplePagesFragmentNextLinkHandleError handles the GetMultiplePagesFragmentNextLink error response.
@@ -272,9 +280,11 @@ func (client PagingClient) getMultiplePagesFragmentWithGroupingNextLinkCreateReq
 
 // getMultiplePagesFragmentWithGroupingNextLinkHandleResponse handles the GetMultiplePagesFragmentWithGroupingNextLink response.
 func (client PagingClient) getMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp *azcore.Response) (OdataProductResultResponse, error) {
-	result := OdataProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OdataProductResult)
-	return result, err
+	var val *OdataProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OdataProductResultResponse{}, err
+	}
+	return OdataProductResultResponse{RawResponse: resp.Response, OdataProductResult: val}, nil
 }
 
 // getMultiplePagesFragmentWithGroupingNextLinkHandleError handles the GetMultiplePagesFragmentWithGroupingNextLink error response.
@@ -311,9 +321,11 @@ func (client PagingClient) BeginGetMultiplePagesLro(ctx context.Context, options
 			return client.getMultiplePagesLroHandleError(resp)
 		},
 		respHandler: func(resp *azcore.Response) (ProductResultResponse, error) {
-			result := ProductResultResponse{RawResponse: resp.Response}
-			err := resp.UnmarshalAsJSON(&result.ProductResult)
-			return result, err
+			var val *ProductResult
+			if err := resp.UnmarshalAsJSON(&val); err != nil {
+				return ProductResultResponse{}, err
+			}
+			return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 		},
 		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
 		pipeline:    client.con.Pipeline(),
@@ -377,9 +389,11 @@ func (client PagingClient) getMultiplePagesLroCreateRequest(ctx context.Context,
 
 // getMultiplePagesLroHandleResponse handles the GetMultiplePagesLro response.
 func (client PagingClient) getMultiplePagesLroHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesLroHandleError handles the GetMultiplePagesLro error response.
@@ -425,9 +439,11 @@ func (client PagingClient) getMultiplePagesRetryFirstCreateRequest(ctx context.C
 
 // getMultiplePagesRetryFirstHandleResponse handles the GetMultiplePagesRetryFirst response.
 func (client PagingClient) getMultiplePagesRetryFirstHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesRetryFirstHandleError handles the GetMultiplePagesRetryFirst error response.
@@ -473,9 +489,11 @@ func (client PagingClient) getMultiplePagesRetrySecondCreateRequest(ctx context.
 
 // getMultiplePagesRetrySecondHandleResponse handles the GetMultiplePagesRetrySecond response.
 func (client PagingClient) getMultiplePagesRetrySecondHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesRetrySecondHandleError handles the GetMultiplePagesRetrySecond error response.
@@ -530,9 +548,11 @@ func (client PagingClient) getMultiplePagesWithOffsetCreateRequest(ctx context.C
 
 // getMultiplePagesWithOffsetHandleResponse handles the GetMultiplePagesWithOffset response.
 func (client PagingClient) getMultiplePagesWithOffsetHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getMultiplePagesWithOffsetHandleError handles the GetMultiplePagesWithOffset error response.
@@ -577,9 +597,11 @@ func (client PagingClient) getNoItemNamePagesCreateRequest(ctx context.Context, 
 
 // getNoItemNamePagesHandleResponse handles the GetNoItemNamePages response.
 func (client PagingClient) getNoItemNamePagesHandleResponse(resp *azcore.Response) (ProductResultValueResponse, error) {
-	result := ProductResultValueResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResultValue)
-	return result, err
+	var val *ProductResultValue
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultValueResponse{}, err
+	}
+	return ProductResultValueResponse{RawResponse: resp.Response, ProductResultValue: val}, nil
 }
 
 // getNoItemNamePagesHandleError handles the GetNoItemNamePages error response.
@@ -607,11 +629,7 @@ func (client PagingClient) GetNullNextLinkNamePages(ctx context.Context, options
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductResultResponse{}, client.getNullNextLinkNamePagesHandleError(resp)
 	}
-	result, err := client.getNullNextLinkNamePagesHandleResponse(resp)
-	if err != nil {
-		return ProductResultResponse{}, err
-	}
-	return result, nil
+	return client.getNullNextLinkNamePagesHandleResponse(resp)
 }
 
 // getNullNextLinkNamePagesCreateRequest creates the GetNullNextLinkNamePages request.
@@ -628,9 +646,11 @@ func (client PagingClient) getNullNextLinkNamePagesCreateRequest(ctx context.Con
 
 // getNullNextLinkNamePagesHandleResponse handles the GetNullNextLinkNamePages response.
 func (client PagingClient) getNullNextLinkNamePagesHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getNullNextLinkNamePagesHandleError handles the GetNullNextLinkNamePages error response.
@@ -684,9 +704,11 @@ func (client PagingClient) getOdataMultiplePagesCreateRequest(ctx context.Contex
 
 // getOdataMultiplePagesHandleResponse handles the GetOdataMultiplePages response.
 func (client PagingClient) getOdataMultiplePagesHandleResponse(resp *azcore.Response) (OdataProductResultResponse, error) {
-	result := OdataProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OdataProductResult)
-	return result, err
+	var val *OdataProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OdataProductResultResponse{}, err
+	}
+	return OdataProductResultResponse{RawResponse: resp.Response, OdataProductResult: val}, nil
 }
 
 // getOdataMultiplePagesHandleError handles the GetOdataMultiplePages error response.
@@ -731,9 +753,11 @@ func (client PagingClient) getPagingModelWithItemNameWithXmsClientNameCreateRequ
 
 // getPagingModelWithItemNameWithXmsClientNameHandleResponse handles the GetPagingModelWithItemNameWithXmsClientName response.
 func (client PagingClient) getPagingModelWithItemNameWithXmsClientNameHandleResponse(resp *azcore.Response) (ProductResultValueWithXmsClientNameResponse, error) {
-	result := ProductResultValueWithXmsClientNameResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResultValueWithXmsClientName)
-	return result, err
+	var val *ProductResultValueWithXmsClientName
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultValueWithXmsClientNameResponse{}, err
+	}
+	return ProductResultValueWithXmsClientNameResponse{RawResponse: resp.Response, ProductResultValueWithXmsClientName: val}, nil
 }
 
 // getPagingModelWithItemNameWithXmsClientNameHandleError handles the GetPagingModelWithItemNameWithXmsClientName error response.
@@ -778,9 +802,11 @@ func (client PagingClient) getSinglePagesCreateRequest(ctx context.Context, opti
 
 // getSinglePagesHandleResponse handles the GetSinglePages response.
 func (client PagingClient) getSinglePagesHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getSinglePagesHandleError handles the GetSinglePages error response.
@@ -825,9 +851,11 @@ func (client PagingClient) getSinglePagesFailureCreateRequest(ctx context.Contex
 
 // getSinglePagesFailureHandleResponse handles the GetSinglePagesFailure response.
 func (client PagingClient) getSinglePagesFailureHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getSinglePagesFailureHandleError handles the GetSinglePagesFailure error response.
@@ -877,9 +905,11 @@ func (client PagingClient) getWithQueryParamsCreateRequest(ctx context.Context, 
 
 // getWithQueryParamsHandleResponse handles the GetWithQueryParams response.
 func (client PagingClient) getWithQueryParamsHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // getWithQueryParamsHandleError handles the GetWithQueryParams error response.
@@ -913,9 +943,11 @@ func (client PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVer
 
 // nextFragmentHandleResponse handles the NextFragment response.
 func (client PagingClient) nextFragmentHandleResponse(resp *azcore.Response) (OdataProductResultResponse, error) {
-	result := OdataProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OdataProductResult)
-	return result, err
+	var val *OdataProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OdataProductResultResponse{}, err
+	}
+	return OdataProductResultResponse{RawResponse: resp.Response, OdataProductResult: val}, nil
 }
 
 // nextFragmentHandleError handles the NextFragment error response.
@@ -949,9 +981,11 @@ func (client PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Con
 
 // nextFragmentWithGroupingHandleResponse handles the NextFragmentWithGrouping response.
 func (client PagingClient) nextFragmentWithGroupingHandleResponse(resp *azcore.Response) (OdataProductResultResponse, error) {
-	result := OdataProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OdataProductResult)
-	return result, err
+	var val *OdataProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OdataProductResultResponse{}, err
+	}
+	return OdataProductResultResponse{RawResponse: resp.Response, OdataProductResult: val}, nil
 }
 
 // nextFragmentWithGroupingHandleError handles the NextFragmentWithGrouping error response.
@@ -983,9 +1017,11 @@ func (client PagingClient) nextOperationWithQueryParamsCreateRequest(ctx context
 
 // nextOperationWithQueryParamsHandleResponse handles the NextOperationWithQueryParams response.
 func (client PagingClient) nextOperationWithQueryParamsHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	result := ProductResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProductResult)
-	return result, err
+	var val *ProductResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResultResponse{}, err
+	}
+	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
 }
 
 // nextOperationWithQueryParamsHandleError handles the NextOperationWithQueryParams error response.

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -42,11 +42,7 @@ func (client AutoRestReportServiceClient) GetOptionalReport(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getOptionalReportHandleError(resp)
 	}
-	result, err := client.getOptionalReportHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getOptionalReportHandleResponse(resp)
 }
 
 // getOptionalReportCreateRequest creates the GetOptionalReport request.
@@ -68,9 +64,11 @@ func (client AutoRestReportServiceClient) getOptionalReportCreateRequest(ctx con
 
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client AutoRestReportServiceClient) getOptionalReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getOptionalReportHandleError handles the GetOptionalReport error response.
@@ -95,11 +93,7 @@ func (client AutoRestReportServiceClient) GetReport(ctx context.Context, options
 	if !resp.HasStatusCode(http.StatusOK) {
 		return MapOfInt32Response{}, client.getReportHandleError(resp)
 	}
-	result, err := client.getReportHandleResponse(resp)
-	if err != nil {
-		return MapOfInt32Response{}, err
-	}
-	return result, nil
+	return client.getReportHandleResponse(resp)
 }
 
 // getReportCreateRequest creates the GetReport request.
@@ -121,9 +115,11 @@ func (client AutoRestReportServiceClient) getReportCreateRequest(ctx context.Con
 
 // getReportHandleResponse handles the GetReport response.
 func (client AutoRestReportServiceClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	result := MapOfInt32Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *map[string]int32
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return MapOfInt32Response{}, err
+	}
+	return MapOfInt32Response{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getReportHandleError handles the GetReport error response.

--- a/test/autorest/stringgroup/zz_generated_enum.go
+++ b/test/autorest/stringgroup/zz_generated_enum.go
@@ -42,11 +42,7 @@ func (client EnumClient) GetNotExpandable(ctx context.Context, options *EnumGetN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ColorsResponse{}, client.getNotExpandableHandleError(resp)
 	}
-	result, err := client.getNotExpandableHandleResponse(resp)
-	if err != nil {
-		return ColorsResponse{}, err
-	}
-	return result, nil
+	return client.getNotExpandableHandleResponse(resp)
 }
 
 // getNotExpandableCreateRequest creates the GetNotExpandable request.
@@ -63,9 +59,11 @@ func (client EnumClient) getNotExpandableCreateRequest(ctx context.Context, opti
 
 // getNotExpandableHandleResponse handles the GetNotExpandable response.
 func (client EnumClient) getNotExpandableHandleResponse(resp *azcore.Response) (ColorsResponse, error) {
-	result := ColorsResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *Colors
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ColorsResponse{}, err
+	}
+	return ColorsResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNotExpandableHandleError handles the GetNotExpandable error response.
@@ -90,11 +88,7 @@ func (client EnumClient) GetReferenced(ctx context.Context, options *EnumGetRefe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ColorsResponse{}, client.getReferencedHandleError(resp)
 	}
-	result, err := client.getReferencedHandleResponse(resp)
-	if err != nil {
-		return ColorsResponse{}, err
-	}
-	return result, nil
+	return client.getReferencedHandleResponse(resp)
 }
 
 // getReferencedCreateRequest creates the GetReferenced request.
@@ -111,9 +105,11 @@ func (client EnumClient) getReferencedCreateRequest(ctx context.Context, options
 
 // getReferencedHandleResponse handles the GetReferenced response.
 func (client EnumClient) getReferencedHandleResponse(resp *azcore.Response) (ColorsResponse, error) {
-	result := ColorsResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *Colors
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ColorsResponse{}, err
+	}
+	return ColorsResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getReferencedHandleError handles the GetReferenced error response.
@@ -138,11 +134,7 @@ func (client EnumClient) GetReferencedConstant(ctx context.Context, options *Enu
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RefColorConstantResponse{}, client.getReferencedConstantHandleError(resp)
 	}
-	result, err := client.getReferencedConstantHandleResponse(resp)
-	if err != nil {
-		return RefColorConstantResponse{}, err
-	}
-	return result, nil
+	return client.getReferencedConstantHandleResponse(resp)
 }
 
 // getReferencedConstantCreateRequest creates the GetReferencedConstant request.
@@ -159,9 +151,11 @@ func (client EnumClient) getReferencedConstantCreateRequest(ctx context.Context,
 
 // getReferencedConstantHandleResponse handles the GetReferencedConstant response.
 func (client EnumClient) getReferencedConstantHandleResponse(resp *azcore.Response) (RefColorConstantResponse, error) {
-	result := RefColorConstantResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RefColorConstant)
-	return result, err
+	var val *RefColorConstant
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RefColorConstantResponse{}, err
+	}
+	return RefColorConstantResponse{RawResponse: resp.Response, RefColorConstant: val}, nil
 }
 
 // getReferencedConstantHandleError handles the GetReferencedConstant error response.

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -42,11 +42,7 @@ func (client StringClient) GetBase64Encoded(ctx context.Context, options *String
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getBase64EncodedHandleError(resp)
 	}
-	result, err := client.getBase64EncodedHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBase64EncodedHandleResponse(resp)
 }
 
 // getBase64EncodedCreateRequest creates the GetBase64Encoded request.
@@ -63,9 +59,11 @@ func (client StringClient) getBase64EncodedCreateRequest(ctx context.Context, op
 
 // getBase64EncodedHandleResponse handles the GetBase64Encoded response.
 func (client StringClient) getBase64EncodedHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64StdFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64StdFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBase64EncodedHandleError handles the GetBase64Encoded error response.
@@ -90,11 +88,7 @@ func (client StringClient) GetBase64URLEncoded(ctx context.Context, options *Str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getBase64UrlEncodedHandleError(resp)
 	}
-	result, err := client.getBase64UrlEncodedHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getBase64UrlEncodedHandleResponse(resp)
 }
 
 // getBase64UrlEncodedCreateRequest creates the GetBase64URLEncoded request.
@@ -111,9 +105,11 @@ func (client StringClient) getBase64UrlEncodedCreateRequest(ctx context.Context,
 
 // getBase64UrlEncodedHandleResponse handles the GetBase64URLEncoded response.
 func (client StringClient) getBase64UrlEncodedHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64URLFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64URLFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getBase64UrlEncodedHandleError handles the GetBase64URLEncoded error response.
@@ -138,11 +134,7 @@ func (client StringClient) GetEmpty(ctx context.Context, options *StringGetEmpty
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getEmptyHandleError(resp)
 	}
-	result, err := client.getEmptyHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyHandleResponse(resp)
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
@@ -159,9 +151,11 @@ func (client StringClient) getEmptyCreateRequest(ctx context.Context, options *S
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client StringClient) getEmptyHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getEmptyHandleError handles the GetEmpty error response.
@@ -186,11 +180,7 @@ func (client StringClient) GetMBCS(ctx context.Context, options *StringGetMBCSOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getMbcsHandleError(resp)
 	}
-	result, err := client.getMbcsHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getMbcsHandleResponse(resp)
 }
 
 // getMbcsCreateRequest creates the GetMBCS request.
@@ -207,9 +197,11 @@ func (client StringClient) getMbcsCreateRequest(ctx context.Context, options *St
 
 // getMbcsHandleResponse handles the GetMBCS response.
 func (client StringClient) getMbcsHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getMbcsHandleError handles the GetMBCS error response.
@@ -234,11 +226,7 @@ func (client StringClient) GetNotProvided(ctx context.Context, options *StringGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getNotProvidedHandleError(resp)
 	}
-	result, err := client.getNotProvidedHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getNotProvidedHandleResponse(resp)
 }
 
 // getNotProvidedCreateRequest creates the GetNotProvided request.
@@ -255,9 +243,11 @@ func (client StringClient) getNotProvidedCreateRequest(ctx context.Context, opti
 
 // getNotProvidedHandleResponse handles the GetNotProvided response.
 func (client StringClient) getNotProvidedHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNotProvidedHandleError handles the GetNotProvided error response.
@@ -282,11 +272,7 @@ func (client StringClient) GetNull(ctx context.Context, options *StringGetNullOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getNullHandleError(resp)
 	}
-	result, err := client.getNullHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getNullHandleResponse(resp)
 }
 
 // getNullCreateRequest creates the GetNull request.
@@ -303,9 +289,11 @@ func (client StringClient) getNullCreateRequest(ctx context.Context, options *St
 
 // getNullHandleResponse handles the GetNull response.
 func (client StringClient) getNullHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullHandleError handles the GetNull error response.
@@ -330,11 +318,7 @@ func (client StringClient) GetNullBase64URLEncoded(ctx context.Context, options 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ByteArrayResponse{}, client.getNullBase64UrlEncodedHandleError(resp)
 	}
-	result, err := client.getNullBase64UrlEncodedHandleResponse(resp)
-	if err != nil {
-		return ByteArrayResponse{}, err
-	}
-	return result, nil
+	return client.getNullBase64UrlEncodedHandleResponse(resp)
 }
 
 // getNullBase64UrlEncodedCreateRequest creates the GetNullBase64URLEncoded request.
@@ -351,9 +335,11 @@ func (client StringClient) getNullBase64UrlEncodedCreateRequest(ctx context.Cont
 
 // getNullBase64UrlEncodedHandleResponse handles the GetNullBase64URLEncoded response.
 func (client StringClient) getNullBase64UrlEncodedHandleResponse(resp *azcore.Response) (ByteArrayResponse, error) {
-	result := ByteArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsByteArray(&result.Value, azcore.Base64URLFormat)
-	return result, err
+	var val *[]byte
+	if err := resp.UnmarshalAsByteArray(&val, azcore.Base64URLFormat); err != nil {
+		return ByteArrayResponse{}, err
+	}
+	return ByteArrayResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getNullBase64UrlEncodedHandleError handles the GetNullBase64URLEncoded error response.
@@ -378,11 +364,7 @@ func (client StringClient) GetWhitespace(ctx context.Context, options *StringGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.getWhitespaceHandleError(resp)
 	}
-	result, err := client.getWhitespaceHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.getWhitespaceHandleResponse(resp)
 }
 
 // getWhitespaceCreateRequest creates the GetWhitespace request.
@@ -399,9 +381,11 @@ func (client StringClient) getWhitespaceCreateRequest(ctx context.Context, optio
 
 // getWhitespaceHandleResponse handles the GetWhitespace response.
 func (client StringClient) getWhitespaceHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getWhitespaceHandleError handles the GetWhitespace error response.

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -87,11 +87,7 @@ func (client AutoRestValidationTestClient) PostWithConstantInBody(ctx context.Co
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductResponse{}, client.postWithConstantInBodyHandleError(resp)
 	}
-	result, err := client.postWithConstantInBodyHandleResponse(resp)
-	if err != nil {
-		return ProductResponse{}, err
-	}
-	return result, nil
+	return client.postWithConstantInBodyHandleResponse(resp)
 }
 
 // postWithConstantInBodyCreateRequest creates the PostWithConstantInBody request.
@@ -112,9 +108,11 @@ func (client AutoRestValidationTestClient) postWithConstantInBodyCreateRequest(c
 
 // postWithConstantInBodyHandleResponse handles the PostWithConstantInBody response.
 func (client AutoRestValidationTestClient) postWithConstantInBodyHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postWithConstantInBodyHandleError handles the PostWithConstantInBody error response.
@@ -142,11 +140,7 @@ func (client AutoRestValidationTestClient) ValidationOfBody(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductResponse{}, client.validationOfBodyHandleError(resp)
 	}
-	result, err := client.validationOfBodyHandleResponse(resp)
-	if err != nil {
-		return ProductResponse{}, err
-	}
-	return result, nil
+	return client.validationOfBodyHandleResponse(resp)
 }
 
 // validationOfBodyCreateRequest creates the ValidationOfBody request.
@@ -172,9 +166,11 @@ func (client AutoRestValidationTestClient) validationOfBodyCreateRequest(ctx con
 
 // validationOfBodyHandleResponse handles the ValidationOfBody response.
 func (client AutoRestValidationTestClient) validationOfBodyHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // validationOfBodyHandleError handles the ValidationOfBody error response.
@@ -199,11 +195,7 @@ func (client AutoRestValidationTestClient) ValidationOfMethodParameters(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProductResponse{}, client.validationOfMethodParametersHandleError(resp)
 	}
-	result, err := client.validationOfMethodParametersHandleResponse(resp)
-	if err != nil {
-		return ProductResponse{}, err
-	}
-	return result, nil
+	return client.validationOfMethodParametersHandleResponse(resp)
 }
 
 // validationOfMethodParametersCreateRequest creates the ValidationOfMethodParameters request.
@@ -226,9 +218,11 @@ func (client AutoRestValidationTestClient) validationOfMethodParametersCreateReq
 
 // validationOfMethodParametersHandleResponse handles the ValidationOfMethodParameters response.
 func (client AutoRestValidationTestClient) validationOfMethodParametersHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	result := ProductResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Product)
-	return result, err
+	var val *Product
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProductResponse{}, err
+	}
+	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // validationOfMethodParametersHandleError handles the ValidationOfMethodParameters error response.

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -46,11 +46,7 @@ func (client XMLClient) GetACLs(ctx context.Context, options *XMLGetACLsOptions)
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SignedIDentifierArrayResponse{}, client.getAcLsHandleError(resp)
 	}
-	result, err := client.getAcLsHandleResponse(resp)
-	if err != nil {
-		return SignedIDentifierArrayResponse{}, err
-	}
-	return result, nil
+	return client.getAcLsHandleResponse(resp)
 }
 
 // getAcLsCreateRequest creates the GetACLs request.
@@ -72,8 +68,10 @@ func (client XMLClient) getAcLsCreateRequest(ctx context.Context, options *XMLGe
 // getAcLsHandleResponse handles the GetACLs response.
 func (client XMLClient) getAcLsHandleResponse(resp *azcore.Response) (SignedIDentifierArrayResponse, error) {
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result)
-	return result, err
+	if err := resp.UnmarshalAsXML(&result); err != nil {
+		return SignedIDentifierArrayResponse{}, err
+	}
+	return result, nil
 }
 
 // getAcLsHandleError handles the GetACLs error response.
@@ -101,11 +99,7 @@ func (client XMLClient) GetComplexTypeRefNoMeta(ctx context.Context, options *XM
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RootWithRefAndNoMetaResponse{}, client.getComplexTypeRefNoMetaHandleError(resp)
 	}
-	result, err := client.getComplexTypeRefNoMetaHandleResponse(resp)
-	if err != nil {
-		return RootWithRefAndNoMetaResponse{}, err
-	}
-	return result, nil
+	return client.getComplexTypeRefNoMetaHandleResponse(resp)
 }
 
 // getComplexTypeRefNoMetaCreateRequest creates the GetComplexTypeRefNoMeta request.
@@ -122,9 +116,11 @@ func (client XMLClient) getComplexTypeRefNoMetaCreateRequest(ctx context.Context
 
 // getComplexTypeRefNoMetaHandleResponse handles the GetComplexTypeRefNoMeta response.
 func (client XMLClient) getComplexTypeRefNoMetaHandleResponse(resp *azcore.Response) (RootWithRefAndNoMetaResponse, error) {
-	result := RootWithRefAndNoMetaResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.RootWithRefAndNoMeta)
-	return result, err
+	var val *RootWithRefAndNoMeta
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return RootWithRefAndNoMetaResponse{}, err
+	}
+	return RootWithRefAndNoMetaResponse{RawResponse: resp.Response, RootWithRefAndNoMeta: val}, nil
 }
 
 // getComplexTypeRefNoMetaHandleError handles the GetComplexTypeRefNoMeta error response.
@@ -152,11 +148,7 @@ func (client XMLClient) GetComplexTypeRefWithMeta(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RootWithRefAndMetaResponse{}, client.getComplexTypeRefWithMetaHandleError(resp)
 	}
-	result, err := client.getComplexTypeRefWithMetaHandleResponse(resp)
-	if err != nil {
-		return RootWithRefAndMetaResponse{}, err
-	}
-	return result, nil
+	return client.getComplexTypeRefWithMetaHandleResponse(resp)
 }
 
 // getComplexTypeRefWithMetaCreateRequest creates the GetComplexTypeRefWithMeta request.
@@ -173,9 +165,11 @@ func (client XMLClient) getComplexTypeRefWithMetaCreateRequest(ctx context.Conte
 
 // getComplexTypeRefWithMetaHandleResponse handles the GetComplexTypeRefWithMeta response.
 func (client XMLClient) getComplexTypeRefWithMetaHandleResponse(resp *azcore.Response) (RootWithRefAndMetaResponse, error) {
-	result := RootWithRefAndMetaResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.RootWithRefAndMeta)
-	return result, err
+	var val *RootWithRefAndMeta
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return RootWithRefAndMetaResponse{}, err
+	}
+	return RootWithRefAndMetaResponse{RawResponse: resp.Response, RootWithRefAndMeta: val}, nil
 }
 
 // getComplexTypeRefWithMetaHandleError handles the GetComplexTypeRefWithMeta error response.
@@ -203,11 +197,7 @@ func (client XMLClient) GetEmptyChildElement(ctx context.Context, options *XMLGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BananaResponse{}, client.getEmptyChildElementHandleError(resp)
 	}
-	result, err := client.getEmptyChildElementHandleResponse(resp)
-	if err != nil {
-		return BananaResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyChildElementHandleResponse(resp)
 }
 
 // getEmptyChildElementCreateRequest creates the GetEmptyChildElement request.
@@ -224,9 +214,11 @@ func (client XMLClient) getEmptyChildElementCreateRequest(ctx context.Context, o
 
 // getEmptyChildElementHandleResponse handles the GetEmptyChildElement response.
 func (client XMLClient) getEmptyChildElementHandleResponse(resp *azcore.Response) (BananaResponse, error) {
-	result := BananaResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.Banana)
-	return result, err
+	var val *Banana
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return BananaResponse{}, err
+	}
+	return BananaResponse{RawResponse: resp.Response, Banana: val}, nil
 }
 
 // getEmptyChildElementHandleError handles the GetEmptyChildElement error response.
@@ -254,11 +246,7 @@ func (client XMLClient) GetEmptyList(ctx context.Context, options *XMLGetEmptyLi
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SlideshowResponse{}, client.getEmptyListHandleError(resp)
 	}
-	result, err := client.getEmptyListHandleResponse(resp)
-	if err != nil {
-		return SlideshowResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyListHandleResponse(resp)
 }
 
 // getEmptyListCreateRequest creates the GetEmptyList request.
@@ -275,9 +263,11 @@ func (client XMLClient) getEmptyListCreateRequest(ctx context.Context, options *
 
 // getEmptyListHandleResponse handles the GetEmptyList response.
 func (client XMLClient) getEmptyListHandleResponse(resp *azcore.Response) (SlideshowResponse, error) {
-	result := SlideshowResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.Slideshow)
-	return result, err
+	var val *Slideshow
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return SlideshowResponse{}, err
+	}
+	return SlideshowResponse{RawResponse: resp.Response, Slideshow: val}, nil
 }
 
 // getEmptyListHandleError handles the GetEmptyList error response.
@@ -305,11 +295,7 @@ func (client XMLClient) GetEmptyRootList(ctx context.Context, options *XMLGetEmp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BananaArrayResponse{}, client.getEmptyRootListHandleError(resp)
 	}
-	result, err := client.getEmptyRootListHandleResponse(resp)
-	if err != nil {
-		return BananaArrayResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyRootListHandleResponse(resp)
 }
 
 // getEmptyRootListCreateRequest creates the GetEmptyRootList request.
@@ -327,8 +313,10 @@ func (client XMLClient) getEmptyRootListCreateRequest(ctx context.Context, optio
 // getEmptyRootListHandleResponse handles the GetEmptyRootList response.
 func (client XMLClient) getEmptyRootListHandleResponse(resp *azcore.Response) (BananaArrayResponse, error) {
 	result := BananaArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result)
-	return result, err
+	if err := resp.UnmarshalAsXML(&result); err != nil {
+		return BananaArrayResponse{}, err
+	}
+	return result, nil
 }
 
 // getEmptyRootListHandleError handles the GetEmptyRootList error response.
@@ -356,11 +344,7 @@ func (client XMLClient) GetEmptyWrappedLists(ctx context.Context, options *XMLGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AppleBarrelResponse{}, client.getEmptyWrappedListsHandleError(resp)
 	}
-	result, err := client.getEmptyWrappedListsHandleResponse(resp)
-	if err != nil {
-		return AppleBarrelResponse{}, err
-	}
-	return result, nil
+	return client.getEmptyWrappedListsHandleResponse(resp)
 }
 
 // getEmptyWrappedListsCreateRequest creates the GetEmptyWrappedLists request.
@@ -377,9 +361,11 @@ func (client XMLClient) getEmptyWrappedListsCreateRequest(ctx context.Context, o
 
 // getEmptyWrappedListsHandleResponse handles the GetEmptyWrappedLists response.
 func (client XMLClient) getEmptyWrappedListsHandleResponse(resp *azcore.Response) (AppleBarrelResponse, error) {
-	result := AppleBarrelResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.AppleBarrel)
-	return result, err
+	var val *AppleBarrel
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return AppleBarrelResponse{}, err
+	}
+	return AppleBarrelResponse{RawResponse: resp.Response, AppleBarrel: val}, nil
 }
 
 // getEmptyWrappedListsHandleError handles the GetEmptyWrappedLists error response.
@@ -407,11 +393,7 @@ func (client XMLClient) GetHeaders(ctx context.Context, options *XMLGetHeadersOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return XMLGetHeadersResponse{}, client.getHeadersHandleError(resp)
 	}
-	result, err := client.getHeadersHandleResponse(resp)
-	if err != nil {
-		return XMLGetHeadersResponse{}, err
-	}
-	return result, nil
+	return client.getHeadersHandleResponse(resp)
 }
 
 // getHeadersCreateRequest creates the GetHeaders request.
@@ -459,11 +441,7 @@ func (client XMLClient) GetRootList(ctx context.Context, options *XMLGetRootList
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BananaArrayResponse{}, client.getRootListHandleError(resp)
 	}
-	result, err := client.getRootListHandleResponse(resp)
-	if err != nil {
-		return BananaArrayResponse{}, err
-	}
-	return result, nil
+	return client.getRootListHandleResponse(resp)
 }
 
 // getRootListCreateRequest creates the GetRootList request.
@@ -481,8 +459,10 @@ func (client XMLClient) getRootListCreateRequest(ctx context.Context, options *X
 // getRootListHandleResponse handles the GetRootList response.
 func (client XMLClient) getRootListHandleResponse(resp *azcore.Response) (BananaArrayResponse, error) {
 	result := BananaArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result)
-	return result, err
+	if err := resp.UnmarshalAsXML(&result); err != nil {
+		return BananaArrayResponse{}, err
+	}
+	return result, nil
 }
 
 // getRootListHandleError handles the GetRootList error response.
@@ -510,11 +490,7 @@ func (client XMLClient) GetRootListSingleItem(ctx context.Context, options *XMLG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BananaArrayResponse{}, client.getRootListSingleItemHandleError(resp)
 	}
-	result, err := client.getRootListSingleItemHandleResponse(resp)
-	if err != nil {
-		return BananaArrayResponse{}, err
-	}
-	return result, nil
+	return client.getRootListSingleItemHandleResponse(resp)
 }
 
 // getRootListSingleItemCreateRequest creates the GetRootListSingleItem request.
@@ -532,8 +508,10 @@ func (client XMLClient) getRootListSingleItemCreateRequest(ctx context.Context, 
 // getRootListSingleItemHandleResponse handles the GetRootListSingleItem response.
 func (client XMLClient) getRootListSingleItemHandleResponse(resp *azcore.Response) (BananaArrayResponse, error) {
 	result := BananaArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result)
-	return result, err
+	if err := resp.UnmarshalAsXML(&result); err != nil {
+		return BananaArrayResponse{}, err
+	}
+	return result, nil
 }
 
 // getRootListSingleItemHandleError handles the GetRootListSingleItem error response.
@@ -561,11 +539,7 @@ func (client XMLClient) GetServiceProperties(ctx context.Context, options *XMLGe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StorageServicePropertiesResponse{}, client.getServicePropertiesHandleError(resp)
 	}
-	result, err := client.getServicePropertiesHandleResponse(resp)
-	if err != nil {
-		return StorageServicePropertiesResponse{}, err
-	}
-	return result, nil
+	return client.getServicePropertiesHandleResponse(resp)
 }
 
 // getServicePropertiesCreateRequest creates the GetServiceProperties request.
@@ -586,9 +560,11 @@ func (client XMLClient) getServicePropertiesCreateRequest(ctx context.Context, o
 
 // getServicePropertiesHandleResponse handles the GetServiceProperties response.
 func (client XMLClient) getServicePropertiesHandleResponse(resp *azcore.Response) (StorageServicePropertiesResponse, error) {
-	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.StorageServiceProperties)
-	return result, err
+	var val *StorageServiceProperties
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return StorageServicePropertiesResponse{}, err
+	}
+	return StorageServicePropertiesResponse{RawResponse: resp.Response, StorageServiceProperties: val}, nil
 }
 
 // getServicePropertiesHandleError handles the GetServiceProperties error response.
@@ -616,11 +592,7 @@ func (client XMLClient) GetSimple(ctx context.Context, options *XMLGetSimpleOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SlideshowResponse{}, client.getSimpleHandleError(resp)
 	}
-	result, err := client.getSimpleHandleResponse(resp)
-	if err != nil {
-		return SlideshowResponse{}, err
-	}
-	return result, nil
+	return client.getSimpleHandleResponse(resp)
 }
 
 // getSimpleCreateRequest creates the GetSimple request.
@@ -637,9 +609,11 @@ func (client XMLClient) getSimpleCreateRequest(ctx context.Context, options *XML
 
 // getSimpleHandleResponse handles the GetSimple response.
 func (client XMLClient) getSimpleHandleResponse(resp *azcore.Response) (SlideshowResponse, error) {
-	result := SlideshowResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.Slideshow)
-	return result, err
+	var val *Slideshow
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return SlideshowResponse{}, err
+	}
+	return SlideshowResponse{RawResponse: resp.Response, Slideshow: val}, nil
 }
 
 // getSimpleHandleError handles the GetSimple error response.
@@ -664,11 +638,7 @@ func (client XMLClient) GetWrappedLists(ctx context.Context, options *XMLGetWrap
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AppleBarrelResponse{}, client.getWrappedListsHandleError(resp)
 	}
-	result, err := client.getWrappedListsHandleResponse(resp)
-	if err != nil {
-		return AppleBarrelResponse{}, err
-	}
-	return result, nil
+	return client.getWrappedListsHandleResponse(resp)
 }
 
 // getWrappedListsCreateRequest creates the GetWrappedLists request.
@@ -685,9 +655,11 @@ func (client XMLClient) getWrappedListsCreateRequest(ctx context.Context, option
 
 // getWrappedListsHandleResponse handles the GetWrappedLists response.
 func (client XMLClient) getWrappedListsHandleResponse(resp *azcore.Response) (AppleBarrelResponse, error) {
-	result := AppleBarrelResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.AppleBarrel)
-	return result, err
+	var val *AppleBarrel
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return AppleBarrelResponse{}, err
+	}
+	return AppleBarrelResponse{RawResponse: resp.Response, AppleBarrel: val}, nil
 }
 
 // getWrappedListsHandleError handles the GetWrappedLists error response.
@@ -716,11 +688,7 @@ func (client XMLClient) GetXMSText(ctx context.Context, options *XMLGetXMSTextOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ObjectWithXMSTextPropertyResponse{}, client.getXmsTextHandleError(resp)
 	}
-	result, err := client.getXmsTextHandleResponse(resp)
-	if err != nil {
-		return ObjectWithXMSTextPropertyResponse{}, err
-	}
-	return result, nil
+	return client.getXmsTextHandleResponse(resp)
 }
 
 // getXmsTextCreateRequest creates the GetXMSText request.
@@ -737,9 +705,11 @@ func (client XMLClient) getXmsTextCreateRequest(ctx context.Context, options *XM
 
 // getXmsTextHandleResponse handles the GetXMSText response.
 func (client XMLClient) getXmsTextHandleResponse(resp *azcore.Response) (ObjectWithXMSTextPropertyResponse, error) {
-	result := ObjectWithXMSTextPropertyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.Data)
-	return result, err
+	var val *ObjectWithXMSTextProperty
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ObjectWithXMSTextPropertyResponse{}, err
+	}
+	return ObjectWithXMSTextPropertyResponse{RawResponse: resp.Response, Data: val}, nil
 }
 
 // getXmsTextHandleError handles the GetXMSText error response.
@@ -806,11 +776,7 @@ func (client XMLClient) JSONOutput(ctx context.Context, options *XMLJSONOutputOp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return JSONOutputResponse{}, client.jsonOutputHandleError(resp)
 	}
-	result, err := client.jsonOutputHandleResponse(resp)
-	if err != nil {
-		return JSONOutputResponse{}, err
-	}
-	return result, nil
+	return client.jsonOutputHandleResponse(resp)
 }
 
 // jsonOutputCreateRequest creates the JSONOutput request.
@@ -827,9 +793,11 @@ func (client XMLClient) jsonOutputCreateRequest(ctx context.Context, options *XM
 
 // jsonOutputHandleResponse handles the JSONOutput response.
 func (client XMLClient) jsonOutputHandleResponse(resp *azcore.Response) (JSONOutputResponse, error) {
-	result := JSONOutputResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.JSONOutput)
-	return result, err
+	var val *JSONOutput
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return JSONOutputResponse{}, err
+	}
+	return JSONOutputResponse{RawResponse: resp.Response, JSONOutput: val}, nil
 }
 
 // jsonOutputHandleError handles the JSONOutput error response.
@@ -857,11 +825,7 @@ func (client XMLClient) ListBlobs(ctx context.Context, options *XMLListBlobsOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ListBlobsResponseResponse{}, client.listBlobsHandleError(resp)
 	}
-	result, err := client.listBlobsHandleResponse(resp)
-	if err != nil {
-		return ListBlobsResponseResponse{}, err
-	}
-	return result, nil
+	return client.listBlobsHandleResponse(resp)
 }
 
 // listBlobsCreateRequest creates the ListBlobs request.
@@ -882,9 +846,11 @@ func (client XMLClient) listBlobsCreateRequest(ctx context.Context, options *XML
 
 // listBlobsHandleResponse handles the ListBlobs response.
 func (client XMLClient) listBlobsHandleResponse(resp *azcore.Response) (ListBlobsResponseResponse, error) {
-	result := ListBlobsResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.EnumerationResults)
-	return result, err
+	var val *ListBlobsResponse
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ListBlobsResponseResponse{}, err
+	}
+	return ListBlobsResponseResponse{RawResponse: resp.Response, EnumerationResults: val}, nil
 }
 
 // listBlobsHandleError handles the ListBlobs error response.
@@ -912,11 +878,7 @@ func (client XMLClient) ListContainers(ctx context.Context, options *XMLListCont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ListContainersResponseResponse{}, client.listContainersHandleError(resp)
 	}
-	result, err := client.listContainersHandleResponse(resp)
-	if err != nil {
-		return ListContainersResponseResponse{}, err
-	}
-	return result, nil
+	return client.listContainersHandleResponse(resp)
 }
 
 // listContainersCreateRequest creates the ListContainers request.
@@ -936,9 +898,11 @@ func (client XMLClient) listContainersCreateRequest(ctx context.Context, options
 
 // listContainersHandleResponse handles the ListContainers response.
 func (client XMLClient) listContainersHandleResponse(resp *azcore.Response) (ListContainersResponseResponse, error) {
-	result := ListContainersResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsXML(&result.EnumerationResults)
-	return result, err
+	var val *ListContainersResponse
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ListContainersResponseResponse{}, err
+	}
+	return ListContainersResponseResponse{RawResponse: resp.Response, EnumerationResults: val}, nil
 }
 
 // listContainersHandleError handles the ListContainers error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets.go
@@ -49,11 +49,7 @@ func (client AvailabilitySetsClient) CreateOrUpdate(ctx context.Context, resourc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AvailabilitySetResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return AvailabilitySetResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -76,9 +72,11 @@ func (client AvailabilitySetsClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client AvailabilitySetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (AvailabilitySetResponse, error) {
-	result := AvailabilitySetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailabilitySet)
-	return result, err
+	var val *AvailabilitySet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailabilitySetResponse{}, err
+	}
+	return AvailabilitySetResponse{RawResponse: resp.Response, AvailabilitySet: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -151,11 +149,7 @@ func (client AvailabilitySetsClient) Get(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AvailabilitySetResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return AvailabilitySetResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -178,9 +172,11 @@ func (client AvailabilitySetsClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client AvailabilitySetsClient) getHandleResponse(resp *azcore.Response) (AvailabilitySetResponse, error) {
-	result := AvailabilitySetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailabilitySet)
-	return result, err
+	var val *AvailabilitySet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailabilitySetResponse{}, err
+	}
+	return AvailabilitySetResponse{RawResponse: resp.Response, AvailabilitySet: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -230,9 +226,11 @@ func (client AvailabilitySetsClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client AvailabilitySetsClient) listHandleResponse(resp *azcore.Response) (AvailabilitySetListResultResponse, error) {
-	result := AvailabilitySetListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailabilitySetListResult)
-	return result, err
+	var val *AvailabilitySetListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailabilitySetListResultResponse{}, err
+	}
+	return AvailabilitySetListResultResponse{RawResponse: resp.Response, AvailabilitySetListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -260,11 +258,7 @@ func (client AvailabilitySetsClient) ListAvailableSizes(ctx context.Context, res
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineSizeListResultResponse{}, client.listAvailableSizesHandleError(resp)
 	}
-	result, err := client.listAvailableSizesHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineSizeListResultResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableSizesHandleResponse(resp)
 }
 
 // listAvailableSizesCreateRequest creates the ListAvailableSizes request.
@@ -287,9 +281,11 @@ func (client AvailabilitySetsClient) listAvailableSizesCreateRequest(ctx context
 
 // listAvailableSizesHandleResponse handles the ListAvailableSizes response.
 func (client AvailabilitySetsClient) listAvailableSizesHandleResponse(resp *azcore.Response) (VirtualMachineSizeListResultResponse, error) {
-	result := VirtualMachineSizeListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineSizeListResult)
-	return result, err
+	var val *VirtualMachineSizeListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineSizeListResultResponse{}, err
+	}
+	return VirtualMachineSizeListResultResponse{RawResponse: resp.Response, VirtualMachineSizeListResult: val}, nil
 }
 
 // listAvailableSizesHandleError handles the ListAvailableSizes error response.
@@ -341,9 +337,11 @@ func (client AvailabilitySetsClient) listBySubscriptionCreateRequest(ctx context
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client AvailabilitySetsClient) listBySubscriptionHandleResponse(resp *azcore.Response) (AvailabilitySetListResultResponse, error) {
-	result := AvailabilitySetListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailabilitySetListResult)
-	return result, err
+	var val *AvailabilitySetListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailabilitySetListResultResponse{}, err
+	}
+	return AvailabilitySetListResultResponse{RawResponse: resp.Response, AvailabilitySetListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.
@@ -371,11 +369,7 @@ func (client AvailabilitySetsClient) Update(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AvailabilitySetResponse{}, client.updateHandleError(resp)
 	}
-	result, err := client.updateHandleResponse(resp)
-	if err != nil {
-		return AvailabilitySetResponse{}, err
-	}
-	return result, nil
+	return client.updateHandleResponse(resp)
 }
 
 // updateCreateRequest creates the Update request.
@@ -398,9 +392,11 @@ func (client AvailabilitySetsClient) updateCreateRequest(ctx context.Context, re
 
 // updateHandleResponse handles the Update response.
 func (client AvailabilitySetsClient) updateHandleResponse(resp *azcore.Response) (AvailabilitySetResponse, error) {
-	result := AvailabilitySetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailabilitySet)
-	return result, err
+	var val *AvailabilitySet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailabilitySetResponse{}, err
+	}
+	return AvailabilitySetResponse{RawResponse: resp.Response, AvailabilitySet: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices.go
@@ -110,9 +110,11 @@ func (client ContainerServicesClient) createOrUpdateCreateRequest(ctx context.Co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ContainerServicesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ContainerServiceResponse, error) {
-	result := ContainerServiceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ContainerService)
-	return result, err
+	var val *ContainerService
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ContainerServiceResponse{}, err
+	}
+	return ContainerServiceResponse{RawResponse: resp.Response, ContainerService: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -230,11 +232,7 @@ func (client ContainerServicesClient) Get(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerServiceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ContainerServiceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -257,9 +255,11 @@ func (client ContainerServicesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client ContainerServicesClient) getHandleResponse(resp *azcore.Response) (ContainerServiceResponse, error) {
-	result := ContainerServiceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ContainerService)
-	return result, err
+	var val *ContainerService
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ContainerServiceResponse{}, err
+	}
+	return ContainerServiceResponse{RawResponse: resp.Response, ContainerService: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -310,9 +310,11 @@ func (client ContainerServicesClient) listCreateRequest(ctx context.Context, opt
 
 // listHandleResponse handles the List response.
 func (client ContainerServicesClient) listHandleResponse(resp *azcore.Response) (ContainerServiceListResultResponse, error) {
-	result := ContainerServiceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ContainerServiceListResult)
-	return result, err
+	var val *ContainerServiceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ContainerServiceListResultResponse{}, err
+	}
+	return ContainerServiceListResultResponse{RawResponse: resp.Response, ContainerServiceListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -364,9 +366,11 @@ func (client ContainerServicesClient) listByResourceGroupCreateRequest(ctx conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ContainerServicesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ContainerServiceListResultResponse, error) {
-	result := ContainerServiceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ContainerServiceListResult)
-	return result, err
+	var val *ContainerServiceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ContainerServiceListResultResponse{}, err
+	}
+	return ContainerServiceListResultResponse{RawResponse: resp.Response, ContainerServiceListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups.go
@@ -50,11 +50,7 @@ func (client DedicatedHostGroupsClient) CreateOrUpdate(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return DedicatedHostGroupResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return DedicatedHostGroupResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -77,9 +73,11 @@ func (client DedicatedHostGroupsClient) createOrUpdateCreateRequest(ctx context.
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DedicatedHostGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (DedicatedHostGroupResponse, error) {
-	result := DedicatedHostGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostGroup)
-	return result, err
+	var val *DedicatedHostGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostGroupResponse{}, err
+	}
+	return DedicatedHostGroupResponse{RawResponse: resp.Response, DedicatedHostGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -152,11 +150,7 @@ func (client DedicatedHostGroupsClient) Get(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DedicatedHostGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DedicatedHostGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -179,9 +173,11 @@ func (client DedicatedHostGroupsClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client DedicatedHostGroupsClient) getHandleResponse(resp *azcore.Response) (DedicatedHostGroupResponse, error) {
-	result := DedicatedHostGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostGroup)
-	return result, err
+	var val *DedicatedHostGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostGroupResponse{}, err
+	}
+	return DedicatedHostGroupResponse{RawResponse: resp.Response, DedicatedHostGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -232,9 +228,11 @@ func (client DedicatedHostGroupsClient) listByResourceGroupCreateRequest(ctx con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client DedicatedHostGroupsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (DedicatedHostGroupListResultResponse, error) {
-	result := DedicatedHostGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostGroupListResult)
-	return result, err
+	var val *DedicatedHostGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostGroupListResultResponse{}, err
+	}
+	return DedicatedHostGroupListResultResponse{RawResponse: resp.Response, DedicatedHostGroupListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -284,9 +282,11 @@ func (client DedicatedHostGroupsClient) listBySubscriptionCreateRequest(ctx cont
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client DedicatedHostGroupsClient) listBySubscriptionHandleResponse(resp *azcore.Response) (DedicatedHostGroupListResultResponse, error) {
-	result := DedicatedHostGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostGroupListResult)
-	return result, err
+	var val *DedicatedHostGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostGroupListResultResponse{}, err
+	}
+	return DedicatedHostGroupListResultResponse{RawResponse: resp.Response, DedicatedHostGroupListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.
@@ -314,11 +314,7 @@ func (client DedicatedHostGroupsClient) Update(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DedicatedHostGroupResponse{}, client.updateHandleError(resp)
 	}
-	result, err := client.updateHandleResponse(resp)
-	if err != nil {
-		return DedicatedHostGroupResponse{}, err
-	}
-	return result, nil
+	return client.updateHandleResponse(resp)
 }
 
 // updateCreateRequest creates the Update request.
@@ -341,9 +337,11 @@ func (client DedicatedHostGroupsClient) updateCreateRequest(ctx context.Context,
 
 // updateHandleResponse handles the Update response.
 func (client DedicatedHostGroupsClient) updateHandleResponse(resp *azcore.Response) (DedicatedHostGroupResponse, error) {
-	result := DedicatedHostGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostGroup)
-	return result, err
+	var val *DedicatedHostGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostGroupResponse{}, err
+	}
+	return DedicatedHostGroupResponse{RawResponse: resp.Response, DedicatedHostGroup: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts.go
@@ -111,9 +111,11 @@ func (client DedicatedHostsClient) createOrUpdateCreateRequest(ctx context.Conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DedicatedHostsClient) createOrUpdateHandleResponse(resp *azcore.Response) (DedicatedHostResponse, error) {
-	result := DedicatedHostResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHost)
-	return result, err
+	var val *DedicatedHost
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostResponse{}, err
+	}
+	return DedicatedHostResponse{RawResponse: resp.Response, DedicatedHost: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -224,11 +226,7 @@ func (client DedicatedHostsClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DedicatedHostResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DedicatedHostResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -255,9 +253,11 @@ func (client DedicatedHostsClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client DedicatedHostsClient) getHandleResponse(resp *azcore.Response) (DedicatedHostResponse, error) {
-	result := DedicatedHostResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHost)
-	return result, err
+	var val *DedicatedHost
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostResponse{}, err
+	}
+	return DedicatedHostResponse{RawResponse: resp.Response, DedicatedHost: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -309,9 +309,11 @@ func (client DedicatedHostsClient) listByHostGroupCreateRequest(ctx context.Cont
 
 // listByHostGroupHandleResponse handles the ListByHostGroup response.
 func (client DedicatedHostsClient) listByHostGroupHandleResponse(resp *azcore.Response) (DedicatedHostListResultResponse, error) {
-	result := DedicatedHostListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHostListResult)
-	return result, err
+	var val *DedicatedHostListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostListResultResponse{}, err
+	}
+	return DedicatedHostListResultResponse{RawResponse: resp.Response, DedicatedHostListResult: val}, nil
 }
 
 // listByHostGroupHandleError handles the ListByHostGroup error response.
@@ -400,9 +402,11 @@ func (client DedicatedHostsClient) updateCreateRequest(ctx context.Context, reso
 
 // updateHandleResponse handles the Update response.
 func (client DedicatedHostsClient) updateHandleResponse(resp *azcore.Response) (DedicatedHostResponse, error) {
-	result := DedicatedHostResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DedicatedHost)
-	return result, err
+	var val *DedicatedHost
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DedicatedHostResponse{}, err
+	}
+	return DedicatedHostResponse{RawResponse: resp.Response, DedicatedHost: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets.go
@@ -107,9 +107,11 @@ func (client DiskEncryptionSetsClient) createOrUpdateCreateRequest(ctx context.C
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DiskEncryptionSetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (DiskEncryptionSetResponse, error) {
-	result := DiskEncryptionSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskEncryptionSet)
-	return result, err
+	var val *DiskEncryptionSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskEncryptionSetResponse{}, err
+	}
+	return DiskEncryptionSetResponse{RawResponse: resp.Response, DiskEncryptionSet: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client DiskEncryptionSetsClient) Get(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DiskEncryptionSetResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DiskEncryptionSetResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client DiskEncryptionSetsClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client DiskEncryptionSetsClient) getHandleResponse(resp *azcore.Response) (DiskEncryptionSetResponse, error) {
-	result := DiskEncryptionSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskEncryptionSet)
-	return result, err
+	var val *DiskEncryptionSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskEncryptionSetResponse{}, err
+	}
+	return DiskEncryptionSetResponse{RawResponse: resp.Response, DiskEncryptionSet: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client DiskEncryptionSetsClient) listCreateRequest(ctx context.Context, op
 
 // listHandleResponse handles the List response.
 func (client DiskEncryptionSetsClient) listHandleResponse(resp *azcore.Response) (DiskEncryptionSetListResponse, error) {
-	result := DiskEncryptionSetListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskEncryptionSetList)
-	return result, err
+	var val *DiskEncryptionSetList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskEncryptionSetListResponse{}, err
+	}
+	return DiskEncryptionSetListResponse{RawResponse: resp.Response, DiskEncryptionSetList: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client DiskEncryptionSetsClient) listByResourceGroupCreateRequest(ctx cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client DiskEncryptionSetsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (DiskEncryptionSetListResponse, error) {
-	result := DiskEncryptionSetListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskEncryptionSetList)
-	return result, err
+	var val *DiskEncryptionSetList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskEncryptionSetListResponse{}, err
+	}
+	return DiskEncryptionSetListResponse{RawResponse: resp.Response, DiskEncryptionSetList: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -425,9 +429,11 @@ func (client DiskEncryptionSetsClient) updateCreateRequest(ctx context.Context, 
 
 // updateHandleResponse handles the Update response.
 func (client DiskEncryptionSetsClient) updateHandleResponse(resp *azcore.Response) (DiskEncryptionSetResponse, error) {
-	result := DiskEncryptionSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskEncryptionSet)
-	return result, err
+	var val *DiskEncryptionSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskEncryptionSetResponse{}, err
+	}
+	return DiskEncryptionSetResponse{RawResponse: resp.Response, DiskEncryptionSet: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks.go
@@ -110,9 +110,11 @@ func (client DisksClient) createOrUpdateCreateRequest(ctx context.Context, resou
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DisksClient) createOrUpdateHandleResponse(resp *azcore.Response) (DiskResponse, error) {
-	result := DiskResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Disk)
-	return result, err
+	var val *Disk
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskResponse{}, err
+	}
+	return DiskResponse{RawResponse: resp.Response, Disk: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -222,11 +224,7 @@ func (client DisksClient) Get(ctx context.Context, resourceGroupName string, dis
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DiskResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DiskResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -249,9 +247,11 @@ func (client DisksClient) getCreateRequest(ctx context.Context, resourceGroupNam
 
 // getHandleResponse handles the Get response.
 func (client DisksClient) getHandleResponse(resp *azcore.Response) (DiskResponse, error) {
-	result := DiskResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Disk)
-	return result, err
+	var val *Disk
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskResponse{}, err
+	}
+	return DiskResponse{RawResponse: resp.Response, Disk: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -339,9 +339,11 @@ func (client DisksClient) grantAccessCreateRequest(ctx context.Context, resource
 
 // grantAccessHandleResponse handles the GrantAccess response.
 func (client DisksClient) grantAccessHandleResponse(resp *azcore.Response) (AccessURIResponse, error) {
-	result := AccessURIResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AccessURI)
-	return result, err
+	var val *AccessURI
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AccessURIResponse{}, err
+	}
+	return AccessURIResponse{RawResponse: resp.Response, AccessURI: val}, nil
 }
 
 // grantAccessHandleError handles the GrantAccess error response.
@@ -390,9 +392,11 @@ func (client DisksClient) listCreateRequest(ctx context.Context, options *DisksL
 
 // listHandleResponse handles the List response.
 func (client DisksClient) listHandleResponse(resp *azcore.Response) (DiskListResponse, error) {
-	result := DiskListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskList)
-	return result, err
+	var val *DiskList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskListResponse{}, err
+	}
+	return DiskListResponse{RawResponse: resp.Response, DiskList: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -442,9 +446,11 @@ func (client DisksClient) listByResourceGroupCreateRequest(ctx context.Context, 
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client DisksClient) listByResourceGroupHandleResponse(resp *azcore.Response) (DiskListResponse, error) {
-	result := DiskListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DiskList)
-	return result, err
+	var val *DiskList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskListResponse{}, err
+	}
+	return DiskListResponse{RawResponse: resp.Response, DiskList: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -614,9 +620,11 @@ func (client DisksClient) updateCreateRequest(ctx context.Context, resourceGroup
 
 // updateHandleResponse handles the Update response.
 func (client DisksClient) updateHandleResponse(resp *azcore.Response) (DiskResponse, error) {
-	result := DiskResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Disk)
-	return result, err
+	var val *Disk
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DiskResponse{}, err
+	}
+	return DiskResponse{RawResponse: resp.Response, Disk: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries.go
@@ -107,9 +107,11 @@ func (client GalleriesClient) createOrUpdateCreateRequest(ctx context.Context, r
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client GalleriesClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryResponse, error) {
-	result := GalleryResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Gallery)
-	return result, err
+	var val *Gallery
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryResponse{}, err
+	}
+	return GalleryResponse{RawResponse: resp.Response, Gallery: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client GalleriesClient) Get(ctx context.Context, resourceGroupName string,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GalleryResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return GalleryResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client GalleriesClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client GalleriesClient) getHandleResponse(resp *azcore.Response) (GalleryResponse, error) {
-	result := GalleryResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Gallery)
-	return result, err
+	var val *Gallery
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryResponse{}, err
+	}
+	return GalleryResponse{RawResponse: resp.Response, Gallery: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client GalleriesClient) listCreateRequest(ctx context.Context, options *Ga
 
 // listHandleResponse handles the List response.
 func (client GalleriesClient) listHandleResponse(resp *azcore.Response) (GalleryListResponse, error) {
-	result := GalleryListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryList)
-	return result, err
+	var val *GalleryList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryListResponse{}, err
+	}
+	return GalleryListResponse{RawResponse: resp.Response, GalleryList: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client GalleriesClient) listByResourceGroupCreateRequest(ctx context.Conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client GalleriesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (GalleryListResponse, error) {
-	result := GalleryListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryList)
-	return result, err
+	var val *GalleryList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryListResponse{}, err
+	}
+	return GalleryListResponse{RawResponse: resp.Response, GalleryList: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -425,9 +429,11 @@ func (client GalleriesClient) updateCreateRequest(ctx context.Context, resourceG
 
 // updateHandleResponse handles the Update response.
 func (client GalleriesClient) updateHandleResponse(resp *azcore.Response) (GalleryResponse, error) {
-	result := GalleryResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Gallery)
-	return result, err
+	var val *Gallery
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryResponse{}, err
+	}
+	return GalleryResponse{RawResponse: resp.Response, Gallery: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications.go
@@ -108,9 +108,11 @@ func (client GalleryApplicationsClient) createOrUpdateCreateRequest(ctx context.
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client GalleryApplicationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryApplicationResponse, error) {
-	result := GalleryApplicationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplication)
-	return result, err
+	var val *GalleryApplication
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationResponse{}, err
+	}
+	return GalleryApplicationResponse{RawResponse: resp.Response, GalleryApplication: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client GalleryApplicationsClient) Get(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GalleryApplicationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return GalleryApplicationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client GalleryApplicationsClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client GalleryApplicationsClient) getHandleResponse(resp *azcore.Response) (GalleryApplicationResponse, error) {
-	result := GalleryApplicationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplication)
-	return result, err
+	var val *GalleryApplication
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationResponse{}, err
+	}
+	return GalleryApplicationResponse{RawResponse: resp.Response, GalleryApplication: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client GalleryApplicationsClient) listByGalleryCreateRequest(ctx context.C
 
 // listByGalleryHandleResponse handles the ListByGallery response.
 func (client GalleryApplicationsClient) listByGalleryHandleResponse(resp *azcore.Response) (GalleryApplicationListResponse, error) {
-	result := GalleryApplicationListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplicationList)
-	return result, err
+	var val *GalleryApplicationList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationListResponse{}, err
+	}
+	return GalleryApplicationListResponse{RawResponse: resp.Response, GalleryApplicationList: val}, nil
 }
 
 // listByGalleryHandleError handles the ListByGallery error response.
@@ -382,9 +384,11 @@ func (client GalleryApplicationsClient) updateCreateRequest(ctx context.Context,
 
 // updateHandleResponse handles the Update response.
 func (client GalleryApplicationsClient) updateHandleResponse(resp *azcore.Response) (GalleryApplicationResponse, error) {
-	result := GalleryApplicationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplication)
-	return result, err
+	var val *GalleryApplication
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationResponse{}, err
+	}
+	return GalleryApplicationResponse{RawResponse: resp.Response, GalleryApplication: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions.go
@@ -109,9 +109,11 @@ func (client GalleryApplicationVersionsClient) createOrUpdateCreateRequest(ctx c
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client GalleryApplicationVersionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryApplicationVersionResponse, error) {
-	result := GalleryApplicationVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplicationVersion)
-	return result, err
+	var val *GalleryApplicationVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationVersionResponse{}, err
+	}
+	return GalleryApplicationVersionResponse{RawResponse: resp.Response, GalleryApplicationVersion: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -218,11 +220,7 @@ func (client GalleryApplicationVersionsClient) Get(ctx context.Context, resource
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GalleryApplicationVersionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return GalleryApplicationVersionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -250,9 +248,11 @@ func (client GalleryApplicationVersionsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client GalleryApplicationVersionsClient) getHandleResponse(resp *azcore.Response) (GalleryApplicationVersionResponse, error) {
-	result := GalleryApplicationVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplicationVersion)
-	return result, err
+	var val *GalleryApplicationVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationVersionResponse{}, err
+	}
+	return GalleryApplicationVersionResponse{RawResponse: resp.Response, GalleryApplicationVersion: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -301,9 +301,11 @@ func (client GalleryApplicationVersionsClient) listByGalleryApplicationCreateReq
 
 // listByGalleryApplicationHandleResponse handles the ListByGalleryApplication response.
 func (client GalleryApplicationVersionsClient) listByGalleryApplicationHandleResponse(resp *azcore.Response) (GalleryApplicationVersionListResponse, error) {
-	result := GalleryApplicationVersionListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplicationVersionList)
-	return result, err
+	var val *GalleryApplicationVersionList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationVersionListResponse{}, err
+	}
+	return GalleryApplicationVersionListResponse{RawResponse: resp.Response, GalleryApplicationVersionList: val}, nil
 }
 
 // listByGalleryApplicationHandleError handles the ListByGalleryApplication error response.
@@ -390,9 +392,11 @@ func (client GalleryApplicationVersionsClient) updateCreateRequest(ctx context.C
 
 // updateHandleResponse handles the Update response.
 func (client GalleryApplicationVersionsClient) updateHandleResponse(resp *azcore.Response) (GalleryApplicationVersionResponse, error) {
-	result := GalleryApplicationVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryApplicationVersion)
-	return result, err
+	var val *GalleryApplicationVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryApplicationVersionResponse{}, err
+	}
+	return GalleryApplicationVersionResponse{RawResponse: resp.Response, GalleryApplicationVersion: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages.go
@@ -108,9 +108,11 @@ func (client GalleryImagesClient) createOrUpdateCreateRequest(ctx context.Contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client GalleryImagesClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryImageResponse, error) {
-	result := GalleryImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImage)
-	return result, err
+	var val *GalleryImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageResponse{}, err
+	}
+	return GalleryImageResponse{RawResponse: resp.Response, GalleryImage: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client GalleryImagesClient) Get(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GalleryImageResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return GalleryImageResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client GalleryImagesClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client GalleryImagesClient) getHandleResponse(resp *azcore.Response) (GalleryImageResponse, error) {
-	result := GalleryImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImage)
-	return result, err
+	var val *GalleryImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageResponse{}, err
+	}
+	return GalleryImageResponse{RawResponse: resp.Response, GalleryImage: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client GalleryImagesClient) listByGalleryCreateRequest(ctx context.Context
 
 // listByGalleryHandleResponse handles the ListByGallery response.
 func (client GalleryImagesClient) listByGalleryHandleResponse(resp *azcore.Response) (GalleryImageListResponse, error) {
-	result := GalleryImageListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImageList)
-	return result, err
+	var val *GalleryImageList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageListResponse{}, err
+	}
+	return GalleryImageListResponse{RawResponse: resp.Response, GalleryImageList: val}, nil
 }
 
 // listByGalleryHandleError handles the ListByGallery error response.
@@ -382,9 +384,11 @@ func (client GalleryImagesClient) updateCreateRequest(ctx context.Context, resou
 
 // updateHandleResponse handles the Update response.
 func (client GalleryImagesClient) updateHandleResponse(resp *azcore.Response) (GalleryImageResponse, error) {
-	result := GalleryImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImage)
-	return result, err
+	var val *GalleryImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageResponse{}, err
+	}
+	return GalleryImageResponse{RawResponse: resp.Response, GalleryImage: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions.go
@@ -109,9 +109,11 @@ func (client GalleryImageVersionsClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client GalleryImageVersionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryImageVersionResponse, error) {
-	result := GalleryImageVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImageVersion)
-	return result, err
+	var val *GalleryImageVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageVersionResponse{}, err
+	}
+	return GalleryImageVersionResponse{RawResponse: resp.Response, GalleryImageVersion: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -218,11 +220,7 @@ func (client GalleryImageVersionsClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GalleryImageVersionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return GalleryImageVersionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -250,9 +248,11 @@ func (client GalleryImageVersionsClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client GalleryImageVersionsClient) getHandleResponse(resp *azcore.Response) (GalleryImageVersionResponse, error) {
-	result := GalleryImageVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImageVersion)
-	return result, err
+	var val *GalleryImageVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageVersionResponse{}, err
+	}
+	return GalleryImageVersionResponse{RawResponse: resp.Response, GalleryImageVersion: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -301,9 +301,11 @@ func (client GalleryImageVersionsClient) listByGalleryImageCreateRequest(ctx con
 
 // listByGalleryImageHandleResponse handles the ListByGalleryImage response.
 func (client GalleryImageVersionsClient) listByGalleryImageHandleResponse(resp *azcore.Response) (GalleryImageVersionListResponse, error) {
-	result := GalleryImageVersionListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImageVersionList)
-	return result, err
+	var val *GalleryImageVersionList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageVersionListResponse{}, err
+	}
+	return GalleryImageVersionListResponse{RawResponse: resp.Response, GalleryImageVersionList: val}, nil
 }
 
 // listByGalleryImageHandleError handles the ListByGalleryImage error response.
@@ -390,9 +392,11 @@ func (client GalleryImageVersionsClient) updateCreateRequest(ctx context.Context
 
 // updateHandleResponse handles the Update response.
 func (client GalleryImageVersionsClient) updateHandleResponse(resp *azcore.Response) (GalleryImageVersionResponse, error) {
-	result := GalleryImageVersionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GalleryImageVersion)
-	return result, err
+	var val *GalleryImageVersion
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GalleryImageVersionResponse{}, err
+	}
+	return GalleryImageVersionResponse{RawResponse: resp.Response, GalleryImageVersion: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images.go
@@ -110,9 +110,11 @@ func (client ImagesClient) createOrUpdateCreateRequest(ctx context.Context, reso
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ImagesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ImageResponse, error) {
-	result := ImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Image)
-	return result, err
+	var val *Image
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ImageResponse{}, err
+	}
+	return ImageResponse{RawResponse: resp.Response, Image: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -222,11 +224,7 @@ func (client ImagesClient) Get(ctx context.Context, resourceGroupName string, im
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ImageResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ImageResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -252,9 +250,11 @@ func (client ImagesClient) getCreateRequest(ctx context.Context, resourceGroupNa
 
 // getHandleResponse handles the Get response.
 func (client ImagesClient) getHandleResponse(resp *azcore.Response) (ImageResponse, error) {
-	result := ImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Image)
-	return result, err
+	var val *Image
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ImageResponse{}, err
+	}
+	return ImageResponse{RawResponse: resp.Response, Image: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -304,9 +304,11 @@ func (client ImagesClient) listCreateRequest(ctx context.Context, options *Image
 
 // listHandleResponse handles the List response.
 func (client ImagesClient) listHandleResponse(resp *azcore.Response) (ImageListResultResponse, error) {
-	result := ImageListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ImageListResult)
-	return result, err
+	var val *ImageListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ImageListResultResponse{}, err
+	}
+	return ImageListResultResponse{RawResponse: resp.Response, ImageListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -356,9 +358,11 @@ func (client ImagesClient) listByResourceGroupCreateRequest(ctx context.Context,
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ImagesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ImageListResultResponse, error) {
-	result := ImageListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ImageListResult)
-	return result, err
+	var val *ImageListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ImageListResultResponse{}, err
+	}
+	return ImageListResultResponse{RawResponse: resp.Response, ImageListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -446,9 +450,11 @@ func (client ImagesClient) updateCreateRequest(ctx context.Context, resourceGrou
 
 // updateHandleResponse handles the Update response.
 func (client ImagesClient) updateHandleResponse(resp *azcore.Response) (ImageResponse, error) {
-	result := ImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Image)
-	return result, err
+	var val *Image
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ImageResponse{}, err
+	}
+	return ImageResponse{RawResponse: resp.Response, Image: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
@@ -109,9 +109,11 @@ func (client LogAnalyticsClient) exportRequestRateByIntervalCreateRequest(ctx co
 
 // exportRequestRateByIntervalHandleResponse handles the ExportRequestRateByInterval response.
 func (client LogAnalyticsClient) exportRequestRateByIntervalHandleResponse(resp *azcore.Response) (LogAnalyticsOperationResultResponse, error) {
-	result := LogAnalyticsOperationResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LogAnalyticsOperationResult)
-	return result, err
+	var val *LogAnalyticsOperationResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LogAnalyticsOperationResultResponse{}, err
+	}
+	return LogAnalyticsOperationResultResponse{RawResponse: resp.Response, LogAnalyticsOperationResult: val}, nil
 }
 
 // exportRequestRateByIntervalHandleError handles the ExportRequestRateByInterval error response.
@@ -198,9 +200,11 @@ func (client LogAnalyticsClient) exportThrottledRequestsCreateRequest(ctx contex
 
 // exportThrottledRequestsHandleResponse handles the ExportThrottledRequests response.
 func (client LogAnalyticsClient) exportThrottledRequestsHandleResponse(resp *azcore.Response) (LogAnalyticsOperationResultResponse, error) {
-	result := LogAnalyticsOperationResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LogAnalyticsOperationResult)
-	return result, err
+	var val *LogAnalyticsOperationResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LogAnalyticsOperationResultResponse{}, err
+	}
+	return LogAnalyticsOperationResultResponse{RawResponse: resp.Response, LogAnalyticsOperationResult: val}, nil
 }
 
 // exportThrottledRequestsHandleError handles the ExportThrottledRequests error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations.go
@@ -46,11 +46,7 @@ func (client OperationsClient) List(ctx context.Context, options *OperationsList
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ComputeOperationListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ComputeOperationListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -70,9 +66,11 @@ func (client OperationsClient) listCreateRequest(ctx context.Context, options *O
 
 // listHandleResponse handles the List response.
 func (client OperationsClient) listHandleResponse(resp *azcore.Response) (ComputeOperationListResultResponse, error) {
-	result := ComputeOperationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ComputeOperationListResult)
-	return result, err
+	var val *ComputeOperationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ComputeOperationListResultResponse{}, err
+	}
+	return ComputeOperationListResultResponse{RawResponse: resp.Response, ComputeOperationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
@@ -49,11 +49,7 @@ func (client ProximityPlacementGroupsClient) CreateOrUpdate(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return ProximityPlacementGroupResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return ProximityPlacementGroupResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -76,9 +72,11 @@ func (client ProximityPlacementGroupsClient) createOrUpdateCreateRequest(ctx con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ProximityPlacementGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ProximityPlacementGroupResponse, error) {
-	result := ProximityPlacementGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProximityPlacementGroup)
-	return result, err
+	var val *ProximityPlacementGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProximityPlacementGroupResponse{}, err
+	}
+	return ProximityPlacementGroupResponse{RawResponse: resp.Response, ProximityPlacementGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -151,11 +149,7 @@ func (client ProximityPlacementGroupsClient) Get(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProximityPlacementGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ProximityPlacementGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -181,9 +175,11 @@ func (client ProximityPlacementGroupsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client ProximityPlacementGroupsClient) getHandleResponse(resp *azcore.Response) (ProximityPlacementGroupResponse, error) {
-	result := ProximityPlacementGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProximityPlacementGroup)
-	return result, err
+	var val *ProximityPlacementGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProximityPlacementGroupResponse{}, err
+	}
+	return ProximityPlacementGroupResponse{RawResponse: resp.Response, ProximityPlacementGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -233,9 +229,11 @@ func (client ProximityPlacementGroupsClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ProximityPlacementGroupsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ProximityPlacementGroupListResultResponse, error) {
-	result := ProximityPlacementGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProximityPlacementGroupListResult)
-	return result, err
+	var val *ProximityPlacementGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProximityPlacementGroupListResultResponse{}, err
+	}
+	return ProximityPlacementGroupListResultResponse{RawResponse: resp.Response, ProximityPlacementGroupListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -284,9 +282,11 @@ func (client ProximityPlacementGroupsClient) listBySubscriptionCreateRequest(ctx
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client ProximityPlacementGroupsClient) listBySubscriptionHandleResponse(resp *azcore.Response) (ProximityPlacementGroupListResultResponse, error) {
-	result := ProximityPlacementGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProximityPlacementGroupListResult)
-	return result, err
+	var val *ProximityPlacementGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProximityPlacementGroupListResultResponse{}, err
+	}
+	return ProximityPlacementGroupListResultResponse{RawResponse: resp.Response, ProximityPlacementGroupListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.
@@ -314,11 +314,7 @@ func (client ProximityPlacementGroupsClient) Update(ctx context.Context, resourc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProximityPlacementGroupResponse{}, client.updateHandleError(resp)
 	}
-	result, err := client.updateHandleResponse(resp)
-	if err != nil {
-		return ProximityPlacementGroupResponse{}, err
-	}
-	return result, nil
+	return client.updateHandleResponse(resp)
 }
 
 // updateCreateRequest creates the Update request.
@@ -341,9 +337,11 @@ func (client ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Con
 
 // updateHandleResponse handles the Update response.
 func (client ProximityPlacementGroupsClient) updateHandleResponse(resp *azcore.Response) (ProximityPlacementGroupResponse, error) {
-	result := ProximityPlacementGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ProximityPlacementGroup)
-	return result, err
+	var val *ProximityPlacementGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProximityPlacementGroupResponse{}, err
+	}
+	return ProximityPlacementGroupResponse{RawResponse: resp.Response, ProximityPlacementGroup: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus.go
@@ -73,9 +73,11 @@ func (client ResourceSKUsClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client ResourceSKUsClient) listHandleResponse(resp *azcore.Response) (ResourceSKUsResultResponse, error) {
-	result := ResourceSKUsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ResourceSKUsResult)
-	return result, err
+	var val *ResourceSKUsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ResourceSKUsResultResponse{}, err
+	}
+	return ResourceSKUsResultResponse{RawResponse: resp.Response, ResourceSKUsResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots.go
@@ -110,9 +110,11 @@ func (client SnapshotsClient) createOrUpdateCreateRequest(ctx context.Context, r
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client SnapshotsClient) createOrUpdateHandleResponse(resp *azcore.Response) (SnapshotResponse, error) {
-	result := SnapshotResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Snapshot)
-	return result, err
+	var val *Snapshot
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SnapshotResponse{}, err
+	}
+	return SnapshotResponse{RawResponse: resp.Response, Snapshot: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -222,11 +224,7 @@ func (client SnapshotsClient) Get(ctx context.Context, resourceGroupName string,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SnapshotResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SnapshotResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -249,9 +247,11 @@ func (client SnapshotsClient) getCreateRequest(ctx context.Context, resourceGrou
 
 // getHandleResponse handles the Get response.
 func (client SnapshotsClient) getHandleResponse(resp *azcore.Response) (SnapshotResponse, error) {
-	result := SnapshotResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Snapshot)
-	return result, err
+	var val *Snapshot
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SnapshotResponse{}, err
+	}
+	return SnapshotResponse{RawResponse: resp.Response, Snapshot: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -339,9 +339,11 @@ func (client SnapshotsClient) grantAccessCreateRequest(ctx context.Context, reso
 
 // grantAccessHandleResponse handles the GrantAccess response.
 func (client SnapshotsClient) grantAccessHandleResponse(resp *azcore.Response) (AccessURIResponse, error) {
-	result := AccessURIResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AccessURI)
-	return result, err
+	var val *AccessURI
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AccessURIResponse{}, err
+	}
+	return AccessURIResponse{RawResponse: resp.Response, AccessURI: val}, nil
 }
 
 // grantAccessHandleError handles the GrantAccess error response.
@@ -390,9 +392,11 @@ func (client SnapshotsClient) listCreateRequest(ctx context.Context, options *Sn
 
 // listHandleResponse handles the List response.
 func (client SnapshotsClient) listHandleResponse(resp *azcore.Response) (SnapshotListResponse, error) {
-	result := SnapshotListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SnapshotList)
-	return result, err
+	var val *SnapshotList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SnapshotListResponse{}, err
+	}
+	return SnapshotListResponse{RawResponse: resp.Response, SnapshotList: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -442,9 +446,11 @@ func (client SnapshotsClient) listByResourceGroupCreateRequest(ctx context.Conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client SnapshotsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (SnapshotListResponse, error) {
-	result := SnapshotListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SnapshotList)
-	return result, err
+	var val *SnapshotList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SnapshotListResponse{}, err
+	}
+	return SnapshotListResponse{RawResponse: resp.Response, SnapshotList: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -614,9 +620,11 @@ func (client SnapshotsClient) updateCreateRequest(ctx context.Context, resourceG
 
 // updateHandleResponse handles the Update response.
 func (client SnapshotsClient) updateHandleResponse(resp *azcore.Response) (SnapshotResponse, error) {
-	result := SnapshotResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Snapshot)
-	return result, err
+	var val *Snapshot
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SnapshotResponse{}, err
+	}
+	return SnapshotResponse{RawResponse: resp.Response, Snapshot: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys.go
@@ -49,11 +49,7 @@ func (client SSHPublicKeysClient) Create(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return SSHPublicKeyResourceResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return SSHPublicKeyResourceResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.
@@ -76,9 +72,11 @@ func (client SSHPublicKeysClient) createCreateRequest(ctx context.Context, resou
 
 // createHandleResponse handles the Create response.
 func (client SSHPublicKeysClient) createHandleResponse(resp *azcore.Response) (SSHPublicKeyResourceResponse, error) {
-	result := SSHPublicKeyResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeyResource)
-	return result, err
+	var val *SSHPublicKeyResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeyResourceResponse{}, err
+	}
+	return SSHPublicKeyResourceResponse{RawResponse: resp.Response, SSHPublicKeyResource: val}, nil
 }
 
 // createHandleError handles the Create error response.
@@ -153,11 +151,7 @@ func (client SSHPublicKeysClient) GenerateKeyPair(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SSHPublicKeyGenerateKeyPairResultResponse{}, client.generateKeyPairHandleError(resp)
 	}
-	result, err := client.generateKeyPairHandleResponse(resp)
-	if err != nil {
-		return SSHPublicKeyGenerateKeyPairResultResponse{}, err
-	}
-	return result, nil
+	return client.generateKeyPairHandleResponse(resp)
 }
 
 // generateKeyPairCreateRequest creates the GenerateKeyPair request.
@@ -180,9 +174,11 @@ func (client SSHPublicKeysClient) generateKeyPairCreateRequest(ctx context.Conte
 
 // generateKeyPairHandleResponse handles the GenerateKeyPair response.
 func (client SSHPublicKeysClient) generateKeyPairHandleResponse(resp *azcore.Response) (SSHPublicKeyGenerateKeyPairResultResponse, error) {
-	result := SSHPublicKeyGenerateKeyPairResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeyGenerateKeyPairResult)
-	return result, err
+	var val *SSHPublicKeyGenerateKeyPairResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeyGenerateKeyPairResultResponse{}, err
+	}
+	return SSHPublicKeyGenerateKeyPairResultResponse{RawResponse: resp.Response, SSHPublicKeyGenerateKeyPairResult: val}, nil
 }
 
 // generateKeyPairHandleError handles the GenerateKeyPair error response.
@@ -210,11 +206,7 @@ func (client SSHPublicKeysClient) Get(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SSHPublicKeyResourceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SSHPublicKeyResourceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -237,9 +229,11 @@ func (client SSHPublicKeysClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client SSHPublicKeysClient) getHandleResponse(resp *azcore.Response) (SSHPublicKeyResourceResponse, error) {
-	result := SSHPublicKeyResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeyResource)
-	return result, err
+	var val *SSHPublicKeyResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeyResourceResponse{}, err
+	}
+	return SSHPublicKeyResourceResponse{RawResponse: resp.Response, SSHPublicKeyResource: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -290,9 +284,11 @@ func (client SSHPublicKeysClient) listByResourceGroupCreateRequest(ctx context.C
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client SSHPublicKeysClient) listByResourceGroupHandleResponse(resp *azcore.Response) (SSHPublicKeysGroupListResultResponse, error) {
-	result := SSHPublicKeysGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeysGroupListResult)
-	return result, err
+	var val *SSHPublicKeysGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeysGroupListResultResponse{}, err
+	}
+	return SSHPublicKeysGroupListResultResponse{RawResponse: resp.Response, SSHPublicKeysGroupListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -342,9 +338,11 @@ func (client SSHPublicKeysClient) listBySubscriptionCreateRequest(ctx context.Co
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client SSHPublicKeysClient) listBySubscriptionHandleResponse(resp *azcore.Response) (SSHPublicKeysGroupListResultResponse, error) {
-	result := SSHPublicKeysGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeysGroupListResult)
-	return result, err
+	var val *SSHPublicKeysGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeysGroupListResultResponse{}, err
+	}
+	return SSHPublicKeysGroupListResultResponse{RawResponse: resp.Response, SSHPublicKeysGroupListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.
@@ -372,11 +370,7 @@ func (client SSHPublicKeysClient) Update(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SSHPublicKeyResourceResponse{}, client.updateHandleError(resp)
 	}
-	result, err := client.updateHandleResponse(resp)
-	if err != nil {
-		return SSHPublicKeyResourceResponse{}, err
-	}
-	return result, nil
+	return client.updateHandleResponse(resp)
 }
 
 // updateCreateRequest creates the Update request.
@@ -399,9 +393,11 @@ func (client SSHPublicKeysClient) updateCreateRequest(ctx context.Context, resou
 
 // updateHandleResponse handles the Update response.
 func (client SSHPublicKeysClient) updateHandleResponse(resp *azcore.Response) (SSHPublicKeyResourceResponse, error) {
-	result := SSHPublicKeyResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SSHPublicKeyResource)
-	return result, err
+	var val *SSHPublicKeyResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SSHPublicKeyResourceResponse{}, err
+	}
+	return SSHPublicKeyResourceResponse{RawResponse: resp.Response, SSHPublicKeyResource: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage.go
@@ -71,9 +71,11 @@ func (client UsageClient) listCreateRequest(ctx context.Context, location string
 
 // listHandleResponse handles the List response.
 func (client UsageClient) listHandleResponse(resp *azcore.Response) (ListUsagesResultResponse, error) {
-	result := ListUsagesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListUsagesResult)
-	return result, err
+	var val *ListUsagesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListUsagesResultResponse{}, err
+	}
+	return ListUsagesResultResponse{RawResponse: resp.Response, ListUsagesResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
@@ -50,11 +50,7 @@ func (client VirtualMachineExtensionImagesClient) Get(ctx context.Context, locat
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionImageResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionImageResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -79,9 +75,11 @@ func (client VirtualMachineExtensionImagesClient) getCreateRequest(ctx context.C
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineExtensionImagesClient) getHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageResponse, error) {
-	result := VirtualMachineExtensionImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtensionImage)
-	return result, err
+	var val *VirtualMachineExtensionImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionImageResponse{}, err
+	}
+	return VirtualMachineExtensionImageResponse{RawResponse: resp.Response, VirtualMachineExtensionImage: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -109,11 +107,7 @@ func (client VirtualMachineExtensionImagesClient) ListTypes(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionImageArrayResponse{}, client.listTypesHandleError(resp)
 	}
-	result, err := client.listTypesHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionImageArrayResponse{}, err
-	}
-	return result, nil
+	return client.listTypesHandleResponse(resp)
 }
 
 // listTypesCreateRequest creates the ListTypes request.
@@ -136,9 +130,11 @@ func (client VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx con
 
 // listTypesHandleResponse handles the ListTypes response.
 func (client VirtualMachineExtensionImagesClient) listTypesHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	result := VirtualMachineExtensionImageArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtensionImageArray)
-	return result, err
+	var val *[]VirtualMachineExtensionImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionImageArrayResponse{}, err
+	}
+	return VirtualMachineExtensionImageArrayResponse{RawResponse: resp.Response, VirtualMachineExtensionImageArray: val}, nil
 }
 
 // listTypesHandleError handles the ListTypes error response.
@@ -166,11 +162,7 @@ func (client VirtualMachineExtensionImagesClient) ListVersions(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionImageArrayResponse{}, client.listVersionsHandleError(resp)
 	}
-	result, err := client.listVersionsHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionImageArrayResponse{}, err
-	}
-	return result, nil
+	return client.listVersionsHandleResponse(resp)
 }
 
 // listVersionsCreateRequest creates the ListVersions request.
@@ -203,9 +195,11 @@ func (client VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx 
 
 // listVersionsHandleResponse handles the ListVersions response.
 func (client VirtualMachineExtensionImagesClient) listVersionsHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	result := VirtualMachineExtensionImageArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtensionImageArray)
-	return result, err
+	var val *[]VirtualMachineExtensionImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionImageArrayResponse{}, err
+	}
+	return VirtualMachineExtensionImageArrayResponse{RawResponse: resp.Response, VirtualMachineExtensionImageArray: val}, nil
 }
 
 // listVersionsHandleError handles the ListVersions error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions.go
@@ -111,9 +111,11 @@ func (client VirtualMachineExtensionsClient) createOrUpdateCreateRequest(ctx con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualMachineExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -224,11 +226,7 @@ func (client VirtualMachineExtensionsClient) Get(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -255,9 +253,11 @@ func (client VirtualMachineExtensionsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineExtensionsClient) getHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -285,11 +285,7 @@ func (client VirtualMachineExtensionsClient) List(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionsListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionsListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -315,9 +311,11 @@ func (client VirtualMachineExtensionsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineExtensionsClient) listHandleResponse(resp *azcore.Response) (VirtualMachineExtensionsListResultResponse, error) {
-	result := VirtualMachineExtensionsListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtensionsListResult)
-	return result, err
+	var val *VirtualMachineExtensionsListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionsListResultResponse{}, err
+	}
+	return VirtualMachineExtensionsListResultResponse{RawResponse: resp.Response, VirtualMachineExtensionsListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -406,9 +404,11 @@ func (client VirtualMachineExtensionsClient) updateCreateRequest(ctx context.Con
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachineExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
@@ -50,11 +50,7 @@ func (client VirtualMachineImagesClient) Get(ctx context.Context, location strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineImageResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineImageResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -80,9 +76,11 @@ func (client VirtualMachineImagesClient) getCreateRequest(ctx context.Context, l
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineImagesClient) getHandleResponse(resp *azcore.Response) (VirtualMachineImageResponse, error) {
-	result := VirtualMachineImageResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineImage)
-	return result, err
+	var val *VirtualMachineImage
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineImageResponse{}, err
+	}
+	return VirtualMachineImageResponse{RawResponse: resp.Response, VirtualMachineImage: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -110,11 +108,7 @@ func (client VirtualMachineImagesClient) List(ctx context.Context, location stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineImageResourceArrayResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineImageResourceArrayResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -148,9 +142,11 @@ func (client VirtualMachineImagesClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineImagesClient) listHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	result := VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineImageResourceArray)
-	return result, err
+	var val *[]VirtualMachineImageResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineImageResourceArrayResponse{}, err
+	}
+	return VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response, VirtualMachineImageResourceArray: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -178,11 +174,7 @@ func (client VirtualMachineImagesClient) ListOffers(ctx context.Context, locatio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineImageResourceArrayResponse{}, client.listOffersHandleError(resp)
 	}
-	result, err := client.listOffersHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineImageResourceArrayResponse{}, err
-	}
-	return result, nil
+	return client.listOffersHandleResponse(resp)
 }
 
 // listOffersCreateRequest creates the ListOffers request.
@@ -205,9 +197,11 @@ func (client VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Con
 
 // listOffersHandleResponse handles the ListOffers response.
 func (client VirtualMachineImagesClient) listOffersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	result := VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineImageResourceArray)
-	return result, err
+	var val *[]VirtualMachineImageResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineImageResourceArrayResponse{}, err
+	}
+	return VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response, VirtualMachineImageResourceArray: val}, nil
 }
 
 // listOffersHandleError handles the ListOffers error response.
@@ -235,11 +229,7 @@ func (client VirtualMachineImagesClient) ListPublishers(ctx context.Context, loc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineImageResourceArrayResponse{}, client.listPublishersHandleError(resp)
 	}
-	result, err := client.listPublishersHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineImageResourceArrayResponse{}, err
-	}
-	return result, nil
+	return client.listPublishersHandleResponse(resp)
 }
 
 // listPublishersCreateRequest creates the ListPublishers request.
@@ -261,9 +251,11 @@ func (client VirtualMachineImagesClient) listPublishersCreateRequest(ctx context
 
 // listPublishersHandleResponse handles the ListPublishers response.
 func (client VirtualMachineImagesClient) listPublishersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	result := VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineImageResourceArray)
-	return result, err
+	var val *[]VirtualMachineImageResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineImageResourceArrayResponse{}, err
+	}
+	return VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response, VirtualMachineImageResourceArray: val}, nil
 }
 
 // listPublishersHandleError handles the ListPublishers error response.
@@ -291,11 +283,7 @@ func (client VirtualMachineImagesClient) ListSKUs(ctx context.Context, location 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineImageResourceArrayResponse{}, client.listSkUsHandleError(resp)
 	}
-	result, err := client.listSkUsHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineImageResourceArrayResponse{}, err
-	}
-	return result, nil
+	return client.listSkUsHandleResponse(resp)
 }
 
 // listSkUsCreateRequest creates the ListSKUs request.
@@ -319,9 +307,11 @@ func (client VirtualMachineImagesClient) listSkUsCreateRequest(ctx context.Conte
 
 // listSkUsHandleResponse handles the ListSKUs response.
 func (client VirtualMachineImagesClient) listSkUsHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	result := VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineImageResourceArray)
-	return result, err
+	var val *[]VirtualMachineImageResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineImageResourceArrayResponse{}, err
+	}
+	return VirtualMachineImageResourceArrayResponse{RawResponse: resp.Response, VirtualMachineImageResourceArray: val}, nil
 }
 
 // listSkUsHandleError handles the ListSKUs error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands.go
@@ -49,11 +49,7 @@ func (client VirtualMachineRunCommandsClient) Get(ctx context.Context, location 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RunCommandDocumentResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return RunCommandDocumentResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -76,9 +72,11 @@ func (client VirtualMachineRunCommandsClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineRunCommandsClient) getHandleResponse(resp *azcore.Response) (RunCommandDocumentResponse, error) {
-	result := RunCommandDocumentResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RunCommandDocument)
-	return result, err
+	var val *RunCommandDocument
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RunCommandDocumentResponse{}, err
+	}
+	return RunCommandDocumentResponse{RawResponse: resp.Response, RunCommandDocument: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -128,9 +126,11 @@ func (client VirtualMachineRunCommandsClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineRunCommandsClient) listHandleResponse(resp *azcore.Response) (RunCommandListResultResponse, error) {
-	result := RunCommandListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RunCommandListResult)
-	return result, err
+	var val *RunCommandListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RunCommandListResultResponse{}, err
+	}
+	return RunCommandListResultResponse{RawResponse: resp.Response, RunCommandListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -111,9 +111,11 @@ func (client VirtualMachinesClient) captureCreateRequest(ctx context.Context, re
 
 // captureHandleResponse handles the Capture response.
 func (client VirtualMachinesClient) captureHandleResponse(resp *azcore.Response) (VirtualMachineCaptureResultResponse, error) {
-	result := VirtualMachineCaptureResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineCaptureResult)
-	return result, err
+	var val *VirtualMachineCaptureResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineCaptureResultResponse{}, err
+	}
+	return VirtualMachineCaptureResultResponse{RawResponse: resp.Response, VirtualMachineCaptureResult: val}, nil
 }
 
 // captureHandleError handles the Capture error response.
@@ -289,9 +291,11 @@ func (client VirtualMachinesClient) createOrUpdateCreateRequest(ctx context.Cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualMachinesClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineResponse, error) {
-	result := VirtualMachineResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachine)
-	return result, err
+	var val *VirtualMachine
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineResponse{}, err
+	}
+	return VirtualMachineResponse{RawResponse: resp.Response, VirtualMachine: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -532,11 +536,7 @@ func (client VirtualMachinesClient) Get(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -562,9 +562,11 @@ func (client VirtualMachinesClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachinesClient) getHandleResponse(resp *azcore.Response) (VirtualMachineResponse, error) {
-	result := VirtualMachineResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachine)
-	return result, err
+	var val *VirtualMachine
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineResponse{}, err
+	}
+	return VirtualMachineResponse{RawResponse: resp.Response, VirtualMachine: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -592,11 +594,7 @@ func (client VirtualMachinesClient) InstanceView(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineInstanceViewResponse{}, client.instanceViewHandleError(resp)
 	}
-	result, err := client.instanceViewHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineInstanceViewResponse{}, err
-	}
-	return result, nil
+	return client.instanceViewHandleResponse(resp)
 }
 
 // instanceViewCreateRequest creates the InstanceView request.
@@ -619,9 +617,11 @@ func (client VirtualMachinesClient) instanceViewCreateRequest(ctx context.Contex
 
 // instanceViewHandleResponse handles the InstanceView response.
 func (client VirtualMachinesClient) instanceViewHandleResponse(resp *azcore.Response) (VirtualMachineInstanceViewResponse, error) {
-	result := VirtualMachineInstanceViewResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineInstanceView)
-	return result, err
+	var val *VirtualMachineInstanceView
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineInstanceViewResponse{}, err
+	}
+	return VirtualMachineInstanceViewResponse{RawResponse: resp.Response, VirtualMachineInstanceView: val}, nil
 }
 
 // instanceViewHandleError handles the InstanceView error response.
@@ -671,9 +671,11 @@ func (client VirtualMachinesClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client VirtualMachinesClient) listHandleResponse(resp *azcore.Response) (VirtualMachineListResultResponse, error) {
-	result := VirtualMachineListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineListResult)
-	return result, err
+	var val *VirtualMachineListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineListResultResponse{}, err
+	}
+	return VirtualMachineListResultResponse{RawResponse: resp.Response, VirtualMachineListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -726,9 +728,11 @@ func (client VirtualMachinesClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client VirtualMachinesClient) listAllHandleResponse(resp *azcore.Response) (VirtualMachineListResultResponse, error) {
-	result := VirtualMachineListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineListResult)
-	return result, err
+	var val *VirtualMachineListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineListResultResponse{}, err
+	}
+	return VirtualMachineListResultResponse{RawResponse: resp.Response, VirtualMachineListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -756,11 +760,7 @@ func (client VirtualMachinesClient) ListAvailableSizes(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineSizeListResultResponse{}, client.listAvailableSizesHandleError(resp)
 	}
-	result, err := client.listAvailableSizesHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineSizeListResultResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableSizesHandleResponse(resp)
 }
 
 // listAvailableSizesCreateRequest creates the ListAvailableSizes request.
@@ -783,9 +783,11 @@ func (client VirtualMachinesClient) listAvailableSizesCreateRequest(ctx context.
 
 // listAvailableSizesHandleResponse handles the ListAvailableSizes response.
 func (client VirtualMachinesClient) listAvailableSizesHandleResponse(resp *azcore.Response) (VirtualMachineSizeListResultResponse, error) {
-	result := VirtualMachineSizeListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineSizeListResult)
-	return result, err
+	var val *VirtualMachineSizeListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineSizeListResultResponse{}, err
+	}
+	return VirtualMachineSizeListResultResponse{RawResponse: resp.Response, VirtualMachineSizeListResult: val}, nil
 }
 
 // listAvailableSizesHandleError handles the ListAvailableSizes error response.
@@ -835,9 +837,11 @@ func (client VirtualMachinesClient) listByLocationCreateRequest(ctx context.Cont
 
 // listByLocationHandleResponse handles the ListByLocation response.
 func (client VirtualMachinesClient) listByLocationHandleResponse(resp *azcore.Response) (VirtualMachineListResultResponse, error) {
-	result := VirtualMachineListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineListResult)
-	return result, err
+	var val *VirtualMachineListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineListResultResponse{}, err
+	}
+	return VirtualMachineListResultResponse{RawResponse: resp.Response, VirtualMachineListResult: val}, nil
 }
 
 // listByLocationHandleError handles the ListByLocation error response.
@@ -1425,9 +1429,11 @@ func (client VirtualMachinesClient) runCommandCreateRequest(ctx context.Context,
 
 // runCommandHandleResponse handles the RunCommand response.
 func (client VirtualMachinesClient) runCommandHandleResponse(resp *azcore.Response) (RunCommandResultResponse, error) {
-	result := RunCommandResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RunCommandResult)
-	return result, err
+	var val *RunCommandResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RunCommandResultResponse{}, err
+	}
+	return RunCommandResultResponse{RawResponse: resp.Response, RunCommandResult: val}, nil
 }
 
 // runCommandHandleError handles the RunCommand error response.
@@ -1642,9 +1648,11 @@ func (client VirtualMachinesClient) updateCreateRequest(ctx context.Context, res
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachinesClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineResponse, error) {
-	result := VirtualMachineResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachine)
-	return result, err
+	var val *VirtualMachine
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineResponse{}, err
+	}
+	return VirtualMachineResponse{RawResponse: resp.Response, VirtualMachine: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions.go
@@ -111,9 +111,11 @@ func (client VirtualMachineScaleSetExtensionsClient) createOrUpdateCreateRequest
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualMachineScaleSetExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionResponse, error) {
-	result := VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetExtension)
-	return result, err
+	var val *VirtualMachineScaleSetExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetExtensionResponse{}, err
+	}
+	return VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtension: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -224,11 +226,7 @@ func (client VirtualMachineScaleSetExtensionsClient) Get(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineScaleSetExtensionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineScaleSetExtensionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -255,9 +253,11 @@ func (client VirtualMachineScaleSetExtensionsClient) getCreateRequest(ctx contex
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineScaleSetExtensionsClient) getHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionResponse, error) {
-	result := VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetExtension)
-	return result, err
+	var val *VirtualMachineScaleSetExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetExtensionResponse{}, err
+	}
+	return VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtension: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -308,9 +308,11 @@ func (client VirtualMachineScaleSetExtensionsClient) listCreateRequest(ctx conte
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineScaleSetExtensionsClient) listHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionListResultResponse, error) {
-	result := VirtualMachineScaleSetExtensionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetExtensionListResult)
-	return result, err
+	var val *VirtualMachineScaleSetExtensionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetExtensionListResultResponse{}, err
+	}
+	return VirtualMachineScaleSetExtensionListResultResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtensionListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -399,9 +401,11 @@ func (client VirtualMachineScaleSetExtensionsClient) updateCreateRequest(ctx con
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachineScaleSetExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionResponse, error) {
-	result := VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetExtension)
-	return result, err
+	var val *VirtualMachineScaleSetExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetExtensionResponse{}, err
+	}
+	return VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades.go
@@ -132,11 +132,7 @@ func (client VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context.
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RollingUpgradeStatusInfoResponse{}, client.getLatestHandleError(resp)
 	}
-	result, err := client.getLatestHandleResponse(resp)
-	if err != nil {
-		return RollingUpgradeStatusInfoResponse{}, err
-	}
-	return result, nil
+	return client.getLatestHandleResponse(resp)
 }
 
 // getLatestCreateRequest creates the GetLatest request.
@@ -159,9 +155,11 @@ func (client VirtualMachineScaleSetRollingUpgradesClient) getLatestCreateRequest
 
 // getLatestHandleResponse handles the GetLatest response.
 func (client VirtualMachineScaleSetRollingUpgradesClient) getLatestHandleResponse(resp *azcore.Response) (RollingUpgradeStatusInfoResponse, error) {
-	result := RollingUpgradeStatusInfoResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RollingUpgradeStatusInfo)
-	return result, err
+	var val *RollingUpgradeStatusInfo
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RollingUpgradeStatusInfoResponse{}, err
+	}
+	return RollingUpgradeStatusInfoResponse{RawResponse: resp.Response, RollingUpgradeStatusInfo: val}, nil
 }
 
 // getLatestHandleError handles the GetLatest error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
@@ -156,9 +156,11 @@ func (client VirtualMachineScaleSetsClient) createOrUpdateCreateRequest(ctx cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualMachineScaleSetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetResponse, error) {
-	result := VirtualMachineScaleSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSet)
-	return result, err
+	var val *VirtualMachineScaleSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetResponse{}, err
+	}
+	return VirtualMachineScaleSetResponse{RawResponse: resp.Response, VirtualMachineScaleSet: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -440,11 +442,7 @@ func (client VirtualMachineScaleSetsClient) ForceRecoveryServiceFabricPlatformUp
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RecoveryWalkResponseResponse{}, client.forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleError(resp)
 	}
-	result, err := client.forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse(resp)
-	if err != nil {
-		return RecoveryWalkResponseResponse{}, err
-	}
-	return result, nil
+	return client.forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse(resp)
 }
 
 // forceRecoveryServiceFabricPlatformUpdateDomainWalkCreateRequest creates the ForceRecoveryServiceFabricPlatformUpdateDomainWalk request.
@@ -468,9 +466,11 @@ func (client VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformUp
 
 // forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse handles the ForceRecoveryServiceFabricPlatformUpdateDomainWalk response.
 func (client VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse(resp *azcore.Response) (RecoveryWalkResponseResponse, error) {
-	result := RecoveryWalkResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RecoveryWalkResponse)
-	return result, err
+	var val *RecoveryWalkResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RecoveryWalkResponseResponse{}, err
+	}
+	return RecoveryWalkResponseResponse{RawResponse: resp.Response, RecoveryWalkResponse: val}, nil
 }
 
 // forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleError handles the ForceRecoveryServiceFabricPlatformUpdateDomainWalk error response.
@@ -498,11 +498,7 @@ func (client VirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineScaleSetResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineScaleSetResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -525,9 +521,11 @@ func (client VirtualMachineScaleSetsClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineScaleSetsClient) getHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetResponse, error) {
-	result := VirtualMachineScaleSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSet)
-	return result, err
+	var val *VirtualMachineScaleSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetResponse{}, err
+	}
+	return VirtualMachineScaleSetResponse{RawResponse: resp.Response, VirtualMachineScaleSet: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -555,11 +553,7 @@ func (client VirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineScaleSetInstanceViewResponse{}, client.getInstanceViewHandleError(resp)
 	}
-	result, err := client.getInstanceViewHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineScaleSetInstanceViewResponse{}, err
-	}
-	return result, nil
+	return client.getInstanceViewHandleResponse(resp)
 }
 
 // getInstanceViewCreateRequest creates the GetInstanceView request.
@@ -582,9 +576,11 @@ func (client VirtualMachineScaleSetsClient) getInstanceViewCreateRequest(ctx con
 
 // getInstanceViewHandleResponse handles the GetInstanceView response.
 func (client VirtualMachineScaleSetsClient) getInstanceViewHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetInstanceViewResponse, error) {
-	result := VirtualMachineScaleSetInstanceViewResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetInstanceView)
-	return result, err
+	var val *VirtualMachineScaleSetInstanceView
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetInstanceViewResponse{}, err
+	}
+	return VirtualMachineScaleSetInstanceViewResponse{RawResponse: resp.Response, VirtualMachineScaleSetInstanceView: val}, nil
 }
 
 // getInstanceViewHandleError handles the GetInstanceView error response.
@@ -635,9 +631,11 @@ func (client VirtualMachineScaleSetsClient) getOSUpgradeHistoryCreateRequest(ctx
 
 // getOSUpgradeHistoryHandleResponse handles the GetOSUpgradeHistory response.
 func (client VirtualMachineScaleSetsClient) getOSUpgradeHistoryHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetListOSUpgradeHistoryResponse, error) {
-	result := VirtualMachineScaleSetListOSUpgradeHistoryResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetListOSUpgradeHistory)
-	return result, err
+	var val *VirtualMachineScaleSetListOSUpgradeHistory
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetListOSUpgradeHistoryResponse{}, err
+	}
+	return VirtualMachineScaleSetListOSUpgradeHistoryResponse{RawResponse: resp.Response, VirtualMachineScaleSetListOSUpgradeHistory: val}, nil
 }
 
 // getOSUpgradeHistoryHandleError handles the GetOSUpgradeHistory error response.
@@ -687,9 +685,11 @@ func (client VirtualMachineScaleSetsClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineScaleSetsClient) listHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetListResultResponse, error) {
-	result := VirtualMachineScaleSetListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetListResult)
-	return result, err
+	var val *VirtualMachineScaleSetListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetListResultResponse{}, err
+	}
+	return VirtualMachineScaleSetListResultResponse{RawResponse: resp.Response, VirtualMachineScaleSetListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -740,9 +740,11 @@ func (client VirtualMachineScaleSetsClient) listAllCreateRequest(ctx context.Con
 
 // listAllHandleResponse handles the ListAll response.
 func (client VirtualMachineScaleSetsClient) listAllHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetListWithLinkResultResponse, error) {
-	result := VirtualMachineScaleSetListWithLinkResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetListWithLinkResult)
-	return result, err
+	var val *VirtualMachineScaleSetListWithLinkResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetListWithLinkResultResponse{}, err
+	}
+	return VirtualMachineScaleSetListWithLinkResultResponse{RawResponse: resp.Response, VirtualMachineScaleSetListWithLinkResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -793,9 +795,11 @@ func (client VirtualMachineScaleSetsClient) listSkUsCreateRequest(ctx context.Co
 
 // listSkUsHandleResponse handles the ListSKUs response.
 func (client VirtualMachineScaleSetsClient) listSkUsHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetListSKUsResultResponse, error) {
-	result := VirtualMachineScaleSetListSKUsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetListSKUsResult)
-	return result, err
+	var val *VirtualMachineScaleSetListSKUsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetListSKUsResultResponse{}, err
+	}
+	return VirtualMachineScaleSetListSKUsResultResponse{RawResponse: resp.Response, VirtualMachineScaleSetListSKUsResult: val}, nil
 }
 
 // listSkUsHandleError handles the ListSKUs error response.
@@ -1577,9 +1581,11 @@ func (client VirtualMachineScaleSetsClient) updateCreateRequest(ctx context.Cont
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachineScaleSetsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetResponse, error) {
-	result := VirtualMachineScaleSetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSet)
-	return result, err
+	var val *VirtualMachineScaleSet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetResponse{}, err
+	}
+	return VirtualMachineScaleSetResponse{RawResponse: resp.Response, VirtualMachineScaleSet: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions.go
@@ -109,9 +109,11 @@ func (client VirtualMachineScaleSetVMExtensionsClient) createOrUpdateCreateReque
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualMachineScaleSetVMExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -218,11 +220,7 @@ func (client VirtualMachineScaleSetVMExtensionsClient) Get(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -250,9 +248,11 @@ func (client VirtualMachineScaleSetVMExtensionsClient) getCreateRequest(ctx cont
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineScaleSetVMExtensionsClient) getHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -277,11 +277,7 @@ func (client VirtualMachineScaleSetVMExtensionsClient) List(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineExtensionsListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineExtensionsListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -308,9 +304,11 @@ func (client VirtualMachineScaleSetVMExtensionsClient) listCreateRequest(ctx con
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineScaleSetVMExtensionsClient) listHandleResponse(resp *azcore.Response) (VirtualMachineExtensionsListResultResponse, error) {
-	result := VirtualMachineExtensionsListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtensionsListResult)
-	return result, err
+	var val *VirtualMachineExtensionsListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionsListResultResponse{}, err
+	}
+	return VirtualMachineExtensionsListResultResponse{RawResponse: resp.Response, VirtualMachineExtensionsListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -397,9 +395,11 @@ func (client VirtualMachineScaleSetVMExtensionsClient) updateCreateRequest(ctx c
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachineScaleSetVMExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	result := VirtualMachineExtensionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineExtension)
-	return result, err
+	var val *VirtualMachineExtension
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineExtensionResponse{}, err
+	}
+	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
@@ -221,11 +221,7 @@ func (client VirtualMachineScaleSetVMSClient) Get(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineScaleSetVMResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineScaleSetVMResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -252,9 +248,11 @@ func (client VirtualMachineScaleSetVMSClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client VirtualMachineScaleSetVMSClient) getHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetVMResponse, error) {
-	result := VirtualMachineScaleSetVMResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetVM)
-	return result, err
+	var val *VirtualMachineScaleSetVM
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetVMResponse{}, err
+	}
+	return VirtualMachineScaleSetVMResponse{RawResponse: resp.Response, VirtualMachineScaleSetVM: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -282,11 +280,7 @@ func (client VirtualMachineScaleSetVMSClient) GetInstanceView(ctx context.Contex
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineScaleSetVMInstanceViewResponse{}, client.getInstanceViewHandleError(resp)
 	}
-	result, err := client.getInstanceViewHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineScaleSetVMInstanceViewResponse{}, err
-	}
-	return result, nil
+	return client.getInstanceViewHandleResponse(resp)
 }
 
 // getInstanceViewCreateRequest creates the GetInstanceView request.
@@ -310,9 +304,11 @@ func (client VirtualMachineScaleSetVMSClient) getInstanceViewCreateRequest(ctx c
 
 // getInstanceViewHandleResponse handles the GetInstanceView response.
 func (client VirtualMachineScaleSetVMSClient) getInstanceViewHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetVMInstanceViewResponse, error) {
-	result := VirtualMachineScaleSetVMInstanceViewResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetVMInstanceView)
-	return result, err
+	var val *VirtualMachineScaleSetVMInstanceView
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetVMInstanceViewResponse{}, err
+	}
+	return VirtualMachineScaleSetVMInstanceViewResponse{RawResponse: resp.Response, VirtualMachineScaleSetVMInstanceView: val}, nil
 }
 
 // getInstanceViewHandleError handles the GetInstanceView error response.
@@ -372,9 +368,11 @@ func (client VirtualMachineScaleSetVMSClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineScaleSetVMSClient) listHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetVMListResultResponse, error) {
-	result := VirtualMachineScaleSetVMListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetVMListResult)
-	return result, err
+	var val *VirtualMachineScaleSetVMListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetVMListResultResponse{}, err
+	}
+	return VirtualMachineScaleSetVMListResultResponse{RawResponse: resp.Response, VirtualMachineScaleSetVMListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -975,9 +973,11 @@ func (client VirtualMachineScaleSetVMSClient) runCommandCreateRequest(ctx contex
 
 // runCommandHandleResponse handles the RunCommand response.
 func (client VirtualMachineScaleSetVMSClient) runCommandHandleResponse(resp *azcore.Response) (RunCommandResultResponse, error) {
-	result := RunCommandResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RunCommandResult)
-	return result, err
+	var val *RunCommandResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RunCommandResultResponse{}, err
+	}
+	return RunCommandResultResponse{RawResponse: resp.Response, RunCommandResult: val}, nil
 }
 
 // runCommandHandleError handles the RunCommand error response.
@@ -1196,9 +1196,11 @@ func (client VirtualMachineScaleSetVMSClient) updateCreateRequest(ctx context.Co
 
 // updateHandleResponse handles the Update response.
 func (client VirtualMachineScaleSetVMSClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetVMResponse, error) {
-	result := VirtualMachineScaleSetVMResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineScaleSetVM)
-	return result, err
+	var val *VirtualMachineScaleSetVM
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineScaleSetVMResponse{}, err
+	}
+	return VirtualMachineScaleSetVMResponse{RawResponse: resp.Response, VirtualMachineScaleSetVM: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes.go
@@ -49,11 +49,7 @@ func (client VirtualMachineSizesClient) List(ctx context.Context, location strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualMachineSizeListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return VirtualMachineSizeListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -75,9 +71,11 @@ func (client VirtualMachineSizesClient) listCreateRequest(ctx context.Context, l
 
 // listHandleResponse handles the List response.
 func (client VirtualMachineSizesClient) listHandleResponse(resp *azcore.Response) (VirtualMachineSizeListResultResponse, error) {
-	result := VirtualMachineSizeListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualMachineSizeListResult)
-	return result, err
+	var val *VirtualMachineSizeListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualMachineSizeListResultResponse{}, err
+	}
+	return VirtualMachineSizeListResultResponse{RawResponse: resp.Response, VirtualMachineSizeListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -110,9 +110,11 @@ func (client ApplicationGatewaysClient) backendHealthCreateRequest(ctx context.C
 
 // backendHealthHandleResponse handles the BackendHealth response.
 func (client ApplicationGatewaysClient) backendHealthHandleResponse(resp *azcore.Response) (ApplicationGatewayBackendHealthResponse, error) {
-	result := ApplicationGatewayBackendHealthResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayBackendHealth)
-	return result, err
+	var val *ApplicationGatewayBackendHealth
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayBackendHealthResponse{}, err
+	}
+	return ApplicationGatewayBackendHealthResponse{RawResponse: resp.Response, ApplicationGatewayBackendHealth: val}, nil
 }
 
 // backendHealthHandleError handles the BackendHealth error response.
@@ -202,9 +204,11 @@ func (client ApplicationGatewaysClient) backendHealthOnDemandCreateRequest(ctx c
 
 // backendHealthOnDemandHandleResponse handles the BackendHealthOnDemand response.
 func (client ApplicationGatewaysClient) backendHealthOnDemandHandleResponse(resp *azcore.Response) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
-	result := ApplicationGatewayBackendHealthOnDemandResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayBackendHealthOnDemand)
-	return result, err
+	var val *ApplicationGatewayBackendHealthOnDemand
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayBackendHealthOnDemandResponse{}, err
+	}
+	return ApplicationGatewayBackendHealthOnDemandResponse{RawResponse: resp.Response, ApplicationGatewayBackendHealthOnDemand: val}, nil
 }
 
 // backendHealthOnDemandHandleError handles the BackendHealthOnDemand error response.
@@ -289,9 +293,11 @@ func (client ApplicationGatewaysClient) createOrUpdateCreateRequest(ctx context.
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ApplicationGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (ApplicationGatewayResponse, error) {
-	result := ApplicationGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGateway)
-	return result, err
+	var val *ApplicationGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayResponse{}, err
+	}
+	return ApplicationGatewayResponse{RawResponse: resp.Response, ApplicationGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -396,11 +402,7 @@ func (client ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ApplicationGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -423,9 +425,11 @@ func (client ApplicationGatewaysClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client ApplicationGatewaysClient) getHandleResponse(resp *azcore.Response) (ApplicationGatewayResponse, error) {
-	result := ApplicationGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGateway)
-	return result, err
+	var val *ApplicationGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayResponse{}, err
+	}
+	return ApplicationGatewayResponse{RawResponse: resp.Response, ApplicationGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -450,11 +454,7 @@ func (client ApplicationGatewaysClient) GetSslPredefinedPolicy(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationGatewaySslPredefinedPolicyResponse{}, client.getSslPredefinedPolicyHandleError(resp)
 	}
-	result, err := client.getSslPredefinedPolicyHandleResponse(resp)
-	if err != nil {
-		return ApplicationGatewaySslPredefinedPolicyResponse{}, err
-	}
-	return result, nil
+	return client.getSslPredefinedPolicyHandleResponse(resp)
 }
 
 // getSslPredefinedPolicyCreateRequest creates the GetSslPredefinedPolicy request.
@@ -476,9 +476,11 @@ func (client ApplicationGatewaysClient) getSslPredefinedPolicyCreateRequest(ctx 
 
 // getSslPredefinedPolicyHandleResponse handles the GetSslPredefinedPolicy response.
 func (client ApplicationGatewaysClient) getSslPredefinedPolicyHandleResponse(resp *azcore.Response) (ApplicationGatewaySslPredefinedPolicyResponse, error) {
-	result := ApplicationGatewaySslPredefinedPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewaySslPredefinedPolicy)
-	return result, err
+	var val *ApplicationGatewaySslPredefinedPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewaySslPredefinedPolicyResponse{}, err
+	}
+	return ApplicationGatewaySslPredefinedPolicyResponse{RawResponse: resp.Response, ApplicationGatewaySslPredefinedPolicy: val}, nil
 }
 
 // getSslPredefinedPolicyHandleError handles the GetSslPredefinedPolicy error response.
@@ -525,9 +527,11 @@ func (client ApplicationGatewaysClient) listCreateRequest(ctx context.Context, r
 
 // listHandleResponse handles the List response.
 func (client ApplicationGatewaysClient) listHandleResponse(resp *azcore.Response) (ApplicationGatewayListResultResponse, error) {
-	result := ApplicationGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayListResult)
-	return result, err
+	var val *ApplicationGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayListResultResponse{}, err
+	}
+	return ApplicationGatewayListResultResponse{RawResponse: resp.Response, ApplicationGatewayListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -573,9 +577,11 @@ func (client ApplicationGatewaysClient) listAllCreateRequest(ctx context.Context
 
 // listAllHandleResponse handles the ListAll response.
 func (client ApplicationGatewaysClient) listAllHandleResponse(resp *azcore.Response) (ApplicationGatewayListResultResponse, error) {
-	result := ApplicationGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayListResult)
-	return result, err
+	var val *ApplicationGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayListResultResponse{}, err
+	}
+	return ApplicationGatewayListResultResponse{RawResponse: resp.Response, ApplicationGatewayListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -600,11 +606,7 @@ func (client ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context.
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.listAvailableRequestHeadersHandleError(resp)
 	}
-	result, err := client.listAvailableRequestHeadersHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableRequestHeadersHandleResponse(resp)
 }
 
 // listAvailableRequestHeadersCreateRequest creates the ListAvailableRequestHeaders request.
@@ -625,9 +627,11 @@ func (client ApplicationGatewaysClient) listAvailableRequestHeadersCreateRequest
 
 // listAvailableRequestHeadersHandleResponse handles the ListAvailableRequestHeaders response.
 func (client ApplicationGatewaysClient) listAvailableRequestHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // listAvailableRequestHeadersHandleError handles the ListAvailableRequestHeaders error response.
@@ -652,11 +656,7 @@ func (client ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.listAvailableResponseHeadersHandleError(resp)
 	}
-	result, err := client.listAvailableResponseHeadersHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableResponseHeadersHandleResponse(resp)
 }
 
 // listAvailableResponseHeadersCreateRequest creates the ListAvailableResponseHeaders request.
@@ -677,9 +677,11 @@ func (client ApplicationGatewaysClient) listAvailableResponseHeadersCreateReques
 
 // listAvailableResponseHeadersHandleResponse handles the ListAvailableResponseHeaders response.
 func (client ApplicationGatewaysClient) listAvailableResponseHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // listAvailableResponseHeadersHandleError handles the ListAvailableResponseHeaders error response.
@@ -704,11 +706,7 @@ func (client ApplicationGatewaysClient) ListAvailableServerVariables(ctx context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringArrayResponse{}, client.listAvailableServerVariablesHandleError(resp)
 	}
-	result, err := client.listAvailableServerVariablesHandleResponse(resp)
-	if err != nil {
-		return StringArrayResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableServerVariablesHandleResponse(resp)
 }
 
 // listAvailableServerVariablesCreateRequest creates the ListAvailableServerVariables request.
@@ -729,9 +727,11 @@ func (client ApplicationGatewaysClient) listAvailableServerVariablesCreateReques
 
 // listAvailableServerVariablesHandleResponse handles the ListAvailableServerVariables response.
 func (client ApplicationGatewaysClient) listAvailableServerVariablesHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	result := StringArrayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.StringArray)
-	return result, err
+	var val *[]string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringArrayResponse{}, err
+	}
+	return StringArrayResponse{RawResponse: resp.Response, StringArray: val}, nil
 }
 
 // listAvailableServerVariablesHandleError handles the ListAvailableServerVariables error response.
@@ -756,11 +756,7 @@ func (client ApplicationGatewaysClient) ListAvailableSslOptions(ctx context.Cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationGatewayAvailableSslOptionsResponse{}, client.listAvailableSslOptionsHandleError(resp)
 	}
-	result, err := client.listAvailableSslOptionsHandleResponse(resp)
-	if err != nil {
-		return ApplicationGatewayAvailableSslOptionsResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableSslOptionsHandleResponse(resp)
 }
 
 // listAvailableSslOptionsCreateRequest creates the ListAvailableSslOptions request.
@@ -781,9 +777,11 @@ func (client ApplicationGatewaysClient) listAvailableSslOptionsCreateRequest(ctx
 
 // listAvailableSslOptionsHandleResponse handles the ListAvailableSslOptions response.
 func (client ApplicationGatewaysClient) listAvailableSslOptionsHandleResponse(resp *azcore.Response) (ApplicationGatewayAvailableSslOptionsResponse, error) {
-	result := ApplicationGatewayAvailableSslOptionsResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableSslOptions)
-	return result, err
+	var val *ApplicationGatewayAvailableSslOptions
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayAvailableSslOptionsResponse{}, err
+	}
+	return ApplicationGatewayAvailableSslOptionsResponse{RawResponse: resp.Response, ApplicationGatewayAvailableSslOptions: val}, nil
 }
 
 // listAvailableSslOptionsHandleError handles the ListAvailableSslOptions error response.
@@ -829,9 +827,11 @@ func (client ApplicationGatewaysClient) listAvailableSslPredefinedPoliciesCreate
 
 // listAvailableSslPredefinedPoliciesHandleResponse handles the ListAvailableSslPredefinedPolicies response.
 func (client ApplicationGatewaysClient) listAvailableSslPredefinedPoliciesHandleResponse(resp *azcore.Response) (ApplicationGatewayAvailableSslPredefinedPoliciesResponse, error) {
-	result := ApplicationGatewayAvailableSslPredefinedPoliciesResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableSslPredefinedPolicies)
-	return result, err
+	var val *ApplicationGatewayAvailableSslPredefinedPolicies
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayAvailableSslPredefinedPoliciesResponse{}, err
+	}
+	return ApplicationGatewayAvailableSslPredefinedPoliciesResponse{RawResponse: resp.Response, ApplicationGatewayAvailableSslPredefinedPolicies: val}, nil
 }
 
 // listAvailableSslPredefinedPoliciesHandleError handles the ListAvailableSslPredefinedPolicies error response.
@@ -856,11 +856,7 @@ func (client ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Con
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationGatewayAvailableWafRuleSetsResultResponse{}, client.listAvailableWafRuleSetsHandleError(resp)
 	}
-	result, err := client.listAvailableWafRuleSetsHandleResponse(resp)
-	if err != nil {
-		return ApplicationGatewayAvailableWafRuleSetsResultResponse{}, err
-	}
-	return result, nil
+	return client.listAvailableWafRuleSetsHandleResponse(resp)
 }
 
 // listAvailableWafRuleSetsCreateRequest creates the ListAvailableWafRuleSets request.
@@ -881,9 +877,11 @@ func (client ApplicationGatewaysClient) listAvailableWafRuleSetsCreateRequest(ct
 
 // listAvailableWafRuleSetsHandleResponse handles the ListAvailableWafRuleSets response.
 func (client ApplicationGatewaysClient) listAvailableWafRuleSetsHandleResponse(resp *azcore.Response) (ApplicationGatewayAvailableWafRuleSetsResultResponse, error) {
-	result := ApplicationGatewayAvailableWafRuleSetsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGatewayAvailableWafRuleSetsResult)
-	return result, err
+	var val *ApplicationGatewayAvailableWafRuleSetsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayAvailableWafRuleSetsResultResponse{}, err
+	}
+	return ApplicationGatewayAvailableWafRuleSetsResultResponse{RawResponse: resp.Response, ApplicationGatewayAvailableWafRuleSetsResult: val}, nil
 }
 
 // listAvailableWafRuleSetsHandleError handles the ListAvailableWafRuleSets error response.
@@ -1068,11 +1066,7 @@ func (client ApplicationGatewaysClient) UpdateTags(ctx context.Context, resource
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationGatewayResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ApplicationGatewayResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -1095,9 +1089,11 @@ func (client ApplicationGatewaysClient) updateTagsCreateRequest(ctx context.Cont
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ApplicationGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (ApplicationGatewayResponse, error) {
-	result := ApplicationGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationGateway)
-	return result, err
+	var val *ApplicationGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationGatewayResponse{}, err
+	}
+	return ApplicationGatewayResponse{RawResponse: resp.Response, ApplicationGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups.go
@@ -107,9 +107,11 @@ func (client ApplicationSecurityGroupsClient) createOrUpdateCreateRequest(ctx co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ApplicationSecurityGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupResponse, error) {
-	result := ApplicationSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationSecurityGroup)
-	return result, err
+	var val *ApplicationSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationSecurityGroupResponse{}, err
+	}
+	return ApplicationSecurityGroupResponse{RawResponse: resp.Response, ApplicationSecurityGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client ApplicationSecurityGroupsClient) Get(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationSecurityGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ApplicationSecurityGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client ApplicationSecurityGroupsClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client ApplicationSecurityGroupsClient) getHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupResponse, error) {
-	result := ApplicationSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationSecurityGroup)
-	return result, err
+	var val *ApplicationSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationSecurityGroupResponse{}, err
+	}
+	return ApplicationSecurityGroupResponse{RawResponse: resp.Response, ApplicationSecurityGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -290,9 +290,11 @@ func (client ApplicationSecurityGroupsClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client ApplicationSecurityGroupsClient) listHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupListResultResponse, error) {
-	result := ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationSecurityGroupListResult)
-	return result, err
+	var val *ApplicationSecurityGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationSecurityGroupListResultResponse{}, err
+	}
+	return ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response, ApplicationSecurityGroupListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client ApplicationSecurityGroupsClient) listAllCreateRequest(ctx context.C
 
 // listAllHandleResponse handles the ListAll response.
 func (client ApplicationSecurityGroupsClient) listAllHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupListResultResponse, error) {
-	result := ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationSecurityGroupListResult)
-	return result, err
+	var val *ApplicationSecurityGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationSecurityGroupListResultResponse{}, err
+	}
+	return ApplicationSecurityGroupListResultResponse{RawResponse: resp.Response, ApplicationSecurityGroupListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -365,11 +369,7 @@ func (client ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ApplicationSecurityGroupResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ApplicationSecurityGroupResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client ApplicationSecurityGroupsClient) updateTagsCreateRequest(ctx contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ApplicationSecurityGroupsClient) updateTagsHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupResponse, error) {
-	result := ApplicationSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ApplicationSecurityGroup)
-	return result, err
+	var val *ApplicationSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ApplicationSecurityGroupResponse{}, err
+	}
+	return ApplicationSecurityGroupResponse{RawResponse: resp.Response, ApplicationSecurityGroup: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations.go
@@ -68,9 +68,11 @@ func (client AvailableDelegationsClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client AvailableDelegationsClient) listHandleResponse(resp *azcore.Response) (AvailableDelegationsResultResponse, error) {
-	result := AvailableDelegationsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailableDelegationsResult)
-	return result, err
+	var val *AvailableDelegationsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailableDelegationsResultResponse{}, err
+	}
+	return AvailableDelegationsResultResponse{RawResponse: resp.Response, AvailableDelegationsResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices.go
@@ -68,9 +68,11 @@ func (client AvailableEndpointServicesClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client AvailableEndpointServicesClient) listHandleResponse(resp *azcore.Response) (EndpointServicesListResultResponse, error) {
-	result := EndpointServicesListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.EndpointServicesListResult)
-	return result, err
+	var val *EndpointServicesListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return EndpointServicesListResultResponse{}, err
+	}
+	return EndpointServicesListResultResponse{RawResponse: resp.Response, EndpointServicesListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes.go
@@ -68,9 +68,11 @@ func (client AvailablePrivateEndpointTypesClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client AvailablePrivateEndpointTypesClient) listHandleResponse(resp *azcore.Response) (AvailablePrivateEndpointTypesResultResponse, error) {
-	result := AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailablePrivateEndpointTypesResult)
-	return result, err
+	var val *AvailablePrivateEndpointTypesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailablePrivateEndpointTypesResultResponse{}, err
+	}
+	return AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response, AvailablePrivateEndpointTypesResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -118,9 +120,11 @@ func (client AvailablePrivateEndpointTypesClient) listByResourceGroupCreateReque
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client AvailablePrivateEndpointTypesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (AvailablePrivateEndpointTypesResultResponse, error) {
-	result := AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailablePrivateEndpointTypesResult)
-	return result, err
+	var val *AvailablePrivateEndpointTypesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailablePrivateEndpointTypesResultResponse{}, err
+	}
+	return AvailablePrivateEndpointTypesResultResponse{RawResponse: resp.Response, AvailablePrivateEndpointTypesResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations.go
@@ -69,9 +69,11 @@ func (client AvailableResourceGroupDelegationsClient) listCreateRequest(ctx cont
 
 // listHandleResponse handles the List response.
 func (client AvailableResourceGroupDelegationsClient) listHandleResponse(resp *azcore.Response) (AvailableDelegationsResultResponse, error) {
-	result := AvailableDelegationsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailableDelegationsResult)
-	return result, err
+	var val *AvailableDelegationsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailableDelegationsResultResponse{}, err
+	}
+	return AvailableDelegationsResultResponse{RawResponse: resp.Response, AvailableDelegationsResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases.go
@@ -68,9 +68,11 @@ func (client AvailableServiceAliasesClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client AvailableServiceAliasesClient) listHandleResponse(resp *azcore.Response) (AvailableServiceAliasesResultResponse, error) {
-	result := AvailableServiceAliasesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailableServiceAliasesResult)
-	return result, err
+	var val *AvailableServiceAliasesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailableServiceAliasesResultResponse{}, err
+	}
+	return AvailableServiceAliasesResultResponse{RawResponse: resp.Response, AvailableServiceAliasesResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -118,9 +120,11 @@ func (client AvailableServiceAliasesClient) listByResourceGroupCreateRequest(ctx
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client AvailableServiceAliasesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (AvailableServiceAliasesResultResponse, error) {
-	result := AvailableServiceAliasesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailableServiceAliasesResult)
-	return result, err
+	var val *AvailableServiceAliasesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailableServiceAliasesResultResponse{}, err
+	}
+	return AvailableServiceAliasesResultResponse{RawResponse: resp.Response, AvailableServiceAliasesResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags.go
@@ -67,9 +67,11 @@ func (client AzureFirewallFqdnTagsClient) listAllCreateRequest(ctx context.Conte
 
 // listAllHandleResponse handles the ListAll response.
 func (client AzureFirewallFqdnTagsClient) listAllHandleResponse(resp *azcore.Response) (AzureFirewallFqdnTagListResultResponse, error) {
-	result := AzureFirewallFqdnTagListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewallFqdnTagListResult)
-	return result, err
+	var val *AzureFirewallFqdnTagListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallFqdnTagListResultResponse{}, err
+	}
+	return AzureFirewallFqdnTagListResultResponse{RawResponse: resp.Response, AzureFirewallFqdnTagListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls.go
@@ -107,9 +107,11 @@ func (client AzureFirewallsClient) createOrUpdateCreateRequest(ctx context.Conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client AzureFirewallsClient) createOrUpdateHandleResponse(resp *azcore.Response) (AzureFirewallResponse, error) {
-	result := AzureFirewallResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewall)
-	return result, err
+	var val *AzureFirewall
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallResponse{}, err
+	}
+	return AzureFirewallResponse{RawResponse: resp.Response, AzureFirewall: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client AzureFirewallsClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AzureFirewallResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return AzureFirewallResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client AzureFirewallsClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client AzureFirewallsClient) getHandleResponse(resp *azcore.Response) (AzureFirewallResponse, error) {
-	result := AzureFirewallResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewall)
-	return result, err
+	var val *AzureFirewall
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallResponse{}, err
+	}
+	return AzureFirewallResponse{RawResponse: resp.Response, AzureFirewall: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -290,9 +290,11 @@ func (client AzureFirewallsClient) listCreateRequest(ctx context.Context, resour
 
 // listHandleResponse handles the List response.
 func (client AzureFirewallsClient) listHandleResponse(resp *azcore.Response) (AzureFirewallListResultResponse, error) {
-	result := AzureFirewallListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewallListResult)
-	return result, err
+	var val *AzureFirewallListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallListResultResponse{}, err
+	}
+	return AzureFirewallListResultResponse{RawResponse: resp.Response, AzureFirewallListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client AzureFirewallsClient) listAllCreateRequest(ctx context.Context, opt
 
 // listAllHandleResponse handles the ListAll response.
 func (client AzureFirewallsClient) listAllHandleResponse(resp *azcore.Response) (AzureFirewallListResultResponse, error) {
-	result := AzureFirewallListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewallListResult)
-	return result, err
+	var val *AzureFirewallListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallListResultResponse{}, err
+	}
+	return AzureFirewallListResultResponse{RawResponse: resp.Response, AzureFirewallListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -425,9 +429,11 @@ func (client AzureFirewallsClient) updateTagsCreateRequest(ctx context.Context, 
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client AzureFirewallsClient) updateTagsHandleResponse(resp *azcore.Response) (AzureFirewallResponse, error) {
-	result := AzureFirewallResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureFirewall)
-	return result, err
+	var val *AzureFirewall
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureFirewallResponse{}, err
+	}
+	return AzureFirewallResponse{RawResponse: resp.Response, AzureFirewall: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts.go
@@ -107,9 +107,11 @@ func (client BastionHostsClient) createOrUpdateCreateRequest(ctx context.Context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client BastionHostsClient) createOrUpdateHandleResponse(resp *azcore.Response) (BastionHostResponse, error) {
-	result := BastionHostResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionHost)
-	return result, err
+	var val *BastionHost
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionHostResponse{}, err
+	}
+	return BastionHostResponse{RawResponse: resp.Response, BastionHost: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client BastionHostsClient) Get(ctx context.Context, resourceGroupName stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BastionHostResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return BastionHostResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client BastionHostsClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client BastionHostsClient) getHandleResponse(resp *azcore.Response) (BastionHostResponse, error) {
-	result := BastionHostResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionHost)
-	return result, err
+	var val *BastionHost
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionHostResponse{}, err
+	}
+	return BastionHostResponse{RawResponse: resp.Response, BastionHost: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client BastionHostsClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client BastionHostsClient) listHandleResponse(resp *azcore.Response) (BastionHostListResultResponse, error) {
-	result := BastionHostListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionHostListResult)
-	return result, err
+	var val *BastionHostListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionHostListResultResponse{}, err
+	}
+	return BastionHostListResultResponse{RawResponse: resp.Response, BastionHostListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client BastionHostsClient) listByResourceGroupCreateRequest(ctx context.Co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client BastionHostsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (BastionHostListResultResponse, error) {
-	result := BastionHostListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionHostListResult)
-	return result, err
+	var val *BastionHostListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionHostListResultResponse{}, err
+	}
+	return BastionHostListResultResponse{RawResponse: resp.Response, BastionHostListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities.go
@@ -67,9 +67,11 @@ func (client BgpServiceCommunitiesClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client BgpServiceCommunitiesClient) listHandleResponse(resp *azcore.Response) (BgpServiceCommunityListResultResponse, error) {
-	result := BgpServiceCommunityListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BgpServiceCommunityListResult)
-	return result, err
+	var val *BgpServiceCommunityListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BgpServiceCommunityListResultResponse{}, err
+	}
+	return BgpServiceCommunityListResultResponse{RawResponse: resp.Response, BgpServiceCommunityListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors.go
@@ -108,9 +108,11 @@ func (client ConnectionMonitorsClient) createOrUpdateCreateRequest(ctx context.C
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ConnectionMonitorsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ConnectionMonitorResultResponse, error) {
-	result := ConnectionMonitorResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionMonitorResult)
-	return result, err
+	var val *ConnectionMonitorResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionMonitorResultResponse{}, err
+	}
+	return ConnectionMonitorResultResponse{RawResponse: resp.Response, ConnectionMonitorResult: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ConnectionMonitorsClient) Get(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ConnectionMonitorResultResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ConnectionMonitorResultResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ConnectionMonitorsClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client ConnectionMonitorsClient) getHandleResponse(resp *azcore.Response) (ConnectionMonitorResultResponse, error) {
-	result := ConnectionMonitorResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionMonitorResult)
-	return result, err
+	var val *ConnectionMonitorResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionMonitorResultResponse{}, err
+	}
+	return ConnectionMonitorResultResponse{RawResponse: resp.Response, ConnectionMonitorResult: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -271,11 +271,7 @@ func (client ConnectionMonitorsClient) List(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ConnectionMonitorListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ConnectionMonitorListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -298,9 +294,11 @@ func (client ConnectionMonitorsClient) listCreateRequest(ctx context.Context, re
 
 // listHandleResponse handles the List response.
 func (client ConnectionMonitorsClient) listHandleResponse(resp *azcore.Response) (ConnectionMonitorListResultResponse, error) {
-	result := ConnectionMonitorListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionMonitorListResult)
-	return result, err
+	var val *ConnectionMonitorListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionMonitorListResultResponse{}, err
+	}
+	return ConnectionMonitorListResultResponse{RawResponse: resp.Response, ConnectionMonitorListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -386,9 +384,11 @@ func (client ConnectionMonitorsClient) queryCreateRequest(ctx context.Context, r
 
 // queryHandleResponse handles the Query response.
 func (client ConnectionMonitorsClient) queryHandleResponse(resp *azcore.Response) (ConnectionMonitorQueryResultResponse, error) {
-	result := ConnectionMonitorQueryResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionMonitorQueryResult)
-	return result, err
+	var val *ConnectionMonitorQueryResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionMonitorQueryResultResponse{}, err
+	}
+	return ConnectionMonitorQueryResultResponse{RawResponse: resp.Response, ConnectionMonitorQueryResult: val}, nil
 }
 
 // queryHandleError handles the Query error response.
@@ -575,11 +575,7 @@ func (client ConnectionMonitorsClient) UpdateTags(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ConnectionMonitorResultResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ConnectionMonitorResultResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -603,9 +599,11 @@ func (client ConnectionMonitorsClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ConnectionMonitorsClient) updateTagsHandleResponse(resp *azcore.Response) (ConnectionMonitorResultResponse, error) {
-	result := ConnectionMonitorResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionMonitorResult)
-	return result, err
+	var val *ConnectionMonitorResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionMonitorResultResponse{}, err
+	}
+	return ConnectionMonitorResultResponse{RawResponse: resp.Response, ConnectionMonitorResult: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies.go
@@ -107,9 +107,11 @@ func (client DdosCustomPoliciesClient) createOrUpdateCreateRequest(ctx context.C
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DdosCustomPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (DdosCustomPolicyResponse, error) {
-	result := DdosCustomPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosCustomPolicy)
-	return result, err
+	var val *DdosCustomPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosCustomPolicyResponse{}, err
+	}
+	return DdosCustomPolicyResponse{RawResponse: resp.Response, DdosCustomPolicy: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DdosCustomPolicyResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DdosCustomPolicyResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client DdosCustomPoliciesClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client DdosCustomPoliciesClient) getHandleResponse(resp *azcore.Response) (DdosCustomPolicyResponse, error) {
-	result := DdosCustomPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosCustomPolicy)
-	return result, err
+	var val *DdosCustomPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosCustomPolicyResponse{}, err
+	}
+	return DdosCustomPolicyResponse{RawResponse: resp.Response, DdosCustomPolicy: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -268,11 +268,7 @@ func (client DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DdosCustomPolicyResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return DdosCustomPolicyResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -295,9 +291,11 @@ func (client DdosCustomPoliciesClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client DdosCustomPoliciesClient) updateTagsHandleResponse(resp *azcore.Response) (DdosCustomPolicyResponse, error) {
-	result := DdosCustomPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosCustomPolicy)
-	return result, err
+	var val *DdosCustomPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosCustomPolicyResponse{}, err
+	}
+	return DdosCustomPolicyResponse{RawResponse: resp.Response, DdosCustomPolicy: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans.go
@@ -107,9 +107,11 @@ func (client DdosProtectionPlansClient) createOrUpdateCreateRequest(ctx context.
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client DdosProtectionPlansClient) createOrUpdateHandleResponse(resp *azcore.Response) (DdosProtectionPlanResponse, error) {
-	result := DdosProtectionPlanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosProtectionPlan)
-	return result, err
+	var val *DdosProtectionPlan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosProtectionPlanResponse{}, err
+	}
+	return DdosProtectionPlanResponse{RawResponse: resp.Response, DdosProtectionPlan: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DdosProtectionPlanResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return DdosProtectionPlanResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client DdosProtectionPlansClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client DdosProtectionPlansClient) getHandleResponse(resp *azcore.Response) (DdosProtectionPlanResponse, error) {
-	result := DdosProtectionPlanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosProtectionPlan)
-	return result, err
+	var val *DdosProtectionPlan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosProtectionPlanResponse{}, err
+	}
+	return DdosProtectionPlanResponse{RawResponse: resp.Response, DdosProtectionPlan: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client DdosProtectionPlansClient) listCreateRequest(ctx context.Context, o
 
 // listHandleResponse handles the List response.
 func (client DdosProtectionPlansClient) listHandleResponse(resp *azcore.Response) (DdosProtectionPlanListResultResponse, error) {
-	result := DdosProtectionPlanListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosProtectionPlanListResult)
-	return result, err
+	var val *DdosProtectionPlanListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosProtectionPlanListResultResponse{}, err
+	}
+	return DdosProtectionPlanListResultResponse{RawResponse: resp.Response, DdosProtectionPlanListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client DdosProtectionPlansClient) listByResourceGroupCreateRequest(ctx con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client DdosProtectionPlansClient) listByResourceGroupHandleResponse(resp *azcore.Response) (DdosProtectionPlanListResultResponse, error) {
-	result := DdosProtectionPlanListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosProtectionPlanListResult)
-	return result, err
+	var val *DdosProtectionPlanListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosProtectionPlanListResultResponse{}, err
+	}
+	return DdosProtectionPlanListResultResponse{RawResponse: resp.Response, DdosProtectionPlanListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client DdosProtectionPlansClient) UpdateTags(ctx context.Context, resource
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DdosProtectionPlanResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return DdosProtectionPlanResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client DdosProtectionPlansClient) updateTagsCreateRequest(ctx context.Cont
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client DdosProtectionPlansClient) updateTagsHandleResponse(resp *azcore.Response) (DdosProtectionPlanResponse, error) {
-	result := DdosProtectionPlanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DdosProtectionPlan)
-	return result, err
+	var val *DdosProtectionPlan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DdosProtectionPlanResponse{}, err
+	}
+	return DdosProtectionPlanResponse{RawResponse: resp.Response, DdosProtectionPlan: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules.go
@@ -46,11 +46,7 @@ func (client DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SecurityRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SecurityRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client DefaultSecurityRulesClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client DefaultSecurityRulesClient) getHandleResponse(resp *azcore.Response) (SecurityRuleResponse, error) {
-	result := SecurityRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityRule)
-	return result, err
+	var val *SecurityRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityRuleResponse{}, err
+	}
+	return SecurityRuleResponse{RawResponse: resp.Response, SecurityRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client DefaultSecurityRulesClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client DefaultSecurityRulesClient) listHandleResponse(resp *azcore.Response) (SecurityRuleListResultResponse, error) {
-	result := SecurityRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityRuleListResult)
-	return result, err
+	var val *SecurityRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityRuleListResultResponse{}, err
+	}
+	return SecurityRuleListResultResponse{RawResponse: resp.Response, SecurityRuleListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations.go
@@ -108,9 +108,11 @@ func (client ExpressRouteCircuitAuthorizationsClient) createOrUpdateCreateReques
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCircuitAuthorizationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitAuthorizationResponse, error) {
-	result := ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitAuthorization)
-	return result, err
+	var val *ExpressRouteCircuitAuthorization
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitAuthorizationResponse{}, err
+	}
+	return ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response, ExpressRouteCircuitAuthorization: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, r
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitAuthorizationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitAuthorizationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ExpressRouteCircuitAuthorizationsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCircuitAuthorizationsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCircuitAuthorizationResponse, error) {
-	result := ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitAuthorization)
-	return result, err
+	var val *ExpressRouteCircuitAuthorization
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitAuthorizationResponse{}, err
+	}
+	return ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response, ExpressRouteCircuitAuthorization: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client ExpressRouteCircuitAuthorizationsClient) listCreateRequest(ctx cont
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCircuitAuthorizationsClient) listHandleResponse(resp *azcore.Response) (AuthorizationListResultResponse, error) {
-	result := AuthorizationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AuthorizationListResult)
-	return result, err
+	var val *AuthorizationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AuthorizationListResultResponse{}, err
+	}
+	return AuthorizationListResultResponse{RawResponse: resp.Response, AuthorizationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections.go
@@ -109,9 +109,11 @@ func (client ExpressRouteCircuitConnectionsClient) createOrUpdateCreateRequest(c
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCircuitConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitConnectionResponse, error) {
-	result := ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitConnection)
-	return result, err
+	var val *ExpressRouteCircuitConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitConnectionResponse{}, err
+	}
+	return ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response, ExpressRouteCircuitConnection: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -218,11 +220,7 @@ func (client ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -247,9 +245,11 @@ func (client ExpressRouteCircuitConnectionsClient) getCreateRequest(ctx context.
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCircuitConnectionsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCircuitConnectionResponse, error) {
-	result := ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitConnection)
-	return result, err
+	var val *ExpressRouteCircuitConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitConnectionResponse{}, err
+	}
+	return ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response, ExpressRouteCircuitConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -298,9 +298,11 @@ func (client ExpressRouteCircuitConnectionsClient) listCreateRequest(ctx context
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCircuitConnectionsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteCircuitConnectionListResultResponse, error) {
-	result := ExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitConnectionListResult)
-	return result, err
+	var val *ExpressRouteCircuitConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitConnectionListResultResponse{}, err
+	}
+	return ExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitConnectionListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings.go
@@ -108,9 +108,11 @@ func (client ExpressRouteCircuitPeeringsClient) createOrUpdateCreateRequest(ctx 
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCircuitPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitPeeringResponse, error) {
-	result := ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitPeering)
-	return result, err
+	var val *ExpressRouteCircuitPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitPeeringResponse{}, err
+	}
+	return ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response, ExpressRouteCircuitPeering: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resourc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitPeeringResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitPeeringResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ExpressRouteCircuitPeeringsClient) getCreateRequest(ctx context.Con
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCircuitPeeringsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCircuitPeeringResponse, error) {
-	result := ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitPeering)
-	return result, err
+	var val *ExpressRouteCircuitPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitPeeringResponse{}, err
+	}
+	return ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response, ExpressRouteCircuitPeering: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client ExpressRouteCircuitPeeringsClient) listCreateRequest(ctx context.Co
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCircuitPeeringsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteCircuitPeeringListResultResponse, error) {
-	result := ExpressRouteCircuitPeeringListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitPeeringListResult)
-	return result, err
+	var val *ExpressRouteCircuitPeeringListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitPeeringListResultResponse{}, err
+	}
+	return ExpressRouteCircuitPeeringListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitPeeringListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits.go
@@ -107,9 +107,11 @@ func (client ExpressRouteCircuitsClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCircuitsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitResponse, error) {
-	result := ExpressRouteCircuitResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuit)
-	return result, err
+	var val *ExpressRouteCircuit
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitResponse{}, err
+	}
+	return ExpressRouteCircuitResponse{RawResponse: resp.Response, ExpressRouteCircuit: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client ExpressRouteCircuitsClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCircuitsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCircuitResponse, error) {
-	result := ExpressRouteCircuitResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuit)
-	return result, err
+	var val *ExpressRouteCircuit
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitResponse{}, err
+	}
+	return ExpressRouteCircuitResponse{RawResponse: resp.Response, ExpressRouteCircuit: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -268,11 +268,7 @@ func (client ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitStatsResponse{}, client.getPeeringStatsHandleError(resp)
 	}
-	result, err := client.getPeeringStatsHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitStatsResponse{}, err
-	}
-	return result, nil
+	return client.getPeeringStatsHandleResponse(resp)
 }
 
 // getPeeringStatsCreateRequest creates the GetPeeringStats request.
@@ -296,9 +292,11 @@ func (client ExpressRouteCircuitsClient) getPeeringStatsCreateRequest(ctx contex
 
 // getPeeringStatsHandleResponse handles the GetPeeringStats response.
 func (client ExpressRouteCircuitsClient) getPeeringStatsHandleResponse(resp *azcore.Response) (ExpressRouteCircuitStatsResponse, error) {
-	result := ExpressRouteCircuitStatsResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitStats)
-	return result, err
+	var val *ExpressRouteCircuitStats
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitStatsResponse{}, err
+	}
+	return ExpressRouteCircuitStatsResponse{RawResponse: resp.Response, ExpressRouteCircuitStats: val}, nil
 }
 
 // getPeeringStatsHandleError handles the GetPeeringStats error response.
@@ -323,11 +321,7 @@ func (client ExpressRouteCircuitsClient) GetStats(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitStatsResponse{}, client.getStatsHandleError(resp)
 	}
-	result, err := client.getStatsHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitStatsResponse{}, err
-	}
-	return result, nil
+	return client.getStatsHandleResponse(resp)
 }
 
 // getStatsCreateRequest creates the GetStats request.
@@ -350,9 +344,11 @@ func (client ExpressRouteCircuitsClient) getStatsCreateRequest(ctx context.Conte
 
 // getStatsHandleResponse handles the GetStats response.
 func (client ExpressRouteCircuitsClient) getStatsHandleResponse(resp *azcore.Response) (ExpressRouteCircuitStatsResponse, error) {
-	result := ExpressRouteCircuitStatsResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitStats)
-	return result, err
+	var val *ExpressRouteCircuitStats
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitStatsResponse{}, err
+	}
+	return ExpressRouteCircuitStatsResponse{RawResponse: resp.Response, ExpressRouteCircuitStats: val}, nil
 }
 
 // getStatsHandleError handles the GetStats error response.
@@ -399,9 +395,11 @@ func (client ExpressRouteCircuitsClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCircuitsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteCircuitListResultResponse, error) {
-	result := ExpressRouteCircuitListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitListResult)
-	return result, err
+	var val *ExpressRouteCircuitListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitListResultResponse{}, err
+	}
+	return ExpressRouteCircuitListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -447,9 +445,11 @@ func (client ExpressRouteCircuitsClient) listAllCreateRequest(ctx context.Contex
 
 // listAllHandleResponse handles the ListAll response.
 func (client ExpressRouteCircuitsClient) listAllHandleResponse(resp *azcore.Response) (ExpressRouteCircuitListResultResponse, error) {
-	result := ExpressRouteCircuitListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitListResult)
-	return result, err
+	var val *ExpressRouteCircuitListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitListResultResponse{}, err
+	}
+	return ExpressRouteCircuitListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -536,9 +536,11 @@ func (client ExpressRouteCircuitsClient) listArpTableCreateRequest(ctx context.C
 
 // listArpTableHandleResponse handles the ListArpTable response.
 func (client ExpressRouteCircuitsClient) listArpTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsArpTableListResultResponse, error) {
-	result := ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitsArpTableListResult)
-	return result, err
+	var val *ExpressRouteCircuitsArpTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitsArpTableListResultResponse{}, err
+	}
+	return ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsArpTableListResult: val}, nil
 }
 
 // listArpTableHandleError handles the ListArpTable error response.
@@ -625,9 +627,11 @@ func (client ExpressRouteCircuitsClient) listRoutesTableCreateRequest(ctx contex
 
 // listRoutesTableHandleResponse handles the ListRoutesTable response.
 func (client ExpressRouteCircuitsClient) listRoutesTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
-	result := ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitsRoutesTableListResult)
-	return result, err
+	var val *ExpressRouteCircuitsRoutesTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitsRoutesTableListResultResponse{}, err
+	}
+	return ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableListResult: val}, nil
 }
 
 // listRoutesTableHandleError handles the ListRoutesTable error response.
@@ -714,9 +718,11 @@ func (client ExpressRouteCircuitsClient) listRoutesTableSummaryCreateRequest(ctx
 
 // listRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
 func (client ExpressRouteCircuitsClient) listRoutesTableSummaryHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
-	result := ExpressRouteCircuitsRoutesTableSummaryListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitsRoutesTableSummaryListResult)
-	return result, err
+	var val *ExpressRouteCircuitsRoutesTableSummaryListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitsRoutesTableSummaryListResultResponse{}, err
+	}
+	return ExpressRouteCircuitsRoutesTableSummaryListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableSummaryListResult: val}, nil
 }
 
 // listRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
@@ -741,11 +747,7 @@ func (client ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resourc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCircuitResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCircuitResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -768,9 +770,11 @@ func (client ExpressRouteCircuitsClient) updateTagsCreateRequest(ctx context.Con
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ExpressRouteCircuitsClient) updateTagsHandleResponse(resp *azcore.Response) (ExpressRouteCircuitResponse, error) {
-	result := ExpressRouteCircuitResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuit)
-	return result, err
+	var val *ExpressRouteCircuit
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitResponse{}, err
+	}
+	return ExpressRouteCircuitResponse{RawResponse: resp.Response, ExpressRouteCircuit: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections.go
@@ -108,9 +108,11 @@ func (client ExpressRouteConnectionsClient) createOrUpdateCreateRequest(ctx cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteConnectionResponse, error) {
-	result := ExpressRouteConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteConnection)
-	return result, err
+	var val *ExpressRouteConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteConnectionResponse{}, err
+	}
+	return ExpressRouteConnectionResponse{RawResponse: resp.Response, ExpressRouteConnection: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ExpressRouteConnectionsClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteConnectionsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteConnectionResponse, error) {
-	result := ExpressRouteConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteConnection)
-	return result, err
+	var val *ExpressRouteConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteConnectionResponse{}, err
+	}
+	return ExpressRouteConnectionResponse{RawResponse: resp.Response, ExpressRouteConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -271,11 +271,7 @@ func (client ExpressRouteConnectionsClient) List(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteConnectionListResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteConnectionListResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -298,9 +294,11 @@ func (client ExpressRouteConnectionsClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteConnectionsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteConnectionListResponse, error) {
-	result := ExpressRouteConnectionListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteConnectionList)
-	return result, err
+	var val *ExpressRouteConnectionList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteConnectionListResponse{}, err
+	}
+	return ExpressRouteConnectionListResponse{RawResponse: resp.Response, ExpressRouteConnectionList: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings.go
@@ -108,9 +108,11 @@ func (client ExpressRouteCrossConnectionPeeringsClient) createOrUpdateCreateRequ
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCrossConnectionPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionPeeringResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionPeering)
-	return result, err
+	var val *ExpressRouteCrossConnectionPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionPeeringResponse{}, err
+	}
+	return ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionPeering: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCrossConnectionPeeringResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCrossConnectionPeeringResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ExpressRouteCrossConnectionPeeringsClient) getCreateRequest(ctx con
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCrossConnectionPeeringsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionPeeringResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionPeering)
-	return result, err
+	var val *ExpressRouteCrossConnectionPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionPeeringResponse{}, err
+	}
+	return ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionPeering: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client ExpressRouteCrossConnectionPeeringsClient) listCreateRequest(ctx co
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCrossConnectionPeeringsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionPeeringListResponse, error) {
-	result := ExpressRouteCrossConnectionPeeringListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionPeeringList)
-	return result, err
+	var val *ExpressRouteCrossConnectionPeeringList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionPeeringListResponse{}, err
+	}
+	return ExpressRouteCrossConnectionPeeringListResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionPeeringList: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections.go
@@ -107,9 +107,11 @@ func (client ExpressRouteCrossConnectionsClient) createOrUpdateCreateRequest(ctx
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteCrossConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionResponse, error) {
-	result := ExpressRouteCrossConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnection)
-	return result, err
+	var val *ExpressRouteCrossConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionResponse{}, err
+	}
+	return ExpressRouteCrossConnectionResponse{RawResponse: resp.Response, ExpressRouteCrossConnection: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -134,11 +136,7 @@ func (client ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resour
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCrossConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCrossConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -161,9 +159,11 @@ func (client ExpressRouteCrossConnectionsClient) getCreateRequest(ctx context.Co
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteCrossConnectionsClient) getHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionResponse, error) {
-	result := ExpressRouteCrossConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnection)
-	return result, err
+	var val *ExpressRouteCrossConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionResponse{}, err
+	}
+	return ExpressRouteCrossConnectionResponse{RawResponse: resp.Response, ExpressRouteCrossConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -209,9 +209,11 @@ func (client ExpressRouteCrossConnectionsClient) listCreateRequest(ctx context.C
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteCrossConnectionsClient) listHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionListResultResponse, error) {
-	result := ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionListResult)
-	return result, err
+	var val *ExpressRouteCrossConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionListResultResponse{}, err
+	}
+	return ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -298,9 +300,11 @@ func (client ExpressRouteCrossConnectionsClient) listArpTableCreateRequest(ctx c
 
 // listArpTableHandleResponse handles the ListArpTable response.
 func (client ExpressRouteCrossConnectionsClient) listArpTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsArpTableListResultResponse, error) {
-	result := ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitsArpTableListResult)
-	return result, err
+	var val *ExpressRouteCircuitsArpTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitsArpTableListResultResponse{}, err
+	}
+	return ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsArpTableListResult: val}, nil
 }
 
 // listArpTableHandleError handles the ListArpTable error response.
@@ -347,9 +351,11 @@ func (client ExpressRouteCrossConnectionsClient) listByResourceGroupCreateReques
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ExpressRouteCrossConnectionsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionListResultResponse, error) {
-	result := ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionListResult)
-	return result, err
+	var val *ExpressRouteCrossConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionListResultResponse{}, err
+	}
+	return ExpressRouteCrossConnectionListResultResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -436,9 +442,11 @@ func (client ExpressRouteCrossConnectionsClient) listRoutesTableCreateRequest(ct
 
 // listRoutesTableHandleResponse handles the ListRoutesTable response.
 func (client ExpressRouteCrossConnectionsClient) listRoutesTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
-	result := ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCircuitsRoutesTableListResult)
-	return result, err
+	var val *ExpressRouteCircuitsRoutesTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCircuitsRoutesTableListResultResponse{}, err
+	}
+	return ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableListResult: val}, nil
 }
 
 // listRoutesTableHandleError handles the ListRoutesTable error response.
@@ -525,9 +533,11 @@ func (client ExpressRouteCrossConnectionsClient) listRoutesTableSummaryCreateReq
 
 // listRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
 func (client ExpressRouteCrossConnectionsClient) listRoutesTableSummaryHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
-	result := ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
-	return result, err
+	var val *ExpressRouteCrossConnectionsRoutesTableSummaryListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{}, err
+	}
+	return ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionsRoutesTableSummaryListResult: val}, nil
 }
 
 // listRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.
@@ -552,11 +562,7 @@ func (client ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteCrossConnectionResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteCrossConnectionResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -579,9 +585,11 @@ func (client ExpressRouteCrossConnectionsClient) updateTagsCreateRequest(ctx con
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ExpressRouteCrossConnectionsClient) updateTagsHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionResponse, error) {
-	result := ExpressRouteCrossConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteCrossConnection)
-	return result, err
+	var val *ExpressRouteCrossConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteCrossConnectionResponse{}, err
+	}
+	return ExpressRouteCrossConnectionResponse{RawResponse: resp.Response, ExpressRouteCrossConnection: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways.go
@@ -107,9 +107,11 @@ func (client ExpressRouteGatewaysClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRouteGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteGatewayResponse, error) {
-	result := ExpressRouteGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteGateway)
-	return result, err
+	var val *ExpressRouteGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteGatewayResponse{}, err
+	}
+	return ExpressRouteGatewayResponse{RawResponse: resp.Response, ExpressRouteGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -243,9 +241,11 @@ func (client ExpressRouteGatewaysClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteGatewaysClient) getHandleResponse(resp *azcore.Response) (ExpressRouteGatewayResponse, error) {
-	result := ExpressRouteGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteGateway)
-	return result, err
+	var val *ExpressRouteGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteGatewayResponse{}, err
+	}
+	return ExpressRouteGatewayResponse{RawResponse: resp.Response, ExpressRouteGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -270,11 +270,7 @@ func (client ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteGatewayListResponse{}, client.listByResourceGroupHandleError(resp)
 	}
-	result, err := client.listByResourceGroupHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteGatewayListResponse{}, err
-	}
-	return result, nil
+	return client.listByResourceGroupHandleResponse(resp)
 }
 
 // listByResourceGroupCreateRequest creates the ListByResourceGroup request.
@@ -296,9 +292,11 @@ func (client ExpressRouteGatewaysClient) listByResourceGroupCreateRequest(ctx co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ExpressRouteGatewaysClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ExpressRouteGatewayListResponse, error) {
-	result := ExpressRouteGatewayListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteGatewayList)
-	return result, err
+	var val *ExpressRouteGatewayList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteGatewayListResponse{}, err
+	}
+	return ExpressRouteGatewayListResponse{RawResponse: resp.Response, ExpressRouteGatewayList: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -323,11 +321,7 @@ func (client ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context,
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteGatewayListResponse{}, client.listBySubscriptionHandleError(resp)
 	}
-	result, err := client.listBySubscriptionHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteGatewayListResponse{}, err
-	}
-	return result, nil
+	return client.listBySubscriptionHandleResponse(resp)
 }
 
 // listBySubscriptionCreateRequest creates the ListBySubscription request.
@@ -348,9 +342,11 @@ func (client ExpressRouteGatewaysClient) listBySubscriptionCreateRequest(ctx con
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client ExpressRouteGatewaysClient) listBySubscriptionHandleResponse(resp *azcore.Response) (ExpressRouteGatewayListResponse, error) {
-	result := ExpressRouteGatewayListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteGatewayList)
-	return result, err
+	var val *ExpressRouteGatewayList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteGatewayListResponse{}, err
+	}
+	return ExpressRouteGatewayListResponse{RawResponse: resp.Response, ExpressRouteGatewayList: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks.go
@@ -46,11 +46,7 @@ func (client ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRouteLinkResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRouteLinkResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client ExpressRouteLinksClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client ExpressRouteLinksClient) getHandleResponse(resp *azcore.Response) (ExpressRouteLinkResponse, error) {
-	result := ExpressRouteLinkResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteLink)
-	return result, err
+	var val *ExpressRouteLink
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteLinkResponse{}, err
+	}
+	return ExpressRouteLinkResponse{RawResponse: resp.Response, ExpressRouteLink: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client ExpressRouteLinksClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteLinksClient) listHandleResponse(resp *azcore.Response) (ExpressRouteLinkListResultResponse, error) {
-	result := ExpressRouteLinkListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteLinkListResult)
-	return result, err
+	var val *ExpressRouteLinkListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteLinkListResultResponse{}, err
+	}
+	return ExpressRouteLinkListResultResponse{RawResponse: resp.Response, ExpressRouteLinkListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports.go
@@ -107,9 +107,11 @@ func (client ExpressRoutePortsClient) createOrUpdateCreateRequest(ctx context.Co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ExpressRoutePortsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRoutePortResponse, error) {
-	result := ExpressRoutePortResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePort)
-	return result, err
+	var val *ExpressRoutePort
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortResponse{}, err
+	}
+	return ExpressRoutePortResponse{RawResponse: resp.Response, ExpressRoutePort: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRoutePortResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRoutePortResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client ExpressRoutePortsClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client ExpressRoutePortsClient) getHandleResponse(resp *azcore.Response) (ExpressRoutePortResponse, error) {
-	result := ExpressRoutePortResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePort)
-	return result, err
+	var val *ExpressRoutePort
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortResponse{}, err
+	}
+	return ExpressRoutePortResponse{RawResponse: resp.Response, ExpressRoutePort: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client ExpressRoutePortsClient) listCreateRequest(ctx context.Context, opt
 
 // listHandleResponse handles the List response.
 func (client ExpressRoutePortsClient) listHandleResponse(resp *azcore.Response) (ExpressRoutePortListResultResponse, error) {
-	result := ExpressRoutePortListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePortListResult)
-	return result, err
+	var val *ExpressRoutePortListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortListResultResponse{}, err
+	}
+	return ExpressRoutePortListResultResponse{RawResponse: resp.Response, ExpressRoutePortListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client ExpressRoutePortsClient) listByResourceGroupCreateRequest(ctx conte
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ExpressRoutePortsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ExpressRoutePortListResultResponse, error) {
-	result := ExpressRoutePortListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePortListResult)
-	return result, err
+	var val *ExpressRoutePortListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortListResultResponse{}, err
+	}
+	return ExpressRoutePortListResultResponse{RawResponse: resp.Response, ExpressRoutePortListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRoutePortResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ExpressRoutePortResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client ExpressRoutePortsClient) updateTagsCreateRequest(ctx context.Contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ExpressRoutePortsClient) updateTagsHandleResponse(resp *azcore.Response) (ExpressRoutePortResponse, error) {
-	result := ExpressRoutePortResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePort)
-	return result, err
+	var val *ExpressRoutePort
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortResponse{}, err
+	}
+	return ExpressRoutePortResponse{RawResponse: resp.Response, ExpressRoutePort: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations.go
@@ -46,11 +46,7 @@ func (client ExpressRoutePortsLocationsClient) Get(ctx context.Context, location
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ExpressRoutePortsLocationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ExpressRoutePortsLocationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -72,9 +68,11 @@ func (client ExpressRoutePortsLocationsClient) getCreateRequest(ctx context.Cont
 
 // getHandleResponse handles the Get response.
 func (client ExpressRoutePortsLocationsClient) getHandleResponse(resp *azcore.Response) (ExpressRoutePortsLocationResponse, error) {
-	result := ExpressRoutePortsLocationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePortsLocation)
-	return result, err
+	var val *ExpressRoutePortsLocation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortsLocationResponse{}, err
+	}
+	return ExpressRoutePortsLocationResponse{RawResponse: resp.Response, ExpressRoutePortsLocation: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -121,9 +119,11 @@ func (client ExpressRoutePortsLocationsClient) listCreateRequest(ctx context.Con
 
 // listHandleResponse handles the List response.
 func (client ExpressRoutePortsLocationsClient) listHandleResponse(resp *azcore.Response) (ExpressRoutePortsLocationListResultResponse, error) {
-	result := ExpressRoutePortsLocationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRoutePortsLocationListResult)
-	return result, err
+	var val *ExpressRoutePortsLocationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRoutePortsLocationListResultResponse{}, err
+	}
+	return ExpressRoutePortsLocationListResultResponse{RawResponse: resp.Response, ExpressRoutePortsLocationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders.go
@@ -67,9 +67,11 @@ func (client ExpressRouteServiceProvidersClient) listCreateRequest(ctx context.C
 
 // listHandleResponse handles the List response.
 func (client ExpressRouteServiceProvidersClient) listHandleResponse(resp *azcore.Response) (ExpressRouteServiceProviderListResultResponse, error) {
-	result := ExpressRouteServiceProviderListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ExpressRouteServiceProviderListResult)
-	return result, err
+	var val *ExpressRouteServiceProviderListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ExpressRouteServiceProviderListResultResponse{}, err
+	}
+	return ExpressRouteServiceProviderListResultResponse{RawResponse: resp.Response, ExpressRouteServiceProviderListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies.go
@@ -107,9 +107,11 @@ func (client FirewallPoliciesClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client FirewallPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (FirewallPolicyResponse, error) {
-	result := FirewallPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicy)
-	return result, err
+	var val *FirewallPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyResponse{}, err
+	}
+	return FirewallPolicyResponse{RawResponse: resp.Response, FirewallPolicy: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FirewallPolicyResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return FirewallPolicyResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client FirewallPoliciesClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client FirewallPoliciesClient) getHandleResponse(resp *azcore.Response) (FirewallPolicyResponse, error) {
-	result := FirewallPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicy)
-	return result, err
+	var val *FirewallPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyResponse{}, err
+	}
+	return FirewallPolicyResponse{RawResponse: resp.Response, FirewallPolicy: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client FirewallPoliciesClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client FirewallPoliciesClient) listHandleResponse(resp *azcore.Response) (FirewallPolicyListResultResponse, error) {
-	result := FirewallPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicyListResult)
-	return result, err
+	var val *FirewallPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyListResultResponse{}, err
+	}
+	return FirewallPolicyListResultResponse{RawResponse: resp.Response, FirewallPolicyListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client FirewallPoliciesClient) listAllCreateRequest(ctx context.Context, o
 
 // listAllHandleResponse handles the ListAll response.
 func (client FirewallPoliciesClient) listAllHandleResponse(resp *azcore.Response) (FirewallPolicyListResultResponse, error) {
-	result := FirewallPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicyListResult)
-	return result, err
+	var val *FirewallPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyListResultResponse{}, err
+	}
+	return FirewallPolicyListResultResponse{RawResponse: resp.Response, FirewallPolicyListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups.go
@@ -108,9 +108,11 @@ func (client FirewallPolicyRuleGroupsClient) createOrUpdateCreateRequest(ctx con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client FirewallPolicyRuleGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (FirewallPolicyRuleGroupResponse, error) {
-	result := FirewallPolicyRuleGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicyRuleGroup)
-	return result, err
+	var val *FirewallPolicyRuleGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyRuleGroupResponse{}, err
+	}
+	return FirewallPolicyRuleGroupResponse{RawResponse: resp.Response, FirewallPolicyRuleGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client FirewallPolicyRuleGroupsClient) Get(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FirewallPolicyRuleGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return FirewallPolicyRuleGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client FirewallPolicyRuleGroupsClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client FirewallPolicyRuleGroupsClient) getHandleResponse(resp *azcore.Response) (FirewallPolicyRuleGroupResponse, error) {
-	result := FirewallPolicyRuleGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicyRuleGroup)
-	return result, err
+	var val *FirewallPolicyRuleGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyRuleGroupResponse{}, err
+	}
+	return FirewallPolicyRuleGroupResponse{RawResponse: resp.Response, FirewallPolicyRuleGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client FirewallPolicyRuleGroupsClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client FirewallPolicyRuleGroupsClient) listHandleResponse(resp *azcore.Response) (FirewallPolicyRuleGroupListResultResponse, error) {
-	result := FirewallPolicyRuleGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FirewallPolicyRuleGroupListResult)
-	return result, err
+	var val *FirewallPolicyRuleGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FirewallPolicyRuleGroupListResultResponse{}, err
+	}
+	return FirewallPolicyRuleGroupListResultResponse{RawResponse: resp.Response, FirewallPolicyRuleGroupListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs.go
@@ -108,9 +108,11 @@ func (client FlowLogsClient) createOrUpdateCreateRequest(ctx context.Context, re
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client FlowLogsClient) createOrUpdateHandleResponse(resp *azcore.Response) (FlowLogResponse, error) {
-	result := FlowLogResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FlowLog)
-	return result, err
+	var val *FlowLog
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FlowLogResponse{}, err
+	}
+	return FlowLogResponse{RawResponse: resp.Response, FlowLog: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client FlowLogsClient) Get(ctx context.Context, resourceGroupName string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FlowLogResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return FlowLogResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client FlowLogsClient) getCreateRequest(ctx context.Context, resourceGroup
 
 // getHandleResponse handles the Get response.
 func (client FlowLogsClient) getHandleResponse(resp *azcore.Response) (FlowLogResponse, error) {
-	result := FlowLogResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FlowLog)
-	return result, err
+	var val *FlowLog
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FlowLogResponse{}, err
+	}
+	return FlowLogResponse{RawResponse: resp.Response, FlowLog: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client FlowLogsClient) listCreateRequest(ctx context.Context, resourceGrou
 
 // listHandleResponse handles the List response.
 func (client FlowLogsClient) listHandleResponse(resp *azcore.Response) (FlowLogListResultResponse, error) {
-	result := FlowLogListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FlowLogListResult)
-	return result, err
+	var val *FlowLogListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FlowLogListResultResponse{}, err
+	}
+	return FlowLogListResultResponse{RawResponse: resp.Response, FlowLogListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections.go
@@ -46,11 +46,7 @@ func (client HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resour
 	if !resp.HasStatusCode(http.StatusOK) {
 		return HubVirtualNetworkConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return HubVirtualNetworkConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client HubVirtualNetworkConnectionsClient) getCreateRequest(ctx context.Co
 
 // getHandleResponse handles the Get response.
 func (client HubVirtualNetworkConnectionsClient) getHandleResponse(resp *azcore.Response) (HubVirtualNetworkConnectionResponse, error) {
-	result := HubVirtualNetworkConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.HubVirtualNetworkConnection)
-	return result, err
+	var val *HubVirtualNetworkConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return HubVirtualNetworkConnectionResponse{}, err
+	}
+	return HubVirtualNetworkConnectionResponse{RawResponse: resp.Response, HubVirtualNetworkConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client HubVirtualNetworkConnectionsClient) listCreateRequest(ctx context.C
 
 // listHandleResponse handles the List response.
 func (client HubVirtualNetworkConnectionsClient) listHandleResponse(resp *azcore.Response) (ListHubVirtualNetworkConnectionsResultResponse, error) {
-	result := ListHubVirtualNetworkConnectionsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListHubVirtualNetworkConnectionsResult)
-	return result, err
+	var val *ListHubVirtualNetworkConnectionsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListHubVirtualNetworkConnectionsResultResponse{}, err
+	}
+	return ListHubVirtualNetworkConnectionsResultResponse{RawResponse: resp.Response, ListHubVirtualNetworkConnectionsResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules.go
@@ -108,9 +108,11 @@ func (client InboundNatRulesClient) createOrUpdateCreateRequest(ctx context.Cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client InboundNatRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (InboundNatRuleResponse, error) {
-	result := InboundNatRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.InboundNatRule)
-	return result, err
+	var val *InboundNatRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return InboundNatRuleResponse{}, err
+	}
+	return InboundNatRuleResponse{RawResponse: resp.Response, InboundNatRule: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client InboundNatRulesClient) Get(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return InboundNatRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return InboundNatRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -247,9 +245,11 @@ func (client InboundNatRulesClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client InboundNatRulesClient) getHandleResponse(resp *azcore.Response) (InboundNatRuleResponse, error) {
-	result := InboundNatRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.InboundNatRule)
-	return result, err
+	var val *InboundNatRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return InboundNatRuleResponse{}, err
+	}
+	return InboundNatRuleResponse{RawResponse: resp.Response, InboundNatRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -297,9 +297,11 @@ func (client InboundNatRulesClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client InboundNatRulesClient) listHandleResponse(resp *azcore.Response) (InboundNatRuleListResultResponse, error) {
-	result := InboundNatRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.InboundNatRuleListResult)
-	return result, err
+	var val *InboundNatRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return InboundNatRuleListResultResponse{}, err
+	}
+	return InboundNatRuleListResultResponse{RawResponse: resp.Response, InboundNatRuleListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations.go
@@ -107,9 +107,11 @@ func (client IPAllocationsClient) createOrUpdateCreateRequest(ctx context.Contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client IPAllocationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (IPAllocationResponse, error) {
-	result := IPAllocationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAllocation)
-	return result, err
+	var val *IPAllocation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAllocationResponse{}, err
+	}
+	return IPAllocationResponse{RawResponse: resp.Response, IPAllocation: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client IPAllocationsClient) Get(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IPAllocationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return IPAllocationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client IPAllocationsClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client IPAllocationsClient) getHandleResponse(resp *azcore.Response) (IPAllocationResponse, error) {
-	result := IPAllocationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAllocation)
-	return result, err
+	var val *IPAllocation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAllocationResponse{}, err
+	}
+	return IPAllocationResponse{RawResponse: resp.Response, IPAllocation: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client IPAllocationsClient) listCreateRequest(ctx context.Context, options
 
 // listHandleResponse handles the List response.
 func (client IPAllocationsClient) listHandleResponse(resp *azcore.Response) (IPAllocationListResultResponse, error) {
-	result := IPAllocationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAllocationListResult)
-	return result, err
+	var val *IPAllocationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAllocationListResultResponse{}, err
+	}
+	return IPAllocationListResultResponse{RawResponse: resp.Response, IPAllocationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client IPAllocationsClient) listByResourceGroupCreateRequest(ctx context.C
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client IPAllocationsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (IPAllocationListResultResponse, error) {
-	result := IPAllocationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAllocationListResult)
-	return result, err
+	var val *IPAllocationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAllocationListResultResponse{}, err
+	}
+	return IPAllocationListResultResponse{RawResponse: resp.Response, IPAllocationListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -368,11 +372,7 @@ func (client IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IPAllocationResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return IPAllocationResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client IPAllocationsClient) updateTagsCreateRequest(ctx context.Context, r
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client IPAllocationsClient) updateTagsHandleResponse(resp *azcore.Response) (IPAllocationResponse, error) {
-	result := IPAllocationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAllocation)
-	return result, err
+	var val *IPAllocation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAllocationResponse{}, err
+	}
+	return IPAllocationResponse{RawResponse: resp.Response, IPAllocation: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups.go
@@ -107,9 +107,11 @@ func (client IPGroupsClient) createOrUpdateCreateRequest(ctx context.Context, re
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client IPGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (IPGroupResponse, error) {
-	result := IPGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPGroup)
-	return result, err
+	var val *IPGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPGroupResponse{}, err
+	}
+	return IPGroupResponse{RawResponse: resp.Response, IPGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client IPGroupsClient) Get(ctx context.Context, resourceGroupName string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IPGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return IPGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client IPGroupsClient) getCreateRequest(ctx context.Context, resourceGroup
 
 // getHandleResponse handles the Get response.
 func (client IPGroupsClient) getHandleResponse(resp *azcore.Response) (IPGroupResponse, error) {
-	result := IPGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPGroup)
-	return result, err
+	var val *IPGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPGroupResponse{}, err
+	}
+	return IPGroupResponse{RawResponse: resp.Response, IPGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client IPGroupsClient) listCreateRequest(ctx context.Context, options *IPG
 
 // listHandleResponse handles the List response.
 func (client IPGroupsClient) listHandleResponse(resp *azcore.Response) (IPGroupListResultResponse, error) {
-	result := IPGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPGroupListResult)
-	return result, err
+	var val *IPGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPGroupListResultResponse{}, err
+	}
+	return IPGroupListResultResponse{RawResponse: resp.Response, IPGroupListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client IPGroupsClient) listByResourceGroupCreateRequest(ctx context.Contex
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client IPGroupsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (IPGroupListResultResponse, error) {
-	result := IPGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPGroupListResult)
-	return result, err
+	var val *IPGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPGroupListResultResponse{}, err
+	}
+	return IPGroupListResultResponse{RawResponse: resp.Response, IPGroupListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -368,11 +372,7 @@ func (client IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IPGroupResponse{}, client.updateGroupsHandleError(resp)
 	}
-	result, err := client.updateGroupsHandleResponse(resp)
-	if err != nil {
-		return IPGroupResponse{}, err
-	}
-	return result, nil
+	return client.updateGroupsHandleResponse(resp)
 }
 
 // updateGroupsCreateRequest creates the UpdateGroups request.
@@ -395,9 +395,11 @@ func (client IPGroupsClient) updateGroupsCreateRequest(ctx context.Context, reso
 
 // updateGroupsHandleResponse handles the UpdateGroups response.
 func (client IPGroupsClient) updateGroupsHandleResponse(resp *azcore.Response) (IPGroupResponse, error) {
-	result := IPGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPGroup)
-	return result, err
+	var val *IPGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPGroupResponse{}, err
+	}
+	return IPGroupResponse{RawResponse: resp.Response, IPGroup: val}, nil
 }
 
 // updateGroupsHandleError handles the UpdateGroups error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools.go
@@ -46,11 +46,7 @@ func (client LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, res
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BackendAddressPoolResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return BackendAddressPoolResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client LoadBalancerBackendAddressPoolsClient) getCreateRequest(ctx context
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancerBackendAddressPoolsClient) getHandleResponse(resp *azcore.Response) (BackendAddressPoolResponse, error) {
-	result := BackendAddressPoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BackendAddressPool)
-	return result, err
+	var val *BackendAddressPool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BackendAddressPoolResponse{}, err
+	}
+	return BackendAddressPoolResponse{RawResponse: resp.Response, BackendAddressPool: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client LoadBalancerBackendAddressPoolsClient) listCreateRequest(ctx contex
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerBackendAddressPoolsClient) listHandleResponse(resp *azcore.Response) (LoadBalancerBackendAddressPoolListResultResponse, error) {
-	result := LoadBalancerBackendAddressPoolListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerBackendAddressPoolListResult)
-	return result, err
+	var val *LoadBalancerBackendAddressPoolListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerBackendAddressPoolListResultResponse{}, err
+	}
+	return LoadBalancerBackendAddressPoolListResultResponse{RawResponse: resp.Response, LoadBalancerBackendAddressPoolListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations.go
@@ -46,11 +46,7 @@ func (client LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return FrontendIPConfigurationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return FrontendIPConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client LoadBalancerFrontendIPConfigurationsClient) getCreateRequest(ctx co
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancerFrontendIPConfigurationsClient) getHandleResponse(resp *azcore.Response) (FrontendIPConfigurationResponse, error) {
-	result := FrontendIPConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FrontendIPConfiguration)
-	return result, err
+	var val *FrontendIPConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FrontendIPConfigurationResponse{}, err
+	}
+	return FrontendIPConfigurationResponse{RawResponse: resp.Response, FrontendIPConfiguration: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client LoadBalancerFrontendIPConfigurationsClient) listCreateRequest(ctx c
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerFrontendIPConfigurationsClient) listHandleResponse(resp *azcore.Response) (LoadBalancerFrontendIPConfigurationListResultResponse, error) {
-	result := LoadBalancerFrontendIPConfigurationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerFrontendIPConfigurationListResult)
-	return result, err
+	var val *LoadBalancerFrontendIPConfigurationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerFrontendIPConfigurationListResultResponse{}, err
+	}
+	return LoadBalancerFrontendIPConfigurationListResultResponse{RawResponse: resp.Response, LoadBalancerFrontendIPConfigurationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules.go
@@ -46,11 +46,7 @@ func (client LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LoadBalancingRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return LoadBalancingRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client LoadBalancerLoadBalancingRulesClient) getCreateRequest(ctx context.
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancerLoadBalancingRulesClient) getHandleResponse(resp *azcore.Response) (LoadBalancingRuleResponse, error) {
-	result := LoadBalancingRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancingRule)
-	return result, err
+	var val *LoadBalancingRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancingRuleResponse{}, err
+	}
+	return LoadBalancingRuleResponse{RawResponse: resp.Response, LoadBalancingRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client LoadBalancerLoadBalancingRulesClient) listCreateRequest(ctx context
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerLoadBalancingRulesClient) listHandleResponse(resp *azcore.Response) (LoadBalancerLoadBalancingRuleListResultResponse, error) {
-	result := LoadBalancerLoadBalancingRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerLoadBalancingRuleListResult)
-	return result, err
+	var val *LoadBalancerLoadBalancingRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerLoadBalancingRuleListResultResponse{}, err
+	}
+	return LoadBalancerLoadBalancingRuleListResultResponse{RawResponse: resp.Response, LoadBalancerLoadBalancingRuleListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces.go
@@ -69,9 +69,11 @@ func (client LoadBalancerNetworkInterfacesClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerNetworkInterfacesClient) listHandleResponse(resp *azcore.Response) (NetworkInterfaceListResultResponse, error) {
-	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
-	return result, err
+	var val *NetworkInterfaceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceListResultResponse{}, err
+	}
+	return NetworkInterfaceListResultResponse{RawResponse: resp.Response, NetworkInterfaceListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules.go
@@ -46,11 +46,7 @@ func (client LoadBalancerOutboundRulesClient) Get(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return OutboundRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return OutboundRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client LoadBalancerOutboundRulesClient) getCreateRequest(ctx context.Conte
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancerOutboundRulesClient) getHandleResponse(resp *azcore.Response) (OutboundRuleResponse, error) {
-	result := OutboundRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OutboundRule)
-	return result, err
+	var val *OutboundRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OutboundRuleResponse{}, err
+	}
+	return OutboundRuleResponse{RawResponse: resp.Response, OutboundRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client LoadBalancerOutboundRulesClient) listCreateRequest(ctx context.Cont
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerOutboundRulesClient) listHandleResponse(resp *azcore.Response) (LoadBalancerOutboundRuleListResultResponse, error) {
-	result := LoadBalancerOutboundRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerOutboundRuleListResult)
-	return result, err
+	var val *LoadBalancerOutboundRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerOutboundRuleListResultResponse{}, err
+	}
+	return LoadBalancerOutboundRuleListResultResponse{RawResponse: resp.Response, LoadBalancerOutboundRuleListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes.go
@@ -46,11 +46,7 @@ func (client LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ProbeResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ProbeResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client LoadBalancerProbesClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancerProbesClient) getHandleResponse(resp *azcore.Response) (ProbeResponse, error) {
-	result := ProbeResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Probe)
-	return result, err
+	var val *Probe
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ProbeResponse{}, err
+	}
+	return ProbeResponse{RawResponse: resp.Response, Probe: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client LoadBalancerProbesClient) listCreateRequest(ctx context.Context, re
 
 // listHandleResponse handles the List response.
 func (client LoadBalancerProbesClient) listHandleResponse(resp *azcore.Response) (LoadBalancerProbeListResultResponse, error) {
-	result := LoadBalancerProbeListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerProbeListResult)
-	return result, err
+	var val *LoadBalancerProbeListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerProbeListResultResponse{}, err
+	}
+	return LoadBalancerProbeListResultResponse{RawResponse: resp.Response, LoadBalancerProbeListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers.go
@@ -107,9 +107,11 @@ func (client LoadBalancersClient) createOrUpdateCreateRequest(ctx context.Contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client LoadBalancersClient) createOrUpdateHandleResponse(resp *azcore.Response) (LoadBalancerResponse, error) {
-	result := LoadBalancerResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancer)
-	return result, err
+	var val *LoadBalancer
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerResponse{}, err
+	}
+	return LoadBalancerResponse{RawResponse: resp.Response, LoadBalancer: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client LoadBalancersClient) Get(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LoadBalancerResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return LoadBalancerResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client LoadBalancersClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client LoadBalancersClient) getHandleResponse(resp *azcore.Response) (LoadBalancerResponse, error) {
-	result := LoadBalancerResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancer)
-	return result, err
+	var val *LoadBalancer
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerResponse{}, err
+	}
+	return LoadBalancerResponse{RawResponse: resp.Response, LoadBalancer: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client LoadBalancersClient) listCreateRequest(ctx context.Context, resourc
 
 // listHandleResponse handles the List response.
 func (client LoadBalancersClient) listHandleResponse(resp *azcore.Response) (LoadBalancerListResultResponse, error) {
-	result := LoadBalancerListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerListResult)
-	return result, err
+	var val *LoadBalancerListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerListResultResponse{}, err
+	}
+	return LoadBalancerListResultResponse{RawResponse: resp.Response, LoadBalancerListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client LoadBalancersClient) listAllCreateRequest(ctx context.Context, opti
 
 // listAllHandleResponse handles the ListAll response.
 func (client LoadBalancersClient) listAllHandleResponse(resp *azcore.Response) (LoadBalancerListResultResponse, error) {
-	result := LoadBalancerListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancerListResult)
-	return result, err
+	var val *LoadBalancerListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerListResultResponse{}, err
+	}
+	return LoadBalancerListResultResponse{RawResponse: resp.Response, LoadBalancerListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -368,11 +372,7 @@ func (client LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LoadBalancerResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return LoadBalancerResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client LoadBalancersClient) updateTagsCreateRequest(ctx context.Context, r
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client LoadBalancersClient) updateTagsHandleResponse(resp *azcore.Response) (LoadBalancerResponse, error) {
-	result := LoadBalancerResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LoadBalancer)
-	return result, err
+	var val *LoadBalancer
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LoadBalancerResponse{}, err
+	}
+	return LoadBalancerResponse{RawResponse: resp.Response, LoadBalancer: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways.go
@@ -107,9 +107,11 @@ func (client LocalNetworkGatewaysClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client LocalNetworkGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (LocalNetworkGatewayResponse, error) {
-	result := LocalNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LocalNetworkGateway)
-	return result, err
+	var val *LocalNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LocalNetworkGatewayResponse{}, err
+	}
+	return LocalNetworkGatewayResponse{RawResponse: resp.Response, LocalNetworkGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LocalNetworkGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return LocalNetworkGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client LocalNetworkGatewaysClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client LocalNetworkGatewaysClient) getHandleResponse(resp *azcore.Response) (LocalNetworkGatewayResponse, error) {
-	result := LocalNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LocalNetworkGateway)
-	return result, err
+	var val *LocalNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LocalNetworkGatewayResponse{}, err
+	}
+	return LocalNetworkGatewayResponse{RawResponse: resp.Response, LocalNetworkGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -290,9 +290,11 @@ func (client LocalNetworkGatewaysClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client LocalNetworkGatewaysClient) listHandleResponse(resp *azcore.Response) (LocalNetworkGatewayListResultResponse, error) {
-	result := LocalNetworkGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LocalNetworkGatewayListResult)
-	return result, err
+	var val *LocalNetworkGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LocalNetworkGatewayListResultResponse{}, err
+	}
+	return LocalNetworkGatewayListResultResponse{RawResponse: resp.Response, LocalNetworkGatewayListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -317,11 +319,7 @@ func (client LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resourc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return LocalNetworkGatewayResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return LocalNetworkGatewayResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -344,9 +342,11 @@ func (client LocalNetworkGatewaysClient) updateTagsCreateRequest(ctx context.Con
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client LocalNetworkGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (LocalNetworkGatewayResponse, error) {
-	result := LocalNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LocalNetworkGateway)
-	return result, err
+	var val *LocalNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LocalNetworkGatewayResponse{}, err
+	}
+	return LocalNetworkGatewayResponse{RawResponse: resp.Response, LocalNetworkGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways.go
@@ -107,9 +107,11 @@ func (client NatGatewaysClient) createOrUpdateCreateRequest(ctx context.Context,
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NatGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (NatGatewayResponse, error) {
-	result := NatGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NatGateway)
-	return result, err
+	var val *NatGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NatGatewayResponse{}, err
+	}
+	return NatGatewayResponse{RawResponse: resp.Response, NatGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client NatGatewaysClient) Get(ctx context.Context, resourceGroupName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NatGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NatGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client NatGatewaysClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client NatGatewaysClient) getHandleResponse(resp *azcore.Response) (NatGatewayResponse, error) {
-	result := NatGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NatGateway)
-	return result, err
+	var val *NatGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NatGatewayResponse{}, err
+	}
+	return NatGatewayResponse{RawResponse: resp.Response, NatGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client NatGatewaysClient) listCreateRequest(ctx context.Context, resourceG
 
 // listHandleResponse handles the List response.
 func (client NatGatewaysClient) listHandleResponse(resp *azcore.Response) (NatGatewayListResultResponse, error) {
-	result := NatGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NatGatewayListResult)
-	return result, err
+	var val *NatGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NatGatewayListResultResponse{}, err
+	}
+	return NatGatewayListResultResponse{RawResponse: resp.Response, NatGatewayListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client NatGatewaysClient) listAllCreateRequest(ctx context.Context, option
 
 // listAllHandleResponse handles the ListAll response.
 func (client NatGatewaysClient) listAllHandleResponse(resp *azcore.Response) (NatGatewayListResultResponse, error) {
-	result := NatGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NatGatewayListResult)
-	return result, err
+	var val *NatGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NatGatewayListResultResponse{}, err
+	}
+	return NatGatewayListResultResponse{RawResponse: resp.Response, NatGatewayListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -368,11 +372,7 @@ func (client NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NatGatewayResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NatGatewayResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client NatGatewaysClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NatGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (NatGatewayResponse, error) {
-	result := NatGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NatGateway)
-	return result, err
+	var val *NatGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NatGatewayResponse{}, err
+	}
+	return NatGatewayResponse{RawResponse: resp.Response, NatGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations.go
@@ -46,11 +46,7 @@ func (client NetworkInterfaceIPConfigurationsClient) Get(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceIPConfigurationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceIPConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client NetworkInterfaceIPConfigurationsClient) getCreateRequest(ctx contex
 
 // getHandleResponse handles the Get response.
 func (client NetworkInterfaceIPConfigurationsClient) getHandleResponse(resp *azcore.Response) (NetworkInterfaceIPConfigurationResponse, error) {
-	result := NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfiguration)
-	return result, err
+	var val *NetworkInterfaceIPConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceIPConfigurationResponse{}, err
+	}
+	return NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response, NetworkInterfaceIPConfiguration: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client NetworkInterfaceIPConfigurationsClient) listCreateRequest(ctx conte
 
 // listHandleResponse handles the List response.
 func (client NetworkInterfaceIPConfigurationsClient) listHandleResponse(resp *azcore.Response) (NetworkInterfaceIPConfigurationListResultResponse, error) {
-	result := NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfigurationListResult)
-	return result, err
+	var val *NetworkInterfaceIPConfigurationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceIPConfigurationListResultResponse{}, err
+	}
+	return NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response, NetworkInterfaceIPConfigurationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers.go
@@ -69,9 +69,11 @@ func (client NetworkInterfaceLoadBalancersClient) listCreateRequest(ctx context.
 
 // listHandleResponse handles the List response.
 func (client NetworkInterfaceLoadBalancersClient) listHandleResponse(resp *azcore.Response) (NetworkInterfaceLoadBalancerListResultResponse, error) {
-	result := NetworkInterfaceLoadBalancerListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceLoadBalancerListResult)
-	return result, err
+	var val *NetworkInterfaceLoadBalancerListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceLoadBalancerListResultResponse{}, err
+	}
+	return NetworkInterfaceLoadBalancerListResultResponse{RawResponse: resp.Response, NetworkInterfaceLoadBalancerListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces.go
@@ -107,9 +107,11 @@ func (client NetworkInterfacesClient) createOrUpdateCreateRequest(ctx context.Co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkInterfacesClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkInterfaceResponse, error) {
-	result := NetworkInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterface)
-	return result, err
+	var val *NetworkInterface
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceResponse{}, err
+	}
+	return NetworkInterfaceResponse{RawResponse: resp.Response, NetworkInterface: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client NetworkInterfacesClient) Get(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client NetworkInterfacesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client NetworkInterfacesClient) getHandleResponse(resp *azcore.Response) (NetworkInterfaceResponse, error) {
-	result := NetworkInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterface)
-	return result, err
+	var val *NetworkInterface
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceResponse{}, err
+	}
+	return NetworkInterfaceResponse{RawResponse: resp.Response, NetworkInterface: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -331,9 +331,11 @@ func (client NetworkInterfacesClient) getEffectiveRouteTableCreateRequest(ctx co
 
 // getEffectiveRouteTableHandleResponse handles the GetEffectiveRouteTable response.
 func (client NetworkInterfacesClient) getEffectiveRouteTableHandleResponse(resp *azcore.Response) (EffectiveRouteListResultResponse, error) {
-	result := EffectiveRouteListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.EffectiveRouteListResult)
-	return result, err
+	var val *EffectiveRouteListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return EffectiveRouteListResultResponse{}, err
+	}
+	return EffectiveRouteListResultResponse{RawResponse: resp.Response, EffectiveRouteListResult: val}, nil
 }
 
 // getEffectiveRouteTableHandleError handles the GetEffectiveRouteTable error response.
@@ -358,11 +360,7 @@ func (client NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(c
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceIPConfigurationResponse{}, client.getVirtualMachineScaleSetIPConfigurationHandleError(resp)
 	}
-	result, err := client.getVirtualMachineScaleSetIPConfigurationHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceIPConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.getVirtualMachineScaleSetIPConfigurationHandleResponse(resp)
 }
 
 // getVirtualMachineScaleSetIPConfigurationCreateRequest creates the GetVirtualMachineScaleSetIPConfiguration request.
@@ -391,9 +389,11 @@ func (client NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationCr
 
 // getVirtualMachineScaleSetIPConfigurationHandleResponse handles the GetVirtualMachineScaleSetIPConfiguration response.
 func (client NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleResponse(resp *azcore.Response) (NetworkInterfaceIPConfigurationResponse, error) {
-	result := NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfiguration)
-	return result, err
+	var val *NetworkInterfaceIPConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceIPConfigurationResponse{}, err
+	}
+	return NetworkInterfaceIPConfigurationResponse{RawResponse: resp.Response, NetworkInterfaceIPConfiguration: val}, nil
 }
 
 // getVirtualMachineScaleSetIPConfigurationHandleError handles the GetVirtualMachineScaleSetIPConfiguration error response.
@@ -418,11 +418,7 @@ func (client NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceResponse{}, client.getVirtualMachineScaleSetNetworkInterfaceHandleError(resp)
 	}
-	result, err := client.getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp)
 }
 
 // getVirtualMachineScaleSetNetworkInterfaceCreateRequest creates the GetVirtualMachineScaleSetNetworkInterface request.
@@ -450,9 +446,11 @@ func (client NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceC
 
 // getVirtualMachineScaleSetNetworkInterfaceHandleResponse handles the GetVirtualMachineScaleSetNetworkInterface response.
 func (client NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *azcore.Response) (NetworkInterfaceResponse, error) {
-	result := NetworkInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterface)
-	return result, err
+	var val *NetworkInterface
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceResponse{}, err
+	}
+	return NetworkInterfaceResponse{RawResponse: resp.Response, NetworkInterface: val}, nil
 }
 
 // getVirtualMachineScaleSetNetworkInterfaceHandleError handles the GetVirtualMachineScaleSetNetworkInterface error response.
@@ -499,9 +497,11 @@ func (client NetworkInterfacesClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client NetworkInterfacesClient) listHandleResponse(resp *azcore.Response) (NetworkInterfaceListResultResponse, error) {
-	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
-	return result, err
+	var val *NetworkInterfaceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceListResultResponse{}, err
+	}
+	return NetworkInterfaceListResultResponse{RawResponse: resp.Response, NetworkInterfaceListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -547,9 +547,11 @@ func (client NetworkInterfacesClient) listAllCreateRequest(ctx context.Context, 
 
 // listAllHandleResponse handles the ListAll response.
 func (client NetworkInterfacesClient) listAllHandleResponse(resp *azcore.Response) (NetworkInterfaceListResultResponse, error) {
-	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
-	return result, err
+	var val *NetworkInterfaceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceListResultResponse{}, err
+	}
+	return NetworkInterfaceListResultResponse{RawResponse: resp.Response, NetworkInterfaceListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -634,9 +636,11 @@ func (client NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsCreateRe
 
 // listEffectiveNetworkSecurityGroupsHandleResponse handles the ListEffectiveNetworkSecurityGroups response.
 func (client NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsHandleResponse(resp *azcore.Response) (EffectiveNetworkSecurityGroupListResultResponse, error) {
-	result := EffectiveNetworkSecurityGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.EffectiveNetworkSecurityGroupListResult)
-	return result, err
+	var val *EffectiveNetworkSecurityGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return EffectiveNetworkSecurityGroupListResultResponse{}, err
+	}
+	return EffectiveNetworkSecurityGroupListResultResponse{RawResponse: resp.Response, EffectiveNetworkSecurityGroupListResult: val}, nil
 }
 
 // listEffectiveNetworkSecurityGroupsHandleError handles the ListEffectiveNetworkSecurityGroups error response.
@@ -689,9 +693,11 @@ func (client NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurations
 
 // listVirtualMachineScaleSetIPConfigurationsHandleResponse handles the ListVirtualMachineScaleSetIPConfigurations response.
 func (client NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *azcore.Response) (NetworkInterfaceIPConfigurationListResultResponse, error) {
-	result := NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceIPConfigurationListResult)
-	return result, err
+	var val *NetworkInterfaceIPConfigurationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceIPConfigurationListResultResponse{}, err
+	}
+	return NetworkInterfaceIPConfigurationListResultResponse{RawResponse: resp.Response, NetworkInterfaceIPConfigurationListResult: val}, nil
 }
 
 // listVirtualMachineScaleSetIPConfigurationsHandleError handles the ListVirtualMachineScaleSetIPConfigurations error response.
@@ -739,9 +745,11 @@ func (client NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterface
 
 // listVirtualMachineScaleSetNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetNetworkInterfaces response.
 func (client NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *azcore.Response) (NetworkInterfaceListResultResponse, error) {
-	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
-	return result, err
+	var val *NetworkInterfaceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceListResultResponse{}, err
+	}
+	return NetworkInterfaceListResultResponse{RawResponse: resp.Response, NetworkInterfaceListResult: val}, nil
 }
 
 // listVirtualMachineScaleSetNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetNetworkInterfaces error response.
@@ -790,9 +798,11 @@ func (client NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfa
 
 // listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse handles the ListVirtualMachineScaleSetVMNetworkInterfaces response.
 func (client NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *azcore.Response) (NetworkInterfaceListResultResponse, error) {
-	result := NetworkInterfaceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceListResult)
-	return result, err
+	var val *NetworkInterfaceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceListResultResponse{}, err
+	}
+	return NetworkInterfaceListResultResponse{RawResponse: resp.Response, NetworkInterfaceListResult: val}, nil
 }
 
 // listVirtualMachineScaleSetVMNetworkInterfacesHandleError handles the ListVirtualMachineScaleSetVMNetworkInterfaces error response.
@@ -817,11 +827,7 @@ func (client NetworkInterfacesClient) UpdateTags(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -844,9 +850,11 @@ func (client NetworkInterfacesClient) updateTagsCreateRequest(ctx context.Contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NetworkInterfacesClient) updateTagsHandleResponse(resp *azcore.Response) (NetworkInterfaceResponse, error) {
-	result := NetworkInterfaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterface)
-	return result, err
+	var val *NetworkInterface
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceResponse{}, err
+	}
+	return NetworkInterfaceResponse{RawResponse: resp.Response, NetworkInterface: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations.go
@@ -108,9 +108,11 @@ func (client NetworkInterfaceTapConfigurationsClient) createOrUpdateCreateReques
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkInterfaceTapConfigurationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkInterfaceTapConfigurationResponse, error) {
-	result := NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceTapConfiguration)
-	return result, err
+	var val *NetworkInterfaceTapConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceTapConfigurationResponse{}, err
+	}
+	return NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response, NetworkInterfaceTapConfiguration: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client NetworkInterfaceTapConfigurationsClient) Get(ctx context.Context, r
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkInterfaceTapConfigurationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkInterfaceTapConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client NetworkInterfaceTapConfigurationsClient) getCreateRequest(ctx conte
 
 // getHandleResponse handles the Get response.
 func (client NetworkInterfaceTapConfigurationsClient) getHandleResponse(resp *azcore.Response) (NetworkInterfaceTapConfigurationResponse, error) {
-	result := NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceTapConfiguration)
-	return result, err
+	var val *NetworkInterfaceTapConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceTapConfigurationResponse{}, err
+	}
+	return NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response, NetworkInterfaceTapConfiguration: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client NetworkInterfaceTapConfigurationsClient) listCreateRequest(ctx cont
 
 // listHandleResponse handles the List response.
 func (client NetworkInterfaceTapConfigurationsClient) listHandleResponse(resp *azcore.Response) (NetworkInterfaceTapConfigurationListResultResponse, error) {
-	result := NetworkInterfaceTapConfigurationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkInterfaceTapConfigurationListResult)
-	return result, err
+	var val *NetworkInterfaceTapConfigurationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkInterfaceTapConfigurationListResultResponse{}, err
+	}
+	return NetworkInterfaceTapConfigurationListResultResponse{RawResponse: resp.Response, NetworkInterfaceTapConfigurationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient.go
@@ -47,11 +47,7 @@ func (client NetworkManagementClient) CheckDNSNameAvailability(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DNSNameAvailabilityResultResponse{}, client.checkDnsNameAvailabilityHandleError(resp)
 	}
-	result, err := client.checkDnsNameAvailabilityHandleResponse(resp)
-	if err != nil {
-		return DNSNameAvailabilityResultResponse{}, err
-	}
-	return result, nil
+	return client.checkDnsNameAvailabilityHandleResponse(resp)
 }
 
 // checkDnsNameAvailabilityCreateRequest creates the CheckDNSNameAvailability request.
@@ -74,9 +70,11 @@ func (client NetworkManagementClient) checkDnsNameAvailabilityCreateRequest(ctx 
 
 // checkDnsNameAvailabilityHandleResponse handles the CheckDNSNameAvailability response.
 func (client NetworkManagementClient) checkDnsNameAvailabilityHandleResponse(resp *azcore.Response) (DNSNameAvailabilityResultResponse, error) {
-	result := DNSNameAvailabilityResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DNSNameAvailabilityResult)
-	return result, err
+	var val *DNSNameAvailabilityResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DNSNameAvailabilityResultResponse{}, err
+	}
+	return DNSNameAvailabilityResultResponse{RawResponse: resp.Response, DNSNameAvailabilityResult: val}, nil
 }
 
 // checkDnsNameAvailabilityHandleError handles the CheckDNSNameAvailability error response.
@@ -204,9 +202,11 @@ func (client NetworkManagementClient) disconnectActiveSessionsCreateRequest(ctx 
 
 // disconnectActiveSessionsHandleResponse handles the DisconnectActiveSessions response.
 func (client NetworkManagementClient) disconnectActiveSessionsHandleResponse(resp *azcore.Response) (BastionSessionDeleteResultResponse, error) {
-	result := BastionSessionDeleteResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionSessionDeleteResult)
-	return result, err
+	var val *BastionSessionDeleteResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionSessionDeleteResultResponse{}, err
+	}
+	return BastionSessionDeleteResultResponse{RawResponse: resp.Response, BastionSessionDeleteResult: val}, nil
 }
 
 // disconnectActiveSessionsHandleError handles the DisconnectActiveSessions error response.
@@ -293,9 +293,11 @@ func (client NetworkManagementClient) generatevirtualwanvpnserverconfigurationvp
 
 // generatevirtualwanvpnserverconfigurationvpnprofileHandleResponse handles the Generatevirtualwanvpnserverconfigurationvpnprofile response.
 func (client NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileHandleResponse(resp *azcore.Response) (VpnProfileResponseResponse, error) {
-	result := VpnProfileResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnProfileResponse)
-	return result, err
+	var val *VpnProfileResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnProfileResponseResponse{}, err
+	}
+	return VpnProfileResponseResponse{RawResponse: resp.Response, VpnProfileResponse: val}, nil
 }
 
 // generatevirtualwanvpnserverconfigurationvpnprofileHandleError handles the Generatevirtualwanvpnserverconfigurationvpnprofile error response.
@@ -329,9 +331,11 @@ func (client NetworkManagementClient) BeginGetActiveSessions(ctx context.Context
 			return client.getActiveSessionsHandleError(resp)
 		},
 		respHandler: func(resp *azcore.Response) (BastionActiveSessionListResultResponse, error) {
-			result := BastionActiveSessionListResultResponse{RawResponse: resp.Response}
-			err := resp.UnmarshalAsJSON(&result.BastionActiveSessionListResult)
-			return result, err
+			var val *BastionActiveSessionListResult
+			if err := resp.UnmarshalAsJSON(&val); err != nil {
+				return BastionActiveSessionListResultResponse{}, err
+			}
+			return BastionActiveSessionListResultResponse{RawResponse: resp.Response, BastionActiveSessionListResult: val}, nil
 		},
 		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
 		pipeline:    client.con.Pipeline(),
@@ -392,9 +396,11 @@ func (client NetworkManagementClient) getActiveSessionsCreateRequest(ctx context
 
 // getActiveSessionsHandleResponse handles the GetActiveSessions response.
 func (client NetworkManagementClient) getActiveSessionsHandleResponse(resp *azcore.Response) (BastionActiveSessionListResultResponse, error) {
-	result := BastionActiveSessionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionActiveSessionListResult)
-	return result, err
+	var val *BastionActiveSessionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionActiveSessionListResultResponse{}, err
+	}
+	return BastionActiveSessionListResultResponse{RawResponse: resp.Response, BastionActiveSessionListResult: val}, nil
 }
 
 // getActiveSessionsHandleError handles the GetActiveSessions error response.
@@ -442,9 +448,11 @@ func (client NetworkManagementClient) getBastionShareableLinkCreateRequest(ctx c
 
 // getBastionShareableLinkHandleResponse handles the GetBastionShareableLink response.
 func (client NetworkManagementClient) getBastionShareableLinkHandleResponse(resp *azcore.Response) (BastionShareableLinkListResultResponse, error) {
-	result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
-	return result, err
+	var val *BastionShareableLinkListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionShareableLinkListResultResponse{}, err
+	}
+	return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
 }
 
 // getBastionShareableLinkHandleError handles the GetBastionShareableLink error response.
@@ -478,9 +486,11 @@ func (client NetworkManagementClient) BeginPutBastionShareableLink(ctx context.C
 			return client.putBastionShareableLinkHandleError(resp)
 		},
 		respHandler: func(resp *azcore.Response) (BastionShareableLinkListResultResponse, error) {
-			result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
-			err := resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
-			return result, err
+			var val *BastionShareableLinkListResult
+			if err := resp.UnmarshalAsJSON(&val); err != nil {
+				return BastionShareableLinkListResultResponse{}, err
+			}
+			return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
 		},
 		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
 		pipeline:    client.con.Pipeline(),
@@ -541,9 +551,11 @@ func (client NetworkManagementClient) putBastionShareableLinkCreateRequest(ctx c
 
 // putBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
 func (client NetworkManagementClient) putBastionShareableLinkHandleResponse(resp *azcore.Response) (BastionShareableLinkListResultResponse, error) {
-	result := BastionShareableLinkListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BastionShareableLinkListResult)
-	return result, err
+	var val *BastionShareableLinkListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BastionShareableLinkListResultResponse{}, err
+	}
+	return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
 }
 
 // putBastionShareableLinkHandleError handles the PutBastionShareableLink error response.
@@ -568,11 +580,7 @@ func (client NetworkManagementClient) SupportedSecurityProviders(ctx context.Con
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualWanSecurityProvidersResponse{}, client.supportedSecurityProvidersHandleError(resp)
 	}
-	result, err := client.supportedSecurityProvidersHandleResponse(resp)
-	if err != nil {
-		return VirtualWanSecurityProvidersResponse{}, err
-	}
-	return result, nil
+	return client.supportedSecurityProvidersHandleResponse(resp)
 }
 
 // supportedSecurityProvidersCreateRequest creates the SupportedSecurityProviders request.
@@ -595,9 +603,11 @@ func (client NetworkManagementClient) supportedSecurityProvidersCreateRequest(ct
 
 // supportedSecurityProvidersHandleResponse handles the SupportedSecurityProviders response.
 func (client NetworkManagementClient) supportedSecurityProvidersHandleResponse(resp *azcore.Response) (VirtualWanSecurityProvidersResponse, error) {
-	result := VirtualWanSecurityProvidersResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualWanSecurityProviders)
-	return result, err
+	var val *VirtualWanSecurityProviders
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualWanSecurityProvidersResponse{}, err
+	}
+	return VirtualWanSecurityProvidersResponse{RawResponse: resp.Response, VirtualWanSecurityProviders: val}, nil
 }
 
 // supportedSecurityProvidersHandleError handles the SupportedSecurityProviders error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles.go
@@ -47,11 +47,7 @@ func (client NetworkProfilesClient) CreateOrUpdate(ctx context.Context, resource
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return NetworkProfileResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return NetworkProfileResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -74,9 +70,11 @@ func (client NetworkProfilesClient) createOrUpdateCreateRequest(ctx context.Cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkProfilesClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkProfileResponse, error) {
-	result := NetworkProfileResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkProfile)
-	return result, err
+	var val *NetworkProfile
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkProfileResponse{}, err
+	}
+	return NetworkProfileResponse{RawResponse: resp.Response, NetworkProfile: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -181,11 +179,7 @@ func (client NetworkProfilesClient) Get(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkProfileResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkProfileResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -211,9 +205,11 @@ func (client NetworkProfilesClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client NetworkProfilesClient) getHandleResponse(resp *azcore.Response) (NetworkProfileResponse, error) {
-	result := NetworkProfileResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkProfile)
-	return result, err
+	var val *NetworkProfile
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkProfileResponse{}, err
+	}
+	return NetworkProfileResponse{RawResponse: resp.Response, NetworkProfile: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -260,9 +256,11 @@ func (client NetworkProfilesClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client NetworkProfilesClient) listHandleResponse(resp *azcore.Response) (NetworkProfileListResultResponse, error) {
-	result := NetworkProfileListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkProfileListResult)
-	return result, err
+	var val *NetworkProfileListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkProfileListResultResponse{}, err
+	}
+	return NetworkProfileListResultResponse{RawResponse: resp.Response, NetworkProfileListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -308,9 +306,11 @@ func (client NetworkProfilesClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client NetworkProfilesClient) listAllHandleResponse(resp *azcore.Response) (NetworkProfileListResultResponse, error) {
-	result := NetworkProfileListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkProfileListResult)
-	return result, err
+	var val *NetworkProfileListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkProfileListResultResponse{}, err
+	}
+	return NetworkProfileListResultResponse{RawResponse: resp.Response, NetworkProfileListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -335,11 +335,7 @@ func (client NetworkProfilesClient) UpdateTags(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkProfileResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NetworkProfileResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -362,9 +358,11 @@ func (client NetworkProfilesClient) updateTagsCreateRequest(ctx context.Context,
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NetworkProfilesClient) updateTagsHandleResponse(resp *azcore.Response) (NetworkProfileResponse, error) {
-	result := NetworkProfileResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkProfile)
-	return result, err
+	var val *NetworkProfile
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkProfileResponse{}, err
+	}
+	return NetworkProfileResponse{RawResponse: resp.Response, NetworkProfile: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups.go
@@ -107,9 +107,11 @@ func (client NetworkSecurityGroupsClient) createOrUpdateCreateRequest(ctx contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkSecurityGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkSecurityGroupResponse, error) {
-	result := NetworkSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkSecurityGroup)
-	return result, err
+	var val *NetworkSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkSecurityGroupResponse{}, err
+	}
+	return NetworkSecurityGroupResponse{RawResponse: resp.Response, NetworkSecurityGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client NetworkSecurityGroupsClient) Get(ctx context.Context, resourceGroup
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkSecurityGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkSecurityGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client NetworkSecurityGroupsClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client NetworkSecurityGroupsClient) getHandleResponse(resp *azcore.Response) (NetworkSecurityGroupResponse, error) {
-	result := NetworkSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkSecurityGroup)
-	return result, err
+	var val *NetworkSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkSecurityGroupResponse{}, err
+	}
+	return NetworkSecurityGroupResponse{RawResponse: resp.Response, NetworkSecurityGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client NetworkSecurityGroupsClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client NetworkSecurityGroupsClient) listHandleResponse(resp *azcore.Response) (NetworkSecurityGroupListResultResponse, error) {
-	result := NetworkSecurityGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkSecurityGroupListResult)
-	return result, err
+	var val *NetworkSecurityGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkSecurityGroupListResultResponse{}, err
+	}
+	return NetworkSecurityGroupListResultResponse{RawResponse: resp.Response, NetworkSecurityGroupListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client NetworkSecurityGroupsClient) listAllCreateRequest(ctx context.Conte
 
 // listAllHandleResponse handles the ListAll response.
 func (client NetworkSecurityGroupsClient) listAllHandleResponse(resp *azcore.Response) (NetworkSecurityGroupListResultResponse, error) {
-	result := NetworkSecurityGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkSecurityGroupListResult)
-	return result, err
+	var val *NetworkSecurityGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkSecurityGroupListResultResponse{}, err
+	}
+	return NetworkSecurityGroupListResultResponse{RawResponse: resp.Response, NetworkSecurityGroupListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -368,11 +372,7 @@ func (client NetworkSecurityGroupsClient) UpdateTags(ctx context.Context, resour
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkSecurityGroupResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NetworkSecurityGroupResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client NetworkSecurityGroupsClient) updateTagsCreateRequest(ctx context.Co
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NetworkSecurityGroupsClient) updateTagsHandleResponse(resp *azcore.Response) (NetworkSecurityGroupResponse, error) {
-	result := NetworkSecurityGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkSecurityGroup)
-	return result, err
+	var val *NetworkSecurityGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkSecurityGroupResponse{}, err
+	}
+	return NetworkSecurityGroupResponse{RawResponse: resp.Response, NetworkSecurityGroup: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances.go
@@ -107,9 +107,11 @@ func (client NetworkVirtualAppliancesClient) createOrUpdateCreateRequest(ctx con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkVirtualAppliancesClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceResponse, error) {
-	result := NetworkVirtualApplianceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkVirtualAppliance)
-	return result, err
+	var val *NetworkVirtualAppliance
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkVirtualApplianceResponse{}, err
+	}
+	return NetworkVirtualApplianceResponse{RawResponse: resp.Response, NetworkVirtualAppliance: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client NetworkVirtualAppliancesClient) Get(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkVirtualApplianceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkVirtualApplianceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client NetworkVirtualAppliancesClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client NetworkVirtualAppliancesClient) getHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceResponse, error) {
-	result := NetworkVirtualApplianceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkVirtualAppliance)
-	return result, err
+	var val *NetworkVirtualAppliance
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkVirtualApplianceResponse{}, err
+	}
+	return NetworkVirtualApplianceResponse{RawResponse: resp.Response, NetworkVirtualAppliance: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client NetworkVirtualAppliancesClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client NetworkVirtualAppliancesClient) listHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceListResultResponse, error) {
-	result := NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkVirtualApplianceListResult)
-	return result, err
+	var val *NetworkVirtualApplianceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkVirtualApplianceListResultResponse{}, err
+	}
+	return NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response, NetworkVirtualApplianceListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client NetworkVirtualAppliancesClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client NetworkVirtualAppliancesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceListResultResponse, error) {
-	result := NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkVirtualApplianceListResult)
-	return result, err
+	var val *NetworkVirtualApplianceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkVirtualApplianceListResultResponse{}, err
+	}
+	return NetworkVirtualApplianceListResultResponse{RawResponse: resp.Response, NetworkVirtualApplianceListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -368,11 +372,7 @@ func (client NetworkVirtualAppliancesClient) UpdateTags(ctx context.Context, res
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkVirtualApplianceResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NetworkVirtualApplianceResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client NetworkVirtualAppliancesClient) updateTagsCreateRequest(ctx context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NetworkVirtualAppliancesClient) updateTagsHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceResponse, error) {
-	result := NetworkVirtualApplianceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkVirtualAppliance)
-	return result, err
+	var val *NetworkVirtualAppliance
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkVirtualApplianceResponse{}, err
+	}
+	return NetworkVirtualApplianceResponse{RawResponse: resp.Response, NetworkVirtualAppliance: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers.go
@@ -109,9 +109,11 @@ func (client NetworkWatchersClient) checkConnectivityCreateRequest(ctx context.C
 
 // checkConnectivityHandleResponse handles the CheckConnectivity response.
 func (client NetworkWatchersClient) checkConnectivityHandleResponse(resp *azcore.Response) (ConnectivityInformationResponse, error) {
-	result := ConnectivityInformationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectivityInformation)
-	return result, err
+	var val *ConnectivityInformation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectivityInformationResponse{}, err
+	}
+	return ConnectivityInformationResponse{RawResponse: resp.Response, ConnectivityInformation: val}, nil
 }
 
 // checkConnectivityHandleError handles the CheckConnectivity error response.
@@ -136,11 +138,7 @@ func (client NetworkWatchersClient) CreateOrUpdate(ctx context.Context, resource
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return NetworkWatcherResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return NetworkWatcherResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -163,9 +161,11 @@ func (client NetworkWatchersClient) createOrUpdateCreateRequest(ctx context.Cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client NetworkWatchersClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkWatcherResponse, error) {
-	result := NetworkWatcherResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkWatcher)
-	return result, err
+	var val *NetworkWatcher
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkWatcherResponse{}, err
+	}
+	return NetworkWatcherResponse{RawResponse: resp.Response, NetworkWatcher: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -270,11 +270,7 @@ func (client NetworkWatchersClient) Get(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkWatcherResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return NetworkWatcherResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -297,9 +293,11 @@ func (client NetworkWatchersClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client NetworkWatchersClient) getHandleResponse(resp *azcore.Response) (NetworkWatcherResponse, error) {
-	result := NetworkWatcherResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkWatcher)
-	return result, err
+	var val *NetworkWatcher
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkWatcherResponse{}, err
+	}
+	return NetworkWatcherResponse{RawResponse: resp.Response, NetworkWatcher: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -386,9 +384,11 @@ func (client NetworkWatchersClient) getAzureReachabilityReportCreateRequest(ctx 
 
 // getAzureReachabilityReportHandleResponse handles the GetAzureReachabilityReport response.
 func (client NetworkWatchersClient) getAzureReachabilityReportHandleResponse(resp *azcore.Response) (AzureReachabilityReportResponse, error) {
-	result := AzureReachabilityReportResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AzureReachabilityReport)
-	return result, err
+	var val *AzureReachabilityReport
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AzureReachabilityReportResponse{}, err
+	}
+	return AzureReachabilityReportResponse{RawResponse: resp.Response, AzureReachabilityReport: val}, nil
 }
 
 // getAzureReachabilityReportHandleError handles the GetAzureReachabilityReport error response.
@@ -473,9 +473,11 @@ func (client NetworkWatchersClient) getFlowLogStatusCreateRequest(ctx context.Co
 
 // getFlowLogStatusHandleResponse handles the GetFlowLogStatus response.
 func (client NetworkWatchersClient) getFlowLogStatusHandleResponse(resp *azcore.Response) (FlowLogInformationResponse, error) {
-	result := FlowLogInformationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FlowLogInformation)
-	return result, err
+	var val *FlowLogInformation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FlowLogInformationResponse{}, err
+	}
+	return FlowLogInformationResponse{RawResponse: resp.Response, FlowLogInformation: val}, nil
 }
 
 // getFlowLogStatusHandleError handles the GetFlowLogStatus error response.
@@ -568,9 +570,11 @@ func (client NetworkWatchersClient) getNetworkConfigurationDiagnosticCreateReque
 
 // getNetworkConfigurationDiagnosticHandleResponse handles the GetNetworkConfigurationDiagnostic response.
 func (client NetworkWatchersClient) getNetworkConfigurationDiagnosticHandleResponse(resp *azcore.Response) (NetworkConfigurationDiagnosticResponseResponse, error) {
-	result := NetworkConfigurationDiagnosticResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkConfigurationDiagnosticResponse)
-	return result, err
+	var val *NetworkConfigurationDiagnosticResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkConfigurationDiagnosticResponseResponse{}, err
+	}
+	return NetworkConfigurationDiagnosticResponseResponse{RawResponse: resp.Response, NetworkConfigurationDiagnosticResponse: val}, nil
 }
 
 // getNetworkConfigurationDiagnosticHandleError handles the GetNetworkConfigurationDiagnostic error response.
@@ -655,9 +659,11 @@ func (client NetworkWatchersClient) getNextHopCreateRequest(ctx context.Context,
 
 // getNextHopHandleResponse handles the GetNextHop response.
 func (client NetworkWatchersClient) getNextHopHandleResponse(resp *azcore.Response) (NextHopResultResponse, error) {
-	result := NextHopResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NextHopResult)
-	return result, err
+	var val *NextHopResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NextHopResultResponse{}, err
+	}
+	return NextHopResultResponse{RawResponse: resp.Response, NextHopResult: val}, nil
 }
 
 // getNextHopHandleError handles the GetNextHop error response.
@@ -682,11 +688,7 @@ func (client NetworkWatchersClient) GetTopology(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TopologyResponse{}, client.getTopologyHandleError(resp)
 	}
-	result, err := client.getTopologyHandleResponse(resp)
-	if err != nil {
-		return TopologyResponse{}, err
-	}
-	return result, nil
+	return client.getTopologyHandleResponse(resp)
 }
 
 // getTopologyCreateRequest creates the GetTopology request.
@@ -709,9 +711,11 @@ func (client NetworkWatchersClient) getTopologyCreateRequest(ctx context.Context
 
 // getTopologyHandleResponse handles the GetTopology response.
 func (client NetworkWatchersClient) getTopologyHandleResponse(resp *azcore.Response) (TopologyResponse, error) {
-	result := TopologyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Topology)
-	return result, err
+	var val *Topology
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TopologyResponse{}, err
+	}
+	return TopologyResponse{RawResponse: resp.Response, Topology: val}, nil
 }
 
 // getTopologyHandleError handles the GetTopology error response.
@@ -796,9 +800,11 @@ func (client NetworkWatchersClient) getTroubleshootingCreateRequest(ctx context.
 
 // getTroubleshootingHandleResponse handles the GetTroubleshooting response.
 func (client NetworkWatchersClient) getTroubleshootingHandleResponse(resp *azcore.Response) (TroubleshootingResultResponse, error) {
-	result := TroubleshootingResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TroubleshootingResult)
-	return result, err
+	var val *TroubleshootingResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TroubleshootingResultResponse{}, err
+	}
+	return TroubleshootingResultResponse{RawResponse: resp.Response, TroubleshootingResult: val}, nil
 }
 
 // getTroubleshootingHandleError handles the GetTroubleshooting error response.
@@ -883,9 +889,11 @@ func (client NetworkWatchersClient) getTroubleshootingResultCreateRequest(ctx co
 
 // getTroubleshootingResultHandleResponse handles the GetTroubleshootingResult response.
 func (client NetworkWatchersClient) getTroubleshootingResultHandleResponse(resp *azcore.Response) (TroubleshootingResultResponse, error) {
-	result := TroubleshootingResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TroubleshootingResult)
-	return result, err
+	var val *TroubleshootingResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TroubleshootingResultResponse{}, err
+	}
+	return TroubleshootingResultResponse{RawResponse: resp.Response, TroubleshootingResult: val}, nil
 }
 
 // getTroubleshootingResultHandleError handles the GetTroubleshootingResult error response.
@@ -970,9 +978,11 @@ func (client NetworkWatchersClient) getVMSecurityRulesCreateRequest(ctx context.
 
 // getVMSecurityRulesHandleResponse handles the GetVMSecurityRules response.
 func (client NetworkWatchersClient) getVMSecurityRulesHandleResponse(resp *azcore.Response) (SecurityGroupViewResultResponse, error) {
-	result := SecurityGroupViewResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityGroupViewResult)
-	return result, err
+	var val *SecurityGroupViewResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityGroupViewResultResponse{}, err
+	}
+	return SecurityGroupViewResultResponse{RawResponse: resp.Response, SecurityGroupViewResult: val}, nil
 }
 
 // getVMSecurityRulesHandleError handles the GetVMSecurityRules error response.
@@ -997,11 +1007,7 @@ func (client NetworkWatchersClient) List(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkWatcherListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return NetworkWatcherListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -1023,9 +1029,11 @@ func (client NetworkWatchersClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client NetworkWatchersClient) listHandleResponse(resp *azcore.Response) (NetworkWatcherListResultResponse, error) {
-	result := NetworkWatcherListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkWatcherListResult)
-	return result, err
+	var val *NetworkWatcherListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkWatcherListResultResponse{}, err
+	}
+	return NetworkWatcherListResultResponse{RawResponse: resp.Response, NetworkWatcherListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -1050,11 +1058,7 @@ func (client NetworkWatchersClient) ListAll(ctx context.Context, options *Networ
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkWatcherListResultResponse{}, client.listAllHandleError(resp)
 	}
-	result, err := client.listAllHandleResponse(resp)
-	if err != nil {
-		return NetworkWatcherListResultResponse{}, err
-	}
-	return result, nil
+	return client.listAllHandleResponse(resp)
 }
 
 // listAllCreateRequest creates the ListAll request.
@@ -1075,9 +1079,11 @@ func (client NetworkWatchersClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client NetworkWatchersClient) listAllHandleResponse(resp *azcore.Response) (NetworkWatcherListResultResponse, error) {
-	result := NetworkWatcherListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkWatcherListResult)
-	return result, err
+	var val *NetworkWatcherListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkWatcherListResultResponse{}, err
+	}
+	return NetworkWatcherListResultResponse{RawResponse: resp.Response, NetworkWatcherListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -1164,9 +1170,11 @@ func (client NetworkWatchersClient) listAvailableProvidersCreateRequest(ctx cont
 
 // listAvailableProvidersHandleResponse handles the ListAvailableProviders response.
 func (client NetworkWatchersClient) listAvailableProvidersHandleResponse(resp *azcore.Response) (AvailableProvidersListResponse, error) {
-	result := AvailableProvidersListResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AvailableProvidersList)
-	return result, err
+	var val *AvailableProvidersList
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AvailableProvidersListResponse{}, err
+	}
+	return AvailableProvidersListResponse{RawResponse: resp.Response, AvailableProvidersList: val}, nil
 }
 
 // listAvailableProvidersHandleError handles the ListAvailableProviders error response.
@@ -1251,9 +1259,11 @@ func (client NetworkWatchersClient) setFlowLogConfigurationCreateRequest(ctx con
 
 // setFlowLogConfigurationHandleResponse handles the SetFlowLogConfiguration response.
 func (client NetworkWatchersClient) setFlowLogConfigurationHandleResponse(resp *azcore.Response) (FlowLogInformationResponse, error) {
-	result := FlowLogInformationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.FlowLogInformation)
-	return result, err
+	var val *FlowLogInformation
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return FlowLogInformationResponse{}, err
+	}
+	return FlowLogInformationResponse{RawResponse: resp.Response, FlowLogInformation: val}, nil
 }
 
 // setFlowLogConfigurationHandleError handles the SetFlowLogConfiguration error response.
@@ -1278,11 +1288,7 @@ func (client NetworkWatchersClient) UpdateTags(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return NetworkWatcherResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return NetworkWatcherResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -1305,9 +1311,11 @@ func (client NetworkWatchersClient) updateTagsCreateRequest(ctx context.Context,
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client NetworkWatchersClient) updateTagsHandleResponse(resp *azcore.Response) (NetworkWatcherResponse, error) {
-	result := NetworkWatcherResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NetworkWatcher)
-	return result, err
+	var val *NetworkWatcher
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NetworkWatcherResponse{}, err
+	}
+	return NetworkWatcherResponse{RawResponse: resp.Response, NetworkWatcher: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
@@ -1392,9 +1400,11 @@ func (client NetworkWatchersClient) verifyIPFlowCreateRequest(ctx context.Contex
 
 // verifyIPFlowHandleResponse handles the VerifyIPFlow response.
 func (client NetworkWatchersClient) verifyIPFlowHandleResponse(resp *azcore.Response) (VerificationIPFlowResultResponse, error) {
-	result := VerificationIPFlowResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VerificationIPFlowResult)
-	return result, err
+	var val *VerificationIPFlowResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VerificationIPFlowResultResponse{}, err
+	}
+	return VerificationIPFlowResultResponse{RawResponse: resp.Response, VerificationIPFlowResult: val}, nil
 }
 
 // verifyIPFlowHandleError handles the VerifyIPFlow error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations.go
@@ -63,9 +63,11 @@ func (client OperationsClient) listCreateRequest(ctx context.Context, options *O
 
 // listHandleResponse handles the List response.
 func (client OperationsClient) listHandleResponse(resp *azcore.Response) (OperationListResultResponse, error) {
-	result := OperationListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.OperationListResult)
-	return result, err
+	var val *OperationListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return OperationListResultResponse{}, err
+	}
+	return OperationListResultResponse{RawResponse: resp.Response, OperationListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways.go
@@ -107,9 +107,11 @@ func (client P2SVpnGatewaysClient) createOrUpdateCreateRequest(ctx context.Conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client P2SVpnGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (P2SVpnGatewayResponse, error) {
-	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.P2SVpnGateway)
-	return result, err
+	var val *P2SVpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return P2SVpnGatewayResponse{}, err
+	}
+	return P2SVpnGatewayResponse{RawResponse: resp.Response, P2SVpnGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -354,9 +356,11 @@ func (client P2SVpnGatewaysClient) generateVpnProfileCreateRequest(ctx context.C
 
 // generateVpnProfileHandleResponse handles the GenerateVpnProfile response.
 func (client P2SVpnGatewaysClient) generateVpnProfileHandleResponse(resp *azcore.Response) (VpnProfileResponseResponse, error) {
-	result := VpnProfileResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnProfileResponse)
-	return result, err
+	var val *VpnProfileResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnProfileResponseResponse{}, err
+	}
+	return VpnProfileResponseResponse{RawResponse: resp.Response, VpnProfileResponse: val}, nil
 }
 
 // generateVpnProfileHandleError handles the GenerateVpnProfile error response.
@@ -381,11 +385,7 @@ func (client P2SVpnGatewaysClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return P2SVpnGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return P2SVpnGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -408,9 +408,11 @@ func (client P2SVpnGatewaysClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client P2SVpnGatewaysClient) getHandleResponse(resp *azcore.Response) (P2SVpnGatewayResponse, error) {
-	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.P2SVpnGateway)
-	return result, err
+	var val *P2SVpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return P2SVpnGatewayResponse{}, err
+	}
+	return P2SVpnGatewayResponse{RawResponse: resp.Response, P2SVpnGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -495,9 +497,11 @@ func (client P2SVpnGatewaysClient) getP2SVpnConnectionHealthCreateRequest(ctx co
 
 // getP2SVpnConnectionHealthHandleResponse handles the GetP2SVpnConnectionHealth response.
 func (client P2SVpnGatewaysClient) getP2SVpnConnectionHealthHandleResponse(resp *azcore.Response) (P2SVpnGatewayResponse, error) {
-	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.P2SVpnGateway)
-	return result, err
+	var val *P2SVpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return P2SVpnGatewayResponse{}, err
+	}
+	return P2SVpnGatewayResponse{RawResponse: resp.Response, P2SVpnGateway: val}, nil
 }
 
 // getP2SVpnConnectionHealthHandleError handles the GetP2SVpnConnectionHealth error response.
@@ -584,9 +588,11 @@ func (client P2SVpnGatewaysClient) getP2SVpnConnectionHealthDetailedCreateReques
 
 // getP2SVpnConnectionHealthDetailedHandleResponse handles the GetP2SVpnConnectionHealthDetailed response.
 func (client P2SVpnGatewaysClient) getP2SVpnConnectionHealthDetailedHandleResponse(resp *azcore.Response) (P2SVpnConnectionHealthResponse, error) {
-	result := P2SVpnConnectionHealthResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.P2SVpnConnectionHealth)
-	return result, err
+	var val *P2SVpnConnectionHealth
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return P2SVpnConnectionHealthResponse{}, err
+	}
+	return P2SVpnConnectionHealthResponse{RawResponse: resp.Response, P2SVpnConnectionHealth: val}, nil
 }
 
 // getP2SVpnConnectionHealthDetailedHandleError handles the GetP2SVpnConnectionHealthDetailed error response.
@@ -632,9 +638,11 @@ func (client P2SVpnGatewaysClient) listCreateRequest(ctx context.Context, option
 
 // listHandleResponse handles the List response.
 func (client P2SVpnGatewaysClient) listHandleResponse(resp *azcore.Response) (ListP2SVpnGatewaysResultResponse, error) {
-	result := ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListP2SVpnGatewaysResult)
-	return result, err
+	var val *ListP2SVpnGatewaysResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListP2SVpnGatewaysResultResponse{}, err
+	}
+	return ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response, ListP2SVpnGatewaysResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -681,9 +689,11 @@ func (client P2SVpnGatewaysClient) listByResourceGroupCreateRequest(ctx context.
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client P2SVpnGatewaysClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListP2SVpnGatewaysResultResponse, error) {
-	result := ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListP2SVpnGatewaysResult)
-	return result, err
+	var val *ListP2SVpnGatewaysResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListP2SVpnGatewaysResultResponse{}, err
+	}
+	return ListP2SVpnGatewaysResultResponse{RawResponse: resp.Response, ListP2SVpnGatewaysResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -708,11 +718,7 @@ func (client P2SVpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroup
 	if !resp.HasStatusCode(http.StatusOK) {
 		return P2SVpnGatewayResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return P2SVpnGatewayResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -735,9 +741,11 @@ func (client P2SVpnGatewaysClient) updateTagsCreateRequest(ctx context.Context, 
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client P2SVpnGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (P2SVpnGatewayResponse, error) {
-	result := P2SVpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.P2SVpnGateway)
-	return result, err
+	var val *P2SVpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return P2SVpnGatewayResponse{}, err
+	}
+	return P2SVpnGatewayResponse{RawResponse: resp.Response, P2SVpnGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures.go
@@ -108,9 +108,11 @@ func (client PacketCapturesClient) createCreateRequest(ctx context.Context, reso
 
 // createHandleResponse handles the Create response.
 func (client PacketCapturesClient) createHandleResponse(resp *azcore.Response) (PacketCaptureResultResponse, error) {
-	result := PacketCaptureResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PacketCaptureResult)
-	return result, err
+	var val *PacketCaptureResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PacketCaptureResultResponse{}, err
+	}
+	return PacketCaptureResultResponse{RawResponse: resp.Response, PacketCaptureResult: val}, nil
 }
 
 // createHandleError handles the Create error response.
@@ -216,11 +218,7 @@ func (client PacketCapturesClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PacketCaptureResultResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PacketCaptureResultResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client PacketCapturesClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client PacketCapturesClient) getHandleResponse(resp *azcore.Response) (PacketCaptureResultResponse, error) {
-	result := PacketCaptureResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PacketCaptureResult)
-	return result, err
+	var val *PacketCaptureResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PacketCaptureResultResponse{}, err
+	}
+	return PacketCaptureResultResponse{RawResponse: resp.Response, PacketCaptureResult: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -332,9 +332,11 @@ func (client PacketCapturesClient) getStatusCreateRequest(ctx context.Context, r
 
 // getStatusHandleResponse handles the GetStatus response.
 func (client PacketCapturesClient) getStatusHandleResponse(resp *azcore.Response) (PacketCaptureQueryStatusResultResponse, error) {
-	result := PacketCaptureQueryStatusResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PacketCaptureQueryStatusResult)
-	return result, err
+	var val *PacketCaptureQueryStatusResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PacketCaptureQueryStatusResultResponse{}, err
+	}
+	return PacketCaptureQueryStatusResultResponse{RawResponse: resp.Response, PacketCaptureQueryStatusResult: val}, nil
 }
 
 // getStatusHandleError handles the GetStatus error response.
@@ -359,11 +361,7 @@ func (client PacketCapturesClient) List(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PacketCaptureListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return PacketCaptureListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -386,9 +384,11 @@ func (client PacketCapturesClient) listCreateRequest(ctx context.Context, resour
 
 // listHandleResponse handles the List response.
 func (client PacketCapturesClient) listHandleResponse(resp *azcore.Response) (PacketCaptureListResultResponse, error) {
-	result := PacketCaptureListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PacketCaptureListResult)
-	return result, err
+	var val *PacketCaptureListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PacketCaptureListResultResponse{}, err
+	}
+	return PacketCaptureListResultResponse{RawResponse: resp.Response, PacketCaptureListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections.go
@@ -46,11 +46,7 @@ func (client PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PeerExpressRouteCircuitConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PeerExpressRouteCircuitConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -75,9 +71,11 @@ func (client PeerExpressRouteCircuitConnectionsClient) getCreateRequest(ctx cont
 
 // getHandleResponse handles the Get response.
 func (client PeerExpressRouteCircuitConnectionsClient) getHandleResponse(resp *azcore.Response) (PeerExpressRouteCircuitConnectionResponse, error) {
-	result := PeerExpressRouteCircuitConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PeerExpressRouteCircuitConnection)
-	return result, err
+	var val *PeerExpressRouteCircuitConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PeerExpressRouteCircuitConnectionResponse{}, err
+	}
+	return PeerExpressRouteCircuitConnectionResponse{RawResponse: resp.Response, PeerExpressRouteCircuitConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -126,9 +124,11 @@ func (client PeerExpressRouteCircuitConnectionsClient) listCreateRequest(ctx con
 
 // listHandleResponse handles the List response.
 func (client PeerExpressRouteCircuitConnectionsClient) listHandleResponse(resp *azcore.Response) (PeerExpressRouteCircuitConnectionListResultResponse, error) {
-	result := PeerExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PeerExpressRouteCircuitConnectionListResult)
-	return result, err
+	var val *PeerExpressRouteCircuitConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PeerExpressRouteCircuitConnectionListResultResponse{}, err
+	}
+	return PeerExpressRouteCircuitConnectionListResultResponse{RawResponse: resp.Response, PeerExpressRouteCircuitConnectionListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups.go
@@ -108,9 +108,11 @@ func (client PrivateDNSZoneGroupsClient) createOrUpdateCreateRequest(ctx context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client PrivateDNSZoneGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateDNSZoneGroupResponse, error) {
-	result := PrivateDNSZoneGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateDNSZoneGroup)
-	return result, err
+	var val *PrivateDNSZoneGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateDNSZoneGroupResponse{}, err
+	}
+	return PrivateDNSZoneGroupResponse{RawResponse: resp.Response, PrivateDNSZoneGroup: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroupN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PrivateDNSZoneGroupResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PrivateDNSZoneGroupResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client PrivateDNSZoneGroupsClient) getCreateRequest(ctx context.Context, r
 
 // getHandleResponse handles the Get response.
 func (client PrivateDNSZoneGroupsClient) getHandleResponse(resp *azcore.Response) (PrivateDNSZoneGroupResponse, error) {
-	result := PrivateDNSZoneGroupResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateDNSZoneGroup)
-	return result, err
+	var val *PrivateDNSZoneGroup
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateDNSZoneGroupResponse{}, err
+	}
+	return PrivateDNSZoneGroupResponse{RawResponse: resp.Response, PrivateDNSZoneGroup: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client PrivateDNSZoneGroupsClient) listCreateRequest(ctx context.Context, 
 
 // listHandleResponse handles the List response.
 func (client PrivateDNSZoneGroupsClient) listHandleResponse(resp *azcore.Response) (PrivateDNSZoneGroupListResultResponse, error) {
-	result := PrivateDNSZoneGroupListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateDNSZoneGroupListResult)
-	return result, err
+	var val *PrivateDNSZoneGroupListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateDNSZoneGroupListResultResponse{}, err
+	}
+	return PrivateDNSZoneGroupListResultResponse{RawResponse: resp.Response, PrivateDNSZoneGroupListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints.go
@@ -107,9 +107,11 @@ func (client PrivateEndpointsClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client PrivateEndpointsClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateEndpointResponse, error) {
-	result := PrivateEndpointResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpoint)
-	return result, err
+	var val *PrivateEndpoint
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointResponse{}, err
+	}
+	return PrivateEndpointResponse{RawResponse: resp.Response, PrivateEndpoint: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PrivateEndpointResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PrivateEndpointResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client PrivateEndpointsClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client PrivateEndpointsClient) getHandleResponse(resp *azcore.Response) (PrivateEndpointResponse, error) {
-	result := PrivateEndpointResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpoint)
-	return result, err
+	var val *PrivateEndpoint
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointResponse{}, err
+	}
+	return PrivateEndpointResponse{RawResponse: resp.Response, PrivateEndpoint: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client PrivateEndpointsClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client PrivateEndpointsClient) listHandleResponse(resp *azcore.Response) (PrivateEndpointListResultResponse, error) {
-	result := PrivateEndpointListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpointListResult)
-	return result, err
+	var val *PrivateEndpointListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointListResultResponse{}, err
+	}
+	return PrivateEndpointListResultResponse{RawResponse: resp.Response, PrivateEndpointListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client PrivateEndpointsClient) listBySubscriptionCreateRequest(ctx context
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client PrivateEndpointsClient) listBySubscriptionHandleResponse(resp *azcore.Response) (PrivateEndpointListResultResponse, error) {
-	result := PrivateEndpointListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpointListResult)
-	return result, err
+	var val *PrivateEndpointListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointListResultResponse{}, err
+	}
+	return PrivateEndpointListResultResponse{RawResponse: resp.Response, PrivateEndpointListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices.go
@@ -106,9 +106,11 @@ func (client PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityCreateR
 
 // checkPrivateLinkServiceVisibilityHandleResponse handles the CheckPrivateLinkServiceVisibility response.
 func (client PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityHandleResponse(resp *azcore.Response) (PrivateLinkServiceVisibilityResponse, error) {
-	result := PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkServiceVisibility)
-	return result, err
+	var val *PrivateLinkServiceVisibility
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceVisibilityResponse{}, err
+	}
+	return PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response, PrivateLinkServiceVisibility: val}, nil
 }
 
 // checkPrivateLinkServiceVisibilityHandleError handles the CheckPrivateLinkServiceVisibility error response.
@@ -194,9 +196,11 @@ func (client PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByResou
 
 // checkPrivateLinkServiceVisibilityByResourceGroupHandleResponse handles the CheckPrivateLinkServiceVisibilityByResourceGroup response.
 func (client PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByResourceGroupHandleResponse(resp *azcore.Response) (PrivateLinkServiceVisibilityResponse, error) {
-	result := PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkServiceVisibility)
-	return result, err
+	var val *PrivateLinkServiceVisibility
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceVisibilityResponse{}, err
+	}
+	return PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response, PrivateLinkServiceVisibility: val}, nil
 }
 
 // checkPrivateLinkServiceVisibilityByResourceGroupHandleError handles the CheckPrivateLinkServiceVisibilityByResourceGroup error response.
@@ -281,9 +285,11 @@ func (client PrivateLinkServicesClient) createOrUpdateCreateRequest(ctx context.
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client PrivateLinkServicesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateLinkServiceResponse, error) {
-	result := PrivateLinkServiceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkService)
-	return result, err
+	var val *PrivateLinkService
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceResponse{}, err
+	}
+	return PrivateLinkServiceResponse{RawResponse: resp.Response, PrivateLinkService: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -469,11 +475,7 @@ func (client PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PrivateLinkServiceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PrivateLinkServiceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -499,9 +501,11 @@ func (client PrivateLinkServicesClient) getCreateRequest(ctx context.Context, re
 
 // getHandleResponse handles the Get response.
 func (client PrivateLinkServicesClient) getHandleResponse(resp *azcore.Response) (PrivateLinkServiceResponse, error) {
-	result := PrivateLinkServiceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkService)
-	return result, err
+	var val *PrivateLinkService
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceResponse{}, err
+	}
+	return PrivateLinkServiceResponse{RawResponse: resp.Response, PrivateLinkService: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -526,11 +530,7 @@ func (client PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PrivateEndpointConnectionResponse{}, client.getPrivateEndpointConnectionHandleError(resp)
 	}
-	result, err := client.getPrivateEndpointConnectionHandleResponse(resp)
-	if err != nil {
-		return PrivateEndpointConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getPrivateEndpointConnectionHandleResponse(resp)
 }
 
 // getPrivateEndpointConnectionCreateRequest creates the GetPrivateEndpointConnection request.
@@ -557,9 +557,11 @@ func (client PrivateLinkServicesClient) getPrivateEndpointConnectionCreateReques
 
 // getPrivateEndpointConnectionHandleResponse handles the GetPrivateEndpointConnection response.
 func (client PrivateLinkServicesClient) getPrivateEndpointConnectionHandleResponse(resp *azcore.Response) (PrivateEndpointConnectionResponse, error) {
-	result := PrivateEndpointConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpointConnection)
-	return result, err
+	var val *PrivateEndpointConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointConnectionResponse{}, err
+	}
+	return PrivateEndpointConnectionResponse{RawResponse: resp.Response, PrivateEndpointConnection: val}, nil
 }
 
 // getPrivateEndpointConnectionHandleError handles the GetPrivateEndpointConnection error response.
@@ -606,9 +608,11 @@ func (client PrivateLinkServicesClient) listCreateRequest(ctx context.Context, r
 
 // listHandleResponse handles the List response.
 func (client PrivateLinkServicesClient) listHandleResponse(resp *azcore.Response) (PrivateLinkServiceListResultResponse, error) {
-	result := PrivateLinkServiceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkServiceListResult)
-	return result, err
+	var val *PrivateLinkServiceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceListResultResponse{}, err
+	}
+	return PrivateLinkServiceListResultResponse{RawResponse: resp.Response, PrivateLinkServiceListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -656,9 +660,11 @@ func (client PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesCreat
 
 // listAutoApprovedPrivateLinkServicesHandleResponse handles the ListAutoApprovedPrivateLinkServices response.
 func (client PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesHandleResponse(resp *azcore.Response) (AutoApprovedPrivateLinkServicesResultResponse, error) {
-	result := AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AutoApprovedPrivateLinkServicesResult)
-	return result, err
+	var val *AutoApprovedPrivateLinkServicesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AutoApprovedPrivateLinkServicesResultResponse{}, err
+	}
+	return AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response, AutoApprovedPrivateLinkServicesResult: val}, nil
 }
 
 // listAutoApprovedPrivateLinkServicesHandleError handles the ListAutoApprovedPrivateLinkServices error response.
@@ -707,9 +713,11 @@ func (client PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByRes
 
 // listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse handles the ListAutoApprovedPrivateLinkServicesByResourceGroup response.
 func (client PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse(resp *azcore.Response) (AutoApprovedPrivateLinkServicesResultResponse, error) {
-	result := AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AutoApprovedPrivateLinkServicesResult)
-	return result, err
+	var val *AutoApprovedPrivateLinkServicesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AutoApprovedPrivateLinkServicesResultResponse{}, err
+	}
+	return AutoApprovedPrivateLinkServicesResultResponse{RawResponse: resp.Response, AutoApprovedPrivateLinkServicesResult: val}, nil
 }
 
 // listAutoApprovedPrivateLinkServicesByResourceGroupHandleError handles the ListAutoApprovedPrivateLinkServicesByResourceGroup error response.
@@ -755,9 +763,11 @@ func (client PrivateLinkServicesClient) listBySubscriptionCreateRequest(ctx cont
 
 // listBySubscriptionHandleResponse handles the ListBySubscription response.
 func (client PrivateLinkServicesClient) listBySubscriptionHandleResponse(resp *azcore.Response) (PrivateLinkServiceListResultResponse, error) {
-	result := PrivateLinkServiceListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateLinkServiceListResult)
-	return result, err
+	var val *PrivateLinkServiceListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateLinkServiceListResultResponse{}, err
+	}
+	return PrivateLinkServiceListResultResponse{RawResponse: resp.Response, PrivateLinkServiceListResult: val}, nil
 }
 
 // listBySubscriptionHandleError handles the ListBySubscription error response.
@@ -805,9 +815,11 @@ func (client PrivateLinkServicesClient) listPrivateEndpointConnectionsCreateRequ
 
 // listPrivateEndpointConnectionsHandleResponse handles the ListPrivateEndpointConnections response.
 func (client PrivateLinkServicesClient) listPrivateEndpointConnectionsHandleResponse(resp *azcore.Response) (PrivateEndpointConnectionListResultResponse, error) {
-	result := PrivateEndpointConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpointConnectionListResult)
-	return result, err
+	var val *PrivateEndpointConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointConnectionListResultResponse{}, err
+	}
+	return PrivateEndpointConnectionListResultResponse{RawResponse: resp.Response, PrivateEndpointConnectionListResult: val}, nil
 }
 
 // listPrivateEndpointConnectionsHandleError handles the ListPrivateEndpointConnections error response.
@@ -832,11 +844,7 @@ func (client PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PrivateEndpointConnectionResponse{}, client.updatePrivateEndpointConnectionHandleError(resp)
 	}
-	result, err := client.updatePrivateEndpointConnectionHandleResponse(resp)
-	if err != nil {
-		return PrivateEndpointConnectionResponse{}, err
-	}
-	return result, nil
+	return client.updatePrivateEndpointConnectionHandleResponse(resp)
 }
 
 // updatePrivateEndpointConnectionCreateRequest creates the UpdatePrivateEndpointConnection request.
@@ -860,9 +868,11 @@ func (client PrivateLinkServicesClient) updatePrivateEndpointConnectionCreateReq
 
 // updatePrivateEndpointConnectionHandleResponse handles the UpdatePrivateEndpointConnection response.
 func (client PrivateLinkServicesClient) updatePrivateEndpointConnectionHandleResponse(resp *azcore.Response) (PrivateEndpointConnectionResponse, error) {
-	result := PrivateEndpointConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PrivateEndpointConnection)
-	return result, err
+	var val *PrivateEndpointConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PrivateEndpointConnectionResponse{}, err
+	}
+	return PrivateEndpointConnectionResponse{RawResponse: resp.Response, PrivateEndpointConnection: val}, nil
 }
 
 // updatePrivateEndpointConnectionHandleError handles the UpdatePrivateEndpointConnection error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses.go
@@ -107,9 +107,11 @@ func (client PublicIPAddressesClient) createOrUpdateCreateRequest(ctx context.Co
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client PublicIPAddressesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PublicIPAddressResponse, error) {
-	result := PublicIPAddressResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddress)
-	return result, err
+	var val *PublicIPAddress
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressResponse{}, err
+	}
+	return PublicIPAddressResponse{RawResponse: resp.Response, PublicIPAddress: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client PublicIPAddressesClient) Get(ctx context.Context, resourceGroupName
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PublicIPAddressResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PublicIPAddressResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client PublicIPAddressesClient) getCreateRequest(ctx context.Context, reso
 
 // getHandleResponse handles the Get response.
 func (client PublicIPAddressesClient) getHandleResponse(resp *azcore.Response) (PublicIPAddressResponse, error) {
-	result := PublicIPAddressResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddress)
-	return result, err
+	var val *PublicIPAddress
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressResponse{}, err
+	}
+	return PublicIPAddressResponse{RawResponse: resp.Response, PublicIPAddress: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -271,11 +271,7 @@ func (client PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(c
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PublicIPAddressResponse{}, client.getVirtualMachineScaleSetPublicIPAddressHandleError(resp)
 	}
-	result, err := client.getVirtualMachineScaleSetPublicIPAddressHandleResponse(resp)
-	if err != nil {
-		return PublicIPAddressResponse{}, err
-	}
-	return result, nil
+	return client.getVirtualMachineScaleSetPublicIPAddressHandleResponse(resp)
 }
 
 // getVirtualMachineScaleSetPublicIPAddressCreateRequest creates the GetVirtualMachineScaleSetPublicIPAddress request.
@@ -305,9 +301,11 @@ func (client PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressCr
 
 // getVirtualMachineScaleSetPublicIPAddressHandleResponse handles the GetVirtualMachineScaleSetPublicIPAddress response.
 func (client PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressHandleResponse(resp *azcore.Response) (PublicIPAddressResponse, error) {
-	result := PublicIPAddressResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddress)
-	return result, err
+	var val *PublicIPAddress
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressResponse{}, err
+	}
+	return PublicIPAddressResponse{RawResponse: resp.Response, PublicIPAddress: val}, nil
 }
 
 // getVirtualMachineScaleSetPublicIPAddressHandleError handles the GetVirtualMachineScaleSetPublicIPAddress error response.
@@ -354,9 +352,11 @@ func (client PublicIPAddressesClient) listCreateRequest(ctx context.Context, res
 
 // listHandleResponse handles the List response.
 func (client PublicIPAddressesClient) listHandleResponse(resp *azcore.Response) (PublicIPAddressListResultResponse, error) {
-	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
-	return result, err
+	var val *PublicIPAddressListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressListResultResponse{}, err
+	}
+	return PublicIPAddressListResultResponse{RawResponse: resp.Response, PublicIPAddressListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -402,9 +402,11 @@ func (client PublicIPAddressesClient) listAllCreateRequest(ctx context.Context, 
 
 // listAllHandleResponse handles the ListAll response.
 func (client PublicIPAddressesClient) listAllHandleResponse(resp *azcore.Response) (PublicIPAddressListResultResponse, error) {
-	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
-	return result, err
+	var val *PublicIPAddressListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressListResultResponse{}, err
+	}
+	return PublicIPAddressListResultResponse{RawResponse: resp.Response, PublicIPAddressListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -452,9 +454,11 @@ func (client PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddresse
 
 // listVirtualMachineScaleSetPublicIPAddressesHandleResponse handles the ListVirtualMachineScaleSetPublicIPAddresses response.
 func (client PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddressesHandleResponse(resp *azcore.Response) (PublicIPAddressListResultResponse, error) {
-	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
-	return result, err
+	var val *PublicIPAddressListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressListResultResponse{}, err
+	}
+	return PublicIPAddressListResultResponse{RawResponse: resp.Response, PublicIPAddressListResult: val}, nil
 }
 
 // listVirtualMachineScaleSetPublicIPAddressesHandleError handles the ListVirtualMachineScaleSetPublicIPAddresses error response.
@@ -506,9 +510,11 @@ func (client PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIpaddres
 
 // listVirtualMachineScaleSetVMPublicIpaddressesHandleResponse handles the ListVirtualMachineScaleSetVMPublicIPaddresses response.
 func (client PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIpaddressesHandleResponse(resp *azcore.Response) (PublicIPAddressListResultResponse, error) {
-	result := PublicIPAddressListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddressListResult)
-	return result, err
+	var val *PublicIPAddressListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressListResultResponse{}, err
+	}
+	return PublicIPAddressListResultResponse{RawResponse: resp.Response, PublicIPAddressListResult: val}, nil
 }
 
 // listVirtualMachineScaleSetVMPublicIpaddressesHandleError handles the ListVirtualMachineScaleSetVMPublicIPaddresses error response.
@@ -533,11 +539,7 @@ func (client PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PublicIPAddressResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return PublicIPAddressResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -560,9 +562,11 @@ func (client PublicIPAddressesClient) updateTagsCreateRequest(ctx context.Contex
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client PublicIPAddressesClient) updateTagsHandleResponse(resp *azcore.Response) (PublicIPAddressResponse, error) {
-	result := PublicIPAddressResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPAddress)
-	return result, err
+	var val *PublicIPAddress
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPAddressResponse{}, err
+	}
+	return PublicIPAddressResponse{RawResponse: resp.Response, PublicIPAddress: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes.go
@@ -107,9 +107,11 @@ func (client PublicIPPrefixesClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client PublicIPPrefixesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PublicIPPrefixResponse, error) {
-	result := PublicIPPrefixResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPPrefix)
-	return result, err
+	var val *PublicIPPrefix
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPPrefixResponse{}, err
+	}
+	return PublicIPPrefixResponse{RawResponse: resp.Response, PublicIPPrefix: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PublicIPPrefixResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return PublicIPPrefixResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client PublicIPPrefixesClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client PublicIPPrefixesClient) getHandleResponse(resp *azcore.Response) (PublicIPPrefixResponse, error) {
-	result := PublicIPPrefixResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPPrefix)
-	return result, err
+	var val *PublicIPPrefix
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPPrefixResponse{}, err
+	}
+	return PublicIPPrefixResponse{RawResponse: resp.Response, PublicIPPrefix: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client PublicIPPrefixesClient) listCreateRequest(ctx context.Context, reso
 
 // listHandleResponse handles the List response.
 func (client PublicIPPrefixesClient) listHandleResponse(resp *azcore.Response) (PublicIPPrefixListResultResponse, error) {
-	result := PublicIPPrefixListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPPrefixListResult)
-	return result, err
+	var val *PublicIPPrefixListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPPrefixListResultResponse{}, err
+	}
+	return PublicIPPrefixListResultResponse{RawResponse: resp.Response, PublicIPPrefixListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client PublicIPPrefixesClient) listAllCreateRequest(ctx context.Context, o
 
 // listAllHandleResponse handles the ListAll response.
 func (client PublicIPPrefixesClient) listAllHandleResponse(resp *azcore.Response) (PublicIPPrefixListResultResponse, error) {
-	result := PublicIPPrefixListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPPrefixListResult)
-	return result, err
+	var val *PublicIPPrefixListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPPrefixListResultResponse{}, err
+	}
+	return PublicIPPrefixListResultResponse{RawResponse: resp.Response, PublicIPPrefixListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -368,11 +372,7 @@ func (client PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PublicIPPrefixResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return PublicIPPrefixResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client PublicIPPrefixesClient) updateTagsCreateRequest(ctx context.Context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client PublicIPPrefixesClient) updateTagsHandleResponse(resp *azcore.Response) (PublicIPPrefixResponse, error) {
-	result := PublicIPPrefixResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PublicIPPrefix)
-	return result, err
+	var val *PublicIPPrefix
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PublicIPPrefixResponse{}, err
+	}
+	return PublicIPPrefixResponse{RawResponse: resp.Response, PublicIPPrefix: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks.go
@@ -46,11 +46,7 @@ func (client ResourceNavigationLinksClient) List(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ResourceNavigationLinksListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ResourceNavigationLinksListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -74,9 +70,11 @@ func (client ResourceNavigationLinksClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client ResourceNavigationLinksClient) listHandleResponse(resp *azcore.Response) (ResourceNavigationLinksListResultResponse, error) {
-	result := ResourceNavigationLinksListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ResourceNavigationLinksListResult)
-	return result, err
+	var val *ResourceNavigationLinksListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ResourceNavigationLinksListResultResponse{}, err
+	}
+	return ResourceNavigationLinksListResultResponse{RawResponse: resp.Response, ResourceNavigationLinksListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules.go
@@ -108,9 +108,11 @@ func (client RouteFilterRulesClient) createOrUpdateCreateRequest(ctx context.Con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client RouteFilterRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteFilterRuleResponse, error) {
-	result := RouteFilterRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilterRule)
-	return result, err
+	var val *RouteFilterRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterRuleResponse{}, err
+	}
+	return RouteFilterRuleResponse{RawResponse: resp.Response, RouteFilterRule: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteFilterRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return RouteFilterRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client RouteFilterRulesClient) getCreateRequest(ctx context.Context, resou
 
 // getHandleResponse handles the Get response.
 func (client RouteFilterRulesClient) getHandleResponse(resp *azcore.Response) (RouteFilterRuleResponse, error) {
-	result := RouteFilterRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilterRule)
-	return result, err
+	var val *RouteFilterRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterRuleResponse{}, err
+	}
+	return RouteFilterRuleResponse{RawResponse: resp.Response, RouteFilterRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client RouteFilterRulesClient) listByRouteFilterCreateRequest(ctx context.
 
 // listByRouteFilterHandleResponse handles the ListByRouteFilter response.
 func (client RouteFilterRulesClient) listByRouteFilterHandleResponse(resp *azcore.Response) (RouteFilterRuleListResultResponse, error) {
-	result := RouteFilterRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilterRuleListResult)
-	return result, err
+	var val *RouteFilterRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterRuleListResultResponse{}, err
+	}
+	return RouteFilterRuleListResultResponse{RawResponse: resp.Response, RouteFilterRuleListResult: val}, nil
 }
 
 // listByRouteFilterHandleError handles the ListByRouteFilter error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters.go
@@ -107,9 +107,11 @@ func (client RouteFiltersClient) createOrUpdateCreateRequest(ctx context.Context
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client RouteFiltersClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteFilterResponse, error) {
-	result := RouteFilterResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilter)
-	return result, err
+	var val *RouteFilter
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterResponse{}, err
+	}
+	return RouteFilterResponse{RawResponse: resp.Response, RouteFilter: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client RouteFiltersClient) Get(ctx context.Context, resourceGroupName stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteFilterResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return RouteFilterResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client RouteFiltersClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client RouteFiltersClient) getHandleResponse(resp *azcore.Response) (RouteFilterResponse, error) {
-	result := RouteFilterResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilter)
-	return result, err
+	var val *RouteFilter
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterResponse{}, err
+	}
+	return RouteFilterResponse{RawResponse: resp.Response, RouteFilter: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client RouteFiltersClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client RouteFiltersClient) listHandleResponse(resp *azcore.Response) (RouteFilterListResultResponse, error) {
-	result := RouteFilterListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilterListResult)
-	return result, err
+	var val *RouteFilterListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterListResultResponse{}, err
+	}
+	return RouteFilterListResultResponse{RawResponse: resp.Response, RouteFilterListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client RouteFiltersClient) listByResourceGroupCreateRequest(ctx context.Co
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client RouteFiltersClient) listByResourceGroupHandleResponse(resp *azcore.Response) (RouteFilterListResultResponse, error) {
-	result := RouteFilterListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilterListResult)
-	return result, err
+	var val *RouteFilterListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterListResultResponse{}, err
+	}
+	return RouteFilterListResultResponse{RawResponse: resp.Response, RouteFilterListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -368,11 +372,7 @@ func (client RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteFilterResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return RouteFilterResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client RouteFiltersClient) updateTagsCreateRequest(ctx context.Context, re
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client RouteFiltersClient) updateTagsHandleResponse(resp *azcore.Response) (RouteFilterResponse, error) {
-	result := RouteFilterResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteFilter)
-	return result, err
+	var val *RouteFilter
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteFilterResponse{}, err
+	}
+	return RouteFilterResponse{RawResponse: resp.Response, RouteFilter: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes.go
@@ -108,9 +108,11 @@ func (client RoutesClient) createOrUpdateCreateRequest(ctx context.Context, reso
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client RoutesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteResponse, error) {
-	result := RouteResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Route)
-	return result, err
+	var val *Route
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteResponse{}, err
+	}
+	return RouteResponse{RawResponse: resp.Response, Route: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client RoutesClient) Get(ctx context.Context, resourceGroupName string, ro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return RouteResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client RoutesClient) getCreateRequest(ctx context.Context, resourceGroupNa
 
 // getHandleResponse handles the Get response.
 func (client RoutesClient) getHandleResponse(resp *azcore.Response) (RouteResponse, error) {
-	result := RouteResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Route)
-	return result, err
+	var val *Route
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteResponse{}, err
+	}
+	return RouteResponse{RawResponse: resp.Response, Route: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client RoutesClient) listCreateRequest(ctx context.Context, resourceGroupN
 
 // listHandleResponse handles the List response.
 func (client RoutesClient) listHandleResponse(resp *azcore.Response) (RouteListResultResponse, error) {
-	result := RouteListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteListResult)
-	return result, err
+	var val *RouteListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteListResultResponse{}, err
+	}
+	return RouteListResultResponse{RawResponse: resp.Response, RouteListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables.go
@@ -107,9 +107,11 @@ func (client RouteTablesClient) createOrUpdateCreateRequest(ctx context.Context,
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client RouteTablesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteTableResponse, error) {
-	result := RouteTableResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteTable)
-	return result, err
+	var val *RouteTable
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteTableResponse{}, err
+	}
+	return RouteTableResponse{RawResponse: resp.Response, RouteTable: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client RouteTablesClient) Get(ctx context.Context, resourceGroupName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteTableResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return RouteTableResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client RouteTablesClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client RouteTablesClient) getHandleResponse(resp *azcore.Response) (RouteTableResponse, error) {
-	result := RouteTableResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteTable)
-	return result, err
+	var val *RouteTable
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteTableResponse{}, err
+	}
+	return RouteTableResponse{RawResponse: resp.Response, RouteTable: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -293,9 +293,11 @@ func (client RouteTablesClient) listCreateRequest(ctx context.Context, resourceG
 
 // listHandleResponse handles the List response.
 func (client RouteTablesClient) listHandleResponse(resp *azcore.Response) (RouteTableListResultResponse, error) {
-	result := RouteTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteTableListResult)
-	return result, err
+	var val *RouteTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteTableListResultResponse{}, err
+	}
+	return RouteTableListResultResponse{RawResponse: resp.Response, RouteTableListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client RouteTablesClient) listAllCreateRequest(ctx context.Context, option
 
 // listAllHandleResponse handles the ListAll response.
 func (client RouteTablesClient) listAllHandleResponse(resp *azcore.Response) (RouteTableListResultResponse, error) {
-	result := RouteTableListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteTableListResult)
-	return result, err
+	var val *RouteTableListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteTableListResultResponse{}, err
+	}
+	return RouteTableListResultResponse{RawResponse: resp.Response, RouteTableListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -368,11 +372,7 @@ func (client RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return RouteTableResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return RouteTableResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client RouteTablesClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client RouteTablesClient) updateTagsHandleResponse(resp *azcore.Response) (RouteTableResponse, error) {
-	result := RouteTableResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.RouteTable)
-	return result, err
+	var val *RouteTable
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return RouteTableResponse{}, err
+	}
+	return RouteTableResponse{RawResponse: resp.Response, RouteTable: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders.go
@@ -107,9 +107,11 @@ func (client SecurityPartnerProvidersClient) createOrUpdateCreateRequest(ctx con
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client SecurityPartnerProvidersClient) createOrUpdateHandleResponse(resp *azcore.Response) (SecurityPartnerProviderResponse, error) {
-	result := SecurityPartnerProviderResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityPartnerProvider)
-	return result, err
+	var val *SecurityPartnerProvider
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityPartnerProviderResponse{}, err
+	}
+	return SecurityPartnerProviderResponse{RawResponse: resp.Response, SecurityPartnerProvider: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client SecurityPartnerProvidersClient) Get(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SecurityPartnerProviderResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SecurityPartnerProviderResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client SecurityPartnerProvidersClient) getCreateRequest(ctx context.Contex
 
 // getHandleResponse handles the Get response.
 func (client SecurityPartnerProvidersClient) getHandleResponse(resp *azcore.Response) (SecurityPartnerProviderResponse, error) {
-	result := SecurityPartnerProviderResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityPartnerProvider)
-	return result, err
+	var val *SecurityPartnerProvider
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityPartnerProviderResponse{}, err
+	}
+	return SecurityPartnerProviderResponse{RawResponse: resp.Response, SecurityPartnerProvider: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client SecurityPartnerProvidersClient) listCreateRequest(ctx context.Conte
 
 // listHandleResponse handles the List response.
 func (client SecurityPartnerProvidersClient) listHandleResponse(resp *azcore.Response) (SecurityPartnerProviderListResultResponse, error) {
-	result := SecurityPartnerProviderListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityPartnerProviderListResult)
-	return result, err
+	var val *SecurityPartnerProviderListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityPartnerProviderListResultResponse{}, err
+	}
+	return SecurityPartnerProviderListResultResponse{RawResponse: resp.Response, SecurityPartnerProviderListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client SecurityPartnerProvidersClient) listByResourceGroupCreateRequest(ct
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client SecurityPartnerProvidersClient) listByResourceGroupHandleResponse(resp *azcore.Response) (SecurityPartnerProviderListResultResponse, error) {
-	result := SecurityPartnerProviderListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityPartnerProviderListResult)
-	return result, err
+	var val *SecurityPartnerProviderListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityPartnerProviderListResultResponse{}, err
+	}
+	return SecurityPartnerProviderListResultResponse{RawResponse: resp.Response, SecurityPartnerProviderListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, res
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SecurityPartnerProviderResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return SecurityPartnerProviderResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client SecurityPartnerProvidersClient) updateTagsCreateRequest(ctx context
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client SecurityPartnerProvidersClient) updateTagsHandleResponse(resp *azcore.Response) (SecurityPartnerProviderResponse, error) {
-	result := SecurityPartnerProviderResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityPartnerProvider)
-	return result, err
+	var val *SecurityPartnerProvider
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityPartnerProviderResponse{}, err
+	}
+	return SecurityPartnerProviderResponse{RawResponse: resp.Response, SecurityPartnerProvider: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules.go
@@ -108,9 +108,11 @@ func (client SecurityRulesClient) createOrUpdateCreateRequest(ctx context.Contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client SecurityRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (SecurityRuleResponse, error) {
-	result := SecurityRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityRule)
-	return result, err
+	var val *SecurityRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityRuleResponse{}, err
+	}
+	return SecurityRuleResponse{RawResponse: resp.Response, SecurityRule: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client SecurityRulesClient) Get(ctx context.Context, resourceGroupName str
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SecurityRuleResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SecurityRuleResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client SecurityRulesClient) getCreateRequest(ctx context.Context, resource
 
 // getHandleResponse handles the Get response.
 func (client SecurityRulesClient) getHandleResponse(resp *azcore.Response) (SecurityRuleResponse, error) {
-	result := SecurityRuleResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityRule)
-	return result, err
+	var val *SecurityRule
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityRuleResponse{}, err
+	}
+	return SecurityRuleResponse{RawResponse: resp.Response, SecurityRule: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client SecurityRulesClient) listCreateRequest(ctx context.Context, resourc
 
 // listHandleResponse handles the List response.
 func (client SecurityRulesClient) listHandleResponse(resp *azcore.Response) (SecurityRuleListResultResponse, error) {
-	result := SecurityRuleListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SecurityRuleListResult)
-	return result, err
+	var val *SecurityRuleListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SecurityRuleListResultResponse{}, err
+	}
+	return SecurityRuleListResultResponse{RawResponse: resp.Response, SecurityRuleListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks.go
@@ -46,11 +46,7 @@ func (client ServiceAssociationLinksClient) List(ctx context.Context, resourceGr
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceAssociationLinksListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ServiceAssociationLinksListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -74,9 +70,11 @@ func (client ServiceAssociationLinksClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client ServiceAssociationLinksClient) listHandleResponse(resp *azcore.Response) (ServiceAssociationLinksListResultResponse, error) {
-	result := ServiceAssociationLinksListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceAssociationLinksListResult)
-	return result, err
+	var val *ServiceAssociationLinksListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceAssociationLinksListResultResponse{}, err
+	}
+	return ServiceAssociationLinksListResultResponse{RawResponse: resp.Response, ServiceAssociationLinksListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies.go
@@ -107,9 +107,11 @@ func (client ServiceEndpointPoliciesClient) createOrUpdateCreateRequest(ctx cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ServiceEndpointPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyResponse, error) {
-	result := ServiceEndpointPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicy)
-	return result, err
+	var val *ServiceEndpointPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyResponse{}, err
+	}
+	return ServiceEndpointPolicyResponse{RawResponse: resp.Response, ServiceEndpointPolicy: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceEndpointPolicyResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ServiceEndpointPolicyResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ServiceEndpointPoliciesClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client ServiceEndpointPoliciesClient) getHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyResponse, error) {
-	result := ServiceEndpointPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicy)
-	return result, err
+	var val *ServiceEndpointPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyResponse{}, err
+	}
+	return ServiceEndpointPolicyResponse{RawResponse: resp.Response, ServiceEndpointPolicy: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client ServiceEndpointPoliciesClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client ServiceEndpointPoliciesClient) listHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyListResultResponse, error) {
-	result := ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyListResult)
-	return result, err
+	var val *ServiceEndpointPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyListResultResponse{}, err
+	}
+	return ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response, ServiceEndpointPolicyListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client ServiceEndpointPoliciesClient) listByResourceGroupCreateRequest(ctx
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ServiceEndpointPoliciesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyListResultResponse, error) {
-	result := ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyListResult)
-	return result, err
+	var val *ServiceEndpointPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyListResultResponse{}, err
+	}
+	return ServiceEndpointPolicyListResultResponse{RawResponse: resp.Response, ServiceEndpointPolicyListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -368,11 +372,7 @@ func (client ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceEndpointPolicyResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return ServiceEndpointPolicyResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -395,9 +395,11 @@ func (client ServiceEndpointPoliciesClient) updateTagsCreateRequest(ctx context.
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client ServiceEndpointPoliciesClient) updateTagsHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyResponse, error) {
-	result := ServiceEndpointPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicy)
-	return result, err
+	var val *ServiceEndpointPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyResponse{}, err
+	}
+	return ServiceEndpointPolicyResponse{RawResponse: resp.Response, ServiceEndpointPolicy: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions.go
@@ -108,9 +108,11 @@ func (client ServiceEndpointPolicyDefinitionsClient) createOrUpdateCreateRequest
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client ServiceEndpointPolicyDefinitionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyDefinitionResponse, error) {
-	result := ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyDefinition)
-	return result, err
+	var val *ServiceEndpointPolicyDefinition
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyDefinitionResponse{}, err
+	}
+	return ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response, ServiceEndpointPolicyDefinition: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceEndpointPolicyDefinitionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return ServiceEndpointPolicyDefinitionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client ServiceEndpointPolicyDefinitionsClient) getCreateRequest(ctx contex
 
 // getHandleResponse handles the Get response.
 func (client ServiceEndpointPolicyDefinitionsClient) getHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyDefinitionResponse, error) {
-	result := ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyDefinition)
-	return result, err
+	var val *ServiceEndpointPolicyDefinition
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyDefinitionResponse{}, err
+	}
+	return ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response, ServiceEndpointPolicyDefinition: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client ServiceEndpointPolicyDefinitionsClient) listByResourceGroupCreateRe
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client ServiceEndpointPolicyDefinitionsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyDefinitionListResultResponse, error) {
-	result := ServiceEndpointPolicyDefinitionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceEndpointPolicyDefinitionListResult)
-	return result, err
+	var val *ServiceEndpointPolicyDefinitionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceEndpointPolicyDefinitionListResultResponse{}, err
+	}
+	return ServiceEndpointPolicyDefinitionListResultResponse{RawResponse: resp.Response, ServiceEndpointPolicyDefinitionListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags.go
@@ -46,11 +46,7 @@ func (client ServiceTagsClient) List(ctx context.Context, location string, optio
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceTagsListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return ServiceTagsListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -72,9 +68,11 @@ func (client ServiceTagsClient) listCreateRequest(ctx context.Context, location 
 
 // listHandleResponse handles the List response.
 func (client ServiceTagsClient) listHandleResponse(resp *azcore.Response) (ServiceTagsListResultResponse, error) {
-	result := ServiceTagsListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ServiceTagsListResult)
-	return result, err
+	var val *ServiceTagsListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ServiceTagsListResultResponse{}, err
+	}
+	return ServiceTagsListResultResponse{RawResponse: resp.Response, ServiceTagsListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets.go
@@ -108,9 +108,11 @@ func (client SubnetsClient) createOrUpdateCreateRequest(ctx context.Context, res
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client SubnetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (SubnetResponse, error) {
-	result := SubnetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Subnet)
-	return result, err
+	var val *Subnet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SubnetResponse{}, err
+	}
+	return SubnetResponse{RawResponse: resp.Response, Subnet: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client SubnetsClient) Get(ctx context.Context, resourceGroupName string, v
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SubnetResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SubnetResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -247,9 +245,11 @@ func (client SubnetsClient) getCreateRequest(ctx context.Context, resourceGroupN
 
 // getHandleResponse handles the Get response.
 func (client SubnetsClient) getHandleResponse(resp *azcore.Response) (SubnetResponse, error) {
-	result := SubnetResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Subnet)
-	return result, err
+	var val *Subnet
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SubnetResponse{}, err
+	}
+	return SubnetResponse{RawResponse: resp.Response, Subnet: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -297,9 +297,11 @@ func (client SubnetsClient) listCreateRequest(ctx context.Context, resourceGroup
 
 // listHandleResponse handles the List response.
 func (client SubnetsClient) listHandleResponse(resp *azcore.Response) (SubnetListResultResponse, error) {
-	result := SubnetListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SubnetListResult)
-	return result, err
+	var val *SubnetListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SubnetListResultResponse{}, err
+	}
+	return SubnetListResultResponse{RawResponse: resp.Response, SubnetListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages.go
@@ -68,9 +68,11 @@ func (client UsagesClient) listCreateRequest(ctx context.Context, location strin
 
 // listHandleResponse handles the List response.
 func (client UsagesClient) listHandleResponse(resp *azcore.Response) (UsagesListResultResponse, error) {
-	result := UsagesListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.UsagesListResult)
-	return result, err
+	var val *UsagesListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return UsagesListResultResponse{}, err
+	}
+	return UsagesListResultResponse{RawResponse: resp.Response, UsagesListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s.go
@@ -108,9 +108,11 @@ func (client VirtualHubRouteTableV2SClient) createOrUpdateCreateRequest(ctx cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualHubRouteTableV2SClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualHubRouteTableV2Response, error) {
-	result := VirtualHubRouteTableV2Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualHubRouteTableV2)
-	return result, err
+	var val *VirtualHubRouteTableV2
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualHubRouteTableV2Response{}, err
+	}
+	return VirtualHubRouteTableV2Response{RawResponse: resp.Response, VirtualHubRouteTableV2: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualHubRouteTableV2Response{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualHubRouteTableV2Response{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client VirtualHubRouteTableV2SClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client VirtualHubRouteTableV2SClient) getHandleResponse(resp *azcore.Response) (VirtualHubRouteTableV2Response, error) {
-	result := VirtualHubRouteTableV2Response{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualHubRouteTableV2)
-	return result, err
+	var val *VirtualHubRouteTableV2
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualHubRouteTableV2Response{}, err
+	}
+	return VirtualHubRouteTableV2Response{RawResponse: resp.Response, VirtualHubRouteTableV2: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client VirtualHubRouteTableV2SClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client VirtualHubRouteTableV2SClient) listHandleResponse(resp *azcore.Response) (ListVirtualHubRouteTableV2SResultResponse, error) {
-	result := ListVirtualHubRouteTableV2SResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVirtualHubRouteTableV2SResult)
-	return result, err
+	var val *ListVirtualHubRouteTableV2SResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVirtualHubRouteTableV2SResultResponse{}, err
+	}
+	return ListVirtualHubRouteTableV2SResultResponse{RawResponse: resp.Response, ListVirtualHubRouteTableV2SResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs.go
@@ -107,9 +107,11 @@ func (client VirtualHubsClient) createOrUpdateCreateRequest(ctx context.Context,
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualHubsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualHubResponse, error) {
-	result := VirtualHubResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualHub)
-	return result, err
+	var val *VirtualHub
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualHubResponse{}, err
+	}
+	return VirtualHubResponse{RawResponse: resp.Response, VirtualHub: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VirtualHubsClient) Get(ctx context.Context, resourceGroupName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualHubResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualHubResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VirtualHubsClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client VirtualHubsClient) getHandleResponse(resp *azcore.Response) (VirtualHubResponse, error) {
-	result := VirtualHubResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualHub)
-	return result, err
+	var val *VirtualHub
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualHubResponse{}, err
+	}
+	return VirtualHubResponse{RawResponse: resp.Response, VirtualHub: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VirtualHubsClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client VirtualHubsClient) listHandleResponse(resp *azcore.Response) (ListVirtualHubsResultResponse, error) {
-	result := ListVirtualHubsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVirtualHubsResult)
-	return result, err
+	var val *ListVirtualHubsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVirtualHubsResultResponse{}, err
+	}
+	return ListVirtualHubsResultResponse{RawResponse: resp.Response, ListVirtualHubsResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client VirtualHubsClient) listByResourceGroupCreateRequest(ctx context.Con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VirtualHubsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListVirtualHubsResultResponse, error) {
-	result := ListVirtualHubsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVirtualHubsResult)
-	return result, err
+	var val *ListVirtualHubsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVirtualHubsResultResponse{}, err
+	}
+	return ListVirtualHubsResultResponse{RawResponse: resp.Response, ListVirtualHubsResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualHubResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VirtualHubResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client VirtualHubsClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualHubsClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualHubResponse, error) {
-	result := VirtualHubResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualHub)
-	return result, err
+	var val *VirtualHub
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualHubResponse{}, err
+	}
+	return VirtualHubResponse{RawResponse: resp.Response, VirtualHub: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -107,9 +107,11 @@ func (client VirtualNetworkGatewayConnectionsClient) createOrUpdateCreateRequest
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualNetworkGatewayConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionResponse, error) {
-	result := VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnection)
-	return result, err
+	var val *VirtualNetworkGatewayConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayConnectionResponse{}, err
+	}
+	return VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnection: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, re
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkGatewayConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkGatewayConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VirtualNetworkGatewayConnectionsClient) getCreateRequest(ctx contex
 
 // getHandleResponse handles the Get response.
 func (client VirtualNetworkGatewayConnectionsClient) getHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionResponse, error) {
-	result := VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnection)
-	return result, err
+	var val *VirtualNetworkGatewayConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayConnectionResponse{}, err
+	}
+	return VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -269,11 +269,7 @@ func (client VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.Co
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ConnectionSharedKeyResponse{}, client.getSharedKeyHandleError(resp)
 	}
-	result, err := client.getSharedKeyHandleResponse(resp)
-	if err != nil {
-		return ConnectionSharedKeyResponse{}, err
-	}
-	return result, nil
+	return client.getSharedKeyHandleResponse(resp)
 }
 
 // getSharedKeyCreateRequest creates the GetSharedKey request.
@@ -296,9 +292,11 @@ func (client VirtualNetworkGatewayConnectionsClient) getSharedKeyCreateRequest(c
 
 // getSharedKeyHandleResponse handles the GetSharedKey response.
 func (client VirtualNetworkGatewayConnectionsClient) getSharedKeyHandleResponse(resp *azcore.Response) (ConnectionSharedKeyResponse, error) {
-	result := ConnectionSharedKeyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionSharedKey)
-	return result, err
+	var val *ConnectionSharedKey
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionSharedKeyResponse{}, err
+	}
+	return ConnectionSharedKeyResponse{RawResponse: resp.Response, ConnectionSharedKey: val}, nil
 }
 
 // getSharedKeyHandleError handles the GetSharedKey error response.
@@ -345,9 +343,11 @@ func (client VirtualNetworkGatewayConnectionsClient) listCreateRequest(ctx conte
 
 // listHandleResponse handles the List response.
 func (client VirtualNetworkGatewayConnectionsClient) listHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionListResultResponse, error) {
-	result := VirtualNetworkGatewayConnectionListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnectionListResult)
-	return result, err
+	var val *VirtualNetworkGatewayConnectionListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayConnectionListResultResponse{}, err
+	}
+	return VirtualNetworkGatewayConnectionListResultResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnectionListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -436,9 +436,11 @@ func (client VirtualNetworkGatewayConnectionsClient) resetSharedKeyCreateRequest
 
 // resetSharedKeyHandleResponse handles the ResetSharedKey response.
 func (client VirtualNetworkGatewayConnectionsClient) resetSharedKeyHandleResponse(resp *azcore.Response) (ConnectionResetSharedKeyResponse, error) {
-	result := ConnectionResetSharedKeyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionResetSharedKey)
-	return result, err
+	var val *ConnectionResetSharedKey
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionResetSharedKeyResponse{}, err
+	}
+	return ConnectionResetSharedKeyResponse{RawResponse: resp.Response, ConnectionResetSharedKey: val}, nil
 }
 
 // resetSharedKeyHandleError handles the ResetSharedKey error response.
@@ -527,9 +529,11 @@ func (client VirtualNetworkGatewayConnectionsClient) setSharedKeyCreateRequest(c
 
 // setSharedKeyHandleResponse handles the SetSharedKey response.
 func (client VirtualNetworkGatewayConnectionsClient) setSharedKeyHandleResponse(resp *azcore.Response) (ConnectionSharedKeyResponse, error) {
-	result := ConnectionSharedKeyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ConnectionSharedKey)
-	return result, err
+	var val *ConnectionSharedKey
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ConnectionSharedKeyResponse{}, err
+	}
+	return ConnectionSharedKeyResponse{RawResponse: resp.Response, ConnectionSharedKey: val}, nil
 }
 
 // setSharedKeyHandleError handles the SetSharedKey error response.
@@ -617,9 +621,11 @@ func (client VirtualNetworkGatewayConnectionsClient) startPacketCaptureCreateReq
 
 // startPacketCaptureHandleResponse handles the StartPacketCapture response.
 func (client VirtualNetworkGatewayConnectionsClient) startPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // startPacketCaptureHandleError handles the StartPacketCapture error response.
@@ -704,9 +710,11 @@ func (client VirtualNetworkGatewayConnectionsClient) stopPacketCaptureCreateRequ
 
 // stopPacketCaptureHandleResponse handles the StopPacketCapture response.
 func (client VirtualNetworkGatewayConnectionsClient) stopPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // stopPacketCaptureHandleError handles the StopPacketCapture error response.
@@ -791,9 +799,11 @@ func (client VirtualNetworkGatewayConnectionsClient) updateTagsCreateRequest(ctx
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualNetworkGatewayConnectionsClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionResponse, error) {
-	result := VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayConnection)
-	return result, err
+	var val *VirtualNetworkGatewayConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayConnectionResponse{}, err
+	}
+	return VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnection: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -107,9 +107,11 @@ func (client VirtualNetworkGatewaysClient) createOrUpdateCreateRequest(ctx conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualNetworkGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	result := VirtualNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGateway)
-	return result, err
+	var val *VirtualNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayResponse{}, err
+	}
+	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -356,9 +358,11 @@ func (client VirtualNetworkGatewaysClient) generateVpnProfileCreateRequest(ctx c
 
 // generateVpnProfileHandleResponse handles the GenerateVpnProfile response.
 func (client VirtualNetworkGatewaysClient) generateVpnProfileHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // generateVpnProfileHandleError handles the GenerateVpnProfile error response.
@@ -443,9 +447,11 @@ func (client VirtualNetworkGatewaysClient) generatevpnclientpackageCreateRequest
 
 // generatevpnclientpackageHandleResponse handles the Generatevpnclientpackage response.
 func (client VirtualNetworkGatewaysClient) generatevpnclientpackageHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // generatevpnclientpackageHandleError handles the Generatevpnclientpackage error response.
@@ -470,11 +476,7 @@ func (client VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -497,9 +499,11 @@ func (client VirtualNetworkGatewaysClient) getCreateRequest(ctx context.Context,
 
 // getHandleResponse handles the Get response.
 func (client VirtualNetworkGatewaysClient) getHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	result := VirtualNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGateway)
-	return result, err
+	var val *VirtualNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayResponse{}, err
+	}
+	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -585,9 +589,11 @@ func (client VirtualNetworkGatewaysClient) getAdvertisedRoutesCreateRequest(ctx 
 
 // getAdvertisedRoutesHandleResponse handles the GetAdvertisedRoutes response.
 func (client VirtualNetworkGatewaysClient) getAdvertisedRoutesHandleResponse(resp *azcore.Response) (GatewayRouteListResultResponse, error) {
-	result := GatewayRouteListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GatewayRouteListResult)
-	return result, err
+	var val *GatewayRouteListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GatewayRouteListResultResponse{}, err
+	}
+	return GatewayRouteListResultResponse{RawResponse: resp.Response, GatewayRouteListResult: val}, nil
 }
 
 // getAdvertisedRoutesHandleError handles the GetAdvertisedRoutes error response.
@@ -675,9 +681,11 @@ func (client VirtualNetworkGatewaysClient) getBgpPeerStatusCreateRequest(ctx con
 
 // getBgpPeerStatusHandleResponse handles the GetBgpPeerStatus response.
 func (client VirtualNetworkGatewaysClient) getBgpPeerStatusHandleResponse(resp *azcore.Response) (BgpPeerStatusListResultResponse, error) {
-	result := BgpPeerStatusListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BgpPeerStatusListResult)
-	return result, err
+	var val *BgpPeerStatusListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BgpPeerStatusListResultResponse{}, err
+	}
+	return BgpPeerStatusListResultResponse{RawResponse: resp.Response, BgpPeerStatusListResult: val}, nil
 }
 
 // getBgpPeerStatusHandleError handles the GetBgpPeerStatus error response.
@@ -762,9 +770,11 @@ func (client VirtualNetworkGatewaysClient) getLearnedRoutesCreateRequest(ctx con
 
 // getLearnedRoutesHandleResponse handles the GetLearnedRoutes response.
 func (client VirtualNetworkGatewaysClient) getLearnedRoutesHandleResponse(resp *azcore.Response) (GatewayRouteListResultResponse, error) {
-	result := GatewayRouteListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GatewayRouteListResult)
-	return result, err
+	var val *GatewayRouteListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GatewayRouteListResultResponse{}, err
+	}
+	return GatewayRouteListResultResponse{RawResponse: resp.Response, GatewayRouteListResult: val}, nil
 }
 
 // getLearnedRoutesHandleError handles the GetLearnedRoutes error response.
@@ -851,9 +861,11 @@ func (client VirtualNetworkGatewaysClient) getVpnProfilePackageUrlCreateRequest(
 
 // getVpnProfilePackageUrlHandleResponse handles the GetVpnProfilePackageURL response.
 func (client VirtualNetworkGatewaysClient) getVpnProfilePackageUrlHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // getVpnProfilePackageUrlHandleError handles the GetVpnProfilePackageURL error response.
@@ -940,9 +952,11 @@ func (client VirtualNetworkGatewaysClient) getVpnclientConnectionHealthCreateReq
 
 // getVpnclientConnectionHealthHandleResponse handles the GetVpnclientConnectionHealth response.
 func (client VirtualNetworkGatewaysClient) getVpnclientConnectionHealthHandleResponse(resp *azcore.Response) (VpnClientConnectionHealthDetailListResultResponse, error) {
-	result := VpnClientConnectionHealthDetailListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnClientConnectionHealthDetailListResult)
-	return result, err
+	var val *VpnClientConnectionHealthDetailListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnClientConnectionHealthDetailListResultResponse{}, err
+	}
+	return VpnClientConnectionHealthDetailListResultResponse{RawResponse: resp.Response, VpnClientConnectionHealthDetailListResult: val}, nil
 }
 
 // getVpnclientConnectionHealthHandleError handles the GetVpnclientConnectionHealth error response.
@@ -1031,9 +1045,11 @@ func (client VirtualNetworkGatewaysClient) getVpnclientIPsecParametersCreateRequ
 
 // getVpnclientIPsecParametersHandleResponse handles the GetVpnclientIPsecParameters response.
 func (client VirtualNetworkGatewaysClient) getVpnclientIPsecParametersHandleResponse(resp *azcore.Response) (VpnClientIPsecParametersResponse, error) {
-	result := VpnClientIPsecParametersResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnClientIPsecParameters)
-	return result, err
+	var val *VpnClientIPsecParameters
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnClientIPsecParametersResponse{}, err
+	}
+	return VpnClientIPsecParametersResponse{RawResponse: resp.Response, VpnClientIPsecParameters: val}, nil
 }
 
 // getVpnclientIPsecParametersHandleError handles the GetVpnclientIPsecParameters error response.
@@ -1080,9 +1096,11 @@ func (client VirtualNetworkGatewaysClient) listCreateRequest(ctx context.Context
 
 // listHandleResponse handles the List response.
 func (client VirtualNetworkGatewaysClient) listHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayListResultResponse, error) {
-	result := VirtualNetworkGatewayListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayListResult)
-	return result, err
+	var val *VirtualNetworkGatewayListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayListResultResponse{}, err
+	}
+	return VirtualNetworkGatewayListResultResponse{RawResponse: resp.Response, VirtualNetworkGatewayListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -1130,9 +1148,11 @@ func (client VirtualNetworkGatewaysClient) listConnectionsCreateRequest(ctx cont
 
 // listConnectionsHandleResponse handles the ListConnections response.
 func (client VirtualNetworkGatewaysClient) listConnectionsHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayListConnectionsResultResponse, error) {
-	result := VirtualNetworkGatewayListConnectionsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGatewayListConnectionsResult)
-	return result, err
+	var val *VirtualNetworkGatewayListConnectionsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayListConnectionsResultResponse{}, err
+	}
+	return VirtualNetworkGatewayListConnectionsResultResponse{RawResponse: resp.Response, VirtualNetworkGatewayListConnectionsResult: val}, nil
 }
 
 // listConnectionsHandleError handles the ListConnections error response.
@@ -1220,9 +1240,11 @@ func (client VirtualNetworkGatewaysClient) resetCreateRequest(ctx context.Contex
 
 // resetHandleResponse handles the Reset response.
 func (client VirtualNetworkGatewaysClient) resetHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	result := VirtualNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGateway)
-	return result, err
+	var val *VirtualNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayResponse{}, err
+	}
+	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
 }
 
 // resetHandleError handles the Reset error response.
@@ -1389,9 +1411,11 @@ func (client VirtualNetworkGatewaysClient) setVpnclientIPsecParametersCreateRequ
 
 // setVpnclientIPsecParametersHandleResponse handles the SetVpnclientIPsecParameters response.
 func (client VirtualNetworkGatewaysClient) setVpnclientIPsecParametersHandleResponse(resp *azcore.Response) (VpnClientIPsecParametersResponse, error) {
-	result := VpnClientIPsecParametersResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnClientIPsecParameters)
-	return result, err
+	var val *VpnClientIPsecParameters
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnClientIPsecParametersResponse{}, err
+	}
+	return VpnClientIPsecParametersResponse{RawResponse: resp.Response, VpnClientIPsecParameters: val}, nil
 }
 
 // setVpnclientIPsecParametersHandleError handles the SetVpnclientIPsecParameters error response.
@@ -1479,9 +1503,11 @@ func (client VirtualNetworkGatewaysClient) startPacketCaptureCreateRequest(ctx c
 
 // startPacketCaptureHandleResponse handles the StartPacketCapture response.
 func (client VirtualNetworkGatewaysClient) startPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // startPacketCaptureHandleError handles the StartPacketCapture error response.
@@ -1566,9 +1592,11 @@ func (client VirtualNetworkGatewaysClient) stopPacketCaptureCreateRequest(ctx co
 
 // stopPacketCaptureHandleResponse handles the StopPacketCapture response.
 func (client VirtualNetworkGatewaysClient) stopPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // stopPacketCaptureHandleError handles the StopPacketCapture error response.
@@ -1593,11 +1621,7 @@ func (client VirtualNetworkGatewaysClient) SupportedVpnDevices(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.supportedVpnDevicesHandleError(resp)
 	}
-	result, err := client.supportedVpnDevicesHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.supportedVpnDevicesHandleResponse(resp)
 }
 
 // supportedVpnDevicesCreateRequest creates the SupportedVpnDevices request.
@@ -1620,9 +1644,11 @@ func (client VirtualNetworkGatewaysClient) supportedVpnDevicesCreateRequest(ctx 
 
 // supportedVpnDevicesHandleResponse handles the SupportedVpnDevices response.
 func (client VirtualNetworkGatewaysClient) supportedVpnDevicesHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // supportedVpnDevicesHandleError handles the SupportedVpnDevices error response.
@@ -1707,9 +1733,11 @@ func (client VirtualNetworkGatewaysClient) updateTagsCreateRequest(ctx context.C
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualNetworkGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	result := VirtualNetworkGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkGateway)
-	return result, err
+	var val *VirtualNetworkGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkGatewayResponse{}, err
+	}
+	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.
@@ -1734,11 +1762,7 @@ func (client VirtualNetworkGatewaysClient) VpnDeviceConfigurationScript(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StringResponse{}, client.vpnDeviceConfigurationScriptHandleError(resp)
 	}
-	result, err := client.vpnDeviceConfigurationScriptHandleResponse(resp)
-	if err != nil {
-		return StringResponse{}, err
-	}
-	return result, nil
+	return client.vpnDeviceConfigurationScriptHandleResponse(resp)
 }
 
 // vpnDeviceConfigurationScriptCreateRequest creates the VpnDeviceConfigurationScript request.
@@ -1761,9 +1785,11 @@ func (client VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptCreateReq
 
 // vpnDeviceConfigurationScriptHandleResponse handles the VpnDeviceConfigurationScript response.
 func (client VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	result := StringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Value)
-	return result, err
+	var val *string
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return StringResponse{}, err
+	}
+	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // vpnDeviceConfigurationScriptHandleError handles the VpnDeviceConfigurationScript error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings.go
@@ -108,9 +108,11 @@ func (client VirtualNetworkPeeringsClient) createOrUpdateCreateRequest(ctx conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualNetworkPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkPeeringResponse, error) {
-	result := VirtualNetworkPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkPeering)
-	return result, err
+	var val *VirtualNetworkPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkPeeringResponse{}, err
+	}
+	return VirtualNetworkPeeringResponse{RawResponse: resp.Response, VirtualNetworkPeering: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkPeeringResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkPeeringResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client VirtualNetworkPeeringsClient) getCreateRequest(ctx context.Context,
 
 // getHandleResponse handles the Get response.
 func (client VirtualNetworkPeeringsClient) getHandleResponse(resp *azcore.Response) (VirtualNetworkPeeringResponse, error) {
-	result := VirtualNetworkPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkPeering)
-	return result, err
+	var val *VirtualNetworkPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkPeeringResponse{}, err
+	}
+	return VirtualNetworkPeeringResponse{RawResponse: resp.Response, VirtualNetworkPeering: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client VirtualNetworkPeeringsClient) listCreateRequest(ctx context.Context
 
 // listHandleResponse handles the List response.
 func (client VirtualNetworkPeeringsClient) listHandleResponse(resp *azcore.Response) (VirtualNetworkPeeringListResultResponse, error) {
-	result := VirtualNetworkPeeringListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkPeeringListResult)
-	return result, err
+	var val *VirtualNetworkPeeringListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkPeeringListResultResponse{}, err
+	}
+	return VirtualNetworkPeeringListResultResponse{RawResponse: resp.Response, VirtualNetworkPeeringListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks.go
@@ -47,11 +47,7 @@ func (client VirtualNetworksClient) CheckIPAddressAvailability(ctx context.Conte
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IPAddressAvailabilityResultResponse{}, client.checkIPAddressAvailabilityHandleError(resp)
 	}
-	result, err := client.checkIPAddressAvailabilityHandleResponse(resp)
-	if err != nil {
-		return IPAddressAvailabilityResultResponse{}, err
-	}
-	return result, nil
+	return client.checkIPAddressAvailabilityHandleResponse(resp)
 }
 
 // checkIPAddressAvailabilityCreateRequest creates the CheckIPAddressAvailability request.
@@ -75,9 +71,11 @@ func (client VirtualNetworksClient) checkIPAddressAvailabilityCreateRequest(ctx 
 
 // checkIPAddressAvailabilityHandleResponse handles the CheckIPAddressAvailability response.
 func (client VirtualNetworksClient) checkIPAddressAvailabilityHandleResponse(resp *azcore.Response) (IPAddressAvailabilityResultResponse, error) {
-	result := IPAddressAvailabilityResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IPAddressAvailabilityResult)
-	return result, err
+	var val *IPAddressAvailabilityResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IPAddressAvailabilityResultResponse{}, err
+	}
+	return IPAddressAvailabilityResultResponse{RawResponse: resp.Response, IPAddressAvailabilityResult: val}, nil
 }
 
 // checkIPAddressAvailabilityHandleError handles the CheckIPAddressAvailability error response.
@@ -162,9 +160,11 @@ func (client VirtualNetworksClient) createOrUpdateCreateRequest(ctx context.Cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualNetworksClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkResponse, error) {
-	result := VirtualNetworkResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetwork)
-	return result, err
+	var val *VirtualNetwork
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkResponse{}, err
+	}
+	return VirtualNetworkResponse{RawResponse: resp.Response, VirtualNetwork: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -269,11 +269,7 @@ func (client VirtualNetworksClient) Get(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -299,9 +295,11 @@ func (client VirtualNetworksClient) getCreateRequest(ctx context.Context, resour
 
 // getHandleResponse handles the Get response.
 func (client VirtualNetworksClient) getHandleResponse(resp *azcore.Response) (VirtualNetworkResponse, error) {
-	result := VirtualNetworkResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetwork)
-	return result, err
+	var val *VirtualNetwork
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkResponse{}, err
+	}
+	return VirtualNetworkResponse{RawResponse: resp.Response, VirtualNetwork: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -348,9 +346,11 @@ func (client VirtualNetworksClient) listCreateRequest(ctx context.Context, resou
 
 // listHandleResponse handles the List response.
 func (client VirtualNetworksClient) listHandleResponse(resp *azcore.Response) (VirtualNetworkListResultResponse, error) {
-	result := VirtualNetworkListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkListResult)
-	return result, err
+	var val *VirtualNetworkListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkListResultResponse{}, err
+	}
+	return VirtualNetworkListResultResponse{RawResponse: resp.Response, VirtualNetworkListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -396,9 +396,11 @@ func (client VirtualNetworksClient) listAllCreateRequest(ctx context.Context, op
 
 // listAllHandleResponse handles the ListAll response.
 func (client VirtualNetworksClient) listAllHandleResponse(resp *azcore.Response) (VirtualNetworkListResultResponse, error) {
-	result := VirtualNetworkListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkListResult)
-	return result, err
+	var val *VirtualNetworkListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkListResultResponse{}, err
+	}
+	return VirtualNetworkListResultResponse{RawResponse: resp.Response, VirtualNetworkListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -446,9 +448,11 @@ func (client VirtualNetworksClient) listUsageCreateRequest(ctx context.Context, 
 
 // listUsageHandleResponse handles the ListUsage response.
 func (client VirtualNetworksClient) listUsageHandleResponse(resp *azcore.Response) (VirtualNetworkListUsageResultResponse, error) {
-	result := VirtualNetworkListUsageResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkListUsageResult)
-	return result, err
+	var val *VirtualNetworkListUsageResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkListUsageResultResponse{}, err
+	}
+	return VirtualNetworkListUsageResultResponse{RawResponse: resp.Response, VirtualNetworkListUsageResult: val}, nil
 }
 
 // listUsageHandleError handles the ListUsage error response.
@@ -473,11 +477,7 @@ func (client VirtualNetworksClient) UpdateTags(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -500,9 +500,11 @@ func (client VirtualNetworksClient) updateTagsCreateRequest(ctx context.Context,
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualNetworksClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkResponse, error) {
-	result := VirtualNetworkResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetwork)
-	return result, err
+	var val *VirtualNetwork
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkResponse{}, err
+	}
+	return VirtualNetworkResponse{RawResponse: resp.Response, VirtualNetwork: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps.go
@@ -107,9 +107,11 @@ func (client VirtualNetworkTapsClient) createOrUpdateCreateRequest(ctx context.C
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualNetworkTapsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkTapResponse, error) {
-	result := VirtualNetworkTapResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkTap)
-	return result, err
+	var val *VirtualNetworkTap
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkTapResponse{}, err
+	}
+	return VirtualNetworkTapResponse{RawResponse: resp.Response, VirtualNetworkTap: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkTapResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkTapResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VirtualNetworkTapsClient) getCreateRequest(ctx context.Context, res
 
 // getHandleResponse handles the Get response.
 func (client VirtualNetworkTapsClient) getHandleResponse(resp *azcore.Response) (VirtualNetworkTapResponse, error) {
-	result := VirtualNetworkTapResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkTap)
-	return result, err
+	var val *VirtualNetworkTap
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkTapResponse{}, err
+	}
+	return VirtualNetworkTapResponse{RawResponse: resp.Response, VirtualNetworkTap: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VirtualNetworkTapsClient) listAllCreateRequest(ctx context.Context,
 
 // listAllHandleResponse handles the ListAll response.
 func (client VirtualNetworkTapsClient) listAllHandleResponse(resp *azcore.Response) (VirtualNetworkTapListResultResponse, error) {
-	result := VirtualNetworkTapListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkTapListResult)
-	return result, err
+	var val *VirtualNetworkTapListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkTapListResultResponse{}, err
+	}
+	return VirtualNetworkTapListResultResponse{RawResponse: resp.Response, VirtualNetworkTapListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.
@@ -338,9 +340,11 @@ func (client VirtualNetworkTapsClient) listByResourceGroupCreateRequest(ctx cont
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VirtualNetworkTapsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (VirtualNetworkTapListResultResponse, error) {
-	result := VirtualNetworkTapListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkTapListResult)
-	return result, err
+	var val *VirtualNetworkTapListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkTapListResultResponse{}, err
+	}
+	return VirtualNetworkTapListResultResponse{RawResponse: resp.Response, VirtualNetworkTapListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resourceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualNetworkTapResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VirtualNetworkTapResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client VirtualNetworkTapsClient) updateTagsCreateRequest(ctx context.Conte
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualNetworkTapsClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkTapResponse, error) {
-	result := VirtualNetworkTapResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualNetworkTap)
-	return result, err
+	var val *VirtualNetworkTap
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualNetworkTapResponse{}, err
+	}
+	return VirtualNetworkTapResponse{RawResponse: resp.Response, VirtualNetworkTap: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings.go
@@ -108,9 +108,11 @@ func (client VirtualRouterPeeringsClient) createOrUpdateCreateRequest(ctx contex
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualRouterPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualRouterPeeringResponse, error) {
-	result := VirtualRouterPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouterPeering)
-	return result, err
+	var val *VirtualRouterPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterPeeringResponse{}, err
+	}
+	return VirtualRouterPeeringResponse{RawResponse: resp.Response, VirtualRouterPeering: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGroup
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualRouterPeeringResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualRouterPeeringResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client VirtualRouterPeeringsClient) getCreateRequest(ctx context.Context, 
 
 // getHandleResponse handles the Get response.
 func (client VirtualRouterPeeringsClient) getHandleResponse(resp *azcore.Response) (VirtualRouterPeeringResponse, error) {
-	result := VirtualRouterPeeringResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouterPeering)
-	return result, err
+	var val *VirtualRouterPeering
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterPeeringResponse{}, err
+	}
+	return VirtualRouterPeeringResponse{RawResponse: resp.Response, VirtualRouterPeering: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client VirtualRouterPeeringsClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client VirtualRouterPeeringsClient) listHandleResponse(resp *azcore.Response) (VirtualRouterPeeringListResultResponse, error) {
-	result := VirtualRouterPeeringListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouterPeeringListResult)
-	return result, err
+	var val *VirtualRouterPeeringListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterPeeringListResultResponse{}, err
+	}
+	return VirtualRouterPeeringListResultResponse{RawResponse: resp.Response, VirtualRouterPeeringListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters.go
@@ -107,9 +107,11 @@ func (client VirtualRoutersClient) createOrUpdateCreateRequest(ctx context.Conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualRoutersClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualRouterResponse, error) {
-	result := VirtualRouterResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouter)
-	return result, err
+	var val *VirtualRouter
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterResponse{}, err
+	}
+	return VirtualRouterResponse{RawResponse: resp.Response, VirtualRouter: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VirtualRoutersClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualRouterResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualRouterResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client VirtualRoutersClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client VirtualRoutersClient) getHandleResponse(resp *azcore.Response) (VirtualRouterResponse, error) {
-	result := VirtualRouterResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouter)
-	return result, err
+	var val *VirtualRouter
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterResponse{}, err
+	}
+	return VirtualRouterResponse{RawResponse: resp.Response, VirtualRouter: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -292,9 +292,11 @@ func (client VirtualRoutersClient) listCreateRequest(ctx context.Context, option
 
 // listHandleResponse handles the List response.
 func (client VirtualRoutersClient) listHandleResponse(resp *azcore.Response) (VirtualRouterListResultResponse, error) {
-	result := VirtualRouterListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouterListResult)
-	return result, err
+	var val *VirtualRouterListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterListResultResponse{}, err
+	}
+	return VirtualRouterListResultResponse{RawResponse: resp.Response, VirtualRouterListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -341,9 +343,11 @@ func (client VirtualRoutersClient) listByResourceGroupCreateRequest(ctx context.
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VirtualRoutersClient) listByResourceGroupHandleResponse(resp *azcore.Response) (VirtualRouterListResultResponse, error) {
-	result := VirtualRouterListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualRouterListResult)
-	return result, err
+	var val *VirtualRouterListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualRouterListResultResponse{}, err
+	}
+	return VirtualRouterListResultResponse{RawResponse: resp.Response, VirtualRouterListResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans.go
@@ -107,9 +107,11 @@ func (client VirtualWansClient) createOrUpdateCreateRequest(ctx context.Context,
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VirtualWansClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualWanResponse, error) {
-	result := VirtualWanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualWan)
-	return result, err
+	var val *VirtualWan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualWanResponse{}, err
+	}
+	return VirtualWanResponse{RawResponse: resp.Response, VirtualWan: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VirtualWansClient) Get(ctx context.Context, resourceGroupName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualWanResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VirtualWanResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VirtualWansClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client VirtualWansClient) getHandleResponse(resp *azcore.Response) (VirtualWanResponse, error) {
-	result := VirtualWanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualWan)
-	return result, err
+	var val *VirtualWan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualWanResponse{}, err
+	}
+	return VirtualWanResponse{RawResponse: resp.Response, VirtualWan: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VirtualWansClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client VirtualWansClient) listHandleResponse(resp *azcore.Response) (ListVirtualWaNsResultResponse, error) {
-	result := ListVirtualWaNsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVirtualWaNsResult)
-	return result, err
+	var val *ListVirtualWaNsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVirtualWaNsResultResponse{}, err
+	}
+	return ListVirtualWaNsResultResponse{RawResponse: resp.Response, ListVirtualWaNsResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client VirtualWansClient) listByResourceGroupCreateRequest(ctx context.Con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VirtualWansClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListVirtualWaNsResultResponse, error) {
-	result := ListVirtualWaNsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVirtualWaNsResult)
-	return result, err
+	var val *ListVirtualWaNsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVirtualWaNsResultResponse{}, err
+	}
+	return ListVirtualWaNsResultResponse{RawResponse: resp.Response, ListVirtualWaNsResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VirtualWanResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VirtualWanResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client VirtualWansClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VirtualWansClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualWanResponse, error) {
-	result := VirtualWanResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VirtualWan)
-	return result, err
+	var val *VirtualWan
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VirtualWanResponse{}, err
+	}
+	return VirtualWanResponse{RawResponse: resp.Response, VirtualWan: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections.go
@@ -108,9 +108,11 @@ func (client VpnConnectionsClient) createOrUpdateCreateRequest(ctx context.Conte
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VpnConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VpnConnectionResponse, error) {
-	result := VpnConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnConnection)
-	return result, err
+	var val *VpnConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnConnectionResponse{}, err
+	}
+	return VpnConnectionResponse{RawResponse: resp.Response, VpnConnection: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -216,11 +218,7 @@ func (client VpnConnectionsClient) Get(ctx context.Context, resourceGroupName st
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -244,9 +242,11 @@ func (client VpnConnectionsClient) getCreateRequest(ctx context.Context, resourc
 
 // getHandleResponse handles the Get response.
 func (client VpnConnectionsClient) getHandleResponse(resp *azcore.Response) (VpnConnectionResponse, error) {
-	result := VpnConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnConnection)
-	return result, err
+	var val *VpnConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnConnectionResponse{}, err
+	}
+	return VpnConnectionResponse{RawResponse: resp.Response, VpnConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -294,9 +294,11 @@ func (client VpnConnectionsClient) listByVpnGatewayCreateRequest(ctx context.Con
 
 // listByVpnGatewayHandleResponse handles the ListByVpnGateway response.
 func (client VpnConnectionsClient) listByVpnGatewayHandleResponse(resp *azcore.Response) (ListVpnConnectionsResultResponse, error) {
-	result := ListVpnConnectionsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnConnectionsResult)
-	return result, err
+	var val *ListVpnConnectionsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnConnectionsResultResponse{}, err
+	}
+	return ListVpnConnectionsResultResponse{RawResponse: resp.Response, ListVpnConnectionsResult: val}, nil
 }
 
 // listByVpnGatewayHandleError handles the ListByVpnGateway error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways.go
@@ -107,9 +107,11 @@ func (client VpnGatewaysClient) createOrUpdateCreateRequest(ctx context.Context,
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VpnGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (VpnGatewayResponse, error) {
-	result := VpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnGateway)
-	return result, err
+	var val *VpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnGatewayResponse{}, err
+	}
+	return VpnGatewayResponse{RawResponse: resp.Response, VpnGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VpnGatewaysClient) Get(ctx context.Context, resourceGroupName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnGatewayResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnGatewayResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VpnGatewaysClient) getCreateRequest(ctx context.Context, resourceGr
 
 // getHandleResponse handles the Get response.
 func (client VpnGatewaysClient) getHandleResponse(resp *azcore.Response) (VpnGatewayResponse, error) {
-	result := VpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnGateway)
-	return result, err
+	var val *VpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnGatewayResponse{}, err
+	}
+	return VpnGatewayResponse{RawResponse: resp.Response, VpnGateway: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VpnGatewaysClient) listCreateRequest(ctx context.Context, options *
 
 // listHandleResponse handles the List response.
 func (client VpnGatewaysClient) listHandleResponse(resp *azcore.Response) (ListVpnGatewaysResultResponse, error) {
-	result := ListVpnGatewaysResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnGatewaysResult)
-	return result, err
+	var val *ListVpnGatewaysResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnGatewaysResultResponse{}, err
+	}
+	return ListVpnGatewaysResultResponse{RawResponse: resp.Response, ListVpnGatewaysResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client VpnGatewaysClient) listByResourceGroupCreateRequest(ctx context.Con
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VpnGatewaysClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListVpnGatewaysResultResponse, error) {
-	result := ListVpnGatewaysResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnGatewaysResult)
-	return result, err
+	var val *ListVpnGatewaysResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnGatewaysResultResponse{}, err
+	}
+	return ListVpnGatewaysResultResponse{RawResponse: resp.Response, ListVpnGatewaysResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -425,9 +429,11 @@ func (client VpnGatewaysClient) resetCreateRequest(ctx context.Context, resource
 
 // resetHandleResponse handles the Reset response.
 func (client VpnGatewaysClient) resetHandleResponse(resp *azcore.Response) (VpnGatewayResponse, error) {
-	result := VpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnGateway)
-	return result, err
+	var val *VpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnGatewayResponse{}, err
+	}
+	return VpnGatewayResponse{RawResponse: resp.Response, VpnGateway: val}, nil
 }
 
 // resetHandleError handles the Reset error response.
@@ -452,11 +458,7 @@ func (client VpnGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNam
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnGatewayResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VpnGatewayResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -479,9 +481,11 @@ func (client VpnGatewaysClient) updateTagsCreateRequest(ctx context.Context, res
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VpnGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (VpnGatewayResponse, error) {
-	result := VpnGatewayResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnGateway)
-	return result, err
+	var val *VpnGateway
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnGatewayResponse{}, err
+	}
+	return VpnGatewayResponse{RawResponse: resp.Response, VpnGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections.go
@@ -70,9 +70,11 @@ func (client VpnLinkConnectionsClient) listByVpnConnectionCreateRequest(ctx cont
 
 // listByVpnConnectionHandleResponse handles the ListByVpnConnection response.
 func (client VpnLinkConnectionsClient) listByVpnConnectionHandleResponse(resp *azcore.Response) (ListVpnSiteLinkConnectionsResultResponse, error) {
-	result := ListVpnSiteLinkConnectionsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnSiteLinkConnectionsResult)
-	return result, err
+	var val *ListVpnSiteLinkConnectionsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnSiteLinkConnectionsResultResponse{}, err
+	}
+	return ListVpnSiteLinkConnectionsResultResponse{RawResponse: resp.Response, ListVpnSiteLinkConnectionsResult: val}, nil
 }
 
 // listByVpnConnectionHandleError handles the ListByVpnConnection error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations.go
@@ -107,9 +107,11 @@ func (client VpnServerConfigurationsClient) createOrUpdateCreateRequest(ctx cont
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VpnServerConfigurationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VpnServerConfigurationResponse, error) {
-	result := VpnServerConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnServerConfiguration)
-	return result, err
+	var val *VpnServerConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnServerConfigurationResponse{}, err
+	}
+	return VpnServerConfigurationResponse{RawResponse: resp.Response, VpnServerConfiguration: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VpnServerConfigurationsClient) Get(ctx context.Context, resourceGro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnServerConfigurationResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnServerConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VpnServerConfigurationsClient) getCreateRequest(ctx context.Context
 
 // getHandleResponse handles the Get response.
 func (client VpnServerConfigurationsClient) getHandleResponse(resp *azcore.Response) (VpnServerConfigurationResponse, error) {
-	result := VpnServerConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnServerConfiguration)
-	return result, err
+	var val *VpnServerConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnServerConfigurationResponse{}, err
+	}
+	return VpnServerConfigurationResponse{RawResponse: resp.Response, VpnServerConfiguration: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VpnServerConfigurationsClient) listCreateRequest(ctx context.Contex
 
 // listHandleResponse handles the List response.
 func (client VpnServerConfigurationsClient) listHandleResponse(resp *azcore.Response) (ListVpnServerConfigurationsResultResponse, error) {
-	result := ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnServerConfigurationsResult)
-	return result, err
+	var val *ListVpnServerConfigurationsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnServerConfigurationsResultResponse{}, err
+	}
+	return ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response, ListVpnServerConfigurationsResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client VpnServerConfigurationsClient) listByResourceGroupCreateRequest(ctx
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VpnServerConfigurationsClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListVpnServerConfigurationsResultResponse, error) {
-	result := ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnServerConfigurationsResult)
-	return result, err
+	var val *ListVpnServerConfigurationsResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnServerConfigurationsResultResponse{}, err
+	}
+	return ListVpnServerConfigurationsResultResponse{RawResponse: resp.Response, ListVpnServerConfigurationsResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client VpnServerConfigurationsClient) UpdateTags(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnServerConfigurationResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VpnServerConfigurationResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client VpnServerConfigurationsClient) updateTagsCreateRequest(ctx context.
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VpnServerConfigurationsClient) updateTagsHandleResponse(resp *azcore.Response) (VpnServerConfigurationResponse, error) {
-	result := VpnServerConfigurationResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnServerConfiguration)
-	return result, err
+	var val *VpnServerConfiguration
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnServerConfigurationResponse{}, err
+	}
+	return VpnServerConfigurationResponse{RawResponse: resp.Response, VpnServerConfiguration: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan.go
@@ -107,9 +107,11 @@ func (client VpnServerConfigurationsAssociatedWithVirtualWanClient) listCreateRe
 
 // listHandleResponse handles the List response.
 func (client VpnServerConfigurationsAssociatedWithVirtualWanClient) listHandleResponse(resp *azcore.Response) (VpnServerConfigurationsResponseResponse, error) {
-	result := VpnServerConfigurationsResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnServerConfigurationsResponse)
-	return result, err
+	var val *VpnServerConfigurationsResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnServerConfigurationsResponseResponse{}, err
+	}
+	return VpnServerConfigurationsResponseResponse{RawResponse: resp.Response, VpnServerConfigurationsResponse: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections.go
@@ -46,11 +46,7 @@ func (client VpnSiteLinkConnectionsClient) Get(ctx context.Context, resourceGrou
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnSiteLinkConnectionResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnSiteLinkConnectionResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -75,9 +71,11 @@ func (client VpnSiteLinkConnectionsClient) getCreateRequest(ctx context.Context,
 
 // getHandleResponse handles the Get response.
 func (client VpnSiteLinkConnectionsClient) getHandleResponse(resp *azcore.Response) (VpnSiteLinkConnectionResponse, error) {
-	result := VpnSiteLinkConnectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnSiteLinkConnection)
-	return result, err
+	var val *VpnSiteLinkConnection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnSiteLinkConnectionResponse{}, err
+	}
+	return VpnSiteLinkConnectionResponse{RawResponse: resp.Response, VpnSiteLinkConnection: val}, nil
 }
 
 // getHandleError handles the Get error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks.go
@@ -46,11 +46,7 @@ func (client VpnSiteLinksClient) Get(ctx context.Context, resourceGroupName stri
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnSiteLinkResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnSiteLinkResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -74,9 +70,11 @@ func (client VpnSiteLinksClient) getCreateRequest(ctx context.Context, resourceG
 
 // getHandleResponse handles the Get response.
 func (client VpnSiteLinksClient) getHandleResponse(resp *azcore.Response) (VpnSiteLinkResponse, error) {
-	result := VpnSiteLinkResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnSiteLink)
-	return result, err
+	var val *VpnSiteLink
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnSiteLinkResponse{}, err
+	}
+	return VpnSiteLinkResponse{RawResponse: resp.Response, VpnSiteLink: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -124,9 +122,11 @@ func (client VpnSiteLinksClient) listByVpnSiteCreateRequest(ctx context.Context,
 
 // listByVpnSiteHandleResponse handles the ListByVpnSite response.
 func (client VpnSiteLinksClient) listByVpnSiteHandleResponse(resp *azcore.Response) (ListVpnSiteLinksResultResponse, error) {
-	result := ListVpnSiteLinksResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnSiteLinksResult)
-	return result, err
+	var val *ListVpnSiteLinksResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnSiteLinksResultResponse{}, err
+	}
+	return ListVpnSiteLinksResultResponse{RawResponse: resp.Response, ListVpnSiteLinksResult: val}, nil
 }
 
 // listByVpnSiteHandleError handles the ListByVpnSite error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites.go
@@ -107,9 +107,11 @@ func (client VpnSitesClient) createOrUpdateCreateRequest(ctx context.Context, re
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client VpnSitesClient) createOrUpdateHandleResponse(resp *azcore.Response) (VpnSiteResponse, error) {
-	result := VpnSiteResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnSite)
-	return result, err
+	var val *VpnSite
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnSiteResponse{}, err
+	}
+	return VpnSiteResponse{RawResponse: resp.Response, VpnSite: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -214,11 +216,7 @@ func (client VpnSitesClient) Get(ctx context.Context, resourceGroupName string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnSiteResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return VpnSiteResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -241,9 +239,11 @@ func (client VpnSitesClient) getCreateRequest(ctx context.Context, resourceGroup
 
 // getHandleResponse handles the Get response.
 func (client VpnSitesClient) getHandleResponse(resp *azcore.Response) (VpnSiteResponse, error) {
-	result := VpnSiteResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnSite)
-	return result, err
+	var val *VpnSite
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnSiteResponse{}, err
+	}
+	return VpnSiteResponse{RawResponse: resp.Response, VpnSite: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -289,9 +289,11 @@ func (client VpnSitesClient) listCreateRequest(ctx context.Context, options *Vpn
 
 // listHandleResponse handles the List response.
 func (client VpnSitesClient) listHandleResponse(resp *azcore.Response) (ListVpnSitesResultResponse, error) {
-	result := ListVpnSitesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnSitesResult)
-	return result, err
+	var val *ListVpnSitesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnSitesResultResponse{}, err
+	}
+	return ListVpnSitesResultResponse{RawResponse: resp.Response, ListVpnSitesResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -338,9 +340,11 @@ func (client VpnSitesClient) listByResourceGroupCreateRequest(ctx context.Contex
 
 // listByResourceGroupHandleResponse handles the ListByResourceGroup response.
 func (client VpnSitesClient) listByResourceGroupHandleResponse(resp *azcore.Response) (ListVpnSitesResultResponse, error) {
-	result := ListVpnSitesResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ListVpnSitesResult)
-	return result, err
+	var val *ListVpnSitesResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ListVpnSitesResultResponse{}, err
+	}
+	return ListVpnSitesResultResponse{RawResponse: resp.Response, ListVpnSitesResult: val}, nil
 }
 
 // listByResourceGroupHandleError handles the ListByResourceGroup error response.
@@ -365,11 +369,7 @@ func (client VpnSitesClient) UpdateTags(ctx context.Context, resourceGroupName s
 	if !resp.HasStatusCode(http.StatusOK) {
 		return VpnSiteResponse{}, client.updateTagsHandleError(resp)
 	}
-	result, err := client.updateTagsHandleResponse(resp)
-	if err != nil {
-		return VpnSiteResponse{}, err
-	}
-	return result, nil
+	return client.updateTagsHandleResponse(resp)
 }
 
 // updateTagsCreateRequest creates the UpdateTags request.
@@ -392,9 +392,11 @@ func (client VpnSitesClient) updateTagsCreateRequest(ctx context.Context, resour
 
 // updateTagsHandleResponse handles the UpdateTags response.
 func (client VpnSitesClient) updateTagsHandleResponse(resp *azcore.Response) (VpnSiteResponse, error) {
-	result := VpnSiteResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.VpnSite)
-	return result, err
+	var val *VpnSite
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return VpnSiteResponse{}, err
+	}
+	return VpnSiteResponse{RawResponse: resp.Response, VpnSite: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies.go
@@ -47,11 +47,7 @@ func (client WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.Co
 	if !resp.HasStatusCode(http.StatusOK, http.StatusCreated) {
 		return WebApplicationFirewallPolicyResponse{}, client.createOrUpdateHandleError(resp)
 	}
-	result, err := client.createOrUpdateHandleResponse(resp)
-	if err != nil {
-		return WebApplicationFirewallPolicyResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateHandleResponse(resp)
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
@@ -74,9 +70,11 @@ func (client WebApplicationFirewallPoliciesClient) createOrUpdateCreateRequest(c
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
 func (client WebApplicationFirewallPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (WebApplicationFirewallPolicyResponse, error) {
-	result := WebApplicationFirewallPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicy)
-	return result, err
+	var val *WebApplicationFirewallPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return WebApplicationFirewallPolicyResponse{}, err
+	}
+	return WebApplicationFirewallPolicyResponse{RawResponse: resp.Response, WebApplicationFirewallPolicy: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -181,11 +179,7 @@ func (client WebApplicationFirewallPoliciesClient) Get(ctx context.Context, reso
 	if !resp.HasStatusCode(http.StatusOK) {
 		return WebApplicationFirewallPolicyResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return WebApplicationFirewallPolicyResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -208,9 +202,11 @@ func (client WebApplicationFirewallPoliciesClient) getCreateRequest(ctx context.
 
 // getHandleResponse handles the Get response.
 func (client WebApplicationFirewallPoliciesClient) getHandleResponse(resp *azcore.Response) (WebApplicationFirewallPolicyResponse, error) {
-	result := WebApplicationFirewallPolicyResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicy)
-	return result, err
+	var val *WebApplicationFirewallPolicy
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return WebApplicationFirewallPolicyResponse{}, err
+	}
+	return WebApplicationFirewallPolicyResponse{RawResponse: resp.Response, WebApplicationFirewallPolicy: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -257,9 +253,11 @@ func (client WebApplicationFirewallPoliciesClient) listCreateRequest(ctx context
 
 // listHandleResponse handles the List response.
 func (client WebApplicationFirewallPoliciesClient) listHandleResponse(resp *azcore.Response) (WebApplicationFirewallPolicyListResultResponse, error) {
-	result := WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicyListResult)
-	return result, err
+	var val *WebApplicationFirewallPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return WebApplicationFirewallPolicyListResultResponse{}, err
+	}
+	return WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response, WebApplicationFirewallPolicyListResult: val}, nil
 }
 
 // listHandleError handles the List error response.
@@ -305,9 +303,11 @@ func (client WebApplicationFirewallPoliciesClient) listAllCreateRequest(ctx cont
 
 // listAllHandleResponse handles the ListAll response.
 func (client WebApplicationFirewallPoliciesClient) listAllHandleResponse(resp *azcore.Response) (WebApplicationFirewallPolicyListResultResponse, error) {
-	result := WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.WebApplicationFirewallPolicyListResult)
-	return result, err
+	var val *WebApplicationFirewallPolicyListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return WebApplicationFirewallPolicyListResultResponse{}, err
+	}
+	return WebApplicationFirewallPolicyListResultResponse{RawResponse: resp.Response, WebApplicationFirewallPolicyListResult: val}, nil
 }
 
 // listAllHandleError handles the ListAll error response.

--- a/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_appendblob.go
@@ -41,11 +41,7 @@ func (client appendBlobClient) AppendBlock(ctx context.Context, contentLength in
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return AppendBlobAppendBlockResponse{}, client.appendBlockHandleError(resp)
 	}
-	result, err := client.appendBlockHandleResponse(resp)
-	if err != nil {
-		return AppendBlobAppendBlockResponse{}, err
-	}
-	return result, nil
+	return client.appendBlockHandleResponse(resp)
 }
 
 // appendBlockCreateRequest creates the AppendBlock request.
@@ -203,11 +199,7 @@ func (client appendBlobClient) AppendBlockFromURL(ctx context.Context, sourceUrl
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return AppendBlobAppendBlockFromURLResponse{}, client.appendBlockFromUrlHandleError(resp)
 	}
-	result, err := client.appendBlockFromUrlHandleResponse(resp)
-	if err != nil {
-		return AppendBlobAppendBlockFromURLResponse{}, err
-	}
-	return result, nil
+	return client.appendBlockFromUrlHandleResponse(resp)
 }
 
 // appendBlockFromUrlCreateRequest creates the AppendBlockFromURL request.
@@ -379,11 +371,7 @@ func (client appendBlobClient) Create(ctx context.Context, contentLength int64, 
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return AppendBlobCreateResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return AppendBlobCreateResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -42,11 +42,7 @@ func (client blobClient) AbortCopyFromURL(ctx context.Context, copyId string, bl
 	if !resp.HasStatusCode(http.StatusNoContent) {
 		return BlobAbortCopyFromURLResponse{}, client.abortCopyFromUrlHandleError(resp)
 	}
-	result, err := client.abortCopyFromUrlHandleResponse(resp)
-	if err != nil {
-		return BlobAbortCopyFromURLResponse{}, err
-	}
-	return result, nil
+	return client.abortCopyFromUrlHandleResponse(resp)
 }
 
 // abortCopyFromUrlCreateRequest creates the AbortCopyFromURL request.
@@ -119,11 +115,7 @@ func (client blobClient) AcquireLease(ctx context.Context, blobAcquireLeaseOptio
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlobAcquireLeaseResponse{}, client.acquireLeaseHandleError(resp)
 	}
-	result, err := client.acquireLeaseHandleResponse(resp)
-	if err != nil {
-		return BlobAcquireLeaseResponse{}, err
-	}
-	return result, nil
+	return client.acquireLeaseHandleResponse(resp)
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
@@ -223,11 +215,7 @@ func (client blobClient) BreakLease(ctx context.Context, blobBreakLeaseOptions *
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return BlobBreakLeaseResponse{}, client.breakLeaseHandleError(resp)
 	}
-	result, err := client.breakLeaseHandleResponse(resp)
-	if err != nil {
-		return BlobBreakLeaseResponse{}, err
-	}
-	return result, nil
+	return client.breakLeaseHandleResponse(resp)
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
@@ -329,11 +317,7 @@ func (client blobClient) ChangeLease(ctx context.Context, leaseId string, propos
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobChangeLeaseResponse{}, client.changeLeaseHandleError(resp)
 	}
-	result, err := client.changeLeaseHandleResponse(resp)
-	if err != nil {
-		return BlobChangeLeaseResponse{}, err
-	}
-	return result, nil
+	return client.changeLeaseHandleResponse(resp)
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
@@ -429,11 +413,7 @@ func (client blobClient) CopyFromURL(ctx context.Context, copySource url.URL, bl
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return BlobCopyFromURLResponse{}, client.copyFromUrlHandleError(resp)
 	}
-	result, err := client.copyFromUrlHandleResponse(resp)
-	if err != nil {
-		return BlobCopyFromURLResponse{}, err
-	}
-	return result, nil
+	return client.copyFromUrlHandleResponse(resp)
 }
 
 // copyFromUrlCreateRequest creates the CopyFromURL request.
@@ -570,11 +550,7 @@ func (client blobClient) CreateSnapshot(ctx context.Context, blobCreateSnapshotO
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlobCreateSnapshotResponse{}, client.createSnapshotHandleError(resp)
 	}
-	result, err := client.createSnapshotHandleResponse(resp)
-	if err != nil {
-		return BlobCreateSnapshotResponse{}, err
-	}
-	return result, nil
+	return client.createSnapshotHandleResponse(resp)
 }
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
@@ -704,11 +680,7 @@ func (client blobClient) Delete(ctx context.Context, blobDeleteOptions *BlobDele
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return BlobDeleteResponse{}, client.deleteHandleError(resp)
 	}
-	result, err := client.deleteHandleResponse(resp)
-	if err != nil {
-		return BlobDeleteResponse{}, err
-	}
-	return result, nil
+	return client.deleteHandleResponse(resp)
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -797,11 +769,7 @@ func (client blobClient) Download(ctx context.Context, blobDownloadOptions *Blob
 	if !resp.HasStatusCode(http.StatusOK, http.StatusPartialContent) {
 		return BlobDownloadResponse{}, client.downloadHandleError(resp)
 	}
-	result, err := client.downloadHandleResponse(resp)
-	if err != nil {
-		return BlobDownloadResponse{}, err
-	}
-	return result, nil
+	return client.downloadHandleResponse(resp)
 }
 
 // downloadCreateRequest creates the Download request.
@@ -1034,11 +1002,7 @@ func (client blobClient) GetAccessControl(ctx context.Context, blobGetAccessCont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobGetAccessControlResponse{}, client.getAccessControlHandleError(resp)
 	}
-	result, err := client.getAccessControlHandleResponse(resp)
-	if err != nil {
-		return BlobGetAccessControlResponse{}, err
-	}
-	return result, nil
+	return client.getAccessControlHandleResponse(resp)
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
@@ -1143,11 +1107,7 @@ func (client blobClient) GetAccountInfo(ctx context.Context, options *BlobGetAcc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobGetAccountInfoResponse{}, client.getAccountInfoHandleError(resp)
 	}
-	result, err := client.getAccountInfoHandleResponse(resp)
-	if err != nil {
-		return BlobGetAccountInfoResponse{}, err
-	}
-	return result, nil
+	return client.getAccountInfoHandleResponse(resp)
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
@@ -1217,11 +1177,7 @@ func (client blobClient) GetProperties(ctx context.Context, blobGetPropertiesOpt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobGetPropertiesResponse{}, client.getPropertiesHandleError(resp)
 	}
-	result, err := client.getPropertiesHandleResponse(resp)
-	if err != nil {
-		return BlobGetPropertiesResponse{}, err
-	}
-	return result, nil
+	return client.getPropertiesHandleResponse(resp)
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
@@ -1464,11 +1420,7 @@ func (client blobClient) ReleaseLease(ctx context.Context, leaseId string, blobR
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobReleaseLeaseResponse{}, client.releaseLeaseHandleError(resp)
 	}
-	result, err := client.releaseLeaseHandleResponse(resp)
-	if err != nil {
-		return BlobReleaseLeaseResponse{}, err
-	}
-	return result, nil
+	return client.releaseLeaseHandleResponse(resp)
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
@@ -1564,11 +1516,7 @@ func (client blobClient) Rename(ctx context.Context, renameSource string, blobRe
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlobRenameResponse{}, client.renameHandleError(resp)
 	}
-	result, err := client.renameHandleResponse(resp)
-	if err != nil {
-		return BlobRenameResponse{}, err
-	}
-	return result, nil
+	return client.renameHandleResponse(resp)
 }
 
 // renameCreateRequest creates the Rename request.
@@ -1710,11 +1658,7 @@ func (client blobClient) RenewLease(ctx context.Context, leaseId string, blobRen
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobRenewLeaseResponse{}, client.renewLeaseHandleError(resp)
 	}
-	result, err := client.renewLeaseHandleResponse(resp)
-	if err != nil {
-		return BlobRenewLeaseResponse{}, err
-	}
-	return result, nil
+	return client.renewLeaseHandleResponse(resp)
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
@@ -1809,11 +1753,7 @@ func (client blobClient) SetAccessControl(ctx context.Context, blobSetAccessCont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobSetAccessControlResponse{}, client.setAccessControlHandleError(resp)
 	}
-	result, err := client.setAccessControlHandleResponse(resp)
-	if err != nil {
-		return BlobSetAccessControlResponse{}, err
-	}
-	return result, nil
+	return client.setAccessControlHandleResponse(resp)
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
@@ -1915,11 +1855,7 @@ func (client blobClient) SetHTTPHeaders(ctx context.Context, blobSetHttpHeadersO
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobSetHTTPHeadersResponse{}, client.setHttpHeadersHandleError(resp)
 	}
-	result, err := client.setHttpHeadersHandleResponse(resp)
-	if err != nil {
-		return BlobSetHTTPHeadersResponse{}, err
-	}
-	return result, nil
+	return client.setHttpHeadersHandleResponse(resp)
 }
 
 // setHttpHeadersCreateRequest creates the SetHTTPHeaders request.
@@ -2037,11 +1973,7 @@ func (client blobClient) SetMetadata(ctx context.Context, blobSetMetadataOptions
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobSetMetadataResponse{}, client.setMetadataHandleError(resp)
 	}
-	result, err := client.setMetadataHandleResponse(resp)
-	if err != nil {
-		return BlobSetMetadataResponse{}, err
-	}
-	return result, nil
+	return client.setMetadataHandleResponse(resp)
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
@@ -2167,11 +2099,7 @@ func (client blobClient) SetTier(ctx context.Context, tier AccessTier, blobSetTi
 	if !resp.HasStatusCode(http.StatusOK, http.StatusAccepted) {
 		return BlobSetTierResponse{}, client.setTierHandleError(resp)
 	}
-	result, err := client.setTierHandleResponse(resp)
-	if err != nil {
-		return BlobSetTierResponse{}, err
-	}
-	return result, nil
+	return client.setTierHandleResponse(resp)
 }
 
 // setTierCreateRequest creates the SetTier request.
@@ -2239,11 +2167,7 @@ func (client blobClient) StartCopyFromURL(ctx context.Context, copySource url.UR
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return BlobStartCopyFromURLResponse{}, client.startCopyFromUrlHandleError(resp)
 	}
-	result, err := client.startCopyFromUrlHandleResponse(resp)
-	if err != nil {
-		return BlobStartCopyFromURLResponse{}, err
-	}
-	return result, nil
+	return client.startCopyFromUrlHandleResponse(resp)
 }
 
 // startCopyFromUrlCreateRequest creates the StartCopyFromURL request.
@@ -2365,11 +2289,7 @@ func (client blobClient) Undelete(ctx context.Context, options *BlobUndeleteOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlobUndeleteResponse{}, client.undeleteHandleError(resp)
 	}
-	result, err := client.undeleteHandleResponse(resp)
-	if err != nil {
-		return BlobUndeleteResponse{}, err
-	}
-	return result, nil
+	return client.undeleteHandleResponse(resp)
 }
 
 // undeleteCreateRequest creates the Undelete request.

--- a/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blockblob.go
@@ -45,11 +45,7 @@ func (client blockBlobClient) CommitBlockList(ctx context.Context, blocks BlockL
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlockBlobCommitBlockListResponse{}, client.commitBlockListHandleError(resp)
 	}
-	result, err := client.commitBlockListHandleResponse(resp)
-	if err != nil {
-		return BlockBlobCommitBlockListResponse{}, err
-	}
-	return result, nil
+	return client.commitBlockListHandleResponse(resp)
 }
 
 // commitBlockListCreateRequest creates the CommitBlockList request.
@@ -213,11 +209,7 @@ func (client blockBlobClient) GetBlockList(ctx context.Context, listType BlockLi
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BlockListResponse{}, client.getBlockListHandleError(resp)
 	}
-	result, err := client.getBlockListHandleResponse(resp)
-	if err != nil {
-		return BlockListResponse{}, err
-	}
-	return result, nil
+	return client.getBlockListHandleResponse(resp)
 }
 
 // getBlockListCreateRequest creates the GetBlockList request.
@@ -250,7 +242,11 @@ func (client blockBlobClient) getBlockListCreateRequest(ctx context.Context, lis
 
 // getBlockListHandleResponse handles the GetBlockList response.
 func (client blockBlobClient) getBlockListHandleResponse(resp *azcore.Response) (BlockListResponse, error) {
-	result := BlockListResponse{RawResponse: resp.Response}
+	var val *BlockList
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return BlockListResponse{}, err
+	}
+	result := BlockListResponse{RawResponse: resp.Response, BlockList: val}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -287,8 +283,7 @@ func (client blockBlobClient) getBlockListHandleResponse(resp *azcore.Response) 
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.BlockList)
-	return result, err
+	return result, nil
 }
 
 // getBlockListHandleError handles the GetBlockList error response.
@@ -313,11 +308,7 @@ func (client blockBlobClient) StageBlock(ctx context.Context, blockId string, co
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlockBlobStageBlockResponse{}, client.stageBlockHandleError(resp)
 	}
-	result, err := client.stageBlockHandleResponse(resp)
-	if err != nil {
-		return BlockBlobStageBlockResponse{}, err
-	}
-	return result, nil
+	return client.stageBlockHandleResponse(resp)
 }
 
 // stageBlockCreateRequest creates the StageBlock request.
@@ -435,11 +426,7 @@ func (client blockBlobClient) StageBlockFromURL(ctx context.Context, blockId str
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlockBlobStageBlockFromURLResponse{}, client.stageBlockFromUrlHandleError(resp)
 	}
-	result, err := client.stageBlockFromUrlHandleResponse(resp)
-	if err != nil {
-		return BlockBlobStageBlockFromURLResponse{}, err
-	}
-	return result, nil
+	return client.stageBlockFromUrlHandleResponse(resp)
 }
 
 // stageBlockFromUrlCreateRequest creates the StageBlockFromURL request.
@@ -576,11 +563,7 @@ func (client blockBlobClient) Upload(ctx context.Context, contentLength int64, b
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return BlockBlobUploadResponse{}, client.uploadHandleError(resp)
 	}
-	result, err := client.uploadHandleResponse(resp)
-	if err != nil {
-		return BlockBlobUploadResponse{}, err
-	}
-	return result, nil
+	return client.uploadHandleResponse(resp)
 }
 
 // uploadCreateRequest creates the Upload request.

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -40,11 +40,7 @@ func (client containerClient) AcquireLease(ctx context.Context, containerAcquire
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return ContainerAcquireLeaseResponse{}, client.acquireLeaseHandleError(resp)
 	}
-	result, err := client.acquireLeaseHandleResponse(resp)
-	if err != nil {
-		return ContainerAcquireLeaseResponse{}, err
-	}
-	return result, nil
+	return client.acquireLeaseHandleResponse(resp)
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
@@ -139,11 +135,7 @@ func (client containerClient) BreakLease(ctx context.Context, containerBreakLeas
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return ContainerBreakLeaseResponse{}, client.breakLeaseHandleError(resp)
 	}
-	result, err := client.breakLeaseHandleResponse(resp)
-	if err != nil {
-		return ContainerBreakLeaseResponse{}, err
-	}
-	return result, nil
+	return client.breakLeaseHandleResponse(resp)
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
@@ -240,11 +232,7 @@ func (client containerClient) ChangeLease(ctx context.Context, leaseId string, p
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerChangeLeaseResponse{}, client.changeLeaseHandleError(resp)
 	}
-	result, err := client.changeLeaseHandleResponse(resp)
-	if err != nil {
-		return ContainerChangeLeaseResponse{}, err
-	}
-	return result, nil
+	return client.changeLeaseHandleResponse(resp)
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
@@ -335,11 +323,7 @@ func (client containerClient) Create(ctx context.Context, containerCreateOptions
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return ContainerCreateResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return ContainerCreateResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.
@@ -431,11 +415,7 @@ func (client containerClient) Delete(ctx context.Context, containerDeleteOptions
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return ContainerDeleteResponse{}, client.deleteHandleError(resp)
 	}
-	result, err := client.deleteHandleResponse(resp)
-	if err != nil {
-		return ContainerDeleteResponse{}, err
-	}
-	return result, nil
+	return client.deleteHandleResponse(resp)
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -512,11 +492,7 @@ func (client containerClient) GetAccessPolicy(ctx context.Context, containerGetA
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SignedIDentifierArrayResponse{}, client.getAccessPolicyHandleError(resp)
 	}
-	result, err := client.getAccessPolicyHandleResponse(resp)
-	if err != nil {
-		return SignedIDentifierArrayResponse{}, err
-	}
-	return result, nil
+	return client.getAccessPolicyHandleResponse(resp)
 }
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
@@ -547,6 +523,9 @@ func (client containerClient) getAccessPolicyCreateRequest(ctx context.Context, 
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
 func (client containerClient) getAccessPolicyHandleResponse(resp *azcore.Response) (SignedIDentifierArrayResponse, error) {
 	result := SignedIDentifierArrayResponse{RawResponse: resp.Response}
+	if err := resp.UnmarshalAsXML(&result); err != nil {
+		return SignedIDentifierArrayResponse{}, err
+	}
 	if val := resp.Header.Get("x-ms-blob-public-access"); val != "" {
 		result.BlobPublicAccess = (*PublicAccessType)(&val)
 	}
@@ -576,8 +555,7 @@ func (client containerClient) getAccessPolicyHandleResponse(resp *azcore.Respons
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result)
-	return result, err
+	return result, nil
 }
 
 // getAccessPolicyHandleError handles the GetAccessPolicy error response.
@@ -602,11 +580,7 @@ func (client containerClient) GetAccountInfo(ctx context.Context, options *Conta
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerGetAccountInfoResponse{}, client.getAccountInfoHandleError(resp)
 	}
-	result, err := client.getAccountInfoHandleResponse(resp)
-	if err != nil {
-		return ContainerGetAccountInfoResponse{}, err
-	}
-	return result, nil
+	return client.getAccountInfoHandleResponse(resp)
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
@@ -676,11 +650,7 @@ func (client containerClient) GetProperties(ctx context.Context, containerGetPro
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerGetPropertiesResponse{}, client.getPropertiesHandleError(resp)
 	}
-	result, err := client.getPropertiesHandleResponse(resp)
-	if err != nil {
-		return ContainerGetPropertiesResponse{}, err
-	}
-	return result, nil
+	return client.getPropertiesHandleResponse(resp)
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
@@ -844,7 +814,11 @@ func (client containerClient) listBlobFlatSegmentCreateRequest(ctx context.Conte
 
 // listBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
 func (client containerClient) listBlobFlatSegmentHandleResponse(resp *azcore.Response) (ListBlobsFlatSegmentResponseResponse, error) {
-	result := ListBlobsFlatSegmentResponseResponse{RawResponse: resp.Response}
+	var val *ListBlobsFlatSegmentResponse
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ListBlobsFlatSegmentResponseResponse{}, err
+	}
+	result := ListBlobsFlatSegmentResponseResponse{RawResponse: resp.Response, EnumerationResults: val}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
@@ -864,8 +838,7 @@ func (client containerClient) listBlobFlatSegmentHandleResponse(resp *azcore.Res
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.EnumerationResults)
-	return result, err
+	return result, nil
 }
 
 // listBlobFlatSegmentHandleError handles the ListBlobFlatSegment error response.
@@ -930,7 +903,11 @@ func (client containerClient) listBlobHierarchySegmentCreateRequest(ctx context.
 
 // listBlobHierarchySegmentHandleResponse handles the ListBlobHierarchySegment response.
 func (client containerClient) listBlobHierarchySegmentHandleResponse(resp *azcore.Response) (ListBlobsHierarchySegmentResponseResponse, error) {
-	result := ListBlobsHierarchySegmentResponseResponse{RawResponse: resp.Response}
+	var val *ListBlobsHierarchySegmentResponse
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ListBlobsHierarchySegmentResponseResponse{}, err
+	}
+	result := ListBlobsHierarchySegmentResponseResponse{RawResponse: resp.Response, EnumerationResults: val}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
 	}
@@ -950,8 +927,7 @@ func (client containerClient) listBlobHierarchySegmentHandleResponse(resp *azcor
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.EnumerationResults)
-	return result, err
+	return result, nil
 }
 
 // listBlobHierarchySegmentHandleError handles the ListBlobHierarchySegment error response.
@@ -976,11 +952,7 @@ func (client containerClient) ReleaseLease(ctx context.Context, leaseId string, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerReleaseLeaseResponse{}, client.releaseLeaseHandleError(resp)
 	}
-	result, err := client.releaseLeaseHandleResponse(resp)
-	if err != nil {
-		return ContainerReleaseLeaseResponse{}, err
-	}
-	return result, nil
+	return client.releaseLeaseHandleResponse(resp)
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
@@ -1067,11 +1039,7 @@ func (client containerClient) RenewLease(ctx context.Context, leaseId string, co
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerRenewLeaseResponse{}, client.renewLeaseHandleError(resp)
 	}
-	result, err := client.renewLeaseHandleResponse(resp)
-	if err != nil {
-		return ContainerRenewLeaseResponse{}, err
-	}
-	return result, nil
+	return client.renewLeaseHandleResponse(resp)
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
@@ -1161,11 +1129,7 @@ func (client containerClient) SetAccessPolicy(ctx context.Context, containerSetA
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerSetAccessPolicyResponse{}, client.setAccessPolicyHandleError(resp)
 	}
-	result, err := client.setAccessPolicyHandleResponse(resp)
-	if err != nil {
-		return ContainerSetAccessPolicyResponse{}, err
-	}
-	return result, nil
+	return client.setAccessPolicyHandleResponse(resp)
 }
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
@@ -1263,11 +1227,7 @@ func (client containerClient) SetMetadata(ctx context.Context, containerSetMetad
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ContainerSetMetadataResponse{}, client.setMetadataHandleError(resp)
 	}
-	result, err := client.setMetadataHandleResponse(resp)
-	if err != nil {
-		return ContainerSetMetadataResponse{}, err
-	}
-	return result, nil
+	return client.setMetadataHandleResponse(resp)
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.

--- a/test/storage/2019-07-07/azblob/zz_generated_directory.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_directory.go
@@ -42,11 +42,7 @@ func (client directoryClient) Create(ctx context.Context, directoryCreateOptions
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return DirectoryCreateResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return DirectoryCreateResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.
@@ -170,11 +166,7 @@ func (client directoryClient) Delete(ctx context.Context, recursiveDirectoryDele
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DirectoryDeleteResponse{}, client.deleteHandleError(resp)
 	}
-	result, err := client.deleteHandleResponse(resp)
-	if err != nil {
-		return DirectoryDeleteResponse{}, err
-	}
-	return result, nil
+	return client.deleteHandleResponse(resp)
 }
 
 // deleteCreateRequest creates the Delete request.
@@ -263,11 +255,7 @@ func (client directoryClient) GetAccessControl(ctx context.Context, directoryGet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DirectoryGetAccessControlResponse{}, client.getAccessControlHandleError(resp)
 	}
-	result, err := client.getAccessControlHandleResponse(resp)
-	if err != nil {
-		return DirectoryGetAccessControlResponse{}, err
-	}
-	return result, nil
+	return client.getAccessControlHandleResponse(resp)
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
@@ -376,11 +364,7 @@ func (client directoryClient) Rename(ctx context.Context, renameSource string, d
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return DirectoryRenameResponse{}, client.renameHandleError(resp)
 	}
-	result, err := client.renameHandleResponse(resp)
-	if err != nil {
-		return DirectoryRenameResponse{}, err
-	}
-	return result, nil
+	return client.renameHandleResponse(resp)
 }
 
 // renameCreateRequest creates the Rename request.
@@ -528,11 +512,7 @@ func (client directoryClient) SetAccessControl(ctx context.Context, directorySet
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DirectorySetAccessControlResponse{}, client.setAccessControlHandleError(resp)
 	}
-	result, err := client.setAccessControlHandleResponse(resp)
-	if err != nil {
-		return DirectorySetAccessControlResponse{}, err
-	}
-	return result, nil
+	return client.setAccessControlHandleResponse(resp)
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -3105,6 +3105,9 @@ type ServiceGetAccountInfoResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
 
+	// IsHierarchicalNamespaceEnabled contains the information returned from the x-ms-is-hns-enabled header response.
+	IsHierarchicalNamespaceEnabled *bool
+
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 

--- a/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_pageblob.go
@@ -39,11 +39,7 @@ func (client pageBlobClient) ClearPages(ctx context.Context, contentLength int64
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return PageBlobClearPagesResponse{}, client.clearPagesHandleError(resp)
 	}
-	result, err := client.clearPagesHandleResponse(resp)
-	if err != nil {
-		return PageBlobClearPagesResponse{}, err
-	}
-	return result, nil
+	return client.clearPagesHandleResponse(resp)
 }
 
 // clearPagesCreateRequest creates the ClearPages request.
@@ -187,11 +183,7 @@ func (client pageBlobClient) CopyIncremental(ctx context.Context, copySource url
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return PageBlobCopyIncrementalResponse{}, client.copyIncrementalHandleError(resp)
 	}
-	result, err := client.copyIncrementalHandleResponse(resp)
-	if err != nil {
-		return PageBlobCopyIncrementalResponse{}, err
-	}
-	return result, nil
+	return client.copyIncrementalHandleResponse(resp)
 }
 
 // copyIncrementalCreateRequest creates the CopyIncremental request.
@@ -288,11 +280,7 @@ func (client pageBlobClient) Create(ctx context.Context, contentLength int64, bl
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return PageBlobCreateResponse{}, client.createHandleError(resp)
 	}
-	result, err := client.createHandleResponse(resp)
-	if err != nil {
-		return PageBlobCreateResponse{}, err
-	}
-	return result, nil
+	return client.createHandleResponse(resp)
 }
 
 // createCreateRequest creates the Create request.
@@ -448,11 +436,7 @@ func (client pageBlobClient) GetPageRanges(ctx context.Context, pageBlobGetPageR
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PageListResponse{}, client.getPageRangesHandleError(resp)
 	}
-	result, err := client.getPageRangesHandleResponse(resp)
-	if err != nil {
-		return PageListResponse{}, err
-	}
-	return result, nil
+	return client.getPageRangesHandleResponse(resp)
 }
 
 // getPageRangesCreateRequest creates the GetPageRanges request.
@@ -499,7 +483,11 @@ func (client pageBlobClient) getPageRangesCreateRequest(ctx context.Context, pag
 
 // getPageRangesHandleResponse handles the GetPageRanges response.
 func (client pageBlobClient) getPageRangesHandleResponse(resp *azcore.Response) (PageListResponse, error) {
-	result := PageListResponse{RawResponse: resp.Response}
+	var val *PageList
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return PageListResponse{}, err
+	}
+	result := PageListResponse{RawResponse: resp.Response, PageList: val}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -533,8 +521,7 @@ func (client pageBlobClient) getPageRangesHandleResponse(resp *azcore.Response) 
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.PageList)
-	return result, err
+	return result, nil
 }
 
 // getPageRangesHandleError handles the GetPageRanges error response.
@@ -560,11 +547,7 @@ func (client pageBlobClient) GetPageRangesDiff(ctx context.Context, pageBlobGetP
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PageListResponse{}, client.getPageRangesDiffHandleError(resp)
 	}
-	result, err := client.getPageRangesDiffHandleResponse(resp)
-	if err != nil {
-		return PageListResponse{}, err
-	}
-	return result, nil
+	return client.getPageRangesDiffHandleResponse(resp)
 }
 
 // getPageRangesDiffCreateRequest creates the GetPageRangesDiff request.
@@ -617,7 +600,11 @@ func (client pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context,
 
 // getPageRangesDiffHandleResponse handles the GetPageRangesDiff response.
 func (client pageBlobClient) getPageRangesDiffHandleResponse(resp *azcore.Response) (PageListResponse, error) {
-	result := PageListResponse{RawResponse: resp.Response}
+	var val *PageList
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return PageListResponse{}, err
+	}
+	result := PageListResponse{RawResponse: resp.Response, PageList: val}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
 		if err != nil {
@@ -651,8 +638,7 @@ func (client pageBlobClient) getPageRangesDiffHandleResponse(resp *azcore.Respon
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.PageList)
-	return result, err
+	return result, nil
 }
 
 // getPageRangesDiffHandleError handles the GetPageRangesDiff error response.
@@ -677,11 +663,7 @@ func (client pageBlobClient) Resize(ctx context.Context, blobContentLength int64
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PageBlobResizeResponse{}, client.resizeHandleError(resp)
 	}
-	result, err := client.resizeHandleResponse(resp)
-	if err != nil {
-		return PageBlobResizeResponse{}, err
-	}
-	return result, nil
+	return client.resizeHandleResponse(resp)
 }
 
 // resizeCreateRequest creates the Resize request.
@@ -794,11 +776,7 @@ func (client pageBlobClient) UpdateSequenceNumber(ctx context.Context, sequenceN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PageBlobUpdateSequenceNumberResponse{}, client.updateSequenceNumberHandleError(resp)
 	}
-	result, err := client.updateSequenceNumberHandleResponse(resp)
-	if err != nil {
-		return PageBlobUpdateSequenceNumberResponse{}, err
-	}
-	return result, nil
+	return client.updateSequenceNumberHandleResponse(resp)
 }
 
 // updateSequenceNumberCreateRequest creates the UpdateSequenceNumber request.
@@ -902,11 +880,7 @@ func (client pageBlobClient) UploadPages(ctx context.Context, contentLength int6
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return PageBlobUploadPagesResponse{}, client.uploadPagesHandleError(resp)
 	}
-	result, err := client.uploadPagesHandleResponse(resp)
-	if err != nil {
-		return PageBlobUploadPagesResponse{}, err
-	}
-	return result, nil
+	return client.uploadPagesHandleResponse(resp)
 }
 
 // uploadPagesCreateRequest creates the UploadPages request.
@@ -1065,11 +1039,7 @@ func (client pageBlobClient) UploadPagesFromURL(ctx context.Context, sourceUrl u
 	if !resp.HasStatusCode(http.StatusCreated) {
 		return PageBlobUploadPagesFromURLResponse{}, client.uploadPagesFromUrlHandleError(resp)
 	}
-	result, err := client.uploadPagesFromUrlHandleResponse(resp)
-	if err != nil {
-		return PageBlobUploadPagesFromURLResponse{}, err
-	}
-	return result, nil
+	return client.uploadPagesFromUrlHandleResponse(resp)
 }
 
 // uploadPagesFromUrlCreateRequest creates the UploadPagesFromURL request.

--- a/test/storage/2019-07-07/azblob/zz_generated_service.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_service.go
@@ -37,11 +37,7 @@ func (client serviceClient) GetAccountInfo(ctx context.Context, options *Service
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceGetAccountInfoResponse{}, client.getAccountInfoHandleError(resp)
 	}
-	result, err := client.getAccountInfoHandleResponse(resp)
-	if err != nil {
-		return ServiceGetAccountInfoResponse{}, err
-	}
-	return result, nil
+	return client.getAccountInfoHandleResponse(resp)
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
@@ -85,6 +81,13 @@ func (client serviceClient) getAccountInfoHandleResponse(resp *azcore.Response) 
 	if val := resp.Header.Get("x-ms-account-kind"); val != "" {
 		result.AccountKind = (*AccountKind)(&val)
 	}
+	if val := resp.Header.Get("x-ms-is-hns-enabled"); val != "" {
+		isHierarchicalNamespaceEnabled, err := strconv.ParseBool(val)
+		if err != nil {
+			return ServiceGetAccountInfoResponse{}, err
+		}
+		result.IsHierarchicalNamespaceEnabled = &isHierarchicalNamespaceEnabled
+	}
 	return result, nil
 }
 
@@ -111,11 +114,7 @@ func (client serviceClient) GetProperties(ctx context.Context, options *ServiceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StorageServicePropertiesResponse{}, client.getPropertiesHandleError(resp)
 	}
-	result, err := client.getPropertiesHandleResponse(resp)
-	if err != nil {
-		return StorageServicePropertiesResponse{}, err
-	}
-	return result, nil
+	return client.getPropertiesHandleResponse(resp)
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
@@ -142,7 +141,11 @@ func (client serviceClient) getPropertiesCreateRequest(ctx context.Context, opti
 
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client serviceClient) getPropertiesHandleResponse(resp *azcore.Response) (StorageServicePropertiesResponse, error) {
-	result := StorageServicePropertiesResponse{RawResponse: resp.Response}
+	var val *StorageServiceProperties
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return StorageServicePropertiesResponse{}, err
+	}
+	result := StorageServicePropertiesResponse{RawResponse: resp.Response, StorageServiceProperties: val}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -152,8 +155,7 @@ func (client serviceClient) getPropertiesHandleResponse(resp *azcore.Response) (
 	if val := resp.Header.Get("x-ms-version"); val != "" {
 		result.Version = &val
 	}
-	err := resp.UnmarshalAsXML(&result.StorageServiceProperties)
-	return result, err
+	return result, nil
 }
 
 // getPropertiesHandleError handles the GetProperties error response.
@@ -179,11 +181,7 @@ func (client serviceClient) GetStatistics(ctx context.Context, options *ServiceG
 	if !resp.HasStatusCode(http.StatusOK) {
 		return StorageServiceStatsResponse{}, client.getStatisticsHandleError(resp)
 	}
-	result, err := client.getStatisticsHandleResponse(resp)
-	if err != nil {
-		return StorageServiceStatsResponse{}, err
-	}
-	return result, nil
+	return client.getStatisticsHandleResponse(resp)
 }
 
 // getStatisticsCreateRequest creates the GetStatistics request.
@@ -210,7 +208,11 @@ func (client serviceClient) getStatisticsCreateRequest(ctx context.Context, opti
 
 // getStatisticsHandleResponse handles the GetStatistics response.
 func (client serviceClient) getStatisticsHandleResponse(resp *azcore.Response) (StorageServiceStatsResponse, error) {
-	result := StorageServiceStatsResponse{RawResponse: resp.Response}
+	var val *StorageServiceStats
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return StorageServiceStatsResponse{}, err
+	}
+	result := StorageServiceStatsResponse{RawResponse: resp.Response, StorageServiceStats: val}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -227,8 +229,7 @@ func (client serviceClient) getStatisticsHandleResponse(resp *azcore.Response) (
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.StorageServiceStats)
-	return result, err
+	return result, nil
 }
 
 // getStatisticsHandleError handles the GetStatistics error response.
@@ -253,11 +254,7 @@ func (client serviceClient) GetUserDelegationKey(ctx context.Context, keyInfo Ke
 	if !resp.HasStatusCode(http.StatusOK) {
 		return UserDelegationKeyResponse{}, client.getUserDelegationKeyHandleError(resp)
 	}
-	result, err := client.getUserDelegationKeyHandleResponse(resp)
-	if err != nil {
-		return UserDelegationKeyResponse{}, err
-	}
-	return result, nil
+	return client.getUserDelegationKeyHandleResponse(resp)
 }
 
 // getUserDelegationKeyCreateRequest creates the GetUserDelegationKey request.
@@ -284,7 +281,11 @@ func (client serviceClient) getUserDelegationKeyCreateRequest(ctx context.Contex
 
 // getUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
 func (client serviceClient) getUserDelegationKeyHandleResponse(resp *azcore.Response) (UserDelegationKeyResponse, error) {
-	result := UserDelegationKeyResponse{RawResponse: resp.Response}
+	var val *UserDelegationKey
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return UserDelegationKeyResponse{}, err
+	}
+	result := UserDelegationKeyResponse{RawResponse: resp.Response, UserDelegationKey: val}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -301,8 +302,7 @@ func (client serviceClient) getUserDelegationKeyHandleResponse(resp *azcore.Resp
 		}
 		result.Date = &date
 	}
-	err := resp.UnmarshalAsXML(&result.UserDelegationKey)
-	return result, err
+	return result, nil
 }
 
 // getUserDelegationKeyHandleError handles the GetUserDelegationKey error response.
@@ -365,7 +365,11 @@ func (client serviceClient) listContainersSegmentCreateRequest(ctx context.Conte
 
 // listContainersSegmentHandleResponse handles the ListContainersSegment response.
 func (client serviceClient) listContainersSegmentHandleResponse(resp *azcore.Response) (ListContainersSegmentResponseResponse, error) {
-	result := ListContainersSegmentResponseResponse{RawResponse: resp.Response}
+	var val *ListContainersSegmentResponse
+	if err := resp.UnmarshalAsXML(&val); err != nil {
+		return ListContainersSegmentResponseResponse{}, err
+	}
+	result := ListContainersSegmentResponseResponse{RawResponse: resp.Response, EnumerationResults: val}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
 	}
@@ -375,8 +379,7 @@ func (client serviceClient) listContainersSegmentHandleResponse(resp *azcore.Res
 	if val := resp.Header.Get("x-ms-version"); val != "" {
 		result.Version = &val
 	}
-	err := resp.UnmarshalAsXML(&result.EnumerationResults)
-	return result, err
+	return result, nil
 }
 
 // listContainersSegmentHandleError handles the ListContainersSegment error response.
@@ -402,11 +405,7 @@ func (client serviceClient) SetProperties(ctx context.Context, storageServicePro
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return ServiceSetPropertiesResponse{}, client.setPropertiesHandleError(resp)
 	}
-	result, err := client.setPropertiesHandleResponse(resp)
-	if err != nil {
-		return ServiceSetPropertiesResponse{}, err
-	}
-	return result, nil
+	return client.setPropertiesHandleResponse(resp)
 }
 
 // setPropertiesCreateRequest creates the SetProperties request.
@@ -468,11 +467,7 @@ func (client serviceClient) SubmitBatch(ctx context.Context, contentLength int64
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ServiceSubmitBatchResponse{}, client.submitBatchHandleError(resp)
 	}
-	result, err := client.submitBatchHandleResponse(resp)
-	if err != nil {
-		return ServiceSubmitBatchResponse{}, err
-	}
-	return result, nil
+	return client.submitBatchHandleResponse(resp)
 }
 
 // submitBatchCreateRequest creates the SubmitBatch request.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools.go
@@ -37,11 +37,7 @@ func (client bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName string
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BigDataPoolResourceInfoResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return BigDataPoolResourceInfoResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -62,9 +58,11 @@ func (client bigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataPo
 
 // getHandleResponse handles the Get response.
 func (client bigDataPoolsClient) getHandleResponse(resp *azcore.Response) (BigDataPoolResourceInfoResponse, error) {
-	result := BigDataPoolResourceInfoResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BigDataPoolResourceInfo)
-	return result, err
+	var val *BigDataPoolResourceInfo
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BigDataPoolResourceInfoResponse{}, err
+	}
+	return BigDataPoolResourceInfoResponse{RawResponse: resp.Response, BigDataPoolResourceInfo: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -89,11 +87,7 @@ func (client bigDataPoolsClient) List(ctx context.Context, options *BigDataPools
 	if !resp.HasStatusCode(http.StatusOK) {
 		return BigDataPoolResourceInfoListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return BigDataPoolResourceInfoListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -113,9 +107,11 @@ func (client bigDataPoolsClient) listCreateRequest(ctx context.Context, options 
 
 // listHandleResponse handles the List response.
 func (client bigDataPoolsClient) listHandleResponse(resp *azcore.Response) (BigDataPoolResourceInfoListResultResponse, error) {
-	result := BigDataPoolResourceInfoListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.BigDataPoolResourceInfoListResult)
-	return result, err
+	var val *BigDataPoolResourceInfoListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return BigDataPoolResourceInfoListResultResponse{}, err
+	}
+	return BigDataPoolResourceInfoListResultResponse{RawResponse: resp.Response, BigDataPoolResourceInfoListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow.go
@@ -61,9 +61,11 @@ func (client dataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Con
 
 // createOrUpdateDataFlowHandleResponse handles the CreateOrUpdateDataFlow response.
 func (client dataFlowClient) createOrUpdateDataFlowHandleResponse(resp *azcore.Response) (DataFlowResourceResponse, error) {
-	result := DataFlowResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DataFlowResource)
-	return result, err
+	var val *DataFlowResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DataFlowResourceResponse{}, err
+	}
+	return DataFlowResourceResponse{RawResponse: resp.Response, DataFlowResource: val}, nil
 }
 
 // createOrUpdateDataFlowHandleError handles the CreateOrUpdateDataFlow error response.
@@ -129,11 +131,7 @@ func (client dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName strin
 	if !resp.HasStatusCode(http.StatusOK) {
 		return DataFlowResourceResponse{}, client.getDataFlowHandleError(resp)
 	}
-	result, err := client.getDataFlowHandleResponse(resp)
-	if err != nil {
-		return DataFlowResourceResponse{}, err
-	}
-	return result, nil
+	return client.getDataFlowHandleResponse(resp)
 }
 
 // getDataFlowCreateRequest creates the GetDataFlow request.
@@ -157,9 +155,11 @@ func (client dataFlowClient) getDataFlowCreateRequest(ctx context.Context, dataF
 
 // getDataFlowHandleResponse handles the GetDataFlow response.
 func (client dataFlowClient) getDataFlowHandleResponse(resp *azcore.Response) (DataFlowResourceResponse, error) {
-	result := DataFlowResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DataFlowResource)
-	return result, err
+	var val *DataFlowResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DataFlowResourceResponse{}, err
+	}
+	return DataFlowResourceResponse{RawResponse: resp.Response, DataFlowResource: val}, nil
 }
 
 // getDataFlowHandleError handles the GetDataFlow error response.
@@ -204,9 +204,11 @@ func (client dataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.Co
 
 // getDataFlowsByWorkspaceHandleResponse handles the GetDataFlowsByWorkspace response.
 func (client dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *azcore.Response) (DataFlowListResponseResponse, error) {
-	result := DataFlowListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DataFlowListResponse)
-	return result, err
+	var val *DataFlowListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DataFlowListResponseResponse{}, err
+	}
+	return DataFlowListResponseResponse{RawResponse: resp.Response, DataFlowListResponse: val}, nil
 }
 
 // getDataFlowsByWorkspaceHandleError handles the GetDataFlowsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession.go
@@ -35,11 +35,7 @@ func (client dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, reques
 	if !resp.HasStatusCode(http.StatusOK) {
 		return AddDataFlowToDebugSessionResponseResponse{}, client.addDataFlowHandleError(resp)
 	}
-	result, err := client.addDataFlowHandleResponse(resp)
-	if err != nil {
-		return AddDataFlowToDebugSessionResponseResponse{}, err
-	}
-	return result, nil
+	return client.addDataFlowHandleResponse(resp)
 }
 
 // addDataFlowCreateRequest creates the AddDataFlow request.
@@ -59,9 +55,11 @@ func (client dataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.Co
 
 // addDataFlowHandleResponse handles the AddDataFlow response.
 func (client dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *azcore.Response) (AddDataFlowToDebugSessionResponseResponse, error) {
-	result := AddDataFlowToDebugSessionResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.AddDataFlowToDebugSessionResponse)
-	return result, err
+	var val *AddDataFlowToDebugSessionResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return AddDataFlowToDebugSessionResponseResponse{}, err
+	}
+	return AddDataFlowToDebugSessionResponseResponse{RawResponse: resp.Response, AddDataFlowToDebugSessionResponse: val}, nil
 }
 
 // addDataFlowHandleError handles the AddDataFlow error response.
@@ -106,9 +104,11 @@ func (client dataFlowDebugSessionClient) createDataFlowDebugSessionCreateRequest
 
 // createDataFlowDebugSessionHandleResponse handles the CreateDataFlowDebugSession response.
 func (client dataFlowDebugSessionClient) createDataFlowDebugSessionHandleResponse(resp *azcore.Response) (CreateDataFlowDebugSessionResponseResponse, error) {
-	result := CreateDataFlowDebugSessionResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CreateDataFlowDebugSessionResponse)
-	return result, err
+	var val *CreateDataFlowDebugSessionResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CreateDataFlowDebugSessionResponseResponse{}, err
+	}
+	return CreateDataFlowDebugSessionResponseResponse{RawResponse: resp.Response, CreateDataFlowDebugSessionResponse: val}, nil
 }
 
 // createDataFlowDebugSessionHandleError handles the CreateDataFlowDebugSession error response.
@@ -193,9 +193,11 @@ func (client dataFlowDebugSessionClient) executeCommandCreateRequest(ctx context
 
 // executeCommandHandleResponse handles the ExecuteCommand response.
 func (client dataFlowDebugSessionClient) executeCommandHandleResponse(resp *azcore.Response) (DataFlowDebugCommandResponseResponse, error) {
-	result := DataFlowDebugCommandResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DataFlowDebugCommandResponse)
-	return result, err
+	var val *DataFlowDebugCommandResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DataFlowDebugCommandResponseResponse{}, err
+	}
+	return DataFlowDebugCommandResponseResponse{RawResponse: resp.Response, DataFlowDebugCommandResponse: val}, nil
 }
 
 // executeCommandHandleError handles the ExecuteCommand error response.
@@ -240,9 +242,11 @@ func (client dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceCr
 
 // queryDataFlowDebugSessionsByWorkspaceHandleResponse handles the QueryDataFlowDebugSessionsByWorkspace response.
 func (client dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp *azcore.Response) (QueryDataFlowDebugSessionsResponseResponse, error) {
-	result := QueryDataFlowDebugSessionsResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.QueryDataFlowDebugSessionsResponse)
-	return result, err
+	var val *QueryDataFlowDebugSessionsResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return QueryDataFlowDebugSessionsResponseResponse{}, err
+	}
+	return QueryDataFlowDebugSessionsResponseResponse{RawResponse: resp.Response, QueryDataFlowDebugSessionsResponse: val}, nil
 }
 
 // queryDataFlowDebugSessionsByWorkspaceHandleError handles the QueryDataFlowDebugSessionsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset.go
@@ -61,9 +61,11 @@ func (client datasetClient) createOrUpdateDatasetCreateRequest(ctx context.Conte
 
 // createOrUpdateDatasetHandleResponse handles the CreateOrUpdateDataset response.
 func (client datasetClient) createOrUpdateDatasetHandleResponse(resp *azcore.Response) (DatasetResourceResponse, error) {
-	result := DatasetResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DatasetResource)
-	return result, err
+	var val *DatasetResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DatasetResourceResponse{}, err
+	}
+	return DatasetResourceResponse{RawResponse: resp.Response, DatasetResource: val}, nil
 }
 
 // createOrUpdateDatasetHandleError handles the CreateOrUpdateDataset error response.
@@ -129,11 +131,7 @@ func (client datasetClient) GetDataset(ctx context.Context, datasetName string, 
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return DatasetResourceResponse{}, client.getDatasetHandleError(resp)
 	}
-	result, err := client.getDatasetHandleResponse(resp)
-	if err != nil {
-		return DatasetResourceResponse{}, err
-	}
-	return result, nil
+	return client.getDatasetHandleResponse(resp)
 }
 
 // getDatasetCreateRequest creates the GetDataset request.
@@ -157,9 +155,11 @@ func (client datasetClient) getDatasetCreateRequest(ctx context.Context, dataset
 
 // getDatasetHandleResponse handles the GetDataset response.
 func (client datasetClient) getDatasetHandleResponse(resp *azcore.Response) (DatasetResourceResponse, error) {
-	result := DatasetResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DatasetResource)
-	return result, err
+	var val *DatasetResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DatasetResourceResponse{}, err
+	}
+	return DatasetResourceResponse{RawResponse: resp.Response, DatasetResource: val}, nil
 }
 
 // getDatasetHandleError handles the GetDataset error response.
@@ -204,9 +204,11 @@ func (client datasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Cont
 
 // getDatasetsByWorkspaceHandleResponse handles the GetDatasetsByWorkspace response.
 func (client datasetClient) getDatasetsByWorkspaceHandleResponse(resp *azcore.Response) (DatasetListResponseResponse, error) {
-	result := DatasetListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.DatasetListResponse)
-	return result, err
+	var val *DatasetListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return DatasetListResponseResponse{}, err
+	}
+	return DatasetListResponseResponse{RawResponse: resp.Response, DatasetListResponse: val}, nil
 }
 
 // getDatasetsByWorkspaceHandleError handles the GetDatasetsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_enums.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_enums.go
@@ -96,21 +96,21 @@ func (c BigDataPoolReferenceType) ToPtr() *BigDataPoolReferenceType {
 	return &c
 }
 
-type BlobEventTypes string
+type BlobEventType string
 
 const (
-	BlobEventTypesMicrosoftStorageBlobCreated BlobEventTypes = "Microsoft.Storage.BlobCreated"
-	BlobEventTypesMicrosoftStorageBlobDeleted BlobEventTypes = "Microsoft.Storage.BlobDeleted"
+	BlobEventTypeMicrosoftStorageBlobCreated BlobEventType = "Microsoft.Storage.BlobCreated"
+	BlobEventTypeMicrosoftStorageBlobDeleted BlobEventType = "Microsoft.Storage.BlobDeleted"
 )
 
-func PossibleBlobEventTypesValues() []BlobEventTypes {
-	return []BlobEventTypes{
-		BlobEventTypesMicrosoftStorageBlobCreated,
-		BlobEventTypesMicrosoftStorageBlobDeleted,
+func PossibleBlobEventTypeValues() []BlobEventType {
+	return []BlobEventType{
+		BlobEventTypeMicrosoftStorageBlobCreated,
+		BlobEventTypeMicrosoftStorageBlobDeleted,
 	}
 }
 
-func (c BlobEventTypes) ToPtr() *BlobEventTypes {
+func (c BlobEventType) ToPtr() *BlobEventType {
 	return &c
 }
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes.go
@@ -37,11 +37,7 @@ func (client integrationRuntimesClient) Get(ctx context.Context, integrationRunt
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IntegrationRuntimeResourceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return IntegrationRuntimeResourceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -62,9 +58,11 @@ func (client integrationRuntimesClient) getCreateRequest(ctx context.Context, in
 
 // getHandleResponse handles the Get response.
 func (client integrationRuntimesClient) getHandleResponse(resp *azcore.Response) (IntegrationRuntimeResourceResponse, error) {
-	result := IntegrationRuntimeResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IntegrationRuntimeResource)
-	return result, err
+	var val *IntegrationRuntimeResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IntegrationRuntimeResourceResponse{}, err
+	}
+	return IntegrationRuntimeResourceResponse{RawResponse: resp.Response, IntegrationRuntimeResource: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -89,11 +87,7 @@ func (client integrationRuntimesClient) List(ctx context.Context, options *Integ
 	if !resp.HasStatusCode(http.StatusOK) {
 		return IntegrationRuntimeListResponseResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return IntegrationRuntimeListResponseResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -113,9 +107,11 @@ func (client integrationRuntimesClient) listCreateRequest(ctx context.Context, o
 
 // listHandleResponse handles the List response.
 func (client integrationRuntimesClient) listHandleResponse(resp *azcore.Response) (IntegrationRuntimeListResponseResponse, error) {
-	result := IntegrationRuntimeListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.IntegrationRuntimeListResponse)
-	return result, err
+	var val *IntegrationRuntimeListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return IntegrationRuntimeListResponseResponse{}, err
+	}
+	return IntegrationRuntimeListResponseResponse{RawResponse: resp.Response, IntegrationRuntimeListResponse: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice.go
@@ -61,9 +61,11 @@ func (client linkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx c
 
 // createOrUpdateLinkedServiceHandleResponse handles the CreateOrUpdateLinkedService response.
 func (client linkedServiceClient) createOrUpdateLinkedServiceHandleResponse(resp *azcore.Response) (LinkedServiceResourceResponse, error) {
-	result := LinkedServiceResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LinkedServiceResource)
-	return result, err
+	var val *LinkedServiceResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LinkedServiceResourceResponse{}, err
+	}
+	return LinkedServiceResourceResponse{RawResponse: resp.Response, LinkedServiceResource: val}, nil
 }
 
 // createOrUpdateLinkedServiceHandleError handles the CreateOrUpdateLinkedService error response.
@@ -129,11 +131,7 @@ func (client linkedServiceClient) GetLinkedService(ctx context.Context, linkedSe
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return LinkedServiceResourceResponse{}, client.getLinkedServiceHandleError(resp)
 	}
-	result, err := client.getLinkedServiceHandleResponse(resp)
-	if err != nil {
-		return LinkedServiceResourceResponse{}, err
-	}
-	return result, nil
+	return client.getLinkedServiceHandleResponse(resp)
 }
 
 // getLinkedServiceCreateRequest creates the GetLinkedService request.
@@ -157,9 +155,11 @@ func (client linkedServiceClient) getLinkedServiceCreateRequest(ctx context.Cont
 
 // getLinkedServiceHandleResponse handles the GetLinkedService response.
 func (client linkedServiceClient) getLinkedServiceHandleResponse(resp *azcore.Response) (LinkedServiceResourceResponse, error) {
-	result := LinkedServiceResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LinkedServiceResource)
-	return result, err
+	var val *LinkedServiceResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LinkedServiceResourceResponse{}, err
+	}
+	return LinkedServiceResourceResponse{RawResponse: resp.Response, LinkedServiceResource: val}, nil
 }
 
 // getLinkedServiceHandleError handles the GetLinkedService error response.
@@ -204,9 +204,11 @@ func (client linkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx 
 
 // getLinkedServicesByWorkspaceHandleResponse handles the GetLinkedServicesByWorkspace response.
 func (client linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(resp *azcore.Response) (LinkedServiceListResponseResponse, error) {
-	result := LinkedServiceListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.LinkedServiceListResponse)
-	return result, err
+	var val *LinkedServiceListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return LinkedServiceListResponseResponse{}, err
+	}
+	return LinkedServiceListResponseResponse{RawResponse: resp.Response, LinkedServiceListResponse: val}, nil
 }
 
 // getLinkedServicesByWorkspaceHandleError handles the GetLinkedServicesByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -6074,7 +6074,7 @@ type BlobEventsTriggerTypeProperties struct {
 	BlobPathEndsWith *string `json:"blobPathEndsWith,omitempty"`
 
 	// The type of events that cause this trigger to fire.
-	Events *[]BlobEventTypes `json:"events,omitempty"`
+	Events *[]BlobEventType `json:"events,omitempty"`
 
 	// If set to true, blobs with zero bytes will be ignored.
 	IgnoreEmptyBlobs *bool `json:"ignoreEmptyBlobs,omitempty"`
@@ -12249,7 +12249,8 @@ type ExecuteSsisPackageActivityTypeProperties struct {
 // - *AzureMLUpdateResourceActivity, *CopyActivity, *CustomActivity, *DataLakeAnalyticsUsqlActivity, *DatabricksNotebookActivity,
 // - *DatabricksSparkJarActivity, *DatabricksSparkPythonActivity, *DeleteActivity, *ExecuteDataFlowActivity, *ExecuteSsisPackageActivity,
 // - *GetMetadataActivity, *HDInsightHiveActivity, *HDInsightMapReduceActivity, *HDInsightPigActivity, *HDInsightSparkActivity,
-// - *HDInsightStreamingActivity, *LookupActivity, *SqlServerStoredProcedureActivity, *WebActivity
+// - *HDInsightStreamingActivity, *LookupActivity, *SynapseSparkJobDefinitionActivity, *SqlServerStoredProcedureActivity,
+// - *SynapseNotebookActivity, *WebActivity
 type ExecutionActivityClassification interface {
 	ActivityClassification
 	// GetExecutionActivity() returns the ExecutionActivity content of the underlying type.
@@ -31202,14 +31203,14 @@ type SybaseTableDatasetTypeProperties struct {
 
 // Execute Synapse notebook activity.
 type SynapseNotebookActivity struct {
-	Activity
+	ExecutionActivity
 	// Execute Synapse notebook activity properties.
 	TypeProperties *SynapseNotebookActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SynapseNotebookActivity.
 func (s SynapseNotebookActivity) MarshalJSON() ([]byte, error) {
-	objectMap := s.Activity.marshalInternal("SynapseNotebook")
+	objectMap := s.ExecutionActivity.marshalInternal("SynapseNotebook")
 	if s.TypeProperties != nil {
 		objectMap["typeProperties"] = s.TypeProperties
 	}
@@ -31235,7 +31236,7 @@ func (s *SynapseNotebookActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return s.Activity.unmarshalInternal(rawMsg)
+	return s.ExecutionActivity.unmarshalInternal(rawMsg)
 }
 
 // Execute Synapse notebook activity properties.
@@ -31264,14 +31265,14 @@ type SynapseSparkJobActivityTypeProperties struct {
 
 // Execute spark job activity.
 type SynapseSparkJobDefinitionActivity struct {
-	Activity
+	ExecutionActivity
 	// Execute spark job activity properties.
 	TypeProperties *SynapseSparkJobActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SynapseSparkJobDefinitionActivity.
 func (s SynapseSparkJobDefinitionActivity) MarshalJSON() ([]byte, error) {
-	objectMap := s.Activity.marshalInternal("SparkJob")
+	objectMap := s.ExecutionActivity.marshalInternal("SparkJob")
 	if s.TypeProperties != nil {
 		objectMap["typeProperties"] = s.TypeProperties
 	}
@@ -31297,7 +31298,7 @@ func (s *SynapseSparkJobDefinitionActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return s.Activity.unmarshalInternal(rawMsg)
+	return s.ExecutionActivity.unmarshalInternal(rawMsg)
 }
 
 // Synapse spark job reference type.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook.go
@@ -61,9 +61,11 @@ func (client notebookClient) createOrUpdateNotebookCreateRequest(ctx context.Con
 
 // createOrUpdateNotebookHandleResponse handles the CreateOrUpdateNotebook response.
 func (client notebookClient) createOrUpdateNotebookHandleResponse(resp *azcore.Response) (NotebookResourceResponse, error) {
-	result := NotebookResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NotebookResource)
-	return result, err
+	var val *NotebookResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NotebookResourceResponse{}, err
+	}
+	return NotebookResourceResponse{RawResponse: resp.Response, NotebookResource: val}, nil
 }
 
 // createOrUpdateNotebookHandleError handles the CreateOrUpdateNotebook error response.
@@ -129,11 +131,7 @@ func (client notebookClient) GetNotebook(ctx context.Context, notebookName strin
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return NotebookResourceResponse{}, client.getNotebookHandleError(resp)
 	}
-	result, err := client.getNotebookHandleResponse(resp)
-	if err != nil {
-		return NotebookResourceResponse{}, err
-	}
-	return result, nil
+	return client.getNotebookHandleResponse(resp)
 }
 
 // getNotebookCreateRequest creates the GetNotebook request.
@@ -157,9 +155,11 @@ func (client notebookClient) getNotebookCreateRequest(ctx context.Context, noteb
 
 // getNotebookHandleResponse handles the GetNotebook response.
 func (client notebookClient) getNotebookHandleResponse(resp *azcore.Response) (NotebookResourceResponse, error) {
-	result := NotebookResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NotebookResource)
-	return result, err
+	var val *NotebookResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NotebookResourceResponse{}, err
+	}
+	return NotebookResourceResponse{RawResponse: resp.Response, NotebookResource: val}, nil
 }
 
 // getNotebookHandleError handles the GetNotebook error response.
@@ -204,9 +204,11 @@ func (client notebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx cont
 
 // getNotebookSummaryByWorkSpaceHandleResponse handles the GetNotebookSummaryByWorkSpace response.
 func (client notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *azcore.Response) (NotebookListResponseResponse, error) {
-	result := NotebookListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NotebookListResponse)
-	return result, err
+	var val *NotebookListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NotebookListResponseResponse{}, err
+	}
+	return NotebookListResponseResponse{RawResponse: resp.Response, NotebookListResponse: val}, nil
 }
 
 // getNotebookSummaryByWorkSpaceHandleError handles the GetNotebookSummaryByWorkSpace error response.
@@ -251,9 +253,11 @@ func (client notebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.Co
 
 // getNotebooksByWorkspaceHandleResponse handles the GetNotebooksByWorkspace response.
 func (client notebookClient) getNotebooksByWorkspaceHandleResponse(resp *azcore.Response) (NotebookListResponseResponse, error) {
-	result := NotebookListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.NotebookListResponse)
-	return result, err
+	var val *NotebookListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return NotebookListResponseResponse{}, err
+	}
+	return NotebookListResponseResponse{RawResponse: resp.Response, NotebookListResponse: val}, nil
 }
 
 // getNotebooksByWorkspaceHandleError handles the GetNotebooksByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
@@ -62,9 +62,11 @@ func (client pipelineClient) createOrUpdatePipelineCreateRequest(ctx context.Con
 
 // createOrUpdatePipelineHandleResponse handles the CreateOrUpdatePipeline response.
 func (client pipelineClient) createOrUpdatePipelineHandleResponse(resp *azcore.Response) (PipelineResourceResponse, error) {
-	result := PipelineResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PipelineResource)
-	return result, err
+	var val *PipelineResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PipelineResourceResponse{}, err
+	}
+	return PipelineResourceResponse{RawResponse: resp.Response, PipelineResource: val}, nil
 }
 
 // createOrUpdatePipelineHandleError handles the CreateOrUpdatePipeline error response.
@@ -89,11 +91,7 @@ func (client pipelineClient) CreatePipelineRun(ctx context.Context, pipelineName
 	if !resp.HasStatusCode(http.StatusAccepted) {
 		return CreateRunResponseResponse{}, client.createPipelineRunHandleError(resp)
 	}
-	result, err := client.createPipelineRunHandleResponse(resp)
-	if err != nil {
-		return CreateRunResponseResponse{}, err
-	}
-	return result, nil
+	return client.createPipelineRunHandleResponse(resp)
 }
 
 // createPipelineRunCreateRequest creates the CreatePipelineRun request.
@@ -126,9 +124,11 @@ func (client pipelineClient) createPipelineRunCreateRequest(ctx context.Context,
 
 // createPipelineRunHandleResponse handles the CreatePipelineRun response.
 func (client pipelineClient) createPipelineRunHandleResponse(resp *azcore.Response) (CreateRunResponseResponse, error) {
-	result := CreateRunResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.CreateRunResponse)
-	return result, err
+	var val *CreateRunResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return CreateRunResponseResponse{}, err
+	}
+	return CreateRunResponseResponse{RawResponse: resp.Response, CreateRunResponse: val}, nil
 }
 
 // createPipelineRunHandleError handles the CreatePipelineRun error response.
@@ -194,11 +194,7 @@ func (client pipelineClient) GetPipeline(ctx context.Context, pipelineName strin
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return PipelineResourceResponse{}, client.getPipelineHandleError(resp)
 	}
-	result, err := client.getPipelineHandleResponse(resp)
-	if err != nil {
-		return PipelineResourceResponse{}, err
-	}
-	return result, nil
+	return client.getPipelineHandleResponse(resp)
 }
 
 // getPipelineCreateRequest creates the GetPipeline request.
@@ -222,9 +218,11 @@ func (client pipelineClient) getPipelineCreateRequest(ctx context.Context, pipel
 
 // getPipelineHandleResponse handles the GetPipeline response.
 func (client pipelineClient) getPipelineHandleResponse(resp *azcore.Response) (PipelineResourceResponse, error) {
-	result := PipelineResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PipelineResource)
-	return result, err
+	var val *PipelineResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PipelineResourceResponse{}, err
+	}
+	return PipelineResourceResponse{RawResponse: resp.Response, PipelineResource: val}, nil
 }
 
 // getPipelineHandleError handles the GetPipeline error response.
@@ -269,9 +267,11 @@ func (client pipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.Co
 
 // getPipelinesByWorkspaceHandleResponse handles the GetPipelinesByWorkspace response.
 func (client pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *azcore.Response) (PipelineListResponseResponse, error) {
-	result := PipelineListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PipelineListResponse)
-	return result, err
+	var val *PipelineListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PipelineListResponseResponse{}, err
+	}
+	return PipelineListResponseResponse{RawResponse: resp.Response, PipelineListResponse: val}, nil
 }
 
 // getPipelinesByWorkspaceHandleError handles the GetPipelinesByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun.go
@@ -82,11 +82,7 @@ func (client pipelineRunClient) GetPipelineRun(ctx context.Context, runId string
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PipelineRunResponse{}, client.getPipelineRunHandleError(resp)
 	}
-	result, err := client.getPipelineRunHandleResponse(resp)
-	if err != nil {
-		return PipelineRunResponse{}, err
-	}
-	return result, nil
+	return client.getPipelineRunHandleResponse(resp)
 }
 
 // getPipelineRunCreateRequest creates the GetPipelineRun request.
@@ -107,9 +103,11 @@ func (client pipelineRunClient) getPipelineRunCreateRequest(ctx context.Context,
 
 // getPipelineRunHandleResponse handles the GetPipelineRun response.
 func (client pipelineRunClient) getPipelineRunHandleResponse(resp *azcore.Response) (PipelineRunResponse, error) {
-	result := PipelineRunResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PipelineRun)
-	return result, err
+	var val *PipelineRun
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PipelineRunResponse{}, err
+	}
+	return PipelineRunResponse{RawResponse: resp.Response, PipelineRun: val}, nil
 }
 
 // getPipelineRunHandleError handles the GetPipelineRun error response.
@@ -134,11 +132,7 @@ func (client pipelineRunClient) QueryActivityRuns(ctx context.Context, pipelineN
 	if !resp.HasStatusCode(http.StatusOK) {
 		return ActivityRunsQueryResponseResponse{}, client.queryActivityRunsHandleError(resp)
 	}
-	result, err := client.queryActivityRunsHandleResponse(resp)
-	if err != nil {
-		return ActivityRunsQueryResponseResponse{}, err
-	}
-	return result, nil
+	return client.queryActivityRunsHandleResponse(resp)
 }
 
 // queryActivityRunsCreateRequest creates the QueryActivityRuns request.
@@ -160,9 +154,11 @@ func (client pipelineRunClient) queryActivityRunsCreateRequest(ctx context.Conte
 
 // queryActivityRunsHandleResponse handles the QueryActivityRuns response.
 func (client pipelineRunClient) queryActivityRunsHandleResponse(resp *azcore.Response) (ActivityRunsQueryResponseResponse, error) {
-	result := ActivityRunsQueryResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.ActivityRunsQueryResponse)
-	return result, err
+	var val *ActivityRunsQueryResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return ActivityRunsQueryResponseResponse{}, err
+	}
+	return ActivityRunsQueryResponseResponse{RawResponse: resp.Response, ActivityRunsQueryResponse: val}, nil
 }
 
 // queryActivityRunsHandleError handles the QueryActivityRuns error response.
@@ -187,11 +183,7 @@ func (client pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK) {
 		return PipelineRunsQueryResponseResponse{}, client.queryPipelineRunsByWorkspaceHandleError(resp)
 	}
-	result, err := client.queryPipelineRunsByWorkspaceHandleResponse(resp)
-	if err != nil {
-		return PipelineRunsQueryResponseResponse{}, err
-	}
-	return result, nil
+	return client.queryPipelineRunsByWorkspaceHandleResponse(resp)
 }
 
 // queryPipelineRunsByWorkspaceCreateRequest creates the QueryPipelineRunsByWorkspace request.
@@ -211,9 +203,11 @@ func (client pipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx co
 
 // queryPipelineRunsByWorkspaceHandleResponse handles the QueryPipelineRunsByWorkspace response.
 func (client pipelineRunClient) queryPipelineRunsByWorkspaceHandleResponse(resp *azcore.Response) (PipelineRunsQueryResponseResponse, error) {
-	result := PipelineRunsQueryResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.PipelineRunsQueryResponse)
-	return result, err
+	var val *PipelineRunsQueryResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return PipelineRunsQueryResponseResponse{}, err
+	}
+	return PipelineRunsQueryResponseResponse{RawResponse: resp.Response, PipelineRunsQueryResponse: val}, nil
 }
 
 // queryPipelineRunsByWorkspaceHandleError handles the QueryPipelineRunsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
@@ -165,8 +165,12 @@ func unmarshalExecutionActivityClassification(body []byte) (ExecutionActivityCla
 		b = &HdInsightStreamingActivity{}
 	case "Lookup":
 		b = &LookupActivity{}
+	case "SparkJob":
+		b = &SynapseSparkJobDefinitionActivity{}
 	case "SqlServerStoredProcedure":
 		b = &SQLServerStoredProcedureActivity{}
+	case "SynapseNotebook":
+		b = &SynapseNotebookActivity{}
 	case "WebActivity":
 		b = &WebActivity{}
 	default:

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition.go
@@ -37,11 +37,7 @@ func (client sparkJobDefinitionClient) CreateOrUpdateSparkJobDefinition(ctx cont
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkJobDefinitionResourceResponse{}, client.createOrUpdateSparkJobDefinitionHandleError(resp)
 	}
-	result, err := client.createOrUpdateSparkJobDefinitionHandleResponse(resp)
-	if err != nil {
-		return SparkJobDefinitionResourceResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateSparkJobDefinitionHandleResponse(resp)
 }
 
 // createOrUpdateSparkJobDefinitionCreateRequest creates the CreateOrUpdateSparkJobDefinition request.
@@ -65,9 +61,11 @@ func (client sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateReq
 
 // createOrUpdateSparkJobDefinitionHandleResponse handles the CreateOrUpdateSparkJobDefinition response.
 func (client sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkJobDefinitionResourceResponse, error) {
-	result := SparkJobDefinitionResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkJobDefinitionResource)
-	return result, err
+	var val *SparkJobDefinitionResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkJobDefinitionResourceResponse{}, err
+	}
+	return SparkJobDefinitionResourceResponse{RawResponse: resp.Response, SparkJobDefinitionResource: val}, nil
 }
 
 // createOrUpdateSparkJobDefinitionHandleError handles the CreateOrUpdateSparkJobDefinition error response.
@@ -112,9 +110,11 @@ func (client sparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx 
 
 // debugSparkJobDefinitionHandleResponse handles the DebugSparkJobDefinition response.
 func (client sparkJobDefinitionClient) debugSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	result := SparkBatchJobResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkBatchJob)
-	return result, err
+	var val *SparkBatchJob
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // debugSparkJobDefinitionHandleError handles the DebugSparkJobDefinition error response.
@@ -201,9 +201,11 @@ func (client sparkJobDefinitionClient) executeSparkJobDefinitionCreateRequest(ct
 
 // executeSparkJobDefinitionHandleResponse handles the ExecuteSparkJobDefinition response.
 func (client sparkJobDefinitionClient) executeSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	result := SparkBatchJobResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkBatchJob)
-	return result, err
+	var val *SparkBatchJob
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // executeSparkJobDefinitionHandleError handles the ExecuteSparkJobDefinition error response.
@@ -228,11 +230,7 @@ func (client sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Context
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return SparkJobDefinitionResourceResponse{}, client.getSparkJobDefinitionHandleError(resp)
 	}
-	result, err := client.getSparkJobDefinitionHandleResponse(resp)
-	if err != nil {
-		return SparkJobDefinitionResourceResponse{}, err
-	}
-	return result, nil
+	return client.getSparkJobDefinitionHandleResponse(resp)
 }
 
 // getSparkJobDefinitionCreateRequest creates the GetSparkJobDefinition request.
@@ -256,9 +254,11 @@ func (client sparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx co
 
 // getSparkJobDefinitionHandleResponse handles the GetSparkJobDefinition response.
 func (client sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkJobDefinitionResourceResponse, error) {
-	result := SparkJobDefinitionResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkJobDefinitionResource)
-	return result, err
+	var val *SparkJobDefinitionResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkJobDefinitionResourceResponse{}, err
+	}
+	return SparkJobDefinitionResourceResponse{RawResponse: resp.Response, SparkJobDefinitionResource: val}, nil
 }
 
 // getSparkJobDefinitionHandleError handles the GetSparkJobDefinition error response.
@@ -303,9 +303,11 @@ func (client sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateRe
 
 // getSparkJobDefinitionsByWorkspaceHandleResponse handles the GetSparkJobDefinitionsByWorkspace response.
 func (client sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleResponse(resp *azcore.Response) (SparkJobDefinitionsListResponseResponse, error) {
-	result := SparkJobDefinitionsListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkJobDefinitionsListResponse)
-	return result, err
+	var val *SparkJobDefinitionsListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkJobDefinitionsListResponseResponse{}, err
+	}
+	return SparkJobDefinitionsListResponseResponse{RawResponse: resp.Response, SparkJobDefinitionsListResponse: val}, nil
 }
 
 // getSparkJobDefinitionsByWorkspaceHandleError handles the GetSparkJobDefinitionsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools.go
@@ -37,11 +37,7 @@ func (client sqlPoolsClient) Get(ctx context.Context, sqlPoolName string, option
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SQLPoolResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return SQLPoolResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -62,9 +58,11 @@ func (client sqlPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName s
 
 // getHandleResponse handles the Get response.
 func (client sqlPoolsClient) getHandleResponse(resp *azcore.Response) (SQLPoolResponse, error) {
-	result := SQLPoolResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SQLPool)
-	return result, err
+	var val *SQLPool
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SQLPoolResponse{}, err
+	}
+	return SQLPoolResponse{RawResponse: resp.Response, SQLPool: val}, nil
 }
 
 // getHandleError handles the Get error response.
@@ -89,11 +87,7 @@ func (client sqlPoolsClient) List(ctx context.Context, options *SQLPoolsListOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SQLPoolInfoListResultResponse{}, client.listHandleError(resp)
 	}
-	result, err := client.listHandleResponse(resp)
-	if err != nil {
-		return SQLPoolInfoListResultResponse{}, err
-	}
-	return result, nil
+	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
@@ -113,9 +107,11 @@ func (client sqlPoolsClient) listCreateRequest(ctx context.Context, options *SQL
 
 // listHandleResponse handles the List response.
 func (client sqlPoolsClient) listHandleResponse(resp *azcore.Response) (SQLPoolInfoListResultResponse, error) {
-	result := SQLPoolInfoListResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SQLPoolInfoListResult)
-	return result, err
+	var val *SQLPoolInfoListResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SQLPoolInfoListResultResponse{}, err
+	}
+	return SQLPoolInfoListResultResponse{RawResponse: resp.Response, SQLPoolInfoListResult: val}, nil
 }
 
 // listHandleError handles the List error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript.go
@@ -37,11 +37,7 @@ func (client sqlScriptClient) CreateOrUpdateSQLScript(ctx context.Context, sqlSc
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SQLScriptResourceResponse{}, client.createOrUpdateSqlScriptHandleError(resp)
 	}
-	result, err := client.createOrUpdateSqlScriptHandleResponse(resp)
-	if err != nil {
-		return SQLScriptResourceResponse{}, err
-	}
-	return result, nil
+	return client.createOrUpdateSqlScriptHandleResponse(resp)
 }
 
 // createOrUpdateSqlScriptCreateRequest creates the CreateOrUpdateSQLScript request.
@@ -65,9 +61,11 @@ func (client sqlScriptClient) createOrUpdateSqlScriptCreateRequest(ctx context.C
 
 // createOrUpdateSqlScriptHandleResponse handles the CreateOrUpdateSQLScript response.
 func (client sqlScriptClient) createOrUpdateSqlScriptHandleResponse(resp *azcore.Response) (SQLScriptResourceResponse, error) {
-	result := SQLScriptResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SQLScriptResource)
-	return result, err
+	var val *SQLScriptResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SQLScriptResourceResponse{}, err
+	}
+	return SQLScriptResourceResponse{RawResponse: resp.Response, SQLScriptResource: val}, nil
 }
 
 // createOrUpdateSqlScriptHandleError handles the CreateOrUpdateSQLScript error response.
@@ -133,11 +131,7 @@ func (client sqlScriptClient) GetSQLScript(ctx context.Context, sqlScriptName st
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return SQLScriptResourceResponse{}, client.getSqlScriptHandleError(resp)
 	}
-	result, err := client.getSqlScriptHandleResponse(resp)
-	if err != nil {
-		return SQLScriptResourceResponse{}, err
-	}
-	return result, nil
+	return client.getSqlScriptHandleResponse(resp)
 }
 
 // getSqlScriptCreateRequest creates the GetSQLScript request.
@@ -161,9 +155,11 @@ func (client sqlScriptClient) getSqlScriptCreateRequest(ctx context.Context, sql
 
 // getSqlScriptHandleResponse handles the GetSQLScript response.
 func (client sqlScriptClient) getSqlScriptHandleResponse(resp *azcore.Response) (SQLScriptResourceResponse, error) {
-	result := SQLScriptResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SQLScriptResource)
-	return result, err
+	var val *SQLScriptResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SQLScriptResourceResponse{}, err
+	}
+	return SQLScriptResourceResponse{RawResponse: resp.Response, SQLScriptResource: val}, nil
 }
 
 // getSqlScriptHandleError handles the GetSQLScript error response.
@@ -208,9 +204,11 @@ func (client sqlScriptClient) getSqlScriptsByWorkspaceCreateRequest(ctx context.
 
 // getSqlScriptsByWorkspaceHandleResponse handles the GetSQLScriptsByWorkspace response.
 func (client sqlScriptClient) getSqlScriptsByWorkspaceHandleResponse(resp *azcore.Response) (SQLScriptsListResponseResponse, error) {
-	result := SQLScriptsListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SQLScriptsListResponse)
-	return result, err
+	var val *SQLScriptsListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SQLScriptsListResponseResponse{}, err
+	}
+	return SQLScriptsListResponseResponse{RawResponse: resp.Response, SQLScriptsListResponse: val}, nil
 }
 
 // getSqlScriptsByWorkspaceHandleError handles the GetSQLScriptsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger.go
@@ -61,9 +61,11 @@ func (client triggerClient) createOrUpdateTriggerCreateRequest(ctx context.Conte
 
 // createOrUpdateTriggerHandleResponse handles the CreateOrUpdateTrigger response.
 func (client triggerClient) createOrUpdateTriggerHandleResponse(resp *azcore.Response) (TriggerResourceResponse, error) {
-	result := TriggerResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerResource)
-	return result, err
+	var val *TriggerResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerResourceResponse{}, err
+	}
+	return TriggerResourceResponse{RawResponse: resp.Response, TriggerResource: val}, nil
 }
 
 // createOrUpdateTriggerHandleError handles the CreateOrUpdateTrigger error response.
@@ -129,11 +131,7 @@ func (client triggerClient) GetEventSubscriptionStatus(ctx context.Context, trig
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TriggerSubscriptionOperationStatusResponse{}, client.getEventSubscriptionStatusHandleError(resp)
 	}
-	result, err := client.getEventSubscriptionStatusHandleResponse(resp)
-	if err != nil {
-		return TriggerSubscriptionOperationStatusResponse{}, err
-	}
-	return result, nil
+	return client.getEventSubscriptionStatusHandleResponse(resp)
 }
 
 // getEventSubscriptionStatusCreateRequest creates the GetEventSubscriptionStatus request.
@@ -154,9 +152,11 @@ func (client triggerClient) getEventSubscriptionStatusCreateRequest(ctx context.
 
 // getEventSubscriptionStatusHandleResponse handles the GetEventSubscriptionStatus response.
 func (client triggerClient) getEventSubscriptionStatusHandleResponse(resp *azcore.Response) (TriggerSubscriptionOperationStatusResponse, error) {
-	result := TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerSubscriptionOperationStatus)
-	return result, err
+	var val *TriggerSubscriptionOperationStatus
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerSubscriptionOperationStatusResponse{}, err
+	}
+	return TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response, TriggerSubscriptionOperationStatus: val}, nil
 }
 
 // getEventSubscriptionStatusHandleError handles the GetEventSubscriptionStatus error response.
@@ -181,11 +181,7 @@ func (client triggerClient) GetTrigger(ctx context.Context, triggerName string, 
 	if !resp.HasStatusCode(http.StatusOK, http.StatusNotModified) {
 		return TriggerResourceResponse{}, client.getTriggerHandleError(resp)
 	}
-	result, err := client.getTriggerHandleResponse(resp)
-	if err != nil {
-		return TriggerResourceResponse{}, err
-	}
-	return result, nil
+	return client.getTriggerHandleResponse(resp)
 }
 
 // getTriggerCreateRequest creates the GetTrigger request.
@@ -209,9 +205,11 @@ func (client triggerClient) getTriggerCreateRequest(ctx context.Context, trigger
 
 // getTriggerHandleResponse handles the GetTrigger response.
 func (client triggerClient) getTriggerHandleResponse(resp *azcore.Response) (TriggerResourceResponse, error) {
-	result := TriggerResourceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerResource)
-	return result, err
+	var val *TriggerResource
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerResourceResponse{}, err
+	}
+	return TriggerResourceResponse{RawResponse: resp.Response, TriggerResource: val}, nil
 }
 
 // getTriggerHandleError handles the GetTrigger error response.
@@ -256,9 +254,11 @@ func (client triggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Cont
 
 // getTriggersByWorkspaceHandleResponse handles the GetTriggersByWorkspace response.
 func (client triggerClient) getTriggersByWorkspaceHandleResponse(resp *azcore.Response) (TriggerListResponseResponse, error) {
-	result := TriggerListResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerListResponse)
-	return result, err
+	var val *TriggerListResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerListResponseResponse{}, err
+	}
+	return TriggerListResponseResponse{RawResponse: resp.Response, TriggerListResponse: val}, nil
 }
 
 // getTriggersByWorkspaceHandleError handles the GetTriggersByWorkspace error response.
@@ -386,9 +386,11 @@ func (client triggerClient) subscribeTriggerToEventsCreateRequest(ctx context.Co
 
 // subscribeTriggerToEventsHandleResponse handles the SubscribeTriggerToEvents response.
 func (client triggerClient) subscribeTriggerToEventsHandleResponse(resp *azcore.Response) (TriggerSubscriptionOperationStatusResponse, error) {
-	result := TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerSubscriptionOperationStatus)
-	return result, err
+	var val *TriggerSubscriptionOperationStatus
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerSubscriptionOperationStatusResponse{}, err
+	}
+	return TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response, TriggerSubscriptionOperationStatus: val}, nil
 }
 
 // subscribeTriggerToEventsHandleError handles the SubscribeTriggerToEvents error response.
@@ -434,9 +436,11 @@ func (client triggerClient) unsubscribeTriggerFromEventsCreateRequest(ctx contex
 
 // unsubscribeTriggerFromEventsHandleResponse handles the UnsubscribeTriggerFromEvents response.
 func (client triggerClient) unsubscribeTriggerFromEventsHandleResponse(resp *azcore.Response) (TriggerSubscriptionOperationStatusResponse, error) {
-	result := TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerSubscriptionOperationStatus)
-	return result, err
+	var val *TriggerSubscriptionOperationStatus
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerSubscriptionOperationStatusResponse{}, err
+	}
+	return TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response, TriggerSubscriptionOperationStatus: val}, nil
 }
 
 // unsubscribeTriggerFromEventsHandleError handles the UnsubscribeTriggerFromEvents error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun.go
@@ -79,11 +79,7 @@ func (client triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context, 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return TriggerRunsQueryResponseResponse{}, client.queryTriggerRunsByWorkspaceHandleError(resp)
 	}
-	result, err := client.queryTriggerRunsByWorkspaceHandleResponse(resp)
-	if err != nil {
-		return TriggerRunsQueryResponseResponse{}, err
-	}
-	return result, nil
+	return client.queryTriggerRunsByWorkspaceHandleResponse(resp)
 }
 
 // queryTriggerRunsByWorkspaceCreateRequest creates the QueryTriggerRunsByWorkspace request.
@@ -103,9 +99,11 @@ func (client triggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx cont
 
 // queryTriggerRunsByWorkspaceHandleResponse handles the QueryTriggerRunsByWorkspace response.
 func (client triggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *azcore.Response) (TriggerRunsQueryResponseResponse, error) {
-	result := TriggerRunsQueryResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.TriggerRunsQueryResponse)
-	return result, err
+	var val *TriggerRunsQueryResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return TriggerRunsQueryResponseResponse{}, err
+	}
+	return TriggerRunsQueryResponseResponse{RawResponse: resp.Response, TriggerRunsQueryResponse: val}, nil
 }
 
 // queryTriggerRunsByWorkspaceHandleError handles the QueryTriggerRunsByWorkspace error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace.go
@@ -35,11 +35,7 @@ func (client workspaceClient) Get(ctx context.Context, options *WorkspaceGetOpti
 	if !resp.HasStatusCode(http.StatusOK) {
 		return WorkspaceResponse{}, client.getHandleError(resp)
 	}
-	result, err := client.getHandleResponse(resp)
-	if err != nil {
-		return WorkspaceResponse{}, err
-	}
-	return result, nil
+	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
@@ -59,9 +55,11 @@ func (client workspaceClient) getCreateRequest(ctx context.Context, options *Wor
 
 // getHandleResponse handles the Get response.
 func (client workspaceClient) getHandleResponse(resp *azcore.Response) (WorkspaceResponse, error) {
-	result := WorkspaceResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.Workspace)
-	return result, err
+	var val *Workspace
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return WorkspaceResponse{}, err
+	}
+	return WorkspaceResponse{RawResponse: resp.Response, Workspace: val}, nil
 }
 
 // getHandleError handles the Get error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement.go
@@ -38,11 +38,7 @@ func (client workspaceGitRepoManagementClient) GetGitHubAccessToken(ctx context.
 	if !resp.HasStatusCode(http.StatusOK) {
 		return GitHubAccessTokenResponseResponse{}, client.getGitHubAccessTokenHandleError(resp)
 	}
-	result, err := client.getGitHubAccessTokenHandleResponse(resp)
-	if err != nil {
-		return GitHubAccessTokenResponseResponse{}, err
-	}
-	return result, nil
+	return client.getGitHubAccessTokenHandleResponse(resp)
 }
 
 // getGitHubAccessTokenCreateRequest creates the GetGitHubAccessToken request.
@@ -65,9 +61,11 @@ func (client workspaceGitRepoManagementClient) getGitHubAccessTokenCreateRequest
 
 // getGitHubAccessTokenHandleResponse handles the GetGitHubAccessToken response.
 func (client workspaceGitRepoManagementClient) getGitHubAccessTokenHandleResponse(resp *azcore.Response) (GitHubAccessTokenResponseResponse, error) {
-	result := GitHubAccessTokenResponseResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.GitHubAccessTokenResponse)
-	return result, err
+	var val *GitHubAccessTokenResponse
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return GitHubAccessTokenResponseResponse{}, err
+	}
+	return GitHubAccessTokenResponseResponse{RawResponse: resp.Response, GitHubAccessTokenResponse: val}, nil
 }
 
 // getGitHubAccessTokenHandleError handles the GetGitHubAccessToken error response.

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch.go
@@ -81,11 +81,7 @@ func (client sparkBatchClient) CreateSparkBatchJob(ctx context.Context, sparkBat
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkBatchJobResponse{}, client.createSparkBatchJobHandleError(resp)
 	}
-	result, err := client.createSparkBatchJobHandleResponse(resp)
-	if err != nil {
-		return SparkBatchJobResponse{}, err
-	}
-	return result, nil
+	return client.createSparkBatchJobHandleResponse(resp)
 }
 
 // createSparkBatchJobCreateRequest creates the CreateSparkBatchJob request.
@@ -107,9 +103,11 @@ func (client sparkBatchClient) createSparkBatchJobCreateRequest(ctx context.Cont
 
 // createSparkBatchJobHandleResponse handles the CreateSparkBatchJob response.
 func (client sparkBatchClient) createSparkBatchJobHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	result := SparkBatchJobResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkBatchJob)
-	return result, err
+	var val *SparkBatchJob
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // createSparkBatchJobHandleError handles the CreateSparkBatchJob error response.
@@ -137,11 +135,7 @@ func (client sparkBatchClient) GetSparkBatchJob(ctx context.Context, batchId int
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkBatchJobResponse{}, client.getSparkBatchJobHandleError(resp)
 	}
-	result, err := client.getSparkBatchJobHandleResponse(resp)
-	if err != nil {
-		return SparkBatchJobResponse{}, err
-	}
-	return result, nil
+	return client.getSparkBatchJobHandleResponse(resp)
 }
 
 // getSparkBatchJobCreateRequest creates the GetSparkBatchJob request.
@@ -164,9 +158,11 @@ func (client sparkBatchClient) getSparkBatchJobCreateRequest(ctx context.Context
 
 // getSparkBatchJobHandleResponse handles the GetSparkBatchJob response.
 func (client sparkBatchClient) getSparkBatchJobHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	result := SparkBatchJobResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkBatchJob)
-	return result, err
+	var val *SparkBatchJob
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // getSparkBatchJobHandleError handles the GetSparkBatchJob error response.
@@ -194,11 +190,7 @@ func (client sparkBatchClient) GetSparkBatchJobs(ctx context.Context, options *S
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkBatchJobCollectionResponse{}, client.getSparkBatchJobsHandleError(resp)
 	}
-	result, err := client.getSparkBatchJobsHandleResponse(resp)
-	if err != nil {
-		return SparkBatchJobCollectionResponse{}, err
-	}
-	return result, nil
+	return client.getSparkBatchJobsHandleResponse(resp)
 }
 
 // getSparkBatchJobsCreateRequest creates the GetSparkBatchJobs request.
@@ -226,9 +218,11 @@ func (client sparkBatchClient) getSparkBatchJobsCreateRequest(ctx context.Contex
 
 // getSparkBatchJobsHandleResponse handles the GetSparkBatchJobs response.
 func (client sparkBatchClient) getSparkBatchJobsHandleResponse(resp *azcore.Response) (SparkBatchJobCollectionResponse, error) {
-	result := SparkBatchJobCollectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkBatchJobCollection)
-	return result, err
+	var val *SparkBatchJobCollection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkBatchJobCollectionResponse{}, err
+	}
+	return SparkBatchJobCollectionResponse{RawResponse: resp.Response, SparkBatchJobCollection: val}, nil
 }
 
 // getSparkBatchJobsHandleError handles the GetSparkBatchJobs error response.

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparksession.go
@@ -81,11 +81,7 @@ func (client sparkSessionClient) CancelSparkStatement(ctx context.Context, sessi
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkStatementCancellationResultResponse{}, client.cancelSparkStatementHandleError(resp)
 	}
-	result, err := client.cancelSparkStatementHandleResponse(resp)
-	if err != nil {
-		return SparkStatementCancellationResultResponse{}, err
-	}
-	return result, nil
+	return client.cancelSparkStatementHandleResponse(resp)
 }
 
 // cancelSparkStatementCreateRequest creates the CancelSparkStatement request.
@@ -104,9 +100,11 @@ func (client sparkSessionClient) cancelSparkStatementCreateRequest(ctx context.C
 
 // cancelSparkStatementHandleResponse handles the CancelSparkStatement response.
 func (client sparkSessionClient) cancelSparkStatementHandleResponse(resp *azcore.Response) (SparkStatementCancellationResultResponse, error) {
-	result := SparkStatementCancellationResultResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkStatementCancellationResult)
-	return result, err
+	var val *SparkStatementCancellationResult
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkStatementCancellationResultResponse{}, err
+	}
+	return SparkStatementCancellationResultResponse{RawResponse: resp.Response, SparkStatementCancellationResult: val}, nil
 }
 
 // cancelSparkStatementHandleError handles the CancelSparkStatement error response.
@@ -134,11 +132,7 @@ func (client sparkSessionClient) CreateSparkSession(ctx context.Context, sparkSe
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkSessionResponse{}, client.createSparkSessionHandleError(resp)
 	}
-	result, err := client.createSparkSessionHandleResponse(resp)
-	if err != nil {
-		return SparkSessionResponse{}, err
-	}
-	return result, nil
+	return client.createSparkSessionHandleResponse(resp)
 }
 
 // createSparkSessionCreateRequest creates the CreateSparkSession request.
@@ -160,9 +154,11 @@ func (client sparkSessionClient) createSparkSessionCreateRequest(ctx context.Con
 
 // createSparkSessionHandleResponse handles the CreateSparkSession response.
 func (client sparkSessionClient) createSparkSessionHandleResponse(resp *azcore.Response) (SparkSessionResponse, error) {
-	result := SparkSessionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkSession)
-	return result, err
+	var val *SparkSession
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkSessionResponse{}, err
+	}
+	return SparkSessionResponse{RawResponse: resp.Response, SparkSession: val}, nil
 }
 
 // createSparkSessionHandleError handles the CreateSparkSession error response.
@@ -190,11 +186,7 @@ func (client sparkSessionClient) CreateSparkStatement(ctx context.Context, sessi
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkStatementResponse{}, client.createSparkStatementHandleError(resp)
 	}
-	result, err := client.createSparkStatementHandleResponse(resp)
-	if err != nil {
-		return SparkStatementResponse{}, err
-	}
-	return result, nil
+	return client.createSparkStatementHandleResponse(resp)
 }
 
 // createSparkStatementCreateRequest creates the CreateSparkStatement request.
@@ -212,9 +204,11 @@ func (client sparkSessionClient) createSparkStatementCreateRequest(ctx context.C
 
 // createSparkStatementHandleResponse handles the CreateSparkStatement response.
 func (client sparkSessionClient) createSparkStatementHandleResponse(resp *azcore.Response) (SparkStatementResponse, error) {
-	result := SparkStatementResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkStatement)
-	return result, err
+	var val *SparkStatement
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkStatementResponse{}, err
+	}
+	return SparkStatementResponse{RawResponse: resp.Response, SparkStatement: val}, nil
 }
 
 // createSparkStatementHandleError handles the CreateSparkStatement error response.
@@ -242,11 +236,7 @@ func (client sparkSessionClient) GetSparkSession(ctx context.Context, sessionId 
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkSessionResponse{}, client.getSparkSessionHandleError(resp)
 	}
-	result, err := client.getSparkSessionHandleResponse(resp)
-	if err != nil {
-		return SparkSessionResponse{}, err
-	}
-	return result, nil
+	return client.getSparkSessionHandleResponse(resp)
 }
 
 // getSparkSessionCreateRequest creates the GetSparkSession request.
@@ -269,9 +259,11 @@ func (client sparkSessionClient) getSparkSessionCreateRequest(ctx context.Contex
 
 // getSparkSessionHandleResponse handles the GetSparkSession response.
 func (client sparkSessionClient) getSparkSessionHandleResponse(resp *azcore.Response) (SparkSessionResponse, error) {
-	result := SparkSessionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkSession)
-	return result, err
+	var val *SparkSession
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkSessionResponse{}, err
+	}
+	return SparkSessionResponse{RawResponse: resp.Response, SparkSession: val}, nil
 }
 
 // getSparkSessionHandleError handles the GetSparkSession error response.
@@ -299,11 +291,7 @@ func (client sparkSessionClient) GetSparkSessions(ctx context.Context, options *
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkSessionCollectionResponse{}, client.getSparkSessionsHandleError(resp)
 	}
-	result, err := client.getSparkSessionsHandleResponse(resp)
-	if err != nil {
-		return SparkSessionCollectionResponse{}, err
-	}
-	return result, nil
+	return client.getSparkSessionsHandleResponse(resp)
 }
 
 // getSparkSessionsCreateRequest creates the GetSparkSessions request.
@@ -331,9 +319,11 @@ func (client sparkSessionClient) getSparkSessionsCreateRequest(ctx context.Conte
 
 // getSparkSessionsHandleResponse handles the GetSparkSessions response.
 func (client sparkSessionClient) getSparkSessionsHandleResponse(resp *azcore.Response) (SparkSessionCollectionResponse, error) {
-	result := SparkSessionCollectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkSessionCollection)
-	return result, err
+	var val *SparkSessionCollection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkSessionCollectionResponse{}, err
+	}
+	return SparkSessionCollectionResponse{RawResponse: resp.Response, SparkSessionCollection: val}, nil
 }
 
 // getSparkSessionsHandleError handles the GetSparkSessions error response.
@@ -361,11 +351,7 @@ func (client sparkSessionClient) GetSparkStatement(ctx context.Context, sessionI
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkStatementResponse{}, client.getSparkStatementHandleError(resp)
 	}
-	result, err := client.getSparkStatementHandleResponse(resp)
-	if err != nil {
-		return SparkStatementResponse{}, err
-	}
-	return result, nil
+	return client.getSparkStatementHandleResponse(resp)
 }
 
 // getSparkStatementCreateRequest creates the GetSparkStatement request.
@@ -384,9 +370,11 @@ func (client sparkSessionClient) getSparkStatementCreateRequest(ctx context.Cont
 
 // getSparkStatementHandleResponse handles the GetSparkStatement response.
 func (client sparkSessionClient) getSparkStatementHandleResponse(resp *azcore.Response) (SparkStatementResponse, error) {
-	result := SparkStatementResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkStatement)
-	return result, err
+	var val *SparkStatement
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkStatementResponse{}, err
+	}
+	return SparkStatementResponse{RawResponse: resp.Response, SparkStatement: val}, nil
 }
 
 // getSparkStatementHandleError handles the GetSparkStatement error response.
@@ -414,11 +402,7 @@ func (client sparkSessionClient) GetSparkStatements(ctx context.Context, session
 	if !resp.HasStatusCode(http.StatusOK) {
 		return SparkStatementCollectionResponse{}, client.getSparkStatementsHandleError(resp)
 	}
-	result, err := client.getSparkStatementsHandleResponse(resp)
-	if err != nil {
-		return SparkStatementCollectionResponse{}, err
-	}
-	return result, nil
+	return client.getSparkStatementsHandleResponse(resp)
 }
 
 // getSparkStatementsCreateRequest creates the GetSparkStatements request.
@@ -436,9 +420,11 @@ func (client sparkSessionClient) getSparkStatementsCreateRequest(ctx context.Con
 
 // getSparkStatementsHandleResponse handles the GetSparkStatements response.
 func (client sparkSessionClient) getSparkStatementsHandleResponse(resp *azcore.Response) (SparkStatementCollectionResponse, error) {
-	result := SparkStatementCollectionResponse{RawResponse: resp.Response}
-	err := resp.UnmarshalAsJSON(&result.SparkStatementCollection)
-	return result, err
+	var val *SparkStatementCollection
+	if err := resp.UnmarshalAsJSON(&val); err != nil {
+		return SparkStatementCollectionResponse{}, err
+	}
+	return SparkStatementCollectionResponse{RawResponse: resp.Response, SparkStatementCollection: val}, nil
 }
 
 // getSparkStatementsHandleError handles the GetSparkStatements error response.


### PR DESCRIPTION
To avoid allocating response envelopes on the heap, unmarshall into a
temporary variable.