### PR TITLE
Consolidate unnecessary command line switches

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -53,22 +53,22 @@ const goMappings = {
 for (namespace in goMappings) {
     // for each swagger run the autorest command to generate code based on the swagger for the relevant namespace and output to the /generated directory
     const inputFile = swaggerDir + goMappings[namespace];
-    generate(inputFile, 'test/autorest/' + namespace, '--head-as-boolean=true');
+    generate(inputFile, 'test/autorest/' + namespace);
 }
 
-const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/storage-dataplane-preview/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-07-07/blob.json';
+const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1a7b2bbb84370bd96c0bf53f13f56f4fc2cafab9/specification/storage/data-plane/Microsoft.BlobStorage/preview/2019-07-07/blob.json';
 generate(blobStorage, 'test/storage/2019-07-07/azblob', '--credential-scope="https://storage.azure.com/.default" --module="azstorage" --openapi-type="data-plane"');
 
-const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/network/resource-manager/readme.md';
-generateFromReadme(network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--credential-scope="https://management.azure.com//.default" --armcore-connection=true --module=armnetwork');
+const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1c100daabed6a008c76f3e4e0cae4e7eac5a5bf4/specification/network/resource-manager/readme.md';
+generateFromReadme(network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--credential-scope="https://management.azure.com//.default" --module=armnetwork --azure-arm=true');
 
-const compute = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/compute/resource-manager/readme.md';
-generateFromReadme(compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--credential-scope="https://management.azure.com//.default" --armcore-connection=true --module=armcompute');
+const compute = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d680d0ed31643857b38d63668148f462437493b0/specification/compute/resource-manager/readme.md';
+generateFromReadme(compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--credential-scope="https://management.azure.com//.default" --module=armcompute --azure-arm=true');
 
-const synapseArtifacts = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/synapse/data-plane/readme.md';
+const synapseArtifacts = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f19f3c059c96ba8cbbf84d658b260ad61b4fa635/specification/synapse/data-plane/readme.md';
 generateFromReadme(synapseArtifacts, 'package-artifacts-2019-06-01-preview', 'test/synapse/2019-06-01/azartifacts', '--credential-scope="https://dev.azuresynapse.net/.default" --module="azartifacts" --openapi-type="data-plane"');
 
-const synapseSpark = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/synapse/data-plane/readme.md';
+const synapseSpark = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/f19f3c059c96ba8cbbf84d658b260ad61b4fa635/specification/synapse/data-plane/readme.md';
 generateFromReadme(synapseSpark, 'package-spark-2019-11-01-preview', 'test/synapse/2019-06-01/azspark', '--credential-scope="https://dev.azuresynapse.net/.default" --module="azspark" --openapi-type="data-plane"');
 
 // helper to log the package being generated before invocation

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -118,9 +118,3 @@ export function getRelationship(obj: ObjectSchema): 'none' | 'root' | 'parent' |
     return 'parent';
   }
 }
-
-// returns true if client types should be exported
-export async function exportClients(session: Session<CodeModel>): Promise<boolean> {
-  const specType = await session.getValue('openapi-type', 'not_specified');
-  return specType === 'arm';
-}

--- a/src/generator/data_plane_pollers.ts
+++ b/src/generator/data_plane_pollers.ts
@@ -15,7 +15,7 @@ import { generateARMPollers } from './arm_pollers';
 // Creates the content in pollers.go
 export async function generatePollers(session: Session<CodeModel>): Promise<string> {
   // get the openapi-type value specified. Default to ARM behavior, unless "data-plane" is specified
-  let isARM = session.model.language.go!.openApiType === 'arm';
+  const isARM = session.model.language.go!.openApiType === 'arm';
   if (isARM) {
     return generateARMPollers(session);
   }

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -17,7 +17,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
   const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0';
-  if (session.model.language.go!.openApiType === 'arm') {
+  if (<boolean>session.model.language.go!.azureARM) {
     text += 'require (\n';
     text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0\n';
     text += `\t${azcore}\n`;

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -319,6 +319,8 @@ export function formatStatusCode(statusCode: string): string {
       return 'http.StatusNotFound';
     case '409':
       return 'http.StatusConflict';
+    case '412':
+      return 'http.StatusPreconditionFailed';
     case '500':
       return 'http.StatusInternalServerError';
     case '501':


### PR DESCRIPTION
The armcore-connection and head-as-boolean switches have been removed in
favor of using azure-arm and openapi-type settings.
Pinned RP swaggers to specific versions to avoid random CI failures due
to swagger changes.
Added new status code to formatStatusCode() helper.