### PR TITLE
Rename @azure-tools/autorest-extension-base dependency to new @autorest/extension-base pkg

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
   '@autorest/autorest': 3.0.6187
   '@azure-tools/async-io': 3.0.252
-  '@azure-tools/autorest-extension-base': 3.1.266
+  '@autorest/extension-base': 3.1.266
   '@azure-tools/codegen': 2.5.290
   '@azure-tools/codemodel': 4.13.348
   '@azure-tools/linq': 3.1.261
@@ -42,7 +42,7 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-RpoaEWGwpdp4FR9YKgnSkvwhdeR1gIzRFFOBotOyd3ow8FMfRIvMZ/eHar2iM3OXUnRKbHnv1M6oapdZah1JWw==
-  /@azure-tools/autorest-extension-base/3.1.266:
+  /@autorest/extension-base/3.1.266:
     dependencies:
       '@azure-tools/codegen': 2.5.290
       js-yaml: 3.13.1
@@ -61,7 +61,7 @@ packages:
       integrity: sha512-D9TuBY9YE+CE/EpbMaB3oVJq1xp7koIAQGlFrRNTLPgKNMelqkWK8HLnYSk810HL0rJFQjJE/BLx5lQsOjMYRQ==
   /@azure-tools/codemodel/4.13.348:
     dependencies:
-      '@azure-tools/autorest-extension-base': 3.1.266
+      '@autorest/extension-base': 3.1.266
       '@azure-tools/codegen': 2.5.290
       '@azure-tools/linq': 3.1.261
     dev: false
@@ -3327,7 +3327,7 @@ packages:
     dependencies:
       '@autorest/autorest': 3.0.6187
       '@azure-tools/async-io': 3.0.252
-      '@azure-tools/autorest-extension-base': 3.1.266
+      '@autorest/extension-base': 3.1.266
       '@azure-tools/codegen': 2.5.290
       '@azure-tools/codemodel': 4.13.348
       '@azure-tools/linq': 3.1.261
@@ -3357,7 +3357,7 @@ packages:
 specifiers:
   '@autorest/autorest': ~3.0.6173
   '@azure-tools/async-io': ~3.0.0
-  '@azure-tools/autorest-extension-base': ~3.1.0
+  '@autorest/extension-base': ~3.1.0
   '@azure-tools/codegen': ~2.5.288
   '@azure-tools/codemodel': ~4.13.348
   '@azure-tools/linq': ~3.1.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
   '@autorest/autorest': 3.0.6187
+  '@autorest/extension-base': 3.1.0
   '@azure-tools/async-io': 3.0.252
-  '@autorest/extension-base': 3.1.266
   '@azure-tools/codegen': 2.5.290
   '@azure-tools/codemodel': 4.13.348
   '@azure-tools/linq': 3.1.261
@@ -33,6 +33,14 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-BUTLfV6GufjgcSp0ysB1wdhMIG8RGQMiY4ZQnP76fHcR2KZW0QinnEAR99mMy7BVOdXiurWkNW7rilEJfKhXWg==
+  /@autorest/extension-base/3.1.0:
+    dependencies:
+      '@azure-tools/codegen': 2.5.290
+      js-yaml: 3.13.1
+      vscode-jsonrpc: 3.6.2
+    dev: false
+    resolution:
+      integrity: sha512-LHSLvPDG0uoMsOmzh0wOtxHu0dvoTaqDRJkgJVAZFVz4VfLocXhFActkwQ31yoB0IO7phZnuvcG8NcvKObURAQ==
   /@azure-tools/async-io/3.0.252:
     dependencies:
       '@azure-tools/tasks': 3.0.252
@@ -42,7 +50,7 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-RpoaEWGwpdp4FR9YKgnSkvwhdeR1gIzRFFOBotOyd3ow8FMfRIvMZ/eHar2iM3OXUnRKbHnv1M6oapdZah1JWw==
-  /@autorest/extension-base/3.1.266:
+  /@azure-tools/autorest-extension-base/3.1.266:
     dependencies:
       '@azure-tools/codegen': 2.5.290
       js-yaml: 3.13.1
@@ -61,7 +69,7 @@ packages:
       integrity: sha512-D9TuBY9YE+CE/EpbMaB3oVJq1xp7koIAQGlFrRNTLPgKNMelqkWK8HLnYSk810HL0rJFQjJE/BLx5lQsOjMYRQ==
   /@azure-tools/codemodel/4.13.348:
     dependencies:
-      '@autorest/extension-base': 3.1.266
+      '@azure-tools/autorest-extension-base': 3.1.266
       '@azure-tools/codegen': 2.5.290
       '@azure-tools/linq': 3.1.261
     dev: false
@@ -3326,8 +3334,9 @@ packages:
   'file:projects/go.tgz':
     dependencies:
       '@autorest/autorest': 3.0.6187
+      '@autorest/extension-base': 3.1.0
       '@azure-tools/async-io': 3.0.252
-      '@autorest/extension-base': 3.1.266
+      '@azure-tools/autorest-extension-base': 3.1.266
       '@azure-tools/codegen': 2.5.290
       '@azure-tools/codemodel': 4.13.348
       '@azure-tools/linq': 3.1.261
@@ -3351,13 +3360,14 @@ packages:
     dev: false
     name: '@rush-temp/go'
     resolution:
-      integrity: sha512-03lh+hdRjCS+QUZ7oglQRHxVecGPiSnlh8PN8yCn/8lY04f4uagaOtXhxvRNSz+VUPSZA7iKOrZCmACxsDZMuw==
+      integrity: sha512-U306jCR2BhZ7AS9jAU91JDVlsB9JJkAFVv3HDDPYN7+mbvIUdZeLRC9uB/VZkKCqM/YZrA+DL2ZHZx5ifzgDqg==
       tarball: 'file:projects/go.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@autorest/autorest': ~3.0.6173
-  '@azure-tools/async-io': ~3.0.0
   '@autorest/extension-base': ~3.1.0
+  '@azure-tools/async-io': ~3.0.0
   '@azure-tools/codegen': ~2.5.288
   '@azure-tools/codemodel': ~4.13.348
   '@azure-tools/linq': ~3.1.0

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { ArraySchema, CodeModel, DictionarySchema, ObjectSchema, Operation, Parameter, Response, Schema, SchemaResponse, SchemaType } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 

--- a/src/generator/arm_pollers.ts
+++ b/src/generator/arm_pollers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { camelCase } from '@azure-tools/codegen';
 import { CodeModel, SchemaType, Schema, ArraySchema } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/connection.ts
+++ b/src/generator/connection.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel, Parameter } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { contentPreamble, formatParameterTypeName } from './helpers';

--- a/src/generator/constants.ts
+++ b/src/generator/constants.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { comment } from '@azure-tools/codegen';
 import { CodeModel, ChoiceValue, Schemas } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/data_plane_pollers.ts
+++ b/src/generator/data_plane_pollers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { camelCase } from '@azure-tools/codegen';
 import { CodeModel, SchemaResponse } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { serialize } from '@azure-tools/codegen';
-import { Host, startSession } from '@azure-tools/autorest-extension-base';
+import { Host, startSession } from '@autorest/extension-base';
 import { codeModelSchema, CodeModel } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { generateOperations } from './operations';

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel } from '@azure-tools/codemodel';
 
 // Creates the content in go.mod if the --module switch was specified

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { values } from '@azure-tools/linq';
 import { comment, camelCase, pascalCase } from '@azure-tools/codegen';
 import { aggregateParameters, isSchemaResponse } from '../common/helpers';

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { comment, pascalCase } from '@azure-tools/codegen';
 import { CodeModel, ComplexSchema, ConstantSchema, DictionarySchema, GroupProperty, ImplementationLocation, ObjectSchema, Language, Schema, SchemaType, Parameter, Property } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { comment, KnownMediaType, pascalCase, camelCase } from '@azure-tools/codegen';
 import { ArraySchema, ByteArraySchema, CodeModel, ConstantSchema, DateTimeSchema, DictionarySchema, GroupProperty, ImplementationLocation, NumberSchema, Operation, OperationGroup, Parameter, Property, Protocols, Response, Schema, SchemaResponse, SchemaType } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/pagers.ts
+++ b/src/generator/pagers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { camelCase } from '@azure-tools/codegen';
 import { CodeModel } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';

--- a/src/generator/polymorphics.ts
+++ b/src/generator/polymorphics.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel, ObjectSchema } from '@azure-tools/codemodel';
 import { values } from '@azure-tools/linq';
 import { contentPreamble, sortAscending } from './helpers';

--- a/src/generator/time.ts
+++ b/src/generator/time.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel } from '@azure-tools/codemodel';
 import { contentPreamble } from './helpers'
 

--- a/src/generator/xmlAdditionalProps.ts
+++ b/src/generator/xmlAdditionalProps.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel } from '@azure-tools/codemodel';
 import { contentPreamble } from './helpers'
 import { ImportManager } from './imports';

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AutoRestExtension, } from '@azure-tools/autorest-extension-base';
+import { AutoRestExtension, } from '@autorest/extension-base';
 import { transform } from './transform/transform';
 import { protocolGen } from './generator/generator';
 

--- a/src/package.json
+++ b/src/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@azure-tools/async-io": "~3.0.0",
-    "@azure-tools/autorest-extension-base": "~3.1.0",
+    "@autorest/extension-base": "~3.1.0",
     "@azure-tools/codegen": "~2.5.288",
     "@azure-tools/codemodel": "~4.13.348",
     "@azure-tools/linq": "~3.1.0",

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -4,7 +4,7 @@
  *  --------------------------------------------------------------------------------------------  */
 
 import { pascalCase, camelCase } from '@azure-tools/codegen';
-import { Session } from '@azure-tools/autorest-extension-base';
+import { Session } from '@autorest/extension-base';
 import { CodeModel, HttpHeader, Language } from '@azure-tools/codemodel';
 import { visitor, clone, values } from '@azure-tools/linq';
 import { CommonAcronyms, ReservedWords } from './mappings';

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { camelCase, KnownMediaType, pascalCase, serialize } from '@azure-tools/codegen';
-import { Host, startSession, Session } from '@azure-tools/autorest-extension-base';
+import { Host, startSession, Session } from '@autorest/extension-base';
 import { ObjectSchema, ArraySchema, ChoiceValue, codeModelSchema, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema, Request, DateSchema } from '@azure-tools/codemodel';
 import { items, values } from '@azure-tools/linq';
 import { aggregateParameters, hasAdditionalProperties, isPageableOperation, isObjectSchema, isSchemaResponse, PagerInfo, isLROOperation, PollerInfo } from '../common/helpers';


### PR DESCRIPTION
This package was renamed when we moved it to the autorest monorepo