### PR TITLE
Add support to build autorest.go with NodeJS version > 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -306,3 +306,5 @@ package/
 *.tgz
 src/obj/
 *.log
+
+**/npm-shrinkwrap.json

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "publish-preview": "gulp publish-preview",
     "regenerate": "gulp regenerate",
     "clean": "gulp clean",
-    "nuke": "git clean -xdf"
+    "nuke": "git clean -xdf",
+    "preinstall": "node preinstall.js"
   },
   "repository": {
     "type": "git",

--- a/preinstall.js
+++ b/preinstall.js
@@ -1,0 +1,26 @@
+console.log('\x1b[36m%s\x1b[0m', 'NPM preinstall ....')
+
+if (10 < process.versions.node.split('.')[0]) {
+    console.log('\x1b[31m', 'Running NODEJS VERSION > 10 --> npm-shrinkwarp required\n')
+
+    const fs = require('fs')
+
+    var str = `{
+    "dependencies": {
+        "graceful-fs": {
+            "version": "^4.0.0"
+        }
+    }
+}
+    `
+
+    fs.writeFileSync('npm-shrinkwrap.json', str)
+    if (!fs.existsSync('./autorest.common') || fs.readdirSync('./autorest.common').length === 0) {
+        const proc = require('child_process')
+        proc.execSync('git submodule update --init')
+    }
+    fs.copyFileSync('npm-shrinkwrap.json', './autorest.common/npm-shrinkwrap.json')
+}
+else {
+    console.log('\x1b[32m', 'Running NODEJS VERSION == 10 (or lower) --> NO npm-shrinkwarp required\n')
+}


### PR DESCRIPTION
Currently it is not possible to build `autorest.go` on a machine were NodeJS with a higher version of 10 is installed (used) because `graceful-fs`, which is a dependency of  `gulp`, is using code which is no more supported by NodeJS > 10.

The following error is created in that case `ReferenceError: primordials is not defined`.

The pull request contains a NPM preinstall script which creates a `npm-shrinkwrap.json` file, which forces the dependency of `graceful-fs` to at least version 4.0.0 that does not have the issues with NodeJS what the older versions have and thus create the above mentioned error.

With that preinstall scritpt in place arbitrary versions of NodeJS can used to build, test and deploy `autorest.go` with having to update Gulp and it's corresponding task implementations used by `autorest.go`