### PR TITLE
Fix handling of multi-request operations

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -79,7 +79,7 @@ function generate(inputFile, outputDir, additionalArgs) {
     sem.take(function() {
         console.log('generating ' + inputFile);
         cleanGeneratedFiles(outputDir);
-        exec('autorest --version:3.0.6338 --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, inputFile));
+        exec('autorest --version:3.0.6375 --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, inputFile));
     });
 }
 
@@ -87,7 +87,7 @@ function generateFromReadme(readme, tag, outputDir, additionalArgs) {
     sem.take(function() {
         console.log('generating ' + readme);
         cleanGeneratedFiles(outputDir);
-        exec('autorest  --version:3.0.6338 --use=. ' + readme + ' --tag=' + tag + ' --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, readme));
+        exec('autorest --version:3.0.6375 --use=. ' + readme + ' --tag=' + tag + ' --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, readme));
     });
 }
 

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -45,7 +45,7 @@ func TestAnalyzeBodyWithSourcePath(t *testing.T) {
 
 func TestContentTypeWithEncoding(t *testing.T) {
 	client := newMediaTypesClient()
-	result, err := client.ContentTypeWithEncoding(context.Background(), "foo")
+	result, err := client.ContentTypeWithEncoding(context.Background(), "foo", nil)
 	if err != nil {
 		t.Fatalf("ContentTypeWithEncoding: %v", err)
 	}

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -131,8 +131,8 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleError(resp *azcor
 }
 
 // ContentTypeWithEncoding - Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter
-func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, input string) (StringResponse, error) {
-	req, err := client.contentTypeWithEncodingCreateRequest(ctx, input)
+func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, input string, options *MediaTypesClientContentTypeWithEncodingOptions) (StringResponse, error) {
+	req, err := client.contentTypeWithEncodingCreateRequest(ctx, input, options)
 	if err != nil {
 		return StringResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, inp
 }
 
 // contentTypeWithEncodingCreateRequest creates the ContentTypeWithEncoding request.
-func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context.Context, input string) (*azcore.Request, error) {
+func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context.Context, input string, options *MediaTypesClientContentTypeWithEncodingOptions) (*azcore.Request, error) {
 	urlPath := "/mediatypes/contentTypeWithEncoding"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {

--- a/test/autorest/mediatypesgroup/zz_generated_models.go
+++ b/test/autorest/mediatypesgroup/zz_generated_models.go
@@ -20,6 +20,11 @@ type MediaTypesClientAnalyzeBodyWithSourcePathOptions struct {
 	Input *SourcePath
 }
 
+// MediaTypesClientContentTypeWithEncodingOptions contains the optional parameters for the MediaTypesClient.ContentTypeWithEncoding method.
+type MediaTypesClientContentTypeWithEncodingOptions struct {
+	// placeholder for future optional parameters
+}
+
 // Uri or local path to source data.
 type SourcePath struct {
 	// File source path.

--- a/test/autorest/stringgroup/zz_generated_constants.go
+++ b/test/autorest/stringgroup/zz_generated_constants.go
@@ -7,6 +7,7 @@
 
 package stringgroup
 
+// Colors - Referenced Color Enum Description.
 type Colors string
 
 const (

--- a/test/autorest/stringgroup/zz_generated_models.go
+++ b/test/autorest/stringgroup/zz_generated_models.go
@@ -23,7 +23,9 @@ type ByteArrayResponse struct {
 type ColorsResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
-	Value       *Colors
+
+	// Referenced Color Enum Description.
+	Value *Colors
 }
 
 // EnumGetNotExpandableOptions contains the optional parameters for the Enum.GetNotExpandable method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -126,9 +126,10 @@ func (client *VirtualMachinesClient) captureHandleError(resp *azcore.Response) e
 }
 
 // BeginConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated before invoking
-// this operation.
-// For Windows, please refer to Convert a virtual machine from unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks].
-// For Linux, please refer to Convert a virtual machine from unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks].
+// this operation. For Windows, please refer to Convert a virtual machine from
+// unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks]. For Linux, please
+// refer to Convert a virtual machine from
+// unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks].
 func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesBeginConvertToManagedDisksOptions) (HTTPPollerResponse, error) {
 	resp, err := client.convertToManagedDisks(ctx, resourceGroupName, vmName, options)
 	if err != nil {
@@ -166,9 +167,10 @@ func (client *VirtualMachinesClient) ResumeConvertToManagedDisks(token string) (
 }
 
 // ConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated before invoking this
-// operation.
-// For Windows, please refer to Convert a virtual machine from unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks].
-// For Linux, please refer to Convert a virtual machine from unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks].
+// operation. For Windows, please refer to Convert a virtual machine from
+// unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/convert-unmanaged-to-managed-disks]. For Linux, please
+// refer to Convert a virtual machine from
+// unmanaged disks to managed disks. [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/convert-unmanaged-to-managed-disks].
 func (client *VirtualMachinesClient) convertToManagedDisks(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesBeginConvertToManagedDisksOptions) (*azcore.Response, error) {
 	req, err := client.convertToManagedDisksCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {
@@ -472,8 +474,10 @@ func (client *VirtualMachinesClient) deleteHandleError(resp *azcore.Response) er
 }
 
 // Generalize - Sets the OS state of the virtual machine to generalized. It is recommended to sysprep the virtual machine before performing this operation.
-// For Windows, please refer to Create a managed image of a generalized VM in Azure [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource].
-// For Linux, please refer to How to create an image of a virtual machine or VHD [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/capture-image].
+// For Windows, please refer to Create a managed image of a
+// generalized VM in Azure [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/capture-image-resource]. For Linux, please refer to How to create
+// an image of a virtual machine or VHD
+// [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/capture-image].
 func (client *VirtualMachinesClient) Generalize(ctx context.Context, resourceGroupName string, vmName string, options *VirtualMachinesGeneralizeOptions) (*http.Response, error) {
 	req, err := client.generalizeCreateRequest(ctx, resourceGroupName, vmName, options)
 	if err != nil {


### PR DESCRIPTION
Modifying the operations collection while iterating over it caused some
operations to be skipped in processing.
Updated version of autorest.core to latest version.