### PR TITLE
[Track2] fix the parameters of NewRPRegistrationPolicy

### DIFF
--- a/src/generator/connection.ts
+++ b/src/generator/connection.ts
@@ -158,7 +158,7 @@ function generateContent(session: Session<CodeModel>): string {
     text += `\t\t${telemetryPolicy},\n`;
     text += '\t}\n';
     // RP registration policy must appear before the retry policy
-    text += '\tpolicies = append(policies, armcore.NewRPRegistrationPolicy(cred, &options.RegisterRPOptions))\n';
+    text += `\tpolicies = append(policies, armcore.NewRPRegistrationPolicy(${ctorParams}, cred, &options.RegisterRPOptions))\n`;
     text += '\tpolicies = append(policies,\n';
     text += `\t\t${retryPolicy},\n`;
     // ARM implies authentication is required


### PR DESCRIPTION
Test regeneration might not work properly on windows now. When I run `npm run generate-tests` I get this:
```
> @autorest/go@ generate-tests C:\Users\dapzhang\Documents\workspace\autorest.go
> node .scripts/generate-test-files

(node:22672) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'indexOf' of undefined
    at execute (C:\Users\dapzhang\Documents\workspace\autorest.go\.scripts\process.js:116:67)
    at async main (C:\Users\dapzhang\Documents\workspace\autorest.go\.scripts\generate-test-files.js:53:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:22672) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:22672) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```