### PR TITLE
Return arrays and maps by value

### DIFF
--- a/src/generator/arm_pollers.ts
+++ b/src/generator/arm_pollers.ts
@@ -89,8 +89,15 @@ export async function generateARMPollers(session: Session<CodeModel>): Promise<s
       // for operations that do return a model add a final response method that handles the final get URL scenario
       finalResponseDeclaration = `FinalResponse(ctx context.Context) (${responseType}, error)`;
       finalResponse = `FinalResponse(ctx context.Context) (${responseType}, error) {`;
-      let respType = `respType := ${responseType}{${poller.respField}: &${poller.respType.language.go!.name}{}}`;
       let reference = '';
+      let respByRef = '&';
+      if (poller.respType.type === SchemaType.Array || poller.respType.type === SchemaType.Dictionary) {
+        // arrays and maps are returned by value
+        respByRef = '';
+        // but we need to pass them by reference to the unmarshaller
+        reference = '&';
+      }
+      let respType = `respType := ${responseType}{${poller.respField}: ${respByRef}${poller.respType.language.go!.name}{}}`;
       const isScalar = isScalarType(poller.respType);
       if (isScalar) {
         respType = `respType := ${responseType}{}\n`;

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -169,7 +169,7 @@ class StructDef {
         tag = '';
       }
       let pointer = '*';
-      if (prop.schema.language.go!.byValue) {
+      if (prop.language.go!.byValue === true) {
         pointer = '';
       }
       text += `\t${prop.language.go!.name} ${pointer}${typeName}${tag}\n`;
@@ -186,7 +186,7 @@ class StructDef {
         text += `\t${comment(param.language.go!.description, '// ', undefined, commentLength)}\n`;
       }
       let pointer = '*';
-      if (param.required || param.schema.language.go!.byValue) {
+      if (param.required || param.language.go!.byValue === true) {
         pointer = '';
       }
       text += `\t${pascalCase(param.language.go!.name)} ${pointer}${param.schema.language.go!.name}\n`;
@@ -261,8 +261,9 @@ function generateStructs(objects?: ObjectSchema[]): StructDef[] {
                 if (p.language.go!.errorType) {
                   text += `\t\tmsg += fmt.Sprintf("${prop.language.go!.name}: %v\\n", *e.${prop.language.go!.name}.Error())\n`;
                 } else {
-                  text += `\t\t\tmsg += fmt.Sprintf("\\t${p.language.go!.name}: %v\\n", *e.${prop.language.go!.name}.${p.language.go!.name})\n`;                  }
-                  text += '\t\t}\n';
+                  text += `\t\t\tmsg += fmt.Sprintf("\\t${p.language.go!.name}: %v\\n", *e.${prop.language.go!.name}.${p.language.go!.name})\n`;
+                }
+                text += '\t\t}\n';
               }
               break;
             }

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -66,7 +66,6 @@ export async function namer(session: Session<CodeModel>) {
     if (obj.discriminator) {
       // if this is a discriminator add the interface name
       details.discriminatorInterface = createPolymorphicInterfaceName(details.name);
-      details.byValue = true;
       details.discriminatorTypes = new Array<string>();
       details.discriminatorTypes.push('*' + details.name);
       for (const child of values(obj.discriminator.all)) {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -707,7 +707,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
       const respProp = newRespProperty(propName, response.schema.language.go!.description, response.schema);
       if (respProp.language.go!.byValue === true) {
         // promote the byValue setting to the response type as it's needed during
-        // respone unmarshalling and we don't have access to the underlying property
+        // response unmarshalling and we don't have access to the underlying property
         response.schema.language.go!.responseType.byValue = true;
       }
       (<Array<Property>>response.schema.language.go!.properties).push(respProp);
@@ -863,9 +863,10 @@ function newProperty(name: string, desc: string, schema: Schema): Property {
 
 function newRespProperty(name: string, desc: string, schema: Schema): Property {
   const prop = newProperty(name, desc, schema);
-  if (schema.type === SchemaType.Any || schema.type === SchemaType.Array || schema.type === SchemaType.Dictionary) {
-    prop.language.go!.byValue = true;
-  } else if (isObjectSchema(schema) && schema.discriminator) {
+  if (schema.type === SchemaType.Any ||
+    schema.type === SchemaType.Array ||
+    schema.type === SchemaType.Dictionary ||
+    (isObjectSchema(schema) && schema.discriminator)) {
     prop.language.go!.byValue = true;
   }
   return prop;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -84,7 +84,9 @@ async function process(session: Session<CodeModel>) {
       }
       const details = <Language>prop.schema.language.go;
       details.name = `${schemaTypeToGoType(session.model, prop.schema, true)}`;
-      if (prop.schema.type === SchemaType.DateTime) {
+      if (prop.schema.type === SchemaType.Any || (isObjectSchema(prop.schema) && prop.schema.discriminator)) {
+        prop.language.go!.byValue = true;
+      } else if (prop.schema.type === SchemaType.DateTime) {
         obj.language.go!.needsDateTimeMarshalling = true;
       } else if (prop.schema.type === SchemaType.Date) {
         obj.language.go!.needsDateMarshalling = true;
@@ -127,7 +129,6 @@ async function process(session: Session<CodeModel>) {
 function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, inBody: boolean): string {
   switch (schema.type) {
     case SchemaType.Any:
-      schema.language.go!.byValue = true;
       return 'interface{}';
     case SchemaType.Array:
       const arraySchema = <ArraySchema>schema;
@@ -601,9 +602,10 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
     return newProperty('RawResponse', 'RawResponse contains the underlying HTTP response.', newObject('http.Response', 'raw HTTP response'));
   }
   const createSuccessProp = function (): Property {
-    const successProp = newObject('bool', 'bool response');
+    const successSchema = newObject('bool', 'bool response');
+    const successProp = newProperty('Success', 'Success indicates if the operation succeeded or failed.', successSchema);
     successProp.language.go!.byValue = true;
-    return newProperty('Success', 'Success indicates if the operation succeeded or failed.', successProp);
+    return successProp;
   }
   // if this is an ARM spec and this is a HEAD method then return a BooleanResponse
   // response envelope instead of http.Response.  only do this if the operation doesn't model any
@@ -647,7 +649,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
           createRawResponseProp()
         ];
         for (const item of items(headers)) {
-          const prop = newProperty(item.key, item.value.description, item.value.schema);
+          const prop = newRespProperty(item.key, item.value.description, item.value.schema);
           prop.language.go!.fromHeader = item.value.header;
           (<Array<Property>>respEnv.language.go!.properties).push(prop);
         }
@@ -702,7 +704,13 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
         }
       }
       // the Widget response doesn't belong in the poller response envelope
-      (<Array<Property>>response.schema.language.go!.properties).push(newProperty(propName, response.schema.language.go!.description, response.schema));
+      const respProp = newRespProperty(propName, response.schema.language.go!.description, response.schema);
+      if (respProp.language.go!.byValue === true) {
+        // promote the byValue setting to the response type as it's needed during
+        // respone unmarshalling and we don't have access to the underlying property
+        response.schema.language.go!.responseType.byValue = true;
+      }
+      (<Array<Property>>response.schema.language.go!.properties).push(respProp);
       if (!responseEnvelopeExists(codeModel, response.schema.language.go!.name)) {
         // add this response schema to the global list of response
         const responseEnvelopes = <Array<Schema>>codeModel.language.go!.responseEnvelopes;
@@ -727,7 +735,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
               }
             }
             if (!exists) {
-              const prop = newProperty(header.key, header.value.description, header.value.schema);
+              const prop = newRespProperty(header.key, header.value.description, header.value.schema);
               prop.language.go!.fromHeader = header.value.header;
               respProps.push(prop);
             }
@@ -850,6 +858,16 @@ function newProperty(name: string, desc: string, schema: Schema): Property {
     prop.isDiscriminator = true;
   }
   prop.language.go = prop.language.default;
+  return prop;
+}
+
+function newRespProperty(name: string, desc: string, schema: Schema): Property {
+  const prop = newProperty(name, desc, schema);
+  if (schema.type === SchemaType.Any || schema.type === SchemaType.Array || schema.type === SchemaType.Dictionary) {
+    prop.language.go!.byValue = true;
+  } else if (isObjectSchema(schema) && schema.discriminator) {
+    prop.language.go!.byValue = true;
+  }
   return prop;
 }
 
@@ -1012,14 +1030,13 @@ function generateLROResponseEnvelope(response: Response, op: Operation, codeMode
   }
   // create PollUntilDone
   const pollerFunc = newObject(`func(ctx context.Context, frequency time.Duration) (${pollerResponse}, error)`, 'PollUntilDone');
-  pollerFunc.language.go!.byValue = true;
   const pollUntilDone = newProperty('PollUntilDone', 'PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received',
     pollerFunc);
   pollUntilDone.language.go!.byValue = true;
   // create Poller
   const pollerType = newObject(pollerTypeName, 'poller');
-  pollerType.language.go!.byValue = true;
   const poller = newProperty('Poller', 'Poller contains an initialized poller.', pollerType);
+  poller.language.go!.byValue = true;
   respTypeObject.language.go!.properties = [
     newProperty('RawResponse', 'RawResponse contains the underlying HTTP response.', newObject('http.Response', 'HTTP response')),
     pollUntilDone,

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -28,7 +28,7 @@ func TestGetArrayEmpty(t *testing.T) {
 	if resp.StringArrayArray == nil {
 		t.Fatal("unexpected nil array")
 	}
-	if r := cmp.Diff(len(*resp.StringArrayArray), 0); r != "" {
+	if r := cmp.Diff(len(resp.StringArrayArray), 0); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -40,7 +40,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, &[][]string{
+	if r := cmp.Diff(resp.StringArrayArray, [][]string{
 		{"1", "2", "3"},
 		{},
 		{"7", "8", "9"},
@@ -56,7 +56,7 @@ func TestGetArrayItemNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, &[][]string{
+	if r := cmp.Diff(resp.StringArrayArray, [][]string{
 		{"1", "2", "3"},
 		nil,
 		{"7", "8", "9"},
@@ -84,7 +84,7 @@ func TestGetArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, &[][]string{
+	if r := cmp.Diff(resp.StringArrayArray, [][]string{
 		{"1", "2", "3"},
 		{"4", "5", "6"},
 		{"7", "8", "9"},
@@ -101,7 +101,7 @@ func TestGetBase64URL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ByteArrayArray, &[][]byte{
+	if r := cmp.Diff(resp.ByteArrayArray, [][]byte{
 		{0},
 		{0},
 		{0},
@@ -142,7 +142,7 @@ func TestGetBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.BoolArray, &[]bool{true, false, false, true}); r != "" {
+	if r := cmp.Diff(resp.BoolArray, []bool{true, false, false, true}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -167,7 +167,7 @@ func TestGetByteValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ByteArrayArray, &[][]byte{
+	if r := cmp.Diff(resp.ByteArrayArray, [][]byte{
 		{255, 255, 255, 250},
 		{1, 2, 3},
 		{37, 41, 67},
@@ -186,7 +186,7 @@ func TestGetComplexEmpty(t *testing.T) {
 	if resp.ProductArray == nil {
 		t.Fatal("unexpected nil array")
 	}
-	if r := cmp.Diff(len(*resp.ProductArray), 0); r != "" {
+	if r := cmp.Diff(len(resp.ProductArray), 0); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -198,7 +198,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ProductArray, &[]Product{
+	if r := cmp.Diff(resp.ProductArray, []Product{
 		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		{},
 		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -231,7 +231,7 @@ func TestGetComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ProductArray, &[]Product{
+	if r := cmp.Diff(resp.ProductArray, []Product{
 		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -291,7 +291,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	if r := cmp.Diff(resp.TimeArray, &[]time.Time{
+	if r := cmp.Diff(resp.TimeArray, []time.Time{
 		v1,
 		v2,
 		v3,
@@ -310,7 +310,7 @@ func TestGetDateTimeValid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T01:11:35+01:00")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T02:15:01-08:00")
-	if r := cmp.Diff(resp.TimeArray, &[]time.Time{
+	if r := cmp.Diff(resp.TimeArray, []time.Time{
 		v1,
 		v2,
 		v3,
@@ -326,7 +326,7 @@ func TestGetDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.TimeArray, &[]time.Time{
+	if r := cmp.Diff(resp.TimeArray, []time.Time{
 		time.Date(2000, time.December, 01, 0, 0, 0, 0, time.UTC),
 		time.Date(1980, time.January, 02, 0, 0, 0, 0, time.UTC),
 		time.Date(1492, time.October, 12, 0, 0, 0, 0, time.UTC),
@@ -342,7 +342,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, &[]map[string]string{}); r != "" {
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -354,7 +354,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, &[]map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
 		{
 			"1": "one",
 			"2": "two",
@@ -378,7 +378,7 @@ func TestGetDictionaryItemNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, &[]map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
 		{
 			"1": "one",
 			"2": "two",
@@ -414,7 +414,7 @@ func TestGetDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, &[]map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
 		{
 			"1": "one",
 			"2": "two",
@@ -467,7 +467,7 @@ func TestGetDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Float64Array, &[]float64{0, -0.01, -1.2e20}); r != "" {
+	if r := cmp.Diff(resp.Float64Array, []float64{0, -0.01, -1.2e20}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -479,7 +479,7 @@ func TestGetDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, &[]string{"P123DT22H14M12.011S", "P5DT1H0M0S"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, []string{"P123DT22H14M12.011S", "P5DT1H0M0S"}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -494,7 +494,7 @@ func TestGetEmpty(t *testing.T) {
 	if resp.Int32Array == nil {
 		t.Fatal("unexpected nil array")
 	}
-	if r := cmp.Diff(len(*resp.Int32Array), 0); r != "" {
+	if r := cmp.Diff(len(resp.Int32Array), 0); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -506,7 +506,7 @@ func TestGetEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.FooEnumArray, &[]FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}); r != "" {
+	if r := cmp.Diff(resp.FooEnumArray, []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -543,7 +543,7 @@ func TestGetFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Float32Array, &[]float32{0, -0.01, -1.2e20}); r != "" {
+	if r := cmp.Diff(resp.Float32Array, []float32{0, -0.01, -1.2e20}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -580,7 +580,7 @@ func TestGetIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Int32Array, &[]int32{1, -1, 3, 300}); r != "" {
+	if r := cmp.Diff(resp.Int32Array, []int32{1, -1, 3, 300}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -629,7 +629,7 @@ func TestGetLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Int64Array, &[]int64{1, -1, 3, 300}); r != "" {
+	if r := cmp.Diff(resp.Int64Array, []int64{1, -1, 3, 300}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -653,7 +653,7 @@ func TestGetStringEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Enum0Array, &[]Enum0{Enum0Foo1, Enum0Foo2, Enum0Foo3}); r != "" {
+	if r := cmp.Diff(resp.Enum0Array, []Enum0{Enum0Foo1, Enum0Foo2, Enum0Foo3}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -665,7 +665,7 @@ func TestGetStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, &[]string{"foo1", "foo2", "foo3"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, []string{"foo1", "foo2", "foo3"}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -707,7 +707,7 @@ func TestGetUUIDValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, &[]string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"}); r != "" {
 		t.Fatal(r)
 	}
 }

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -55,7 +55,7 @@ func (client *ArrayClient) getArrayEmptyCreateRequest(ctx context.Context, optio
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *ArrayClient) getArrayEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val *[][]string
+	var val [][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -101,7 +101,7 @@ func (client *ArrayClient) getArrayItemEmptyCreateRequest(ctx context.Context, o
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *ArrayClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val *[][]string
+	var val [][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *ArrayClient) getArrayItemNullCreateRequest(ctx context.Context, op
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *ArrayClient) getArrayItemNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val *[][]string
+	var val [][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -193,7 +193,7 @@ func (client *ArrayClient) getArrayNullCreateRequest(ctx context.Context, option
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *ArrayClient) getArrayNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val *[][]string
+	var val [][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -239,7 +239,7 @@ func (client *ArrayClient) getArrayValidCreateRequest(ctx context.Context, optio
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *ArrayClient) getArrayValidHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val *[][]string
+	var val [][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -285,7 +285,7 @@ func (client *ArrayClient) getBase64UrlCreateRequest(ctx context.Context, option
 
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client *ArrayClient) getBase64UrlHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	var val *[][]byte
+	var val [][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ByteArrayArrayResponse{}, err
 	}
@@ -331,7 +331,7 @@ func (client *ArrayClient) getBooleanInvalidNullCreateRequest(ctx context.Contex
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *ArrayClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val *[]bool
+	var val []bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *ArrayClient) getBooleanInvalidStringCreateRequest(ctx context.Cont
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *ArrayClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val *[]bool
+	var val []bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -423,7 +423,7 @@ func (client *ArrayClient) getBooleanTfftCreateRequest(ctx context.Context, opti
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *ArrayClient) getBooleanTfftHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val *[]bool
+	var val []bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -469,7 +469,7 @@ func (client *ArrayClient) getByteInvalidNullCreateRequest(ctx context.Context, 
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *ArrayClient) getByteInvalidNullHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	var val *[][]byte
+	var val [][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ByteArrayArrayResponse{}, err
 	}
@@ -515,7 +515,7 @@ func (client *ArrayClient) getByteValidCreateRequest(ctx context.Context, option
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *ArrayClient) getByteValidHandleResponse(resp *azcore.Response) (ByteArrayArrayResponse, error) {
-	var val *[][]byte
+	var val [][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ByteArrayArrayResponse{}, err
 	}
@@ -561,7 +561,7 @@ func (client *ArrayClient) getComplexEmptyCreateRequest(ctx context.Context, opt
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *ArrayClient) getComplexEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -607,7 +607,7 @@ func (client *ArrayClient) getComplexItemEmptyCreateRequest(ctx context.Context,
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *ArrayClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -653,7 +653,7 @@ func (client *ArrayClient) getComplexItemNullCreateRequest(ctx context.Context, 
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *ArrayClient) getComplexItemNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -699,7 +699,7 @@ func (client *ArrayClient) getComplexNullCreateRequest(ctx context.Context, opti
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *ArrayClient) getComplexNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -745,7 +745,7 @@ func (client *ArrayClient) getComplexValidCreateRequest(ctx context.Context, opt
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *ArrayClient) getComplexValidHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -791,15 +791,15 @@ func (client *ArrayClient) getDateInvalidCharsCreateRequest(ctx context.Context,
 
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *ArrayClient) getDateInvalidCharsHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]dateType
+	var aux []dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
@@ -841,15 +841,15 @@ func (client *ArrayClient) getDateInvalidNullCreateRequest(ctx context.Context, 
 
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *ArrayClient) getDateInvalidNullHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]dateType
+	var aux []dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateInvalidNullHandleError handles the GetDateInvalidNull error response.
@@ -891,15 +891,15 @@ func (client *ArrayClient) getDateTimeInvalidCharsCreateRequest(ctx context.Cont
 
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *ArrayClient) getDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]timeRFC3339
+	var aux []timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
@@ -941,15 +941,15 @@ func (client *ArrayClient) getDateTimeInvalidNullCreateRequest(ctx context.Conte
 
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *ArrayClient) getDateTimeInvalidNullHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]timeRFC3339
+	var aux []timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
@@ -991,15 +991,15 @@ func (client *ArrayClient) getDateTimeRfc1123ValidCreateRequest(ctx context.Cont
 
 // getDateTimeRfc1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *ArrayClient) getDateTimeRfc1123ValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]timeRFC1123
+	var aux []timeRFC1123
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateTimeRfc1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
@@ -1041,15 +1041,15 @@ func (client *ArrayClient) getDateTimeValidCreateRequest(ctx context.Context, op
 
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *ArrayClient) getDateTimeValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]timeRFC3339
+	var aux []timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateTimeValidHandleError handles the GetDateTimeValid error response.
@@ -1091,15 +1091,15 @@ func (client *ArrayClient) getDateValidCreateRequest(ctx context.Context, option
 
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *ArrayClient) getDateValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux *[]dateType
+	var aux []dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(*aux), len(*aux))
-	for i := 0; i < len(*aux); i++ {
-		cp[i] = time.Time((*aux)[i])
+	cp := make([]time.Time, len(aux), len(aux))
+	for i := 0; i < len(aux); i++ {
+		cp[i] = time.Time(aux[i])
 	}
-	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: &cp}, nil
+	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
 
 // getDateValidHandleError handles the GetDateValid error response.
@@ -1141,7 +1141,7 @@ func (client *ArrayClient) getDictionaryEmptyCreateRequest(ctx context.Context, 
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *ArrayClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *[]map[string]string
+	var val []map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1188,7 +1188,7 @@ func (client *ArrayClient) getDictionaryItemEmptyCreateRequest(ctx context.Conte
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *ArrayClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *[]map[string]string
+	var val []map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1235,7 +1235,7 @@ func (client *ArrayClient) getDictionaryItemNullCreateRequest(ctx context.Contex
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *ArrayClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *[]map[string]string
+	var val []map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1281,7 +1281,7 @@ func (client *ArrayClient) getDictionaryNullCreateRequest(ctx context.Context, o
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *ArrayClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *[]map[string]string
+	var val []map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1328,7 +1328,7 @@ func (client *ArrayClient) getDictionaryValidCreateRequest(ctx context.Context, 
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *ArrayClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *[]map[string]string
+	var val []map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1374,7 +1374,7 @@ func (client *ArrayClient) getDoubleInvalidNullCreateRequest(ctx context.Context
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *ArrayClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val *[]float64
+	var val []float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1420,7 +1420,7 @@ func (client *ArrayClient) getDoubleInvalidStringCreateRequest(ctx context.Conte
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *ArrayClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val *[]float64
+	var val []float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1466,7 +1466,7 @@ func (client *ArrayClient) getDoubleValidCreateRequest(ctx context.Context, opti
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *ArrayClient) getDoubleValidHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val *[]float64
+	var val []float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1512,7 +1512,7 @@ func (client *ArrayClient) getDurationValidCreateRequest(ctx context.Context, op
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *ArrayClient) getDurationValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -1558,7 +1558,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) getEmptyHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1604,7 +1604,7 @@ func (client *ArrayClient) getEnumValidCreateRequest(ctx context.Context, option
 
 // getEnumValidHandleResponse handles the GetEnumValid response.
 func (client *ArrayClient) getEnumValidHandleResponse(resp *azcore.Response) (FooEnumArrayResponse, error) {
-	var val *[]FooEnum
+	var val []FooEnum
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return FooEnumArrayResponse{}, err
 	}
@@ -1650,7 +1650,7 @@ func (client *ArrayClient) getFloatInvalidNullCreateRequest(ctx context.Context,
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *ArrayClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val *[]float32
+	var val []float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1696,7 +1696,7 @@ func (client *ArrayClient) getFloatInvalidStringCreateRequest(ctx context.Contex
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *ArrayClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val *[]float32
+	var val []float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1742,7 +1742,7 @@ func (client *ArrayClient) getFloatValidCreateRequest(ctx context.Context, optio
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *ArrayClient) getFloatValidHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val *[]float32
+	var val []float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1788,7 +1788,7 @@ func (client *ArrayClient) getIntInvalidNullCreateRequest(ctx context.Context, o
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *ArrayClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1834,7 +1834,7 @@ func (client *ArrayClient) getIntInvalidStringCreateRequest(ctx context.Context,
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *ArrayClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1880,7 +1880,7 @@ func (client *ArrayClient) getIntegerValidCreateRequest(ctx context.Context, opt
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *ArrayClient) getIntegerValidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1926,7 +1926,7 @@ func (client *ArrayClient) getInvalidCreateRequest(ctx context.Context, options 
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *ArrayClient) getInvalidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1972,7 +1972,7 @@ func (client *ArrayClient) getLongInvalidNullCreateRequest(ctx context.Context, 
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *ArrayClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val *[]int64
+	var val []int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2018,7 +2018,7 @@ func (client *ArrayClient) getLongInvalidStringCreateRequest(ctx context.Context
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *ArrayClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val *[]int64
+	var val []int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2064,7 +2064,7 @@ func (client *ArrayClient) getLongValidCreateRequest(ctx context.Context, option
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *ArrayClient) getLongValidHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val *[]int64
+	var val []int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2110,7 +2110,7 @@ func (client *ArrayClient) getNullCreateRequest(ctx context.Context, options *Ar
 
 // getNullHandleResponse handles the GetNull response.
 func (client *ArrayClient) getNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val *[]int32
+	var val []int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -2156,7 +2156,7 @@ func (client *ArrayClient) getStringEnumValidCreateRequest(ctx context.Context, 
 
 // getStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client *ArrayClient) getStringEnumValidHandleResponse(resp *azcore.Response) (Enum0ArrayResponse, error) {
-	var val *[]Enum0
+	var val []Enum0
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Enum0ArrayResponse{}, err
 	}
@@ -2202,7 +2202,7 @@ func (client *ArrayClient) getStringValidCreateRequest(ctx context.Context, opti
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *ArrayClient) getStringValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2248,7 +2248,7 @@ func (client *ArrayClient) getStringWithInvalidCreateRequest(ctx context.Context
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *ArrayClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2294,7 +2294,7 @@ func (client *ArrayClient) getStringWithNullCreateRequest(ctx context.Context, o
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *ArrayClient) getStringWithNullHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2340,7 +2340,7 @@ func (client *ArrayClient) getUuidInvalidCharsCreateRequest(ctx context.Context,
 
 // getUuidInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client *ArrayClient) getUuidInvalidCharsHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2386,7 +2386,7 @@ func (client *ArrayClient) getUuidValidCreateRequest(ctx context.Context, option
 
 // getUuidValidHandleResponse handles the GetUUIDValid response.
 func (client *ArrayClient) getUuidValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}

--- a/test/autorest/arraygroup/zz_generated_models.go
+++ b/test/autorest/arraygroup/zz_generated_models.go
@@ -361,7 +361,7 @@ type ArrayPutUUIDValidOptions struct {
 // BoolArrayResponse is the response envelope for operations that return a []bool type.
 type BoolArrayResponse struct {
 	// The array value [true, false, false, true]
-	BoolArray *[]bool
+	BoolArray []bool
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -370,7 +370,7 @@ type BoolArrayResponse struct {
 // ByteArrayArrayResponse is the response envelope for operations that return a [][]byte type.
 type ByteArrayArrayResponse struct {
 	// The array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
-	ByteArrayArray *[][]byte
+	ByteArrayArray [][]byte
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -379,7 +379,7 @@ type ByteArrayArrayResponse struct {
 // Enum0ArrayResponse is the response envelope for operations that return a []Enum0 type.
 type Enum0ArrayResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
-	Enum0Array *[]Enum0
+	Enum0Array []Enum0
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -408,7 +408,7 @@ func (e Error) Error() string {
 // Float32ArrayResponse is the response envelope for operations that return a []float32 type.
 type Float32ArrayResponse struct {
 	// The array value [0, -0.01, 1.2e20]
-	Float32Array *[]float32
+	Float32Array []float32
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -417,7 +417,7 @@ type Float32ArrayResponse struct {
 // Float64ArrayResponse is the response envelope for operations that return a []float64 type.
 type Float64ArrayResponse struct {
 	// The array value [0, -0.01, 1.2e20]
-	Float64Array *[]float64
+	Float64Array []float64
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -426,7 +426,7 @@ type Float64ArrayResponse struct {
 // FooEnumArrayResponse is the response envelope for operations that return a []FooEnum type.
 type FooEnumArrayResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
-	FooEnumArray *[]FooEnum
+	FooEnumArray []FooEnum
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -435,7 +435,7 @@ type FooEnumArrayResponse struct {
 // Int32ArrayResponse is the response envelope for operations that return a []int32 type.
 type Int32ArrayResponse struct {
 	// The null Array value
-	Int32Array *[]int32
+	Int32Array []int32
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -444,7 +444,7 @@ type Int32ArrayResponse struct {
 // Int64ArrayResponse is the response envelope for operations that return a []int64 type.
 type Int64ArrayResponse struct {
 	// The array value [1, -1, 3, 300]
-	Int64Array *[]int64
+	Int64Array []int64
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -453,7 +453,7 @@ type Int64ArrayResponse struct {
 // MapOfStringArrayResponse is the response envelope for operations that return a []map[string]string type.
 type MapOfStringArrayResponse struct {
 	// An array of Dictionaries with value null
-	MapOfStringArray *[]map[string]string
+	MapOfStringArray []map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -467,7 +467,7 @@ type Product struct {
 // ProductArrayResponse is the response envelope for operations that return a []Product type.
 type ProductArrayResponse struct {
 	// array of complex type with null value
-	ProductArray *[]Product
+	ProductArray []Product
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -479,7 +479,7 @@ type StringArrayArrayResponse struct {
 	RawResponse *http.Response
 
 	// a null array
-	StringArrayArray *[][]string
+	StringArrayArray [][]string
 }
 
 // StringArrayResponse is the response envelope for operations that return a []string type.
@@ -488,7 +488,7 @@ type StringArrayResponse struct {
 	RawResponse *http.Response
 
 	// The array value ['foo1', 'foo2', 'foo3']
-	StringArray *[]string
+	StringArray []string
 }
 
 // TimeArrayResponse is the response envelope for operations that return a []time.Time type.
@@ -497,5 +497,5 @@ type TimeArrayResponse struct {
 	RawResponse *http.Response
 
 	// The array value ['2000-12-01', '1980-01-02', '1492-10-12']
-	TimeArray *[]time.Time
+	TimeArray []time.Time
 }

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -59,7 +59,7 @@ func (client *AutoRestReportServiceForAzureClient) getReportCreateRequest(ctx co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceForAzureClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}

--- a/test/autorest/azurereportgroup/zz_generated_models.go
+++ b/test/autorest/azurereportgroup/zz_generated_models.go
@@ -45,5 +45,5 @@ type MapOfInt32Response struct {
 	RawResponse *http.Response
 
 	// Dictionary of <integer>
-	Value *map[string]int32
+	Value map[string]int32
 }

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -24,12 +24,12 @@ func main() {
 		panic(err)
 	}
 	notRun := []string{}
-	for key, val := range *vanillaReport.Value {
+	for key, val := range vanillaReport.Value {
 		if val <= 0 {
 			notRun = append(notRun, fmt.Sprintf("GENERAL: %s", key))
 		}
 	}
-	for key, val := range *azureReport.Value {
+	for key, val := range azureReport.Value {
 		if val <= 0 {
 			notRun = append(notRun, fmt.Sprintf("AZURE: %s", key))
 		}
@@ -38,6 +38,6 @@ func main() {
 	for _, s := range notRun {
 		fmt.Printf("Not Run: %s\n", s)
 	}
-	passed := len(*vanillaReport.Value) + len(*azureReport.Value) - len(notRun)
+	passed := len(vanillaReport.Value) + len(azureReport.Value) - len(notRun)
 	fmt.Printf("\nReport:	Passed(%d)  Not Run(%d)\n", passed, len(notRun))
 }

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -25,7 +25,7 @@ func TestGetArrayEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(len(*resp.Value), 0); r != "" {
+	if r := cmp.Diff(len(resp.Value), 0); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -37,7 +37,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string][]string{
+	if r := cmp.Diff(resp.Value, map[string][]string{
 		"0": {"1", "2", "3"},
 		"1": {},
 		"2": {"7", "8", "9"},
@@ -54,7 +54,7 @@ func TestGetArrayItemNull(t *testing.T) {
 		t.Fatal(err)
 	}
 	// TODO: this should technically fail since there's no x-nullable
-	if r := cmp.Diff(resp.Value, &map[string][]string{
+	if r := cmp.Diff(resp.Value, map[string][]string{
 		"0": {"1", "2", "3"},
 		"1": nil,
 		"2": {"7", "8", "9"},
@@ -82,7 +82,7 @@ func TestGetArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string][]string{
+	if r := cmp.Diff(resp.Value, map[string][]string{
 		"0": {"1", "2", "3"},
 		"1": {"4", "5", "6"},
 		"2": {"7", "8", "9"},
@@ -99,7 +99,7 @@ func TestGetBase64URL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string][]byte{
+	if r := cmp.Diff(resp.Value, map[string][]byte{
 		"0": {},
 		"1": {},
 		"2": {},
@@ -140,7 +140,7 @@ func TestGetBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]bool{
+	if r := cmp.Diff(resp.Value, map[string]bool{
 		"0": true,
 		"1": false,
 		"2": false,
@@ -170,7 +170,7 @@ func TestGetByteValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string][]byte{
+	if r := cmp.Diff(resp.Value, map[string][]byte{
 		"0": {255, 255, 255, 250},
 		"1": {1, 2, 3},
 		"2": {37, 41, 67},
@@ -186,7 +186,7 @@ func TestGetComplexEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]Widget{}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]Widget{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -198,7 +198,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]Widget{
+	if r := cmp.Diff(resp.Value, map[string]Widget{
 		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": {},
 		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -215,7 +215,7 @@ func TestGetComplexItemNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]Widget{
+	if r := cmp.Diff(resp.Value, map[string]Widget{
 		"0": Widget{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": nil,
 		"2": Widget{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -241,7 +241,7 @@ func TestGetComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]Widget{
+	if r := cmp.Diff(resp.Value, map[string]Widget{
 		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": {Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -301,7 +301,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	dt2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	dt3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	if r := cmp.Diff(resp.Value, &map[string]time.Time{
+	if r := cmp.Diff(resp.Value, map[string]time.Time{
 		"0": dt1,
 		"1": dt2,
 		"2": dt3,
@@ -320,7 +320,7 @@ func TestGetDateTimeValid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	dt2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35+01:00")
 	dt3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01-08:00")
-	if r := cmp.Diff(resp.Value, &map[string]time.Time{
+	if r := cmp.Diff(resp.Value, map[string]time.Time{
 		"0": dt1,
 		"1": dt2,
 		"2": dt3,
@@ -339,7 +339,7 @@ func TestGetDateValid(t *testing.T) {
 	dt1 := time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC)
 	dt2 := time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC)
 	dt3 := time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)
-	if r := cmp.Diff(resp.Value, &map[string]time.Time{
+	if r := cmp.Diff(resp.Value, map[string]time.Time{
 		"0": dt1,
 		"1": dt2,
 		"2": dt3,
@@ -355,7 +355,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]map[string]string{}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]map[string]string{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -367,7 +367,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]map[string]string{
 		"0": {
 			"1": "one",
 			"2": "two",
@@ -401,7 +401,7 @@ func TestGetDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]map[string]string{
 		"0": {
 			"1": "one",
 			"2": "two",
@@ -454,7 +454,7 @@ func TestGetDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]float64{
+	if r := cmp.Diff(resp.Value, map[string]float64{
 		"0": 0,
 		"1": -0.01,
 		"2": -1.2e20,
@@ -470,7 +470,7 @@ func TestGetDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]string{
 		"0": "P123DT22H14M12.011S",
 		"1": "P5DT1H",
 	}); r != "" {
@@ -485,7 +485,7 @@ func TestGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(*resp.Value) != 0 {
+	if len(resp.Value) != 0 {
 		t.Fatal("expected empty dictionary")
 	}
 }
@@ -497,7 +497,7 @@ func TestGetEmptyStringKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]string{"": "val1"}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]string{"": "val1"}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -534,7 +534,7 @@ func TestGetFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]float32{
+	if r := cmp.Diff(resp.Value, map[string]float32{
 		"0": 0,
 		"1": -0.01,
 		"2": -1.2e20,
@@ -575,7 +575,7 @@ func TestGetIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]int32{
+	if r := cmp.Diff(resp.Value, map[string]int32{
 		"0": 1,
 		"1": -1,
 		"2": 3,
@@ -629,7 +629,7 @@ func TestGetLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]int64{
+	if r := cmp.Diff(resp.Value, map[string]int64{
 		"0": 1,
 		"1": -1,
 		"2": 3,
@@ -683,7 +683,7 @@ func TestGetStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, &map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]string{
 		"0": "foo1",
 		"1": "foo2",
 		"2": "foo3",

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -55,7 +55,7 @@ func (client *DictionaryClient) getArrayEmptyCreateRequest(ctx context.Context, 
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *DictionaryClient) getArrayEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *map[string][]string
+	var val map[string][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -101,7 +101,7 @@ func (client *DictionaryClient) getArrayItemEmptyCreateRequest(ctx context.Conte
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *DictionaryClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *map[string][]string
+	var val map[string][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *DictionaryClient) getArrayItemNullCreateRequest(ctx context.Contex
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *DictionaryClient) getArrayItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *map[string][]string
+	var val map[string][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -193,7 +193,7 @@ func (client *DictionaryClient) getArrayNullCreateRequest(ctx context.Context, o
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *DictionaryClient) getArrayNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *map[string][]string
+	var val map[string][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -239,7 +239,7 @@ func (client *DictionaryClient) getArrayValidCreateRequest(ctx context.Context, 
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *DictionaryClient) getArrayValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val *map[string][]string
+	var val map[string][]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -285,7 +285,7 @@ func (client *DictionaryClient) getBase64UrlCreateRequest(ctx context.Context, o
 
 // getBase64UrlHandleResponse handles the GetBase64URL response.
 func (client *DictionaryClient) getBase64UrlHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	var val *map[string][]byte
+	var val map[string][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfByteArrayResponse{}, err
 	}
@@ -331,7 +331,7 @@ func (client *DictionaryClient) getBooleanInvalidNullCreateRequest(ctx context.C
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *DictionaryClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val *map[string]bool
+	var val map[string]bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *DictionaryClient) getBooleanInvalidStringCreateRequest(ctx context
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *DictionaryClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val *map[string]bool
+	var val map[string]bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -423,7 +423,7 @@ func (client *DictionaryClient) getBooleanTfftCreateRequest(ctx context.Context,
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *DictionaryClient) getBooleanTfftHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val *map[string]bool
+	var val map[string]bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -469,7 +469,7 @@ func (client *DictionaryClient) getByteInvalidNullCreateRequest(ctx context.Cont
 
 // getByteInvalidNullHandleResponse handles the GetByteInvalidNull response.
 func (client *DictionaryClient) getByteInvalidNullHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	var val *map[string][]byte
+	var val map[string][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfByteArrayResponse{}, err
 	}
@@ -515,7 +515,7 @@ func (client *DictionaryClient) getByteValidCreateRequest(ctx context.Context, o
 
 // getByteValidHandleResponse handles the GetByteValid response.
 func (client *DictionaryClient) getByteValidHandleResponse(resp *azcore.Response) (MapOfByteArrayResponse, error) {
-	var val *map[string][]byte
+	var val map[string][]byte
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfByteArrayResponse{}, err
 	}
@@ -561,7 +561,7 @@ func (client *DictionaryClient) getComplexEmptyCreateRequest(ctx context.Context
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *DictionaryClient) getComplexEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val *map[string]Widget
+	var val map[string]Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -607,7 +607,7 @@ func (client *DictionaryClient) getComplexItemEmptyCreateRequest(ctx context.Con
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *DictionaryClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val *map[string]Widget
+	var val map[string]Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -653,7 +653,7 @@ func (client *DictionaryClient) getComplexItemNullCreateRequest(ctx context.Cont
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *DictionaryClient) getComplexItemNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val *map[string]Widget
+	var val map[string]Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -699,7 +699,7 @@ func (client *DictionaryClient) getComplexNullCreateRequest(ctx context.Context,
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *DictionaryClient) getComplexNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val *map[string]Widget
+	var val map[string]Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -746,7 +746,7 @@ func (client *DictionaryClient) getComplexValidCreateRequest(ctx context.Context
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *DictionaryClient) getComplexValidHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val *map[string]Widget
+	var val map[string]Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -800,7 +800,7 @@ func (client *DictionaryClient) getDateInvalidCharsHandleResponse(resp *azcore.R
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateInvalidCharsHandleError handles the GetDateInvalidChars error response.
@@ -850,7 +850,7 @@ func (client *DictionaryClient) getDateInvalidNullHandleResponse(resp *azcore.Re
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateInvalidNullHandleError handles the GetDateInvalidNull error response.
@@ -900,7 +900,7 @@ func (client *DictionaryClient) getDateTimeInvalidCharsHandleResponse(resp *azco
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateTimeInvalidCharsHandleError handles the GetDateTimeInvalidChars error response.
@@ -950,7 +950,7 @@ func (client *DictionaryClient) getDateTimeInvalidNullHandleResponse(resp *azcor
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateTimeInvalidNullHandleError handles the GetDateTimeInvalidNull error response.
@@ -1001,7 +1001,7 @@ func (client *DictionaryClient) getDateTimeRfc1123ValidHandleResponse(resp *azco
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateTimeRfc1123ValidHandleError handles the GetDateTimeRFC1123Valid error response.
@@ -1051,7 +1051,7 @@ func (client *DictionaryClient) getDateTimeValidHandleResponse(resp *azcore.Resp
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateTimeValidHandleError handles the GetDateTimeValid error response.
@@ -1101,7 +1101,7 @@ func (client *DictionaryClient) getDateValidHandleResponse(resp *azcore.Response
 	for k, v := range aux {
 		cp[k] = time.Time(v)
 	}
-	return MapOfTimeResponse{RawResponse: resp.Response, Value: &cp}, nil
+	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
 
 // getDateValidHandleError handles the GetDateValid error response.
@@ -1143,7 +1143,7 @@ func (client *DictionaryClient) getDictionaryEmptyCreateRequest(ctx context.Cont
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *DictionaryClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val *map[string]map[string]string
+	var val map[string]map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1190,7 +1190,7 @@ func (client *DictionaryClient) getDictionaryItemEmptyCreateRequest(ctx context.
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *DictionaryClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val *map[string]map[string]string
+	var val map[string]map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1237,7 +1237,7 @@ func (client *DictionaryClient) getDictionaryItemNullCreateRequest(ctx context.C
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *DictionaryClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val *map[string]map[string]string
+	var val map[string]map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1283,7 +1283,7 @@ func (client *DictionaryClient) getDictionaryNullCreateRequest(ctx context.Conte
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *DictionaryClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val *map[string]map[string]string
+	var val map[string]map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1330,7 +1330,7 @@ func (client *DictionaryClient) getDictionaryValidCreateRequest(ctx context.Cont
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *DictionaryClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val *map[string]map[string]string
+	var val map[string]map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1376,7 +1376,7 @@ func (client *DictionaryClient) getDoubleInvalidNullCreateRequest(ctx context.Co
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *DictionaryClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val *map[string]float64
+	var val map[string]float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1422,7 +1422,7 @@ func (client *DictionaryClient) getDoubleInvalidStringCreateRequest(ctx context.
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *DictionaryClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val *map[string]float64
+	var val map[string]float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1468,7 +1468,7 @@ func (client *DictionaryClient) getDoubleValidCreateRequest(ctx context.Context,
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *DictionaryClient) getDoubleValidHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val *map[string]float64
+	var val map[string]float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1514,7 +1514,7 @@ func (client *DictionaryClient) getDurationValidCreateRequest(ctx context.Contex
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *DictionaryClient) getDurationValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1560,7 +1560,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) getEmptyHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1606,7 +1606,7 @@ func (client *DictionaryClient) getEmptyStringKeyCreateRequest(ctx context.Conte
 
 // getEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client *DictionaryClient) getEmptyStringKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1652,7 +1652,7 @@ func (client *DictionaryClient) getFloatInvalidNullCreateRequest(ctx context.Con
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *DictionaryClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val *map[string]float32
+	var val map[string]float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1698,7 +1698,7 @@ func (client *DictionaryClient) getFloatInvalidStringCreateRequest(ctx context.C
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *DictionaryClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val *map[string]float32
+	var val map[string]float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1744,7 +1744,7 @@ func (client *DictionaryClient) getFloatValidCreateRequest(ctx context.Context, 
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *DictionaryClient) getFloatValidHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val *map[string]float32
+	var val map[string]float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1790,7 +1790,7 @@ func (client *DictionaryClient) getIntInvalidNullCreateRequest(ctx context.Conte
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *DictionaryClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1836,7 +1836,7 @@ func (client *DictionaryClient) getIntInvalidStringCreateRequest(ctx context.Con
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *DictionaryClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1882,7 +1882,7 @@ func (client *DictionaryClient) getIntegerValidCreateRequest(ctx context.Context
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *DictionaryClient) getIntegerValidHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1928,7 +1928,7 @@ func (client *DictionaryClient) getInvalidCreateRequest(ctx context.Context, opt
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *DictionaryClient) getInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1974,7 +1974,7 @@ func (client *DictionaryClient) getLongInvalidNullCreateRequest(ctx context.Cont
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *DictionaryClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val *map[string]int64
+	var val map[string]int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2020,7 +2020,7 @@ func (client *DictionaryClient) getLongInvalidStringCreateRequest(ctx context.Co
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *DictionaryClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val *map[string]int64
+	var val map[string]int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2066,7 +2066,7 @@ func (client *DictionaryClient) getLongValidCreateRequest(ctx context.Context, o
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *DictionaryClient) getLongValidHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val *map[string]int64
+	var val map[string]int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2112,7 +2112,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) getNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -2158,7 +2158,7 @@ func (client *DictionaryClient) getNullKeyCreateRequest(ctx context.Context, opt
 
 // getNullKeyHandleResponse handles the GetNullKey response.
 func (client *DictionaryClient) getNullKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2204,7 +2204,7 @@ func (client *DictionaryClient) getNullValueCreateRequest(ctx context.Context, o
 
 // getNullValueHandleResponse handles the GetNullValue response.
 func (client *DictionaryClient) getNullValueHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2250,7 +2250,7 @@ func (client *DictionaryClient) getStringValidCreateRequest(ctx context.Context,
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *DictionaryClient) getStringValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2296,7 +2296,7 @@ func (client *DictionaryClient) getStringWithInvalidCreateRequest(ctx context.Co
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *DictionaryClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2342,7 +2342,7 @@ func (client *DictionaryClient) getStringWithNullCreateRequest(ctx context.Conte
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *DictionaryClient) getStringWithNullHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val *map[string]string
+	var val map[string]string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}

--- a/test/autorest/dictionarygroup/zz_generated_models.go
+++ b/test/autorest/dictionarygroup/zz_generated_models.go
@@ -364,7 +364,7 @@ type MapOfBoolResponse struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": true, "1": false, "2": false, "3": true }
-	Value *map[string]bool
+	Value map[string]bool
 }
 
 // MapOfByteArrayResponse is the response envelope for operations that return a map[string][]byte type.
@@ -373,7 +373,7 @@ type MapOfByteArrayResponse struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
-	Value *map[string][]byte
+	Value map[string][]byte
 }
 
 // MapOfFloat32Response is the response envelope for operations that return a map[string]float32 type.
@@ -382,7 +382,7 @@ type MapOfFloat32Response struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	Value *map[string]float32
+	Value map[string]float32
 }
 
 // MapOfFloat64Response is the response envelope for operations that return a map[string]float64 type.
@@ -391,7 +391,7 @@ type MapOfFloat64Response struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	Value *map[string]float64
+	Value map[string]float64
 }
 
 // MapOfInt32Response is the response envelope for operations that return a map[string]int32 type.
@@ -400,7 +400,7 @@ type MapOfInt32Response struct {
 	RawResponse *http.Response
 
 	// The null dictionary value
-	Value *map[string]int32
+	Value map[string]int32
 }
 
 // MapOfInt64Response is the response envelope for operations that return a map[string]int64 type.
@@ -409,7 +409,7 @@ type MapOfInt64Response struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-	Value *map[string]int64
+	Value map[string]int64
 }
 
 // MapOfMapOfStringResponse is the response envelope for operations that return a map[string]map[string]string type.
@@ -418,7 +418,7 @@ type MapOfMapOfStringResponse struct {
 	RawResponse *http.Response
 
 	// An dictionaries of dictionaries with value null
-	Value *map[string]map[string]string
+	Value map[string]map[string]string
 }
 
 // MapOfStringArrayResponse is the response envelope for operations that return a map[string][]string type.
@@ -427,7 +427,7 @@ type MapOfStringArrayResponse struct {
 	RawResponse *http.Response
 
 	// a null array
-	Value *map[string][]string
+	Value map[string][]string
 }
 
 // MapOfStringResponse is the response envelope for operations that return a map[string]string type.
@@ -436,7 +436,7 @@ type MapOfStringResponse struct {
 	RawResponse *http.Response
 
 	// Dictionary of <string>
-	Value *map[string]string
+	Value map[string]string
 }
 
 // MapOfTimeResponse is the response envelope for operations that return a map[string]time.Time type.
@@ -445,7 +445,7 @@ type MapOfTimeResponse struct {
 	RawResponse *http.Response
 
 	// The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-	Value *map[string]time.Time
+	Value map[string]time.Time
 }
 
 // MapOfWidgetResponse is the response envelope for operations that return a map[string]Widget type.
@@ -454,7 +454,7 @@ type MapOfWidgetResponse struct {
 	RawResponse *http.Response
 
 	// Dictionary of complex type with null value
-	Value *map[string]Widget
+	Value map[string]Widget
 }
 
 type Widget struct {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -101,7 +101,7 @@ func (client *HTTPRedirectsClient) get300HandleResponse(resp *azcore.Response) (
 		}
 		return result, nil
 	case http.StatusMultipleChoices:
-		var val *[]string
+		var val []string
 		if err := resp.UnmarshalAsJSON(&val); err != nil {
 			return nil, err
 		}

--- a/test/autorest/httpinfrastructuregroup/zz_generated_models.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_models.go
@@ -742,5 +742,5 @@ type StringArrayResponse struct {
 	RawResponse *http.Response
 
 	// A list of location options for the request ['/http/success/get/200']
-	StringArray *[]string
+	StringArray []string
 }

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -404,7 +404,7 @@ func TestLROBeginPost202List(t *testing.T) {
 	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	if r := cmp.Diff(pollResp.ProductArray, &[]Product{
+	if r := cmp.Diff(pollResp.ProductArray, []Product{
 		{
 			Resource: Resource{
 				ID:   to.StringPtr("100"),

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -1141,7 +1141,7 @@ func (client *LrOSClient) post202ListCreateRequest(ctx context.Context, options 
 
 // post202ListHandleResponse handles the Post202List response.
 func (client *LrOSClient) post202ListHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val *[]Product
+	var val []Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -530,7 +530,7 @@ type ProductArrayPollerResponse struct {
 // ProductArrayResponse is the response envelope for operations that return a []Product type.
 type ProductArrayResponse struct {
 	// Array of Product
-	ProductArray *[]Product
+	ProductArray []Product
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -82,8 +82,8 @@ func (p *productArrayPoller) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *productArrayPoller) FinalResponse(ctx context.Context) (ProductArrayResponse, error) {
-	respType := ProductArrayResponse{ProductArray: &[]Product{}}
-	resp, err := p.pt.FinalResponse(ctx, p.pipeline, respType.ProductArray)
+	respType := ProductArrayResponse{ProductArray: []Product{}}
+	resp, err := p.pt.FinalResponse(ctx, p.pipeline, &respType.ProductArray)
 	if err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -98,8 +98,8 @@ func (p *productArrayPoller) ResumeToken() (string, error) {
 }
 
 func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error) {
-	respType := ProductArrayResponse{ProductArray: &[]Product{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ProductArray)
+	respType := ProductArrayResponse{ProductArray: []Product{}}
+	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, &respType.ProductArray)
 	if err != nil {
 		return ProductArrayResponse{}, err
 	}

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -59,7 +59,7 @@ func (client *AutoRestReportServiceClient) getOptionalReportCreateRequest(ctx co
 
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client *AutoRestReportServiceClient) getOptionalReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -110,7 +110,7 @@ func (client *AutoRestReportServiceClient) getReportCreateRequest(ctx context.Co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val *map[string]int32
+	var val map[string]int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}

--- a/test/autorest/reportgroup/zz_generated_models.go
+++ b/test/autorest/reportgroup/zz_generated_models.go
@@ -52,5 +52,5 @@ type MapOfInt32Response struct {
 	RawResponse *http.Response
 
 	// Dictionary of <integer>
-	Value *map[string]int32
+	Value map[string]int32
 }

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -34,7 +34,7 @@ func TestGetACLs(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := &[]SignedIDentifier{
+	expected := []SignedIDentifier{
 		{
 			ID: to.StringPtr("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
 			AccessPolicy: &AccessPolicy{
@@ -169,7 +169,7 @@ func TestGetRootList(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := &[]Banana{
+	expected := []Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),
@@ -195,7 +195,7 @@ func TestGetRootListSingleItem(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := &[]Banana{
+	expected := []Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),

--- a/test/autorest/xmlgroup/zz_generated_models.go
+++ b/test/autorest/xmlgroup/zz_generated_models.go
@@ -115,7 +115,7 @@ func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 // BananaArrayResponse is the response envelope for operations that return a []Banana type.
 type BananaArrayResponse struct {
 	// Array of Banana
-	Bananas *[]Banana `xml:"banana"`
+	Bananas []Banana `xml:"banana"`
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -526,7 +526,7 @@ type SignedIDentifierArrayResponse struct {
 	RawResponse *http.Response
 
 	// a collection of signed identifiers
-	SignedIdentifiers *[]SignedIDentifier `xml:"SignedIdentifier"`
+	SignedIdentifiers []SignedIDentifier `xml:"SignedIdentifier"`
 }
 
 // A slide in a slideshow

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -4940,7 +4940,7 @@ type VirtualMachineExtensionImageArrayResponse struct {
 	RawResponse *http.Response
 
 	// Array of VirtualMachineExtensionImage
-	VirtualMachineExtensionImageArray *[]VirtualMachineExtensionImage
+	VirtualMachineExtensionImageArray []VirtualMachineExtensionImage
 }
 
 // Describes the properties of a Virtual Machine Extension Image.
@@ -5203,7 +5203,7 @@ type VirtualMachineImageResourceArrayResponse struct {
 	RawResponse *http.Response
 
 	// Array of VirtualMachineImageResource
-	VirtualMachineImageResourceArray *[]VirtualMachineImageResource
+	VirtualMachineImageResourceArray []VirtualMachineImageResource
 }
 
 // VirtualMachineImageResponse is the response envelope for operations that return a VirtualMachineImage type.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
@@ -125,7 +125,7 @@ func (client *VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx co
 
 // listTypesHandleResponse handles the ListTypes response.
 func (client *VirtualMachineExtensionImagesClient) listTypesHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	var val *[]VirtualMachineExtensionImage
+	var val []VirtualMachineExtensionImage
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineExtensionImageArrayResponse{}, err
 	}
@@ -190,7 +190,7 @@ func (client *VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx
 
 // listVersionsHandleResponse handles the ListVersions response.
 func (client *VirtualMachineExtensionImagesClient) listVersionsHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	var val *[]VirtualMachineExtensionImage
+	var val []VirtualMachineExtensionImage
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineExtensionImageArrayResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
@@ -137,7 +137,7 @@ func (client *VirtualMachineImagesClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineImagesClient) listHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val *[]VirtualMachineImageResource
+	var val []VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -192,7 +192,7 @@ func (client *VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Co
 
 // listOffersHandleResponse handles the ListOffers response.
 func (client *VirtualMachineImagesClient) listOffersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val *[]VirtualMachineImageResource
+	var val []VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -246,7 +246,7 @@ func (client *VirtualMachineImagesClient) listPublishersCreateRequest(ctx contex
 
 // listPublishersHandleResponse handles the ListPublishers response.
 func (client *VirtualMachineImagesClient) listPublishersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val *[]VirtualMachineImageResource
+	var val []VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -302,7 +302,7 @@ func (client *VirtualMachineImagesClient) listSkUsCreateRequest(ctx context.Cont
 
 // listSkUsHandleResponse handles the ListSKUs response.
 func (client *VirtualMachineImagesClient) listSkUsHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val *[]VirtualMachineImageResource
+	var val []VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -622,7 +622,7 @@ func (client *ApplicationGatewaysClient) listAvailableRequestHeadersCreateReques
 
 // listAvailableRequestHeadersHandleResponse handles the ListAvailableRequestHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableRequestHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -672,7 +672,7 @@ func (client *ApplicationGatewaysClient) listAvailableResponseHeadersCreateReque
 
 // listAvailableResponseHeadersHandleResponse handles the ListAvailableResponseHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableResponseHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -722,7 +722,7 @@ func (client *ApplicationGatewaysClient) listAvailableServerVariablesCreateReque
 
 // listAvailableServerVariablesHandleResponse handles the ListAvailableServerVariables response.
 func (client *ApplicationGatewaysClient) listAvailableServerVariablesHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val *[]string
+	var val []string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -11999,7 +11999,7 @@ type StringArrayResponse struct {
 	RawResponse *http.Response
 
 	// Response for ApplicationGatewayAvailableServerVariables API service call.
-	StringArray *[]string
+	StringArray []string
 }
 
 // StringPollerResponse is the response envelope for operations that asynchronously return a string type.

--- a/test/storage/2019-07-07/azblob/zz_generated_blob.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob.go
@@ -837,9 +837,9 @@ func (client *blobClient) downloadHandleResponse(resp *azcore.Response) (BlobDow
 	for hh := range resp.Header {
 		if strings.HasPrefix(hh, "x-ms-meta-") {
 			if result.Metadata == nil {
-				result.Metadata = &map[string]string{}
+				result.Metadata = map[string]string{}
 			}
-			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("Content-Length"); val != "" {
@@ -1242,9 +1242,9 @@ func (client *blobClient) getPropertiesHandleResponse(resp *azcore.Response) (Bl
 	for hh := range resp.Header {
 		if strings.HasPrefix(hh, "x-ms-meta-") {
 			if result.Metadata == nil {
-				result.Metadata = &map[string]string{}
+				result.Metadata = map[string]string{}
 			}
-			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("x-ms-blob-type"); val != "" {

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -678,9 +678,9 @@ func (client *containerClient) getPropertiesHandleResponse(resp *azcore.Response
 	for hh := range resp.Header {
 		if strings.HasPrefix(hh, "x-ms-meta-") {
 			if result.Metadata == nil {
-				result.Metadata = &map[string]string{}
+				result.Metadata = map[string]string{}
 			}
-			(*result.Metadata)[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("ETag"); val != "" {

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -631,7 +631,7 @@ type BlobDownloadResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *map[string]string
+	Metadata map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -840,7 +840,7 @@ type BlobGetPropertiesResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *map[string]string
+	Metadata map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -1892,7 +1892,7 @@ type ContainerGetPropertiesResponse struct {
 	LeaseStatus *LeaseStatusType
 
 	// Metadata contains the information returned from the x-ms-meta header response.
-	Metadata *map[string]string
+	Metadata map[string]string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -3257,7 +3257,7 @@ type SignedIDentifierArrayResponse struct {
 	RequestID *string `xml:"RequestID"`
 
 	// a collection of signed identifiers
-	SignedIdentifiers *[]SignedIDentifier `xml:"SignedIdentifier"`
+	SignedIdentifiers []SignedIDentifier `xml:"SignedIdentifier"`
 
 	// Version contains the information returned from the x-ms-version header response.
 	Version *string `xml:"Version"`


### PR DESCRIPTION
Removed the extra indirection as it's not necessary and negatively
impacts useability.
Moved byValue off the schema and onto the property for better control of
where it can be applied.
Fixed impacted tests.