### PR TITLE
Fold identical error schemas into one unmarshaller

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -820,7 +820,7 @@ function createProtocolErrHandler(op: Operation, imports: ImportManager): string
       foldedMap.set(errSchema, new Array<string>());
     }
     for (const statusCode of values(<Array<string>>exception.protocol.http!.statusCodes)) {
-      foldedMap.get(errSchema)?.push(statusCode);
+      foldedMap.get(errSchema)!.push(statusCode);
     }
   }
   // only one entry in the map means all status codes return the same error schema

--- a/test/autorest/errorsgroup/zz_generated_pet.go
+++ b/test/autorest/errorsgroup/zz_generated_pet.go
@@ -69,20 +69,11 @@ func (client *PetClient) doSomethingHandleResponse(resp *azcore.Response) (PetAc
 
 // doSomethingHandleError handles the DoSomething error response.
 func (client *PetClient) doSomethingHandleError(resp *azcore.Response) error {
-	switch resp.StatusCode {
-	case http.StatusInternalServerError:
-		var err petActionError
-		if err := resp.UnmarshalAsJSON(&err); err != nil {
-			return err
-		}
-		return azcore.NewResponseError(err.wrapped, resp.Response)
-	default:
-		var err petActionError
-		if err := resp.UnmarshalAsJSON(&err); err != nil {
-			return err
-		}
-		return azcore.NewResponseError(err.wrapped, resp.Response)
+	var err petActionError
+	if err := resp.UnmarshalAsJSON(&err); err != nil {
+		return err
 	}
+	return azcore.NewResponseError(err.wrapped, resp.Response)
 }
 
 // GetPetByID - Gets pets by id.


### PR DESCRIPTION
Don't emit separate case statements for status codes when they unmarshal
into the same type.
Include a default case statement if one isn't specified.