### PR TITLE
Make element collections pointer-to-type

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -32,6 +32,11 @@ export function isArraySchema(resp: Schema): resp is ArraySchema {
   return resp.type === SchemaType.Array;
 }
 
+// returns DictionarySchema type predicate if the schema is a DictionarySchema
+export function isDictionarySchema(resp: Schema): resp is DictionarySchema {
+  return resp.type === SchemaType.Dictionary;
+}
+
 // returns SchemaResponse type predicate if the response has a schema
 export function isSchemaResponse(resp?: Response): resp is SchemaResponse {
   return (resp as SchemaResponse).schema !== undefined;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -550,16 +550,16 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
       body = 'aux';
     } else if (isArrayOfTimesForMarshalling(bodyParam!.schema) || isArrayOfDatesForMarshalling(bodyParam!.schema)) {
       const timeType = (<ArraySchema>bodyParam!.schema).elementType.language.go!.internalTimeType;
-      text += `\taux := make([]${timeType}, len(${body}), len(${body}))\n`;
+      text += `\taux := make([]*${timeType}, len(${body}), len(${body}))\n`;
       text += `\tfor i := 0; i < len(${body}); i++ {\n`;
-      text += `\t\taux[i] = ${timeType}(${body}[i])\n`;
+      text += `\t\taux[i] = (*${timeType})(${body}[i])\n`;
       text += '\t}\n';
       body = 'aux';
     } else if (isMapOfDateTime(bodyParam!.schema) || isMapOfDate(bodyParam!.schema)) {
       const timeType = (<ArraySchema>bodyParam!.schema).elementType.language.go!.internalTimeType;
-      text += `\taux := map[string]${timeType}{}\n`;
+      text += `\taux := map[string]*${timeType}{}\n`;
       text += `\tfor k, v := range ${body} {\n`;
-      text += `\t\taux[k] = ${timeType}(v)\n`;
+      text += `\t\taux[k] = (*${timeType})(v)\n`;
       text += '\t}\n';
       body = 'aux';
     }
@@ -659,25 +659,25 @@ function generateResponseUnmarshaller(op: Operation, response: Response, imports
     return unmarshallerText;
   } else if (isArrayOfDateTime(response.schema) || isArrayOfDate(response.schema)) {
     // unmarshalling arrays of date/time is a little more involved
-    unmarshallerText += `\tvar aux []${(<ArraySchema>response.schema).elementType.language.go!.internalTimeType}\n`;
+    unmarshallerText += `\tvar aux []*${(<ArraySchema>response.schema).elementType.language.go!.internalTimeType}\n`;
     unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
     unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
     unmarshallerText += '\t}\n';
-    unmarshallerText += '\tcp := make([]time.Time, len(aux), len(aux))\n';
+    unmarshallerText += '\tcp := make([]*time.Time, len(aux), len(aux))\n';
     unmarshallerText += '\tfor i := 0; i < len(aux); i++ {\n';
-    unmarshallerText += '\t\tcp[i] = time.Time(aux[i])\n';
+    unmarshallerText += '\t\tcp[i] = (*time.Time)(aux[i])\n';
     unmarshallerText += '\t}\n';
     const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: cp}`;
     unmarshallerText += `\treturn ${resp}, nil\n`;
     return unmarshallerText;
   } else if (isMapOfDateTime(response.schema) || isMapOfDate(response.schema)) {
-    unmarshallerText += `\taux := map[string]${(<DictionarySchema>response.schema).elementType.language.go!.internalTimeType}{}\n`;
+    unmarshallerText += `\taux := map[string]*${(<DictionarySchema>response.schema).elementType.language.go!.internalTimeType}{}\n`;
     unmarshallerText += `\tif err := resp.UnmarshalAs${getMediaType(response.protocol)}(&aux); err != nil {\n`;
     unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
     unmarshallerText += '\t}\n';
-    unmarshallerText += `\tcp := map[string]time.Time{}\n`;
+    unmarshallerText += `\tcp := map[string]*time.Time{}\n`;
     unmarshallerText += `\tfor k, v := range aux {\n`;
-    unmarshallerText += `\t\tcp[k] = time.Time(v)\n`;
+    unmarshallerText += `\t\tcp[k] = (*time.Time)(v)\n`;
     unmarshallerText += `\t}\n`;
     const resp = `${response.schema.language.go!.responseType.name}{RawResponse: resp.Response, ${response.schema.language.go!.responseType.value}: cp}`;
     unmarshallerText += `\treturn ${resp}, nil\n`;

--- a/src/generator/xmlAdditionalProps.ts
+++ b/src/generator/xmlAdditionalProps.ts
@@ -21,7 +21,7 @@ export async function generateXMLAdditionalPropsHelpers(session: Session<CodeMod
   imports.add('strings');
   text += imports.text();
   text += `
-type additionalProperties map[string]string
+type additionalProperties map[string]*string
 
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -38,7 +38,8 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if *ap == nil {
 				*ap = additionalProperties{}
 			}
-			(*ap)[tokName] = string(tt)
+			s := string(tt)
+			(*ap)[tokName] = &s
 			tokName = ""
 			break
 		}

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -129,6 +129,7 @@ async function process(session: Session<CodeModel>) {
 
 // returns true if the element type should be pointer-to-type
 function isElementPointerToType(schema: ArraySchema | DictionarySchema): boolean {
+  // types that are implicitly nil should not be pointer-to-type
   const elementType = schema.elementType;
   if (isArraySchema(elementType) || isDictionarySchema(elementType) ||
     elementType.type === SchemaType.Any || elementType.type === SchemaType.ByteArray) {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -7,7 +7,7 @@ import { KnownMediaType, serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@autorest/extension-base';
 import { ObjectSchema, ArraySchema, ChoiceValue, codeModelSchema, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema, Request } from '@azure-tools/codemodel';
 import { items, values } from '@azure-tools/linq';
-import { aggregateParameters, hasAdditionalProperties, isPageableOperation, isObjectSchema, isSchemaResponse, PagerInfo, isLROOperation, PollerInfo } from '../common/helpers';
+import { aggregateParameters, hasAdditionalProperties, isArraySchema, isDictionarySchema, isPageableOperation, isObjectSchema, isSchemaResponse, PagerInfo, isLROOperation, PollerInfo } from '../common/helpers';
 import { namer, protocolMethods } from './namer';
 import { fromString } from 'html-to-text';
 import { Converter } from 'showdown';
@@ -42,6 +42,7 @@ async function process(session: Session<CodeModel>) {
   // schema type being an actual Go type.
   for (const dictionary of values(session.model.schemas.dictionaries)) {
     dictionary.elementType.language.go!.name = schemaTypeToGoType(session.model, dictionary.elementType, false);
+    dictionary.language.go!.elementIsPtr = isElementPointerToType(dictionary);
     if (dictionary.language.go!.description) {
       dictionary.language.go!.description = parseComments(dictionary.language.go!.description);
     }
@@ -126,14 +127,31 @@ async function process(session: Session<CodeModel>) {
   }
 }
 
+// returns true if the element type should be pointer-to-type
+function isElementPointerToType(schema: ArraySchema | DictionarySchema): boolean {
+  const elementType = schema.elementType;
+  if (isArraySchema(elementType) || isDictionarySchema(elementType) ||
+    elementType.type === SchemaType.Any || elementType.type === SchemaType.ByteArray) {
+    return false;
+  }
+  if (isObjectSchema(elementType) && elementType.discriminator) {
+    return false;
+  }
+  return true;
+}
+
 function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, inBody: boolean): string {
   switch (schema.type) {
     case SchemaType.Any:
       return 'interface{}';
     case SchemaType.Array:
       const arraySchema = <ArraySchema>schema;
+      arraySchema.language.go!.elementIsPtr = isElementPointerToType(arraySchema);
       const arrayElem = <Schema>arraySchema.elementType;
       arrayElem.language.go!.name = schemaTypeToGoType(codeModel, arrayElem, inBody);
+      if (<boolean>arraySchema.language.go!.elementIsPtr) {
+        return `[]*${arrayElem.language.go!.name}`;
+      }
       return `[]${arrayElem.language.go!.name}`;
     case SchemaType.Binary:
       return 'azcore.ReadSeekCloser';
@@ -168,8 +186,12 @@ function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, inBody: boolea
       return 'time.Time';
     case SchemaType.Dictionary:
       const dictSchema = <DictionarySchema>schema;
+      dictSchema.language.go!.elementIsPtr = isElementPointerToType(dictSchema);
       const dictElem = <Schema>dictSchema.elementType;
       dictElem.language.go!.name = schemaTypeToGoType(codeModel, dictElem, inBody);
+      if (<boolean>dictSchema.language.go!.elementIsPtr) {
+        return `map[string]*${dictElem.language.go!.name}`;
+      }
       return `map[string]${dictElem.language.go!.name}`;
     case SchemaType.Integer:
       if ((<NumberSchema>schema).precision === 32) {

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -22,10 +22,10 @@ func TestCreateAPInProperties(t *testing.T) {
 	result, err := client.CreateAPInProperties(context.Background(), PetAPInProperties{
 		ID:   to.Int32Ptr(4),
 		Name: to.StringPtr("Bunny"),
-		AdditionalProperties: &map[string]float32{
-			"height":   5.61,
-			"weight":   599,
-			"footsize": 11.5,
+		AdditionalProperties: &map[string]*float32{
+			"height":   to.Float32Ptr(5.61),
+			"weight":   to.Float32Ptr(599),
+			"footsize": to.Float32Ptr(11.5),
 		},
 	}, nil)
 	if err != nil {
@@ -35,10 +35,10 @@ func TestCreateAPInProperties(t *testing.T) {
 		ID:     to.Int32Ptr(4),
 		Name:   to.StringPtr("Bunny"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]float32{
-			"height":   5.61,
-			"weight":   599,
-			"footsize": 11.5,
+		AdditionalProperties: &map[string]*float32{
+			"height":   to.Float32Ptr(5.61),
+			"weight":   to.Float32Ptr(599),
+			"footsize": to.Float32Ptr(11.5),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -52,15 +52,15 @@ func TestCreateAPInPropertiesWithAPString(t *testing.T) {
 		ID:            to.Int32Ptr(5),
 		Name:          to.StringPtr("Funny"),
 		OdataLocation: to.StringPtr("westus"),
-		AdditionalProperties: &map[string]string{
-			"color": "red",
-			"city":  "Seattle",
-			"food":  "tikka masala",
+		AdditionalProperties: &map[string]*string{
+			"color": to.StringPtr("red"),
+			"city":  to.StringPtr("Seattle"),
+			"food":  to.StringPtr("tikka masala"),
 		},
-		AdditionalProperties1: &map[string]float32{
-			"height":   5.61,
-			"weight":   599,
-			"footsize": 11.5,
+		AdditionalProperties1: &map[string]*float32{
+			"height":   to.Float32Ptr(5.61),
+			"weight":   to.Float32Ptr(599),
+			"footsize": to.Float32Ptr(11.5),
 		},
 	}, nil)
 	if err != nil {
@@ -71,15 +71,15 @@ func TestCreateAPInPropertiesWithAPString(t *testing.T) {
 		Name:          to.StringPtr("Funny"),
 		OdataLocation: to.StringPtr("westus"),
 		Status:        to.BoolPtr(true),
-		AdditionalProperties: &map[string]string{
-			"color": "red",
-			"city":  "Seattle",
-			"food":  "tikka masala",
+		AdditionalProperties: &map[string]*string{
+			"color": to.StringPtr("red"),
+			"city":  to.StringPtr("Seattle"),
+			"food":  to.StringPtr("tikka masala"),
 		},
-		AdditionalProperties1: &map[string]float32{
-			"height":   5.61,
-			"weight":   599,
-			"footsize": 11.5,
+		AdditionalProperties1: &map[string]*float32{
+			"height":   to.Float32Ptr(5.61),
+			"weight":   to.Float32Ptr(599),
+			"footsize": to.Float32Ptr(11.5),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -137,10 +137,10 @@ func TestCreateAPString(t *testing.T) {
 	result, err := client.CreateAPString(context.Background(), PetAPString{
 		ID:   to.Int32Ptr(3),
 		Name: to.StringPtr("Tommy"),
-		AdditionalProperties: &map[string]string{
-			"color":  "red",
-			"weight": "10 kg",
-			"city":   "Bombay",
+		AdditionalProperties: &map[string]*string{
+			"color":  to.StringPtr("red"),
+			"weight": to.StringPtr("10 kg"),
+			"city":   to.StringPtr("Bombay"),
 		},
 	}, nil)
 	if err != nil {
@@ -150,10 +150,10 @@ func TestCreateAPString(t *testing.T) {
 		ID:     to.Int32Ptr(3),
 		Name:   to.StringPtr("Tommy"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]string{
-			"color":  "red",
-			"weight": "10 kg",
-			"city":   "Bombay",
+		AdditionalProperties: &map[string]*string{
+			"color":  to.StringPtr("red"),
+			"weight": to.StringPtr("10 kg"),
+			"city":   to.StringPtr("Bombay"),
 		},
 	}); r != "" {
 		t.Fatal(r)

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -77,9 +77,9 @@ func (e Error) Error() string {
 
 type PetAPInProperties struct {
 	// Dictionary of
-	AdditionalProperties *map[string]float32 `json:"additionalProperties,omitempty"`
-	ID                   *int32              `json:"id,omitempty"`
-	Name                 *string             `json:"name,omitempty"`
+	AdditionalProperties *map[string]*float32 `json:"additionalProperties,omitempty"`
+	ID                   *int32               `json:"id,omitempty"`
+	Name                 *string              `json:"name,omitempty"`
 
 	// Status - READ-ONLY
 	Status *bool `json:"status,omitempty" azure:"ro"`
@@ -95,13 +95,13 @@ type PetAPInPropertiesResponse struct {
 
 type PetAPInPropertiesWithAPString struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]string
+	AdditionalProperties *map[string]*string
 
 	// Dictionary of
-	AdditionalProperties1 *map[string]float32 `json:"additionalProperties,omitempty"`
-	ID                    *int32              `json:"id,omitempty"`
-	Name                  *string             `json:"name,omitempty"`
-	OdataLocation         *string             `json:"@odata.location,omitempty"`
+	AdditionalProperties1 *map[string]*float32 `json:"additionalProperties,omitempty"`
+	ID                    *int32               `json:"id,omitempty"`
+	Name                  *string              `json:"name,omitempty"`
+	OdataLocation         *string              `json:"@odata.location,omitempty"`
 
 	// Status - READ-ONLY
 	Status *bool `json:"status,omitempty" azure:"ro"`
@@ -149,12 +149,12 @@ func (p *PetAPInPropertiesWithAPString) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]string{}
+				p.AdditionalProperties = &map[string]*string{}
 			}
 			if val != nil {
 				var aux string
 				err = json.Unmarshal(*val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				(*p.AdditionalProperties)[key] = &aux
 			}
 			delete(rawMsg, key)
 		}
@@ -243,7 +243,7 @@ type PetAPObjectResponse struct {
 
 type PetAPString struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]string
+	AdditionalProperties *map[string]*string
 	ID                   *int32  `json:"id,omitempty"`
 	Name                 *string `json:"name,omitempty"`
 
@@ -285,12 +285,12 @@ func (p *PetAPString) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]string{}
+				p.AdditionalProperties = &map[string]*string{}
 			}
 			if val != nil {
 				var aux string
 				err = json.Unmarshal(*val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				(*p.AdditionalProperties)[key] = &aux
 			}
 			delete(rawMsg, key)
 		}

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -40,10 +40,10 @@ func TestGetArrayItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, [][]string{
-		{"1", "2", "3"},
+	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
+		to.StringPtrArray("1", "2", "3"),
 		{},
-		{"7", "8", "9"},
+		to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -56,10 +56,10 @@ func TestGetArrayItemNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, [][]string{
-		{"1", "2", "3"},
+	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
+		to.StringPtrArray("1", "2", "3"),
 		nil,
-		{"7", "8", "9"},
+		to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -84,10 +84,10 @@ func TestGetArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArrayArray, [][]string{
-		{"1", "2", "3"},
-		{"4", "5", "6"},
-		{"7", "8", "9"},
+	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
+		to.StringPtrArray("1", "2", "3"),
+		to.StringPtrArray("4", "5", "6"),
+		to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -142,7 +142,7 @@ func TestGetBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.BoolArray, []bool{true, false, false, true}); r != "" {
+	if r := cmp.Diff(resp.BoolArray, to.BoolPtrArray(true, false, false, true)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -198,7 +198,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ProductArray, []Product{
+	if r := cmp.Diff(resp.ProductArray, []*Product{
 		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		{},
 		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -209,7 +209,18 @@ func TestGetComplexItemEmpty(t *testing.T) {
 
 // GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 func TestGetComplexItemNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
+	client := newArrayClient()
+	resp, err := client.GetComplexItemNull(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := cmp.Diff(resp.ProductArray, []*Product{
+		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
+		nil,
+		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
+	}); r != "" {
+		t.Fatal(r)
+	}
 }
 
 // GetComplexNull - Get array of complex type null value
@@ -231,7 +242,7 @@ func TestGetComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.ProductArray, []Product{
+	if r := cmp.Diff(resp.ProductArray, []*Product{
 		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -291,10 +302,10 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	if r := cmp.Diff(resp.TimeArray, []time.Time{
-		v1,
-		v2,
-		v3,
+	if r := cmp.Diff(resp.TimeArray, []*time.Time{
+		&v1,
+		&v2,
+		&v3,
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -310,10 +321,10 @@ func TestGetDateTimeValid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T01:11:35+01:00")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T02:15:01-08:00")
-	if r := cmp.Diff(resp.TimeArray, []time.Time{
-		v1,
-		v2,
-		v3,
+	if r := cmp.Diff(resp.TimeArray, []*time.Time{
+		&v1,
+		&v2,
+		&v3,
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -326,11 +337,11 @@ func TestGetDateValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.TimeArray, []time.Time{
+	if r := cmp.Diff(resp.TimeArray, to.TimePtrArray(
 		time.Date(2000, time.December, 01, 0, 0, 0, 0, time.UTC),
 		time.Date(1980, time.January, 02, 0, 0, 0, 0, time.UTC),
 		time.Date(1492, time.October, 12, 0, 0, 0, 0, time.UTC),
-	}); r != "" {
+	)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -342,7 +353,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{}); r != "" {
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -354,17 +365,17 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
 		{
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		{},
 		{
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -378,17 +389,17 @@ func TestGetDictionaryItemNull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
 		{
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		nil,
 		{
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -414,21 +425,21 @@ func TestGetDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.MapOfStringArray, []map[string]string{
+	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
 		{
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		{
-			"4": "four",
-			"5": "five",
-			"6": "six",
+			"4": to.StringPtr("four"),
+			"5": to.StringPtr("five"),
+			"6": to.StringPtr("six"),
 		},
 		{
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -467,7 +478,7 @@ func TestGetDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Float64Array, []float64{0, -0.01, -1.2e20}); r != "" {
+	if r := cmp.Diff(resp.Float64Array, to.Float64PtrArray(0, -0.01, -1.2e20)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -479,7 +490,7 @@ func TestGetDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, []string{"P123DT22H14M12.011S", "P5DT1H0M0S"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, to.StringPtrArray("P123DT22H14M12.011S", "P5DT1H0M0S")); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -506,7 +517,8 @@ func TestGetEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.FooEnumArray, []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}); r != "" {
+	if r := cmp.Diff(resp.FooEnumArray, []*FooEnum{
+		FooEnumFoo1.ToPtr(), FooEnumFoo2.ToPtr(), FooEnumFoo3.ToPtr()}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -543,7 +555,7 @@ func TestGetFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Float32Array, []float32{0, -0.01, -1.2e20}); r != "" {
+	if r := cmp.Diff(resp.Float32Array, to.Float32PtrArray(0, -0.01, -1.2e20)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -580,7 +592,7 @@ func TestGetIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Int32Array, []int32{1, -1, 3, 300}); r != "" {
+	if r := cmp.Diff(resp.Int32Array, to.Int32PtrArray(1, -1, 3, 300)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -629,7 +641,7 @@ func TestGetLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Int64Array, []int64{1, -1, 3, 300}); r != "" {
+	if r := cmp.Diff(resp.Int64Array, to.Int64PtrArray(1, -1, 3, 300)); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -653,7 +665,8 @@ func TestGetStringEnumValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Enum0Array, []Enum0{Enum0Foo1, Enum0Foo2, Enum0Foo3}); r != "" {
+	if r := cmp.Diff(resp.Enum0Array, []*Enum0{
+		Enum0Foo1.ToPtr(), Enum0Foo2.ToPtr(), Enum0Foo3.ToPtr()}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -665,7 +678,7 @@ func TestGetStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, []string{"foo1", "foo2", "foo3"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, to.StringPtrArray("foo1", "foo2", "foo3")); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -684,14 +697,13 @@ func TestGetStringWithInvalid(t *testing.T) {
 
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
 func TestGetStringWithNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
 	client := newArrayClient()
 	resp, err := client.GetStringWithNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.StringArray, []*string{to.StringPtr("foo"), nil, to.StringPtr("foo2")}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -707,7 +719,7 @@ func TestGetUUIDValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.StringArray, []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"}); r != "" {
+	if r := cmp.Diff(resp.StringArray, to.StringPtrArray("6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205")); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -715,10 +727,10 @@ func TestGetUUIDValid(t *testing.T) {
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestPutArrayValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutArrayValid(context.Background(), [][]string{
-		{"1", "2", "3"},
-		{"4", "5", "6"},
-		{"7", "8", "9"},
+	resp, err := client.PutArrayValid(context.Background(), [][]*string{
+		to.StringPtrArray("1", "2", "3"),
+		to.StringPtrArray("4", "5", "6"),
+		to.StringPtrArray("7", "8", "9"),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -731,7 +743,7 @@ func TestPutArrayValid(t *testing.T) {
 // PutBooleanTfft - Set array value empty [true, false, false, true]
 func TestPutBooleanTfft(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutBooleanTfft(context.Background(), []bool{true, false, false, true}, nil)
+	resp, err := client.PutBooleanTfft(context.Background(), to.BoolPtrArray(true, false, false, true), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -759,7 +771,7 @@ func TestPutByteValid(t *testing.T) {
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestPutComplexValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutComplexValid(context.Background(), []Product{
+	resp, err := client.PutComplexValid(context.Background(), []*Product{
 		{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		{Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -778,7 +790,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), []time.Time{v1, v2, v3}, nil)
+	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), []*time.Time{&v1, &v2, &v3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -793,7 +805,7 @@ func TestPutDateTimeValid(t *testing.T) {
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35Z")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01Z")
-	resp, err := client.PutDateTimeValid(context.Background(), []time.Time{v1, v2, v3}, nil)
+	resp, err := client.PutDateTimeValid(context.Background(), []*time.Time{&v1, &v2, &v3}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -805,11 +817,9 @@ func TestPutDateTimeValid(t *testing.T) {
 // PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
 func TestPutDateValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDateValid(context.Background(), []time.Time{
-		time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC),
+	resp, err := client.PutDateValid(context.Background(), to.TimePtrArray(time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC),
 		time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC),
-		time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC),
-	}, nil)
+		time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -821,21 +831,21 @@ func TestPutDateValid(t *testing.T) {
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestPutDictionaryValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDictionaryValid(context.Background(), []map[string]string{
+	resp, err := client.PutDictionaryValid(context.Background(), []map[string]*string{
 		{
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		{
-			"4": "four",
-			"5": "five",
-			"6": "six",
+			"4": to.StringPtr("four"),
+			"5": to.StringPtr("five"),
+			"6": to.StringPtr("six"),
 		},
 		{
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}, nil)
 	if err != nil {
@@ -849,7 +859,7 @@ func TestPutDictionaryValid(t *testing.T) {
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
 func TestPutDoubleValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDoubleValid(context.Background(), []float64{0, -0.01, -1.2e20}, nil)
+	resp, err := client.PutDoubleValid(context.Background(), to.Float64PtrArray(0, -0.01, -1.2e20), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -861,7 +871,7 @@ func TestPutDoubleValid(t *testing.T) {
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestPutDurationValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutDurationValid(context.Background(), []string{"P123DT22H14M12.011S", "P5DT1H"}, nil)
+	resp, err := client.PutDurationValid(context.Background(), to.StringPtrArray("P123DT22H14M12.011S", "P5DT1H"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -873,7 +883,7 @@ func TestPutDurationValid(t *testing.T) {
 // PutEmpty - Set array value empty []
 func TestPutEmpty(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutEmpty(context.Background(), []string{}, nil)
+	resp, err := client.PutEmpty(context.Background(), []*string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -885,7 +895,8 @@ func TestPutEmpty(t *testing.T) {
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutEnumValid(context.Background(), []FooEnum{FooEnumFoo1, FooEnumFoo2, FooEnumFoo3}, nil)
+	resp, err := client.PutEnumValid(context.Background(), []*FooEnum{
+		FooEnumFoo1.ToPtr(), FooEnumFoo2.ToPtr(), FooEnumFoo3.ToPtr()}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -897,7 +908,7 @@ func TestPutEnumValid(t *testing.T) {
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
 func TestPutFloatValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutFloatValid(context.Background(), []float32{0, -0.01, -1.2e20}, nil)
+	resp, err := client.PutFloatValid(context.Background(), to.Float32PtrArray(0, -0.01, -1.2e20), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -909,7 +920,7 @@ func TestPutFloatValid(t *testing.T) {
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
 func TestPutIntegerValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutIntegerValid(context.Background(), []int32{1, -1, 3, 300}, nil)
+	resp, err := client.PutIntegerValid(context.Background(), to.Int32PtrArray(1, -1, 3, 300), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -921,7 +932,7 @@ func TestPutIntegerValid(t *testing.T) {
 // PutLongValid - Set array value empty [1, -1, 3, 300]
 func TestPutLongValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutLongValid(context.Background(), []int64{1, -1, 3, 300}, nil)
+	resp, err := client.PutLongValid(context.Background(), to.Int64PtrArray(1, -1, 3, 300), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -933,7 +944,8 @@ func TestPutLongValid(t *testing.T) {
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringEnumValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutStringEnumValid(context.Background(), []Enum1{Enum1Foo1, Enum1Foo2, Enum1Foo3}, nil)
+	resp, err := client.PutStringEnumValid(context.Background(), []*Enum1{
+		Enum1Foo1.ToPtr(), Enum1Foo2.ToPtr(), Enum1Foo3.ToPtr()}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -945,7 +957,7 @@ func TestPutStringEnumValid(t *testing.T) {
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutStringValid(context.Background(), []string{"foo1", "foo2", "foo3"}, nil)
+	resp, err := client.PutStringValid(context.Background(), to.StringPtrArray("foo1", "foo2", "foo3"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -957,7 +969,7 @@ func TestPutStringValid(t *testing.T) {
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestPutUUIDValid(t *testing.T) {
 	client := newArrayClient()
-	resp, err := client.PutUUIDValid(context.Background(), []string{"6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"}, nil)
+	resp, err := client.PutUUIDValid(context.Background(), to.StringPtrArray("6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -265,7 +265,20 @@ func TestGetDateInvalidChars(t *testing.T) {
 
 // GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
 func TestGetDateInvalidNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
+	client := newArrayClient()
+	resp, err := client.GetDateInvalidNull(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
+	v3 := time.Date(1776, 7, 4, 0, 0, 0, 0, time.UTC)
+	if r := cmp.Diff(resp.TimeArray, []*time.Time{
+		&v1,
+		nil,
+		&v3,
+	}); r != "" {
+		t.Fatal(r)
+	}
 }
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
@@ -452,14 +465,17 @@ func TestGetDictionaryValid(t *testing.T) {
 
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetDoubleInvalidNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
 	client := newArrayClient()
 	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Float64Array, []*float64{
+		to.Float64Ptr(0),
+		nil,
+		to.Float64Ptr(-1.2e20),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -529,14 +545,17 @@ func TestGetEnumValid(t *testing.T) {
 
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetFloatInvalidNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
 	client := newArrayClient()
 	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Float32Array, []*float32{
+		to.Float32Ptr(0),
+		nil,
+		to.Float32Ptr(-1.2e20),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -566,14 +585,17 @@ func TestGetFloatValid(t *testing.T) {
 
 // GetIntInvalidNull - Get integer array value [1, null, 0]
 func TestGetIntInvalidNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
 	client := newArrayClient()
 	resp, err := client.GetIntInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Int32Array, []*int32{
+		to.Int32Ptr(1),
+		nil,
+		to.Int32Ptr(0),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -615,14 +637,17 @@ func TestGetInvalid(t *testing.T) {
 
 // GetLongInvalidNull - Get long array value [1, null, 0]
 func TestGetLongInvalidNull(t *testing.T) {
-	t.Skip("arrays with nil elements")
 	client := newArrayClient()
 	resp, err := client.GetLongInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Int64Array, []*int64{
+		to.Int64Ptr(1),
+		nil,
+		to.Int64Ptr(0),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -284,11 +284,15 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 func TestGetDateTimeInvalidNull(t *testing.T) {
 	client := newArrayClient()
 	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
+	if r := cmp.Diff(resp.TimeArray, []*time.Time{
+		&v1,
+		nil,
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/arraygroup/zz_generated_array.go
+++ b/test/autorest/arraygroup/zz_generated_array.go
@@ -55,7 +55,7 @@ func (client *ArrayClient) getArrayEmptyCreateRequest(ctx context.Context, optio
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *ArrayClient) getArrayEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val [][]string
+	var val [][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -101,7 +101,7 @@ func (client *ArrayClient) getArrayItemEmptyCreateRequest(ctx context.Context, o
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *ArrayClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val [][]string
+	var val [][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *ArrayClient) getArrayItemNullCreateRequest(ctx context.Context, op
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *ArrayClient) getArrayItemNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val [][]string
+	var val [][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -193,7 +193,7 @@ func (client *ArrayClient) getArrayNullCreateRequest(ctx context.Context, option
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *ArrayClient) getArrayNullHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val [][]string
+	var val [][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -239,7 +239,7 @@ func (client *ArrayClient) getArrayValidCreateRequest(ctx context.Context, optio
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *ArrayClient) getArrayValidHandleResponse(resp *azcore.Response) (StringArrayArrayResponse, error) {
-	var val [][]string
+	var val [][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayArrayResponse{}, err
 	}
@@ -331,7 +331,7 @@ func (client *ArrayClient) getBooleanInvalidNullCreateRequest(ctx context.Contex
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *ArrayClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val []bool
+	var val []*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *ArrayClient) getBooleanInvalidStringCreateRequest(ctx context.Cont
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *ArrayClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val []bool
+	var val []*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -423,7 +423,7 @@ func (client *ArrayClient) getBooleanTfftCreateRequest(ctx context.Context, opti
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *ArrayClient) getBooleanTfftHandleResponse(resp *azcore.Response) (BoolArrayResponse, error) {
-	var val []bool
+	var val []*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return BoolArrayResponse{}, err
 	}
@@ -561,7 +561,7 @@ func (client *ArrayClient) getComplexEmptyCreateRequest(ctx context.Context, opt
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *ArrayClient) getComplexEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -607,7 +607,7 @@ func (client *ArrayClient) getComplexItemEmptyCreateRequest(ctx context.Context,
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *ArrayClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -653,7 +653,7 @@ func (client *ArrayClient) getComplexItemNullCreateRequest(ctx context.Context, 
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *ArrayClient) getComplexItemNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -699,7 +699,7 @@ func (client *ArrayClient) getComplexNullCreateRequest(ctx context.Context, opti
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *ArrayClient) getComplexNullHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -745,7 +745,7 @@ func (client *ArrayClient) getComplexValidCreateRequest(ctx context.Context, opt
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *ArrayClient) getComplexValidHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -791,13 +791,13 @@ func (client *ArrayClient) getDateInvalidCharsCreateRequest(ctx context.Context,
 
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *ArrayClient) getDateInvalidCharsHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []dateType
+	var aux []*dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -841,13 +841,13 @@ func (client *ArrayClient) getDateInvalidNullCreateRequest(ctx context.Context, 
 
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *ArrayClient) getDateInvalidNullHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []dateType
+	var aux []*dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -891,13 +891,13 @@ func (client *ArrayClient) getDateTimeInvalidCharsCreateRequest(ctx context.Cont
 
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *ArrayClient) getDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []timeRFC3339
+	var aux []*timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -941,13 +941,13 @@ func (client *ArrayClient) getDateTimeInvalidNullCreateRequest(ctx context.Conte
 
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *ArrayClient) getDateTimeInvalidNullHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []timeRFC3339
+	var aux []*timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -991,13 +991,13 @@ func (client *ArrayClient) getDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 
 // getDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *ArrayClient) getDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []timeRFC1123
+	var aux []*timeRFC1123
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -1041,13 +1041,13 @@ func (client *ArrayClient) getDateTimeValidCreateRequest(ctx context.Context, op
 
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *ArrayClient) getDateTimeValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []timeRFC3339
+	var aux []*timeRFC3339
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -1091,13 +1091,13 @@ func (client *ArrayClient) getDateValidCreateRequest(ctx context.Context, option
 
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *ArrayClient) getDateValidHandleResponse(resp *azcore.Response) (TimeArrayResponse, error) {
-	var aux []dateType
+	var aux []*dateType
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return TimeArrayResponse{}, err
 	}
-	cp := make([]time.Time, len(aux), len(aux))
+	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
-		cp[i] = time.Time(aux[i])
+		cp[i] = (*time.Time)(aux[i])
 	}
 	return TimeArrayResponse{RawResponse: resp.Response, TimeArray: cp}, nil
 }
@@ -1141,7 +1141,7 @@ func (client *ArrayClient) getDictionaryEmptyCreateRequest(ctx context.Context, 
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *ArrayClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val []map[string]string
+	var val []map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1188,7 +1188,7 @@ func (client *ArrayClient) getDictionaryItemEmptyCreateRequest(ctx context.Conte
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *ArrayClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val []map[string]string
+	var val []map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1235,7 +1235,7 @@ func (client *ArrayClient) getDictionaryItemNullCreateRequest(ctx context.Contex
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *ArrayClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val []map[string]string
+	var val []map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1281,7 +1281,7 @@ func (client *ArrayClient) getDictionaryNullCreateRequest(ctx context.Context, o
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *ArrayClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val []map[string]string
+	var val []map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1328,7 +1328,7 @@ func (client *ArrayClient) getDictionaryValidCreateRequest(ctx context.Context, 
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *ArrayClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val []map[string]string
+	var val []map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -1374,7 +1374,7 @@ func (client *ArrayClient) getDoubleInvalidNullCreateRequest(ctx context.Context
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *ArrayClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val []float64
+	var val []*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1420,7 +1420,7 @@ func (client *ArrayClient) getDoubleInvalidStringCreateRequest(ctx context.Conte
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *ArrayClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val []float64
+	var val []*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1466,7 +1466,7 @@ func (client *ArrayClient) getDoubleValidCreateRequest(ctx context.Context, opti
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *ArrayClient) getDoubleValidHandleResponse(resp *azcore.Response) (Float64ArrayResponse, error) {
-	var val []float64
+	var val []*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float64ArrayResponse{}, err
 	}
@@ -1512,7 +1512,7 @@ func (client *ArrayClient) getDurationValidCreateRequest(ctx context.Context, op
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *ArrayClient) getDurationValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -1558,7 +1558,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *ArrayClient) getEmptyHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1604,7 +1604,7 @@ func (client *ArrayClient) getEnumValidCreateRequest(ctx context.Context, option
 
 // getEnumValidHandleResponse handles the GetEnumValid response.
 func (client *ArrayClient) getEnumValidHandleResponse(resp *azcore.Response) (FooEnumArrayResponse, error) {
-	var val []FooEnum
+	var val []*FooEnum
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return FooEnumArrayResponse{}, err
 	}
@@ -1650,7 +1650,7 @@ func (client *ArrayClient) getFloatInvalidNullCreateRequest(ctx context.Context,
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *ArrayClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val []float32
+	var val []*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1696,7 +1696,7 @@ func (client *ArrayClient) getFloatInvalidStringCreateRequest(ctx context.Contex
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *ArrayClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val []float32
+	var val []*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1742,7 +1742,7 @@ func (client *ArrayClient) getFloatValidCreateRequest(ctx context.Context, optio
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *ArrayClient) getFloatValidHandleResponse(resp *azcore.Response) (Float32ArrayResponse, error) {
-	var val []float32
+	var val []*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Float32ArrayResponse{}, err
 	}
@@ -1788,7 +1788,7 @@ func (client *ArrayClient) getIntInvalidNullCreateRequest(ctx context.Context, o
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *ArrayClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1834,7 +1834,7 @@ func (client *ArrayClient) getIntInvalidStringCreateRequest(ctx context.Context,
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *ArrayClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1880,7 +1880,7 @@ func (client *ArrayClient) getIntegerValidCreateRequest(ctx context.Context, opt
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *ArrayClient) getIntegerValidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1926,7 +1926,7 @@ func (client *ArrayClient) getInvalidCreateRequest(ctx context.Context, options 
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *ArrayClient) getInvalidHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -1972,7 +1972,7 @@ func (client *ArrayClient) getLongInvalidNullCreateRequest(ctx context.Context, 
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *ArrayClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val []int64
+	var val []*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2018,7 +2018,7 @@ func (client *ArrayClient) getLongInvalidStringCreateRequest(ctx context.Context
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *ArrayClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val []int64
+	var val []*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2064,7 +2064,7 @@ func (client *ArrayClient) getLongValidCreateRequest(ctx context.Context, option
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *ArrayClient) getLongValidHandleResponse(resp *azcore.Response) (Int64ArrayResponse, error) {
-	var val []int64
+	var val []*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int64ArrayResponse{}, err
 	}
@@ -2110,7 +2110,7 @@ func (client *ArrayClient) getNullCreateRequest(ctx context.Context, options *Ar
 
 // getNullHandleResponse handles the GetNull response.
 func (client *ArrayClient) getNullHandleResponse(resp *azcore.Response) (Int32ArrayResponse, error) {
-	var val []int32
+	var val []*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Int32ArrayResponse{}, err
 	}
@@ -2156,7 +2156,7 @@ func (client *ArrayClient) getStringEnumValidCreateRequest(ctx context.Context, 
 
 // getStringEnumValidHandleResponse handles the GetStringEnumValid response.
 func (client *ArrayClient) getStringEnumValidHandleResponse(resp *azcore.Response) (Enum0ArrayResponse, error) {
-	var val []Enum0
+	var val []*Enum0
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return Enum0ArrayResponse{}, err
 	}
@@ -2202,7 +2202,7 @@ func (client *ArrayClient) getStringValidCreateRequest(ctx context.Context, opti
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *ArrayClient) getStringValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2248,7 +2248,7 @@ func (client *ArrayClient) getStringWithInvalidCreateRequest(ctx context.Context
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *ArrayClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2294,7 +2294,7 @@ func (client *ArrayClient) getStringWithNullCreateRequest(ctx context.Context, o
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *ArrayClient) getStringWithNullHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2340,7 +2340,7 @@ func (client *ArrayClient) getUUIDInvalidCharsCreateRequest(ctx context.Context,
 
 // getUUIDInvalidCharsHandleResponse handles the GetUUIDInvalidChars response.
 func (client *ArrayClient) getUUIDInvalidCharsHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2386,7 +2386,7 @@ func (client *ArrayClient) getUUIDValidCreateRequest(ctx context.Context, option
 
 // getUUIDValidHandleResponse handles the GetUUIDValid response.
 func (client *ArrayClient) getUUIDValidHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -2403,7 +2403,7 @@ func (client *ArrayClient) getUUIDValidHandleError(resp *azcore.Response) error 
 }
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
-func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]string, options *ArrayPutArrayValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]*string, options *ArrayPutArrayValidOptions) (*http.Response, error) {
 	req, err := client.putArrayValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2419,7 +2419,7 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]stri
 }
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
-func (client *ArrayClient) putArrayValidCreateRequest(ctx context.Context, arrayBody [][]string, options *ArrayPutArrayValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putArrayValidCreateRequest(ctx context.Context, arrayBody [][]*string, options *ArrayPutArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2440,7 +2440,7 @@ func (client *ArrayClient) putArrayValidHandleError(resp *azcore.Response) error
 }
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
-func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool, options *ArrayPutBooleanTfftOptions) (*http.Response, error) {
+func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []*bool, options *ArrayPutBooleanTfftOptions) (*http.Response, error) {
 	req, err := client.putBooleanTfftCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2456,7 +2456,7 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []bool,
 }
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
-func (client *ArrayClient) putBooleanTfftCreateRequest(ctx context.Context, arrayBody []bool, options *ArrayPutBooleanTfftOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putBooleanTfftCreateRequest(ctx context.Context, arrayBody []*bool, options *ArrayPutBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2514,7 +2514,7 @@ func (client *ArrayClient) putByteValidHandleError(resp *azcore.Response) error 
 }
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
-func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Product, options *ArrayPutComplexValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []*Product, options *ArrayPutComplexValidOptions) (*http.Response, error) {
 	req, err := client.putComplexValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2530,7 +2530,7 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []Prod
 }
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
-func (client *ArrayClient) putComplexValidCreateRequest(ctx context.Context, arrayBody []Product, options *ArrayPutComplexValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putComplexValidCreateRequest(ctx context.Context, arrayBody []*Product, options *ArrayPutComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2551,7 +2551,7 @@ func (client *ArrayClient) putComplexValidHandleError(resp *azcore.Response) err
 }
 
 // PutDateTimeRFC1123Valid - Set array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
-func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
 	req, err := client.putDateTimeRFC1123ValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2567,7 +2567,7 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 }
 
 // putDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
-func (client *ArrayClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2575,9 +2575,9 @@ func (client *ArrayClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Cont
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	aux := make([]timeRFC1123, len(arrayBody), len(arrayBody))
+	aux := make([]*timeRFC1123, len(arrayBody), len(arrayBody))
 	for i := 0; i < len(arrayBody); i++ {
-		aux[i] = timeRFC1123(arrayBody[i])
+		aux[i] = (*timeRFC1123)(arrayBody[i])
 	}
 	return req, req.MarshalAsJSON(aux)
 }
@@ -2592,7 +2592,7 @@ func (client *ArrayClient) putDateTimeRFC1123ValidHandleError(resp *azcore.Respo
 }
 
 // PutDateTimeValid - Set array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
-func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateTimeValidOptions) (*http.Response, error) {
 	req, err := client.putDateTimeValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2608,7 +2608,7 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []tim
 }
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
-func (client *ArrayClient) putDateTimeValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateTimeValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDateTimeValidCreateRequest(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2629,7 +2629,7 @@ func (client *ArrayClient) putDateTimeValidHandleError(resp *azcore.Response) er
 }
 
 // PutDateValid - Set array value ['2000-12-01', '1980-01-02', '1492-10-12']
-func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateValidOptions) (*http.Response, error) {
 	req, err := client.putDateValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2645,7 +2645,7 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []time.Ti
 }
 
 // putDateValidCreateRequest creates the PutDateValid request.
-func (client *ArrayClient) putDateValidCreateRequest(ctx context.Context, arrayBody []time.Time, options *ArrayPutDateValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDateValidCreateRequest(ctx context.Context, arrayBody []*time.Time, options *ArrayPutDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2653,9 +2653,9 @@ func (client *ArrayClient) putDateValidCreateRequest(ctx context.Context, arrayB
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	aux := make([]dateType, len(arrayBody), len(arrayBody))
+	aux := make([]*dateType, len(arrayBody), len(arrayBody))
 	for i := 0; i < len(arrayBody); i++ {
-		aux[i] = dateType(arrayBody[i])
+		aux[i] = (*dateType)(arrayBody[i])
 	}
 	return req, req.MarshalAsJSON(aux)
 }
@@ -2671,7 +2671,7 @@ func (client *ArrayClient) putDateValidHandleError(resp *azcore.Response) error 
 
 // PutDictionaryValid - Get an array of Dictionaries of type with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'},
 // {'7': 'seven', '8': 'eight', '9': 'nine'}]
-func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []map[string]string, options *ArrayPutDictionaryValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []map[string]*string, options *ArrayPutDictionaryValidOptions) (*http.Response, error) {
 	req, err := client.putDictionaryValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2687,7 +2687,7 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 }
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
-func (client *ArrayClient) putDictionaryValidCreateRequest(ctx context.Context, arrayBody []map[string]string, options *ArrayPutDictionaryValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDictionaryValidCreateRequest(ctx context.Context, arrayBody []map[string]*string, options *ArrayPutDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2708,7 +2708,7 @@ func (client *ArrayClient) putDictionaryValidHandleError(resp *azcore.Response) 
 }
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float64, options *ArrayPutDoubleValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []*float64, options *ArrayPutDoubleValidOptions) (*http.Response, error) {
 	req, err := client.putDoubleValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2724,7 +2724,7 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []float
 }
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
-func (client *ArrayClient) putDoubleValidCreateRequest(ctx context.Context, arrayBody []float64, options *ArrayPutDoubleValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDoubleValidCreateRequest(ctx context.Context, arrayBody []*float64, options *ArrayPutDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2745,7 +2745,7 @@ func (client *ArrayClient) putDoubleValidHandleError(resp *azcore.Response) erro
 }
 
 // PutDurationValid - Set array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
-func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []string, options *ArrayPutDurationValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []*string, options *ArrayPutDurationValidOptions) (*http.Response, error) {
 	req, err := client.putDurationValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2761,7 +2761,7 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []str
 }
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
-func (client *ArrayClient) putDurationValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutDurationValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putDurationValidCreateRequest(ctx context.Context, arrayBody []*string, options *ArrayPutDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2782,7 +2782,7 @@ func (client *ArrayClient) putDurationValidHandleError(resp *azcore.Response) er
 }
 
 // PutEmpty - Set array value empty []
-func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string, options *ArrayPutEmptyOptions) (*http.Response, error) {
+func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []*string, options *ArrayPutEmptyOptions) (*http.Response, error) {
 	req, err := client.putEmptyCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2798,7 +2798,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []string, opt
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
-func (client *ArrayClient) putEmptyCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutEmptyOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putEmptyCreateRequest(ctx context.Context, arrayBody []*string, options *ArrayPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/array/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2819,7 +2819,7 @@ func (client *ArrayClient) putEmptyHandleError(resp *azcore.Response) error {
 }
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum, options *ArrayPutEnumValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []*FooEnum, options *ArrayPutEnumValidOptions) (*http.Response, error) {
 	req, err := client.putEnumValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2835,7 +2835,7 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []FooEnum
 }
 
 // putEnumValidCreateRequest creates the PutEnumValid request.
-func (client *ArrayClient) putEnumValidCreateRequest(ctx context.Context, arrayBody []FooEnum, options *ArrayPutEnumValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putEnumValidCreateRequest(ctx context.Context, arrayBody []*FooEnum, options *ArrayPutEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2856,7 +2856,7 @@ func (client *ArrayClient) putEnumValidHandleError(resp *azcore.Response) error 
 }
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
-func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float32, options *ArrayPutFloatValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []*float32, options *ArrayPutFloatValidOptions) (*http.Response, error) {
 	req, err := client.putFloatValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2872,7 +2872,7 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []float3
 }
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
-func (client *ArrayClient) putFloatValidCreateRequest(ctx context.Context, arrayBody []float32, options *ArrayPutFloatValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putFloatValidCreateRequest(ctx context.Context, arrayBody []*float32, options *ArrayPutFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2893,7 +2893,7 @@ func (client *ArrayClient) putFloatValidHandleError(resp *azcore.Response) error
 }
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
-func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int32, options *ArrayPutIntegerValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []*int32, options *ArrayPutIntegerValidOptions) (*http.Response, error) {
 	req, err := client.putIntegerValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2909,7 +2909,7 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []int3
 }
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
-func (client *ArrayClient) putIntegerValidCreateRequest(ctx context.Context, arrayBody []int32, options *ArrayPutIntegerValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putIntegerValidCreateRequest(ctx context.Context, arrayBody []*int32, options *ArrayPutIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2930,7 +2930,7 @@ func (client *ArrayClient) putIntegerValidHandleError(resp *azcore.Response) err
 }
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
-func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64, options *ArrayPutLongValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []*int64, options *ArrayPutLongValidOptions) (*http.Response, error) {
 	req, err := client.putLongValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2946,7 +2946,7 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []int64, 
 }
 
 // putLongValidCreateRequest creates the PutLongValid request.
-func (client *ArrayClient) putLongValidCreateRequest(ctx context.Context, arrayBody []int64, options *ArrayPutLongValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putLongValidCreateRequest(ctx context.Context, arrayBody []*int64, options *ArrayPutLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2967,7 +2967,7 @@ func (client *ArrayClient) putLongValidHandleError(resp *azcore.Response) error 
 }
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []Enum1, options *ArrayPutStringEnumValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []*Enum1, options *ArrayPutStringEnumValidOptions) (*http.Response, error) {
 	req, err := client.putStringEnumValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2983,7 +2983,7 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []E
 }
 
 // putStringEnumValidCreateRequest creates the PutStringEnumValid request.
-func (client *ArrayClient) putStringEnumValidCreateRequest(ctx context.Context, arrayBody []Enum1, options *ArrayPutStringEnumValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putStringEnumValidCreateRequest(ctx context.Context, arrayBody []*Enum1, options *ArrayPutStringEnumValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string-enum/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -3004,7 +3004,7 @@ func (client *ArrayClient) putStringEnumValidHandleError(resp *azcore.Response) 
 }
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
-func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []string, options *ArrayPutStringValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []*string, options *ArrayPutStringValidOptions) (*http.Response, error) {
 	req, err := client.putStringValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -3020,7 +3020,7 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []strin
 }
 
 // putStringValidCreateRequest creates the PutStringValid request.
-func (client *ArrayClient) putStringValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutStringValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putStringValidCreateRequest(ctx context.Context, arrayBody []*string, options *ArrayPutStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -3041,7 +3041,7 @@ func (client *ArrayClient) putStringValidHandleError(resp *azcore.Response) erro
 }
 
 // PutUUIDValid - Set array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
-func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string, options *ArrayPutUUIDValidOptions) (*http.Response, error) {
+func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []*string, options *ArrayPutUUIDValidOptions) (*http.Response, error) {
 	req, err := client.putUUIDValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -3057,7 +3057,7 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []string,
 }
 
 // putUUIDValidCreateRequest creates the PutUUIDValid request.
-func (client *ArrayClient) putUUIDValidCreateRequest(ctx context.Context, arrayBody []string, options *ArrayPutUUIDValidOptions) (*azcore.Request, error) {
+func (client *ArrayClient) putUUIDValidCreateRequest(ctx context.Context, arrayBody []*string, options *ArrayPutUUIDValidOptions) (*azcore.Request, error) {
 	urlPath := "/array/prim/uuid/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {

--- a/test/autorest/arraygroup/zz_generated_models.go
+++ b/test/autorest/arraygroup/zz_generated_models.go
@@ -358,10 +358,10 @@ type ArrayPutUUIDValidOptions struct {
 	// placeholder for future optional parameters
 }
 
-// BoolArrayResponse is the response envelope for operations that return a []bool type.
+// BoolArrayResponse is the response envelope for operations that return a []*bool type.
 type BoolArrayResponse struct {
 	// The array value [true, false, false, true]
-	BoolArray []bool
+	BoolArray []*bool
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -376,10 +376,10 @@ type ByteArrayArrayResponse struct {
 	RawResponse *http.Response
 }
 
-// Enum0ArrayResponse is the response envelope for operations that return a []Enum0 type.
+// Enum0ArrayResponse is the response envelope for operations that return a []*Enum0 type.
 type Enum0ArrayResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
-	Enum0Array []Enum0
+	Enum0Array []*Enum0
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -405,55 +405,55 @@ func (e Error) Error() string {
 	return msg
 }
 
-// Float32ArrayResponse is the response envelope for operations that return a []float32 type.
+// Float32ArrayResponse is the response envelope for operations that return a []*float32 type.
 type Float32ArrayResponse struct {
 	// The array value [0, -0.01, 1.2e20]
-	Float32Array []float32
+	Float32Array []*float32
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// Float64ArrayResponse is the response envelope for operations that return a []float64 type.
+// Float64ArrayResponse is the response envelope for operations that return a []*float64 type.
 type Float64ArrayResponse struct {
 	// The array value [0, -0.01, 1.2e20]
-	Float64Array []float64
+	Float64Array []*float64
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// FooEnumArrayResponse is the response envelope for operations that return a []FooEnum type.
+// FooEnumArrayResponse is the response envelope for operations that return a []*FooEnum type.
 type FooEnumArrayResponse struct {
 	// The array value ['foo1', 'foo2', 'foo3']
-	FooEnumArray []FooEnum
+	FooEnumArray []*FooEnum
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// Int32ArrayResponse is the response envelope for operations that return a []int32 type.
+// Int32ArrayResponse is the response envelope for operations that return a []*int32 type.
 type Int32ArrayResponse struct {
 	// The null Array value
-	Int32Array []int32
+	Int32Array []*int32
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// Int64ArrayResponse is the response envelope for operations that return a []int64 type.
+// Int64ArrayResponse is the response envelope for operations that return a []*int64 type.
 type Int64ArrayResponse struct {
 	// The array value [1, -1, 3, 300]
-	Int64Array []int64
+	Int64Array []*int64
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// MapOfStringArrayResponse is the response envelope for operations that return a []map[string]string type.
+// MapOfStringArrayResponse is the response envelope for operations that return a []map[string]*string type.
 type MapOfStringArrayResponse struct {
 	// An array of Dictionaries with value null
-	MapOfStringArray []map[string]string
+	MapOfStringArray []map[string]*string
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -464,38 +464,38 @@ type Product struct {
 	String  *string `json:"string,omitempty"`
 }
 
-// ProductArrayResponse is the response envelope for operations that return a []Product type.
+// ProductArrayResponse is the response envelope for operations that return a []*Product type.
 type ProductArrayResponse struct {
 	// array of complex type with null value
-	ProductArray []Product
+	ProductArray []*Product
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// StringArrayArrayResponse is the response envelope for operations that return a [][]string type.
+// StringArrayArrayResponse is the response envelope for operations that return a [][]*string type.
 type StringArrayArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// a null array
-	StringArrayArray [][]string
+	StringArrayArray [][]*string
 }
 
-// StringArrayResponse is the response envelope for operations that return a []string type.
+// StringArrayResponse is the response envelope for operations that return a []*string type.
 type StringArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The array value ['foo1', 'foo2', 'foo3']
-	StringArray []string
+	StringArray []*string
 }
 
-// TimeArrayResponse is the response envelope for operations that return a []time.Time type.
+// TimeArrayResponse is the response envelope for operations that return a []*time.Time type.
 type TimeArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The array value ['2000-12-01', '1980-01-02', '1492-10-12']
-	TimeArray []time.Time
+	TimeArray []*time.Time
 }

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure.go
@@ -59,7 +59,7 @@ func (client *AutoRestReportServiceForAzureClient) getReportCreateRequest(ctx co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceForAzureClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}

--- a/test/autorest/azurereportgroup/zz_generated_models.go
+++ b/test/autorest/azurereportgroup/zz_generated_models.go
@@ -39,11 +39,11 @@ func (e Error) Error() string {
 	return msg
 }
 
-// MapOfInt32Response is the response envelope for operations that return a map[string]int32 type.
+// MapOfInt32Response is the response envelope for operations that return a map[string]*int32 type.
 type MapOfInt32Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Dictionary of <integer>
-	Value map[string]int32
+	Value map[string]*int32
 }

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -70,13 +70,19 @@ func TestArrayPutEmpty(t *testing.T) {
 	}
 }
 
-/*
-test is currently invalid, missing x-nullable but expects null
 func TestArrayPutValid(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.PutValid(context.Background(), ArrayWrapper{Array: &[]string{"1, 2, 3, 4", "", nil, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"}})
+	result, err := client.PutValid(context.Background(), ArrayWrapper{Array: &[]*string{
+		to.StringPtr("1, 2, 3, 4"),
+		to.StringPtr(""),
+		nil,
+		to.StringPtr("&S#$(*Y"),
+		to.StringPtr("The quick brown fox jumps over the lazy dog"),
+	}}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result, http.StatusOK)
-}*/
+	if s := result.StatusCode; s != http.StatusOK {
+		t.Fatalf("unexpected status code %d", s)
+	}
+}

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -22,7 +23,7 @@ func TestArrayGetEmpty(t *testing.T) {
 		t.Fatalf("GetEmpty: %v", err)
 	}
 	if r := cmp.Diff(result.ArrayWrapper, &ArrayWrapper{
-		Array: &[]string{},
+		Array: &[]*string{},
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -46,7 +47,13 @@ func TestArrayGetValid(t *testing.T) {
 		t.Fatalf("GetValid: %v", err)
 	}
 	if r := cmp.Diff(result.ArrayWrapper, &ArrayWrapper{
-		Array: &[]string{"1, 2, 3, 4", "", "", "&S#$(*Y", "The quick brown fox jumps over the lazy dog"},
+		Array: &[]*string{
+			to.StringPtr("1, 2, 3, 4"),
+			to.StringPtr(""),
+			nil,
+			to.StringPtr("&S#$(*Y"),
+			to.StringPtr("The quick brown fox jumps over the lazy dog"),
+		},
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -54,7 +61,7 @@ func TestArrayGetValid(t *testing.T) {
 
 func TestArrayPutEmpty(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: &[]string{}}, nil)
+	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: &[]*string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -48,8 +48,6 @@ func TestDictionaryGetNull(t *testing.T) {
 	}
 }
 
-/*
-test is invalid, expects null values but missing x-nullable
 func TestDictionaryGetValid(t *testing.T) {
 	client := newDictionaryClient()
 	result, err := client.GetValid(context.Background(), nil)
@@ -57,9 +55,11 @@ func TestDictionaryGetValid(t *testing.T) {
 		t.Fatalf("GetValid: %v", err)
 	}
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
-	val := DictionaryWrapper{DefaultProgram: &map[string]string{"txt": s1, "bmp": s2, "xls": s3, "exe": s4, "": nil}}
-	if r := cmp.Diff(result.DictionaryWrapper, &val)
-}*/
+	val := DictionaryWrapper{DefaultProgram: &map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}
+	if r := cmp.Diff(result.DictionaryWrapper, &val); r != "" {
+		t.Fatal(r)
+	}
+}
 
 func TestDictionaryPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
@@ -72,14 +72,14 @@ func TestDictionaryPutEmpty(t *testing.T) {
 	}
 }
 
-/*
-test is invalid, expects null values but missing x-nullable
 func TestDictionaryPutValid(t *testing.T) {
 	client := newDictionaryClient()
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
-	result, err := client.PutValid(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]string{"txt": s1, "bmp": s2, "xls": s3, "exe": s4, "": nil}})
+	result, err := client.PutValid(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}
-	helpers.VerifyStatusCode(t, result, http.StatusOK)
-}*/
+	if s := result.StatusCode; s != http.StatusOK {
+		t.Fatalf("unexpected status code %d", s)
+	}
+}

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -21,7 +21,7 @@ func TestDictionaryGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	if r := cmp.Diff(result.DictionaryWrapper, &DictionaryWrapper{DefaultProgram: &map[string]string{}}); r != "" {
+	if r := cmp.Diff(result.DictionaryWrapper, &DictionaryWrapper{DefaultProgram: &map[string]*string{}}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -63,7 +63,7 @@ func TestDictionaryGetValid(t *testing.T) {
 
 func TestDictionaryPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]string{}}, nil)
+	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]*string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -29,7 +29,7 @@ func TestInheritanceGetValid(t *testing.T) {
 				Name: to.StringPtr("Siameeee"),
 			},
 			Color: to.StringPtr("green"),
-			Hates: &[]Dog{
+			Hates: &[]*Dog{
 				{
 					Pet: Pet{
 						ID:   to.Int32Ptr(1),
@@ -61,7 +61,7 @@ func TestInheritancePutValid(t *testing.T) {
 				Name: to.StringPtr("Siameeee"),
 			},
 			Color: to.StringPtr("green"),
-			Hates: &[]Dog{
+			Hates: &[]*Dog{
 				{
 					Pet: Pet{
 						ID:   to.Int32Ptr(1),

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -127,7 +127,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 				Iswild:   to.BoolPtr(true),
 			},
 		},
-		Salmons: &[]DotSalmon{
+		Salmons: &[]*DotSalmon{
 			{
 				DotFish: DotFish{
 					FishType: to.StringPtr("DotSalmon"),
@@ -182,7 +182,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 				Species: to.StringPtr("king"),
 			},
 		},
-		Salmons: &[]DotSalmon{
+		Salmons: &[]*DotSalmon{
 			{
 				DotFish: DotFish{
 					Species: to.StringPtr("king"),

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -42,7 +42,7 @@ type ArrayPutValidOptions struct {
 }
 
 type ArrayWrapper struct {
-	Array *[]string `json:"array,omitempty"`
+	Array *[]*string `json:"array,omitempty"`
 }
 
 // ArrayWrapperResponse is the response envelope for operations that return a ArrayWrapper type.
@@ -129,7 +129,7 @@ type ByteWrapperResponse struct {
 type Cat struct {
 	Pet
 	Color *string `json:"color,omitempty"`
-	Hates *[]Dog  `json:"hates,omitempty"`
+	Hates *[]*Dog `json:"hates,omitempty"`
 }
 
 type Cookiecuttershark struct {
@@ -318,7 +318,7 @@ type DictionaryPutValidOptions struct {
 
 type DictionaryWrapper struct {
 	// Dictionary of
-	DefaultProgram *map[string]string `json:"defaultProgram,omitempty"`
+	DefaultProgram *map[string]*string `json:"defaultProgram,omitempty"`
 }
 
 // DictionaryWrapperResponse is the response envelope for operations that return a DictionaryWrapper type.
@@ -388,7 +388,7 @@ func (d *DotFish) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
 
 type DotFishMarket struct {
 	Fishes       *[]DotFishClassification `json:"fishes,omitempty"`
-	Salmons      *[]DotSalmon             `json:"salmons,omitempty"`
+	Salmons      *[]*DotSalmon            `json:"salmons,omitempty"`
 	SampleFish   DotFishClassification    `json:"sampleFish,omitempty"`
 	SampleSalmon *DotSalmon               `json:"sampleSalmon,omitempty"`
 }

--- a/test/autorest/complexmodelgroup/zz_generated_models.go
+++ b/test/autorest/complexmodelgroup/zz_generated_models.go
@@ -14,12 +14,12 @@ import (
 
 type CatalogArray struct {
 	// Array of products
-	ProductArray *[]Product `json:"productArray,omitempty"`
+	ProductArray *[]*Product `json:"productArray,omitempty"`
 }
 
 type CatalogArrayOfDictionary struct {
 	// Array of dictionary of products
-	ProductArrayOfDictionary *[]map[string]Product `json:"productArrayOfDictionary,omitempty"`
+	ProductArrayOfDictionary *[]map[string]*Product `json:"productArrayOfDictionary,omitempty"`
 }
 
 // CatalogArrayResponse is the response envelope for operations that return a CatalogArray type.
@@ -32,12 +32,12 @@ type CatalogArrayResponse struct {
 
 type CatalogDictionary struct {
 	// Dictionary of products
-	ProductDictionary *map[string]Product `json:"productDictionary,omitempty"`
+	ProductDictionary *map[string]*Product `json:"productDictionary,omitempty"`
 }
 
 type CatalogDictionaryOfArray struct {
 	// Dictionary of Array of product
-	ProductDictionaryOfArray *map[string][]Product `json:"productDictionaryOfArray,omitempty"`
+	ProductDictionaryOfArray *map[string][]*Product `json:"productDictionaryOfArray,omitempty"`
 }
 
 // CatalogDictionaryResponse is the response envelope for operations that return a CatalogDictionary type.

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -25,12 +25,12 @@ func main() {
 	}
 	notRun := []string{}
 	for key, val := range vanillaReport.Value {
-		if val <= 0 {
+		if *val <= 0 {
 			notRun = append(notRun, fmt.Sprintf("GENERAL: %s", key))
 		}
 	}
 	for key, val := range azureReport.Value {
-		if val <= 0 {
+		if *val <= 0 {
 			notRun = append(notRun, fmt.Sprintf("AZURE: %s", key))
 		}
 	}

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -110,14 +110,17 @@ func TestGetBase64URL(t *testing.T) {
 
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
 func TestGetBooleanInvalidNull(t *testing.T) {
-	t.Skip("no x-nullable, should fail")
 	client := newDictionaryClient()
 	resp, err := client.GetBooleanInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*bool{
+		"0": to.BoolPtr(true),
+		"1": nil,
+		"2": to.BoolPtr(false),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -152,14 +155,16 @@ func TestGetBooleanTfft(t *testing.T) {
 
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
 func TestGetByteInvalidNull(t *testing.T) {
-	t.Skip("no x-nullable, should fail")
 	client := newDictionaryClient()
 	resp, err := client.GetByteInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string][]byte{
+		"0": {0xab, 0xac, 0xad},
+		"1": nil,
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -265,7 +270,20 @@ func TestGetDateInvalidChars(t *testing.T) {
 
 // GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
 func TestGetDateInvalidNull(t *testing.T) {
-	t.Skip("x-nullable")
+	client := newDictionaryClient()
+	resp, err := client.GetDateInvalidNull(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v1 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
+	v3 := time.Date(1776, 7, 4, 0, 0, 0, 0, time.UTC)
+	if r := cmp.Diff(resp.Value, map[string]*time.Time{
+		"0": &v1,
+		"1": nil,
+		"2": &v3,
+	}); r != "" {
+		t.Fatal(r)
+	}
 }
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
@@ -455,14 +473,17 @@ func TestGetDictionaryValid(t *testing.T) {
 
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetDoubleInvalidNull(t *testing.T) {
-	t.Skip("should fail as mising x-nullable")
 	client := newDictionaryClient()
 	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*float64{
+		"0": to.Float64Ptr(0),
+		"1": nil,
+		"2": to.Float64Ptr(-1.2e20),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -535,14 +556,17 @@ func TestGetEmptyStringKey(t *testing.T) {
 
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetFloatInvalidNull(t *testing.T) {
-	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
 	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*float32{
+		"0": to.Float32Ptr(0),
+		"1": nil,
+		"2": to.Float32Ptr(-1.2e20),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -576,14 +600,17 @@ func TestGetFloatValid(t *testing.T) {
 
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetIntInvalidNull(t *testing.T) {
-	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
 	resp, err := client.GetIntInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*int32{
+		"0": to.Int32Ptr(1),
+		"1": nil,
+		"2": to.Int32Ptr(0),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -630,14 +657,17 @@ func TestGetInvalid(t *testing.T) {
 
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetLongInvalidNull(t *testing.T) {
-	t.Skip("should fail, nil but no x-nullable")
 	client := newDictionaryClient()
 	resp, err := client.GetLongInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*int64{
+		"0": to.Int64Ptr(1),
+		"1": nil,
+		"2": to.Int64Ptr(0),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -696,14 +726,15 @@ func TestGetNullKey(t *testing.T) {
 
 // GetNullValue - Get Dictionary with null value
 func TestGetNullValue(t *testing.T) {
-	t.Skip("missing x-nullable in swagger")
 	client := newDictionaryClient()
 	resp, err := client.GetNullValue(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.Value != nil {
-		t.Fatal("expected nil dictionary")
+	if r := cmp.Diff(resp.Value, map[string]*string{
+		"key1": nil,
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 
@@ -737,14 +768,17 @@ func TestGetStringWithInvalid(t *testing.T) {
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
 func TestGetStringWithNull(t *testing.T) {
-	t.Skip("missing x-nullable in swagger")
 	client := newDictionaryClient()
 	resp, err := client.GetStringWithNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	if r := cmp.Diff(resp.Value, map[string]*string{
+		"0": to.StringPtr("foo"),
+		"1": nil,
+		"2": to.StringPtr("foo2"),
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -284,11 +284,15 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 func TestGetDateTimeInvalidNull(t *testing.T) {
 	client := newDictionaryClient()
 	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
-	if err == nil {
-		t.Fatal("unexpected nil error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.ValueOf(resp).IsZero() {
-		t.Fatal("expected empty response")
+	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
+	if r := cmp.Diff(resp.Value, map[string]*time.Time{
+		"0": &dt1,
+		"1": nil,
+	}); r != "" {
+		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -37,10 +37,10 @@ func TestGetArrayItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string][]string{
-		"0": {"1", "2", "3"},
+	if r := cmp.Diff(resp.Value, map[string][]*string{
+		"0": to.StringPtrArray("1", "2", "3"),
 		"1": {},
-		"2": {"7", "8", "9"},
+		"2": to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -54,10 +54,10 @@ func TestGetArrayItemNull(t *testing.T) {
 		t.Fatal(err)
 	}
 	// TODO: this should technically fail since there's no x-nullable
-	if r := cmp.Diff(resp.Value, map[string][]string{
-		"0": {"1", "2", "3"},
+	if r := cmp.Diff(resp.Value, map[string][]*string{
+		"0": to.StringPtrArray("1", "2", "3"),
 		"1": nil,
-		"2": {"7", "8", "9"},
+		"2": to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -82,10 +82,10 @@ func TestGetArrayValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string][]string{
-		"0": {"1", "2", "3"},
-		"1": {"4", "5", "6"},
-		"2": {"7", "8", "9"},
+	if r := cmp.Diff(resp.Value, map[string][]*string{
+		"0": to.StringPtrArray("1", "2", "3"),
+		"1": to.StringPtrArray("4", "5", "6"),
+		"2": to.StringPtrArray("7", "8", "9"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -140,11 +140,11 @@ func TestGetBooleanTfft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]bool{
-		"0": true,
-		"1": false,
-		"2": false,
-		"3": true,
+	if r := cmp.Diff(resp.Value, map[string]*bool{
+		"0": to.BoolPtr(true),
+		"1": to.BoolPtr(false),
+		"2": to.BoolPtr(false),
+		"3": to.BoolPtr(true),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -186,7 +186,7 @@ func TestGetComplexEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]Widget{}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]*Widget{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -198,7 +198,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]Widget{
+	if r := cmp.Diff(resp.Value, map[string]*Widget{
 		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": {},
 		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -209,17 +209,18 @@ func TestGetComplexItemEmpty(t *testing.T) {
 
 // GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexItemNull(t *testing.T) {
-	t.Skip("test is invalid, expects nil value but missing x-nullable")
-	/*client := newDictionaryClient()
+	client := newDictionaryClient()
 	resp, err := client.GetComplexItemNull(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]Widget{
-		"0": Widget{Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
+	if r := cmp.Diff(resp.Value, map[string]*Widget{
+		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": nil,
-		"2": Widget{Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
-	})*/
+		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
+	}); r != "" {
+		t.Fatal(r)
+	}
 }
 
 // GetComplexNull - Get dictionary of complex type null value
@@ -241,7 +242,7 @@ func TestGetComplexValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]Widget{
+	if r := cmp.Diff(resp.Value, map[string]*Widget{
 		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": {Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -301,10 +302,10 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	dt2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	dt3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	if r := cmp.Diff(resp.Value, map[string]time.Time{
-		"0": dt1,
-		"1": dt2,
-		"2": dt3,
+	if r := cmp.Diff(resp.Value, map[string]*time.Time{
+		"0": &dt1,
+		"1": &dt2,
+		"2": &dt3,
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -320,10 +321,10 @@ func TestGetDateTimeValid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	dt2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35+01:00")
 	dt3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01-08:00")
-	if r := cmp.Diff(resp.Value, map[string]time.Time{
-		"0": dt1,
-		"1": dt2,
-		"2": dt3,
+	if r := cmp.Diff(resp.Value, map[string]*time.Time{
+		"0": &dt1,
+		"1": &dt2,
+		"2": &dt3,
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -339,10 +340,10 @@ func TestGetDateValid(t *testing.T) {
 	dt1 := time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC)
 	dt2 := time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC)
 	dt3 := time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)
-	if r := cmp.Diff(resp.Value, map[string]time.Time{
-		"0": dt1,
-		"1": dt2,
-		"2": dt3,
+	if r := cmp.Diff(resp.Value, map[string]*time.Time{
+		"0": &dt1,
+		"1": &dt2,
+		"2": &dt3,
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -355,7 +356,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]map[string]string{}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]map[string]*string{}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -367,17 +368,17 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
 		"0": {
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		"1": {},
 		"2": {
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -386,12 +387,38 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 
 // GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestGetDictionaryItemNull(t *testing.T) {
-	t.Skip("x-nullable")
+	client := newDictionaryClient()
+	resp, err := client.GetDictionaryItemNull(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
+		"0": {
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
+		},
+		"1": nil,
+		"2": {
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
+		},
+	}); r != "" {
+		t.Fatal(r)
+	}
 }
 
 // GetDictionaryNull - Get an dictionaries of dictionaries with value null
 func TestGetDictionaryNull(t *testing.T) {
-	t.Skip("x-nullable")
+	client := newDictionaryClient()
+	resp, err := client.GetDictionaryNull(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Value != nil {
+		t.Fatal("expected nil value")
+	}
 }
 
 // GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
@@ -401,21 +428,21 @@ func TestGetDictionaryValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]map[string]string{
+	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
 		"0": {
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		"1": {
-			"4": "four",
-			"5": "five",
-			"6": "six",
+			"4": to.StringPtr("four"),
+			"5": to.StringPtr("five"),
+			"6": to.StringPtr("six"),
 		},
 		"2": {
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}); r != "" {
 		t.Fatal(r)
@@ -454,10 +481,10 @@ func TestGetDoubleValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]float64{
-		"0": 0,
-		"1": -0.01,
-		"2": -1.2e20,
+	if r := cmp.Diff(resp.Value, map[string]*float64{
+		"0": to.Float64Ptr(0),
+		"1": to.Float64Ptr(-0.01),
+		"2": to.Float64Ptr(-1.2e20),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -470,9 +497,9 @@ func TestGetDurationValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]string{
-		"0": "P123DT22H14M12.011S",
-		"1": "P5DT1H",
+	if r := cmp.Diff(resp.Value, map[string]*string{
+		"0": to.StringPtr("P123DT22H14M12.011S"),
+		"1": to.StringPtr("P5DT1H"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -497,7 +524,7 @@ func TestGetEmptyStringKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]string{"": "val1"}); r != "" {
+	if r := cmp.Diff(resp.Value, map[string]*string{"": to.StringPtr("val1")}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -534,10 +561,10 @@ func TestGetFloatValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]float32{
-		"0": 0,
-		"1": -0.01,
-		"2": -1.2e20,
+	if r := cmp.Diff(resp.Value, map[string]*float32{
+		"0": to.Float32Ptr(0),
+		"1": to.Float32Ptr(-0.01),
+		"2": to.Float32Ptr(-1.2e20),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -575,11 +602,11 @@ func TestGetIntegerValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]int32{
-		"0": 1,
-		"1": -1,
-		"2": 3,
-		"3": 300,
+	if r := cmp.Diff(resp.Value, map[string]*int32{
+		"0": to.Int32Ptr(1),
+		"1": to.Int32Ptr(-1),
+		"2": to.Int32Ptr(3),
+		"3": to.Int32Ptr(300),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -629,11 +656,11 @@ func TestGetLongValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]int64{
-		"0": 1,
-		"1": -1,
-		"2": 3,
-		"3": 300,
+	if r := cmp.Diff(resp.Value, map[string]*int64{
+		"0": to.Int64Ptr(1),
+		"1": to.Int64Ptr(-1),
+		"2": to.Int64Ptr(3),
+		"3": to.Int64Ptr(300),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -665,7 +692,7 @@ func TestGetNullKey(t *testing.T) {
 
 // GetNullValue - Get Dictionary with null value
 func TestGetNullValue(t *testing.T) {
-	t.Skip("should fail, nil but no x-nullable")
+	t.Skip("missing x-nullable in swagger")
 	client := newDictionaryClient()
 	resp, err := client.GetNullValue(context.Background(), nil)
 	if err != nil {
@@ -683,10 +710,10 @@ func TestGetStringValid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r := cmp.Diff(resp.Value, map[string]string{
-		"0": "foo1",
-		"1": "foo2",
-		"2": "foo3",
+	if r := cmp.Diff(resp.Value, map[string]*string{
+		"0": to.StringPtr("foo1"),
+		"1": to.StringPtr("foo2"),
+		"2": to.StringPtr("foo3"),
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -706,7 +733,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
 func TestGetStringWithNull(t *testing.T) {
-	t.Skip("should fail, nil but no x-nullable")
+	t.Skip("missing x-nullable in swagger")
 	client := newDictionaryClient()
 	resp, err := client.GetStringWithNull(context.Background(), nil)
 	if err == nil {
@@ -720,10 +747,10 @@ func TestGetStringWithNull(t *testing.T) {
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestPutArrayValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutArrayValid(context.Background(), map[string][]string{
-		"0": {"1", "2", "3"},
-		"1": {"4", "5", "6"},
-		"2": {"7", "8", "9"},
+	resp, err := client.PutArrayValid(context.Background(), map[string][]*string{
+		"0": to.StringPtrArray("1", "2", "3"),
+		"1": to.StringPtrArray("4", "5", "6"),
+		"2": to.StringPtrArray("7", "8", "9"),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -736,11 +763,11 @@ func TestPutArrayValid(t *testing.T) {
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
 func TestPutBooleanTfft(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutBooleanTfft(context.Background(), map[string]bool{
-		"0": true,
-		"1": false,
-		"2": false,
-		"3": true,
+	resp, err := client.PutBooleanTfft(context.Background(), map[string]*bool{
+		"0": to.BoolPtr(true),
+		"1": to.BoolPtr(false),
+		"2": to.BoolPtr(false),
+		"3": to.BoolPtr(true),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -769,7 +796,7 @@ func TestPutByteValid(t *testing.T) {
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestPutComplexValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutComplexValid(context.Background(), map[string]Widget{
+	resp, err := client.PutComplexValid(context.Background(), map[string]*Widget{
 		"0": {Integer: to.Int32Ptr(1), String: to.StringPtr("2")},
 		"1": {Integer: to.Int32Ptr(3), String: to.StringPtr("4")},
 		"2": {Integer: to.Int32Ptr(5), String: to.StringPtr("6")},
@@ -788,10 +815,10 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	dt2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	dt3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
-	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), map[string]time.Time{
-		"0": dt1,
-		"1": dt2,
-		"2": dt3,
+	resp, err := client.PutDateTimeRFC1123Valid(context.Background(), map[string]*time.Time{
+		"0": &dt1,
+		"1": &dt2,
+		"2": &dt3,
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -807,10 +834,10 @@ func TestPutDateTimeValid(t *testing.T) {
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	dt2, _ := time.Parse(time.RFC3339, "1980-01-01T23:11:35Z")
 	dt3, _ := time.Parse(time.RFC3339, "1492-10-12T18:15:01Z")
-	resp, err := client.PutDateTimeValid(context.Background(), map[string]time.Time{
-		"0": dt1,
-		"1": dt2,
-		"2": dt3,
+	resp, err := client.PutDateTimeValid(context.Background(), map[string]*time.Time{
+		"0": &dt1,
+		"1": &dt2,
+		"2": &dt3,
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -826,10 +853,10 @@ func TestPutDateValid(t *testing.T) {
 	d1 := time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC)
 	d2 := time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC)
 	d3 := time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)
-	resp, err := client.PutDateValid(context.Background(), map[string]time.Time{
-		"0": d1,
-		"1": d2,
-		"2": d3,
+	resp, err := client.PutDateValid(context.Background(), map[string]*time.Time{
+		"0": &d1,
+		"1": &d2,
+		"2": &d3,
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -842,21 +869,21 @@ func TestPutDateValid(t *testing.T) {
 // PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestPutDictionaryValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutDictionaryValid(context.Background(), map[string]map[string]string{
+	resp, err := client.PutDictionaryValid(context.Background(), map[string]map[string]*string{
 		"0": {
-			"1": "one",
-			"2": "two",
-			"3": "three",
+			"1": to.StringPtr("one"),
+			"2": to.StringPtr("two"),
+			"3": to.StringPtr("three"),
 		},
 		"1": {
-			"4": "four",
-			"5": "five",
-			"6": "six",
+			"4": to.StringPtr("four"),
+			"5": to.StringPtr("five"),
+			"6": to.StringPtr("six"),
 		},
 		"2": {
-			"7": "seven",
-			"8": "eight",
-			"9": "nine",
+			"7": to.StringPtr("seven"),
+			"8": to.StringPtr("eight"),
+			"9": to.StringPtr("nine"),
 		},
 	}, nil)
 	if err != nil {
@@ -870,10 +897,10 @@ func TestPutDictionaryValid(t *testing.T) {
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutDoubleValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutDoubleValid(context.Background(), map[string]float64{
-		"0": 0,
-		"1": -0.01,
-		"2": -1.2e20,
+	resp, err := client.PutDoubleValid(context.Background(), map[string]*float64{
+		"0": to.Float64Ptr(0),
+		"1": to.Float64Ptr(-0.01),
+		"2": to.Float64Ptr(-1.2e20),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -886,9 +913,9 @@ func TestPutDoubleValid(t *testing.T) {
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestPutDurationValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutDurationValid(context.Background(), map[string]string{
-		"0": "P123DT22H14M12.011S",
-		"1": "P5DT1H",
+	resp, err := client.PutDurationValid(context.Background(), map[string]*string{
+		"0": to.StringPtr("P123DT22H14M12.011S"),
+		"1": to.StringPtr("P5DT1H"),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -901,7 +928,7 @@ func TestPutDurationValid(t *testing.T) {
 // PutEmpty - Set dictionary value empty {}
 func TestPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutEmpty(context.Background(), map[string]string{}, nil)
+	resp, err := client.PutEmpty(context.Background(), map[string]*string{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -913,10 +940,10 @@ func TestPutEmpty(t *testing.T) {
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutFloatValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutFloatValid(context.Background(), map[string]float32{
-		"0": 0,
-		"1": -0.01,
-		"2": -1.2e20,
+	resp, err := client.PutFloatValid(context.Background(), map[string]*float32{
+		"0": to.Float32Ptr(0),
+		"1": to.Float32Ptr(-0.01),
+		"2": to.Float32Ptr(-1.2e20),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -929,11 +956,11 @@ func TestPutFloatValid(t *testing.T) {
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutIntegerValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutIntegerValid(context.Background(), map[string]int32{
-		"0": 1,
-		"1": -1,
-		"2": 3,
-		"3": 300,
+	resp, err := client.PutIntegerValid(context.Background(), map[string]*int32{
+		"0": to.Int32Ptr(1),
+		"1": to.Int32Ptr(-1),
+		"2": to.Int32Ptr(3),
+		"3": to.Int32Ptr(300),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -946,11 +973,11 @@ func TestPutIntegerValid(t *testing.T) {
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutLongValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutLongValid(context.Background(), map[string]int64{
-		"0": 1,
-		"1": -1,
-		"2": 3,
-		"3": 300,
+	resp, err := client.PutLongValid(context.Background(), map[string]*int64{
+		"0": to.Int64Ptr(1),
+		"1": to.Int64Ptr(-1),
+		"2": to.Int64Ptr(3),
+		"3": to.Int64Ptr(300),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -963,10 +990,10 @@ func TestPutLongValid(t *testing.T) {
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestPutStringValid(t *testing.T) {
 	client := newDictionaryClient()
-	resp, err := client.PutStringValid(context.Background(), map[string]string{
-		"0": "foo1",
-		"1": "foo2",
-		"2": "foo3",
+	resp, err := client.PutStringValid(context.Background(), map[string]*string{
+		"0": to.StringPtr("foo1"),
+		"1": to.StringPtr("foo2"),
+		"2": to.StringPtr("foo3"),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/test/autorest/dictionarygroup/zz_generated_dictionary.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary.go
@@ -55,7 +55,7 @@ func (client *DictionaryClient) getArrayEmptyCreateRequest(ctx context.Context, 
 
 // getArrayEmptyHandleResponse handles the GetArrayEmpty response.
 func (client *DictionaryClient) getArrayEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val map[string][]string
+	var val map[string][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -101,7 +101,7 @@ func (client *DictionaryClient) getArrayItemEmptyCreateRequest(ctx context.Conte
 
 // getArrayItemEmptyHandleResponse handles the GetArrayItemEmpty response.
 func (client *DictionaryClient) getArrayItemEmptyHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val map[string][]string
+	var val map[string][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -147,7 +147,7 @@ func (client *DictionaryClient) getArrayItemNullCreateRequest(ctx context.Contex
 
 // getArrayItemNullHandleResponse handles the GetArrayItemNull response.
 func (client *DictionaryClient) getArrayItemNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val map[string][]string
+	var val map[string][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -193,7 +193,7 @@ func (client *DictionaryClient) getArrayNullCreateRequest(ctx context.Context, o
 
 // getArrayNullHandleResponse handles the GetArrayNull response.
 func (client *DictionaryClient) getArrayNullHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val map[string][]string
+	var val map[string][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -239,7 +239,7 @@ func (client *DictionaryClient) getArrayValidCreateRequest(ctx context.Context, 
 
 // getArrayValidHandleResponse handles the GetArrayValid response.
 func (client *DictionaryClient) getArrayValidHandleResponse(resp *azcore.Response) (MapOfStringArrayResponse, error) {
-	var val map[string][]string
+	var val map[string][]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringArrayResponse{}, err
 	}
@@ -331,7 +331,7 @@ func (client *DictionaryClient) getBooleanInvalidNullCreateRequest(ctx context.C
 
 // getBooleanInvalidNullHandleResponse handles the GetBooleanInvalidNull response.
 func (client *DictionaryClient) getBooleanInvalidNullHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val map[string]bool
+	var val map[string]*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -377,7 +377,7 @@ func (client *DictionaryClient) getBooleanInvalidStringCreateRequest(ctx context
 
 // getBooleanInvalidStringHandleResponse handles the GetBooleanInvalidString response.
 func (client *DictionaryClient) getBooleanInvalidStringHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val map[string]bool
+	var val map[string]*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -423,7 +423,7 @@ func (client *DictionaryClient) getBooleanTfftCreateRequest(ctx context.Context,
 
 // getBooleanTfftHandleResponse handles the GetBooleanTfft response.
 func (client *DictionaryClient) getBooleanTfftHandleResponse(resp *azcore.Response) (MapOfBoolResponse, error) {
-	var val map[string]bool
+	var val map[string]*bool
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfBoolResponse{}, err
 	}
@@ -561,7 +561,7 @@ func (client *DictionaryClient) getComplexEmptyCreateRequest(ctx context.Context
 
 // getComplexEmptyHandleResponse handles the GetComplexEmpty response.
 func (client *DictionaryClient) getComplexEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val map[string]Widget
+	var val map[string]*Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -607,7 +607,7 @@ func (client *DictionaryClient) getComplexItemEmptyCreateRequest(ctx context.Con
 
 // getComplexItemEmptyHandleResponse handles the GetComplexItemEmpty response.
 func (client *DictionaryClient) getComplexItemEmptyHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val map[string]Widget
+	var val map[string]*Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -653,7 +653,7 @@ func (client *DictionaryClient) getComplexItemNullCreateRequest(ctx context.Cont
 
 // getComplexItemNullHandleResponse handles the GetComplexItemNull response.
 func (client *DictionaryClient) getComplexItemNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val map[string]Widget
+	var val map[string]*Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -699,7 +699,7 @@ func (client *DictionaryClient) getComplexNullCreateRequest(ctx context.Context,
 
 // getComplexNullHandleResponse handles the GetComplexNull response.
 func (client *DictionaryClient) getComplexNullHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val map[string]Widget
+	var val map[string]*Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -746,7 +746,7 @@ func (client *DictionaryClient) getComplexValidCreateRequest(ctx context.Context
 
 // getComplexValidHandleResponse handles the GetComplexValid response.
 func (client *DictionaryClient) getComplexValidHandleResponse(resp *azcore.Response) (MapOfWidgetResponse, error) {
-	var val map[string]Widget
+	var val map[string]*Widget
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfWidgetResponse{}, err
 	}
@@ -792,13 +792,13 @@ func (client *DictionaryClient) getDateInvalidCharsCreateRequest(ctx context.Con
 
 // getDateInvalidCharsHandleResponse handles the GetDateInvalidChars response.
 func (client *DictionaryClient) getDateInvalidCharsHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]dateType{}
+	aux := map[string]*dateType{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -842,13 +842,13 @@ func (client *DictionaryClient) getDateInvalidNullCreateRequest(ctx context.Cont
 
 // getDateInvalidNullHandleResponse handles the GetDateInvalidNull response.
 func (client *DictionaryClient) getDateInvalidNullHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]dateType{}
+	aux := map[string]*dateType{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -892,13 +892,13 @@ func (client *DictionaryClient) getDateTimeInvalidCharsCreateRequest(ctx context
 
 // getDateTimeInvalidCharsHandleResponse handles the GetDateTimeInvalidChars response.
 func (client *DictionaryClient) getDateTimeInvalidCharsHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]timeRFC3339{}
+	aux := map[string]*timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -942,13 +942,13 @@ func (client *DictionaryClient) getDateTimeInvalidNullCreateRequest(ctx context.
 
 // getDateTimeInvalidNullHandleResponse handles the GetDateTimeInvalidNull response.
 func (client *DictionaryClient) getDateTimeInvalidNullHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]timeRFC3339{}
+	aux := map[string]*timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -993,13 +993,13 @@ func (client *DictionaryClient) getDateTimeRFC1123ValidCreateRequest(ctx context
 
 // getDateTimeRFC1123ValidHandleResponse handles the GetDateTimeRFC1123Valid response.
 func (client *DictionaryClient) getDateTimeRFC1123ValidHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]timeRFC1123{}
+	aux := map[string]*timeRFC1123{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -1043,13 +1043,13 @@ func (client *DictionaryClient) getDateTimeValidCreateRequest(ctx context.Contex
 
 // getDateTimeValidHandleResponse handles the GetDateTimeValid response.
 func (client *DictionaryClient) getDateTimeValidHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]timeRFC3339{}
+	aux := map[string]*timeRFC3339{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -1093,13 +1093,13 @@ func (client *DictionaryClient) getDateValidCreateRequest(ctx context.Context, o
 
 // getDateValidHandleResponse handles the GetDateValid response.
 func (client *DictionaryClient) getDateValidHandleResponse(resp *azcore.Response) (MapOfTimeResponse, error) {
-	aux := map[string]dateType{}
+	aux := map[string]*dateType{}
 	if err := resp.UnmarshalAsJSON(&aux); err != nil {
 		return MapOfTimeResponse{}, err
 	}
-	cp := map[string]time.Time{}
+	cp := map[string]*time.Time{}
 	for k, v := range aux {
-		cp[k] = time.Time(v)
+		cp[k] = (*time.Time)(v)
 	}
 	return MapOfTimeResponse{RawResponse: resp.Response, Value: cp}, nil
 }
@@ -1143,7 +1143,7 @@ func (client *DictionaryClient) getDictionaryEmptyCreateRequest(ctx context.Cont
 
 // getDictionaryEmptyHandleResponse handles the GetDictionaryEmpty response.
 func (client *DictionaryClient) getDictionaryEmptyHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val map[string]map[string]string
+	var val map[string]map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1190,7 +1190,7 @@ func (client *DictionaryClient) getDictionaryItemEmptyCreateRequest(ctx context.
 
 // getDictionaryItemEmptyHandleResponse handles the GetDictionaryItemEmpty response.
 func (client *DictionaryClient) getDictionaryItemEmptyHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val map[string]map[string]string
+	var val map[string]map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1237,7 +1237,7 @@ func (client *DictionaryClient) getDictionaryItemNullCreateRequest(ctx context.C
 
 // getDictionaryItemNullHandleResponse handles the GetDictionaryItemNull response.
 func (client *DictionaryClient) getDictionaryItemNullHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val map[string]map[string]string
+	var val map[string]map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1283,7 +1283,7 @@ func (client *DictionaryClient) getDictionaryNullCreateRequest(ctx context.Conte
 
 // getDictionaryNullHandleResponse handles the GetDictionaryNull response.
 func (client *DictionaryClient) getDictionaryNullHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val map[string]map[string]string
+	var val map[string]map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1330,7 +1330,7 @@ func (client *DictionaryClient) getDictionaryValidCreateRequest(ctx context.Cont
 
 // getDictionaryValidHandleResponse handles the GetDictionaryValid response.
 func (client *DictionaryClient) getDictionaryValidHandleResponse(resp *azcore.Response) (MapOfMapOfStringResponse, error) {
-	var val map[string]map[string]string
+	var val map[string]map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfMapOfStringResponse{}, err
 	}
@@ -1376,7 +1376,7 @@ func (client *DictionaryClient) getDoubleInvalidNullCreateRequest(ctx context.Co
 
 // getDoubleInvalidNullHandleResponse handles the GetDoubleInvalidNull response.
 func (client *DictionaryClient) getDoubleInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val map[string]float64
+	var val map[string]*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1422,7 +1422,7 @@ func (client *DictionaryClient) getDoubleInvalidStringCreateRequest(ctx context.
 
 // getDoubleInvalidStringHandleResponse handles the GetDoubleInvalidString response.
 func (client *DictionaryClient) getDoubleInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val map[string]float64
+	var val map[string]*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1468,7 +1468,7 @@ func (client *DictionaryClient) getDoubleValidCreateRequest(ctx context.Context,
 
 // getDoubleValidHandleResponse handles the GetDoubleValid response.
 func (client *DictionaryClient) getDoubleValidHandleResponse(resp *azcore.Response) (MapOfFloat64Response, error) {
-	var val map[string]float64
+	var val map[string]*float64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat64Response{}, err
 	}
@@ -1514,7 +1514,7 @@ func (client *DictionaryClient) getDurationValidCreateRequest(ctx context.Contex
 
 // getDurationValidHandleResponse handles the GetDurationValid response.
 func (client *DictionaryClient) getDurationValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1560,7 +1560,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 
 // getEmptyHandleResponse handles the GetEmpty response.
 func (client *DictionaryClient) getEmptyHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1606,7 +1606,7 @@ func (client *DictionaryClient) getEmptyStringKeyCreateRequest(ctx context.Conte
 
 // getEmptyStringKeyHandleResponse handles the GetEmptyStringKey response.
 func (client *DictionaryClient) getEmptyStringKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1652,7 +1652,7 @@ func (client *DictionaryClient) getFloatInvalidNullCreateRequest(ctx context.Con
 
 // getFloatInvalidNullHandleResponse handles the GetFloatInvalidNull response.
 func (client *DictionaryClient) getFloatInvalidNullHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val map[string]float32
+	var val map[string]*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1698,7 +1698,7 @@ func (client *DictionaryClient) getFloatInvalidStringCreateRequest(ctx context.C
 
 // getFloatInvalidStringHandleResponse handles the GetFloatInvalidString response.
 func (client *DictionaryClient) getFloatInvalidStringHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val map[string]float32
+	var val map[string]*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1744,7 +1744,7 @@ func (client *DictionaryClient) getFloatValidCreateRequest(ctx context.Context, 
 
 // getFloatValidHandleResponse handles the GetFloatValid response.
 func (client *DictionaryClient) getFloatValidHandleResponse(resp *azcore.Response) (MapOfFloat32Response, error) {
-	var val map[string]float32
+	var val map[string]*float32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfFloat32Response{}, err
 	}
@@ -1790,7 +1790,7 @@ func (client *DictionaryClient) getIntInvalidNullCreateRequest(ctx context.Conte
 
 // getIntInvalidNullHandleResponse handles the GetIntInvalidNull response.
 func (client *DictionaryClient) getIntInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1836,7 +1836,7 @@ func (client *DictionaryClient) getIntInvalidStringCreateRequest(ctx context.Con
 
 // getIntInvalidStringHandleResponse handles the GetIntInvalidString response.
 func (client *DictionaryClient) getIntInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1882,7 +1882,7 @@ func (client *DictionaryClient) getIntegerValidCreateRequest(ctx context.Context
 
 // getIntegerValidHandleResponse handles the GetIntegerValid response.
 func (client *DictionaryClient) getIntegerValidHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -1928,7 +1928,7 @@ func (client *DictionaryClient) getInvalidCreateRequest(ctx context.Context, opt
 
 // getInvalidHandleResponse handles the GetInvalid response.
 func (client *DictionaryClient) getInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -1974,7 +1974,7 @@ func (client *DictionaryClient) getLongInvalidNullCreateRequest(ctx context.Cont
 
 // getLongInvalidNullHandleResponse handles the GetLongInvalidNull response.
 func (client *DictionaryClient) getLongInvalidNullHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val map[string]int64
+	var val map[string]*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2020,7 +2020,7 @@ func (client *DictionaryClient) getLongInvalidStringCreateRequest(ctx context.Co
 
 // getLongInvalidStringHandleResponse handles the GetLongInvalidString response.
 func (client *DictionaryClient) getLongInvalidStringHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val map[string]int64
+	var val map[string]*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2066,7 +2066,7 @@ func (client *DictionaryClient) getLongValidCreateRequest(ctx context.Context, o
 
 // getLongValidHandleResponse handles the GetLongValid response.
 func (client *DictionaryClient) getLongValidHandleResponse(resp *azcore.Response) (MapOfInt64Response, error) {
-	var val map[string]int64
+	var val map[string]*int64
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt64Response{}, err
 	}
@@ -2112,7 +2112,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 
 // getNullHandleResponse handles the GetNull response.
 func (client *DictionaryClient) getNullHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -2158,7 +2158,7 @@ func (client *DictionaryClient) getNullKeyCreateRequest(ctx context.Context, opt
 
 // getNullKeyHandleResponse handles the GetNullKey response.
 func (client *DictionaryClient) getNullKeyHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2204,7 +2204,7 @@ func (client *DictionaryClient) getNullValueCreateRequest(ctx context.Context, o
 
 // getNullValueHandleResponse handles the GetNullValue response.
 func (client *DictionaryClient) getNullValueHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2250,7 +2250,7 @@ func (client *DictionaryClient) getStringValidCreateRequest(ctx context.Context,
 
 // getStringValidHandleResponse handles the GetStringValid response.
 func (client *DictionaryClient) getStringValidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2296,7 +2296,7 @@ func (client *DictionaryClient) getStringWithInvalidCreateRequest(ctx context.Co
 
 // getStringWithInvalidHandleResponse handles the GetStringWithInvalid response.
 func (client *DictionaryClient) getStringWithInvalidHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2342,7 +2342,7 @@ func (client *DictionaryClient) getStringWithNullCreateRequest(ctx context.Conte
 
 // getStringWithNullHandleResponse handles the GetStringWithNull response.
 func (client *DictionaryClient) getStringWithNullHandleResponse(resp *azcore.Response) (MapOfStringResponse, error) {
-	var val map[string]string
+	var val map[string]*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfStringResponse{}, err
 	}
@@ -2359,7 +2359,7 @@ func (client *DictionaryClient) getStringWithNullHandleError(resp *azcore.Respon
 }
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
-func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map[string][]string, options *DictionaryPutArrayValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map[string][]*string, options *DictionaryPutArrayValidOptions) (*http.Response, error) {
 	req, err := client.putArrayValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2375,7 +2375,7 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 }
 
 // putArrayValidCreateRequest creates the PutArrayValid request.
-func (client *DictionaryClient) putArrayValidCreateRequest(ctx context.Context, arrayBody map[string][]string, options *DictionaryPutArrayValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putArrayValidCreateRequest(ctx context.Context, arrayBody map[string][]*string, options *DictionaryPutArrayValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/array/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2396,7 +2396,7 @@ func (client *DictionaryClient) putArrayValidHandleError(resp *azcore.Response) 
 }
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
-func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody map[string]bool, options *DictionaryPutBooleanTfftOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody map[string]*bool, options *DictionaryPutBooleanTfftOptions) (*http.Response, error) {
 	req, err := client.putBooleanTfftCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2412,7 +2412,7 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 }
 
 // putBooleanTfftCreateRequest creates the PutBooleanTfft request.
-func (client *DictionaryClient) putBooleanTfftCreateRequest(ctx context.Context, arrayBody map[string]bool, options *DictionaryPutBooleanTfftOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putBooleanTfftCreateRequest(ctx context.Context, arrayBody map[string]*bool, options *DictionaryPutBooleanTfftOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/boolean/tfft"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2471,7 +2471,7 @@ func (client *DictionaryClient) putByteValidHandleError(resp *azcore.Response) e
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer":
 // 5, "string": "6"}}
-func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody map[string]Widget, options *DictionaryPutComplexValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody map[string]*Widget, options *DictionaryPutComplexValidOptions) (*http.Response, error) {
 	req, err := client.putComplexValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2487,7 +2487,7 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 }
 
 // putComplexValidCreateRequest creates the PutComplexValid request.
-func (client *DictionaryClient) putComplexValidCreateRequest(ctx context.Context, arrayBody map[string]Widget, options *DictionaryPutComplexValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putComplexValidCreateRequest(ctx context.Context, arrayBody map[string]*Widget, options *DictionaryPutComplexValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/complex/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2509,7 +2509,7 @@ func (client *DictionaryClient) putComplexValidHandleError(resp *azcore.Response
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
 // 10:15:01 GMT"}
-func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*http.Response, error) {
 	req, err := client.putDateTimeRFC1123ValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2525,7 +2525,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 }
 
 // putDateTimeRFC1123ValidCreateRequest creates the PutDateTimeRFC1123Valid request.
-func (client *DictionaryClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDateTimeRFC1123ValidCreateRequest(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateTimeRFC1123ValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time-rfc1123/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2533,9 +2533,9 @@ func (client *DictionaryClient) putDateTimeRFC1123ValidCreateRequest(ctx context
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	aux := map[string]timeRFC1123{}
+	aux := map[string]*timeRFC1123{}
 	for k, v := range arrayBody {
-		aux[k] = timeRFC1123(v)
+		aux[k] = (*timeRFC1123)(v)
 	}
 	return req, req.MarshalAsJSON(aux)
 }
@@ -2550,7 +2550,7 @@ func (client *DictionaryClient) putDateTimeRFC1123ValidHandleError(resp *azcore.
 }
 
 // PutDateTimeValid - Set dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
-func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateTimeValidOptions) (*http.Response, error) {
 	req, err := client.putDateTimeValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2566,7 +2566,7 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 }
 
 // putDateTimeValidCreateRequest creates the PutDateTimeValid request.
-func (client *DictionaryClient) putDateTimeValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateTimeValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDateTimeValidCreateRequest(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateTimeValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date-time/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2574,9 +2574,9 @@ func (client *DictionaryClient) putDateTimeValidCreateRequest(ctx context.Contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	aux := map[string]timeRFC3339{}
+	aux := map[string]*timeRFC3339{}
 	for k, v := range arrayBody {
-		aux[k] = timeRFC3339(v)
+		aux[k] = (*timeRFC3339)(v)
 	}
 	return req, req.MarshalAsJSON(aux)
 }
@@ -2591,7 +2591,7 @@ func (client *DictionaryClient) putDateTimeValidHandleError(resp *azcore.Respons
 }
 
 // PutDateValid - Set dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateValidOptions) (*http.Response, error) {
 	req, err := client.putDateValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2607,7 +2607,7 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 }
 
 // putDateValidCreateRequest creates the PutDateValid request.
-func (client *DictionaryClient) putDateValidCreateRequest(ctx context.Context, arrayBody map[string]time.Time, options *DictionaryPutDateValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDateValidCreateRequest(ctx context.Context, arrayBody map[string]*time.Time, options *DictionaryPutDateValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/date/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2615,9 +2615,9 @@ func (client *DictionaryClient) putDateValidCreateRequest(ctx context.Context, a
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	aux := map[string]dateType{}
+	aux := map[string]*dateType{}
 	for k, v := range arrayBody {
-		aux[k] = dateType(v)
+		aux[k] = (*dateType)(v)
 	}
 	return req, req.MarshalAsJSON(aux)
 }
@@ -2633,7 +2633,7 @@ func (client *DictionaryClient) putDateValidHandleError(resp *azcore.Response) e
 
 // PutDictionaryValid - Get an dictionaries of dictionaries of type with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five",
 // "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
-func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBody map[string]map[string]string, options *DictionaryPutDictionaryValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBody map[string]map[string]*string, options *DictionaryPutDictionaryValidOptions) (*http.Response, error) {
 	req, err := client.putDictionaryValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2649,7 +2649,7 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 }
 
 // putDictionaryValidCreateRequest creates the PutDictionaryValid request.
-func (client *DictionaryClient) putDictionaryValidCreateRequest(ctx context.Context, arrayBody map[string]map[string]string, options *DictionaryPutDictionaryValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDictionaryValidCreateRequest(ctx context.Context, arrayBody map[string]map[string]*string, options *DictionaryPutDictionaryValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/dictionary/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2670,7 +2670,7 @@ func (client *DictionaryClient) putDictionaryValidHandleError(resp *azcore.Respo
 }
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody map[string]float64, options *DictionaryPutDoubleValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody map[string]*float64, options *DictionaryPutDoubleValidOptions) (*http.Response, error) {
 	req, err := client.putDoubleValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2686,7 +2686,7 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 }
 
 // putDoubleValidCreateRequest creates the PutDoubleValid request.
-func (client *DictionaryClient) putDoubleValidCreateRequest(ctx context.Context, arrayBody map[string]float64, options *DictionaryPutDoubleValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDoubleValidCreateRequest(ctx context.Context, arrayBody map[string]*float64, options *DictionaryPutDoubleValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/double/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2707,7 +2707,7 @@ func (client *DictionaryClient) putDoubleValidHandleError(resp *azcore.Response)
 }
 
 // PutDurationValid - Set dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
-func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutDurationValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutDurationValidOptions) (*http.Response, error) {
 	req, err := client.putDurationValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2723,7 +2723,7 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 }
 
 // putDurationValidCreateRequest creates the PutDurationValid request.
-func (client *DictionaryClient) putDurationValidCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutDurationValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putDurationValidCreateRequest(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutDurationValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/duration/valid"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2744,7 +2744,7 @@ func (client *DictionaryClient) putDurationValidHandleError(resp *azcore.Respons
 }
 
 // PutEmpty - Set dictionary value empty {}
-func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[string]string, options *DictionaryPutEmptyOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutEmptyOptions) (*http.Response, error) {
 	req, err := client.putEmptyCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2760,7 +2760,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
-func (client *DictionaryClient) putEmptyCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutEmptyOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putEmptyCreateRequest(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutEmptyOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/empty"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2781,7 +2781,7 @@ func (client *DictionaryClient) putEmptyHandleError(resp *azcore.Response) error
 }
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map[string]float32, options *DictionaryPutFloatValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map[string]*float32, options *DictionaryPutFloatValidOptions) (*http.Response, error) {
 	req, err := client.putFloatValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2797,7 +2797,7 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 }
 
 // putFloatValidCreateRequest creates the PutFloatValid request.
-func (client *DictionaryClient) putFloatValidCreateRequest(ctx context.Context, arrayBody map[string]float32, options *DictionaryPutFloatValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putFloatValidCreateRequest(ctx context.Context, arrayBody map[string]*float32, options *DictionaryPutFloatValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/float/0--0.01-1.2e20"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2818,7 +2818,7 @@ func (client *DictionaryClient) putFloatValidHandleError(resp *azcore.Response) 
 }
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody map[string]int32, options *DictionaryPutIntegerValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody map[string]*int32, options *DictionaryPutIntegerValidOptions) (*http.Response, error) {
 	req, err := client.putIntegerValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2834,7 +2834,7 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 }
 
 // putIntegerValidCreateRequest creates the PutIntegerValid request.
-func (client *DictionaryClient) putIntegerValidCreateRequest(ctx context.Context, arrayBody map[string]int32, options *DictionaryPutIntegerValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putIntegerValidCreateRequest(ctx context.Context, arrayBody map[string]*int32, options *DictionaryPutIntegerValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/integer/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2855,7 +2855,7 @@ func (client *DictionaryClient) putIntegerValidHandleError(resp *azcore.Response
 }
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
-func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[string]int64, options *DictionaryPutLongValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[string]*int64, options *DictionaryPutLongValidOptions) (*http.Response, error) {
 	req, err := client.putLongValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2871,7 +2871,7 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 }
 
 // putLongValidCreateRequest creates the PutLongValid request.
-func (client *DictionaryClient) putLongValidCreateRequest(ctx context.Context, arrayBody map[string]int64, options *DictionaryPutLongValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putLongValidCreateRequest(ctx context.Context, arrayBody map[string]*int64, options *DictionaryPutLongValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/long/1.-1.3.300"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -2892,7 +2892,7 @@ func (client *DictionaryClient) putLongValidHandleError(resp *azcore.Response) e
 }
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
-func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody map[string]string, options *DictionaryPutStringValidOptions) (*http.Response, error) {
+func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutStringValidOptions) (*http.Response, error) {
 	req, err := client.putStringValidCreateRequest(ctx, arrayBody, options)
 	if err != nil {
 		return nil, err
@@ -2908,7 +2908,7 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 }
 
 // putStringValidCreateRequest creates the PutStringValid request.
-func (client *DictionaryClient) putStringValidCreateRequest(ctx context.Context, arrayBody map[string]string, options *DictionaryPutStringValidOptions) (*azcore.Request, error) {
+func (client *DictionaryClient) putStringValidCreateRequest(ctx context.Context, arrayBody map[string]*string, options *DictionaryPutStringValidOptions) (*azcore.Request, error) {
 	urlPath := "/dictionary/prim/string/foo1.foo2.foo3"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {

--- a/test/autorest/dictionarygroup/zz_generated_models.go
+++ b/test/autorest/dictionarygroup/zz_generated_models.go
@@ -358,13 +358,13 @@ func (e Error) Error() string {
 	return msg
 }
 
-// MapOfBoolResponse is the response envelope for operations that return a map[string]bool type.
+// MapOfBoolResponse is the response envelope for operations that return a map[string]*bool type.
 type MapOfBoolResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The dictionary value {"0": true, "1": false, "2": false, "3": true }
-	Value map[string]bool
+	Value map[string]*bool
 }
 
 // MapOfByteArrayResponse is the response envelope for operations that return a map[string][]byte type.
@@ -376,85 +376,85 @@ type MapOfByteArrayResponse struct {
 	Value map[string][]byte
 }
 
-// MapOfFloat32Response is the response envelope for operations that return a map[string]float32 type.
+// MapOfFloat32Response is the response envelope for operations that return a map[string]*float32 type.
 type MapOfFloat32Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	Value map[string]float32
+	Value map[string]*float32
 }
 
-// MapOfFloat64Response is the response envelope for operations that return a map[string]float64 type.
+// MapOfFloat64Response is the response envelope for operations that return a map[string]*float64 type.
 type MapOfFloat64Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
-	Value map[string]float64
+	Value map[string]*float64
 }
 
-// MapOfInt32Response is the response envelope for operations that return a map[string]int32 type.
+// MapOfInt32Response is the response envelope for operations that return a map[string]*int32 type.
 type MapOfInt32Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The null dictionary value
-	Value map[string]int32
+	Value map[string]*int32
 }
 
-// MapOfInt64Response is the response envelope for operations that return a map[string]int64 type.
+// MapOfInt64Response is the response envelope for operations that return a map[string]*int64 type.
 type MapOfInt64Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
-	Value map[string]int64
+	Value map[string]*int64
 }
 
-// MapOfMapOfStringResponse is the response envelope for operations that return a map[string]map[string]string type.
+// MapOfMapOfStringResponse is the response envelope for operations that return a map[string]map[string]*string type.
 type MapOfMapOfStringResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// An dictionaries of dictionaries with value null
-	Value map[string]map[string]string
+	Value map[string]map[string]*string
 }
 
-// MapOfStringArrayResponse is the response envelope for operations that return a map[string][]string type.
+// MapOfStringArrayResponse is the response envelope for operations that return a map[string][]*string type.
 type MapOfStringArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// a null array
-	Value map[string][]string
+	Value map[string][]*string
 }
 
-// MapOfStringResponse is the response envelope for operations that return a map[string]string type.
+// MapOfStringResponse is the response envelope for operations that return a map[string]*string type.
 type MapOfStringResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Dictionary of <string>
-	Value map[string]string
+	Value map[string]*string
 }
 
-// MapOfTimeResponse is the response envelope for operations that return a map[string]time.Time type.
+// MapOfTimeResponse is the response envelope for operations that return a map[string]*time.Time type.
 type MapOfTimeResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// The dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
-	Value map[string]time.Time
+	Value map[string]*time.Time
 }
 
-// MapOfWidgetResponse is the response envelope for operations that return a map[string]Widget type.
+// MapOfWidgetResponse is the response envelope for operations that return a map[string]*Widget type.
 type MapOfWidgetResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Dictionary of complex type with null value
-	Value map[string]Widget
+	Value map[string]*Widget
 }
 
 type Widget struct {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects.go
@@ -101,7 +101,7 @@ func (client *HTTPRedirectsClient) get300HandleResponse(resp *azcore.Response) (
 		}
 		return result, nil
 	case http.StatusMultipleChoices:
-		var val []string
+		var val []*string
 		if err := resp.UnmarshalAsJSON(&val); err != nil {
 			return nil, err
 		}

--- a/test/autorest/httpinfrastructuregroup/zz_generated_models.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_models.go
@@ -733,7 +733,7 @@ type MyExceptionResponse struct {
 	RawResponse *http.Response
 }
 
-// StringArrayResponse is the response envelope for operations that return a []string type.
+// StringArrayResponse is the response envelope for operations that return a []*string type.
 type StringArrayResponse struct {
 	// Location contains the information returned from the Location header response.
 	Location *string
@@ -742,5 +742,5 @@ type StringArrayResponse struct {
 	RawResponse *http.Response
 
 	// A list of location options for the request ['/http/success/get/200']
-	StringArray []string
+	StringArray []*string
 }

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -404,7 +404,7 @@ func TestLROBeginPost202List(t *testing.T) {
 	if s := pollResp.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	if r := cmp.Diff(pollResp.ProductArray, []Product{
+	if r := cmp.Diff(pollResp.ProductArray, []*Product{
 		{
 			Resource: Resource{
 				ID:   to.StringPtr("100"),

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -1141,7 +1141,7 @@ func (client *LROsClient) post202ListCreateRequest(ctx context.Context, options 
 
 // post202ListHandleResponse handles the Post202List response.
 func (client *LROsClient) post202ListHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []Product
+	var val []*Product
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return ProductArrayResponse{}, err
 	}

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -515,7 +515,7 @@ type Product struct {
 	Properties *ProductProperties `json:"properties,omitempty"`
 }
 
-// ProductArrayPollerResponse is the response envelope for operations that asynchronously return a []Product type.
+// ProductArrayPollerResponse is the response envelope for operations that asynchronously return a []*Product type.
 type ProductArrayPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
 	PollUntilDone func(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error)
@@ -527,10 +527,10 @@ type ProductArrayPollerResponse struct {
 	RawResponse *http.Response
 }
 
-// ProductArrayResponse is the response envelope for operations that return a []Product type.
+// ProductArrayResponse is the response envelope for operations that return a []*Product type.
 type ProductArrayResponse struct {
 	// Array of Product
-	ProductArray []Product
+	ProductArray []*Product
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -574,7 +574,7 @@ type Resource struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Dictionary of
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource Type
 	Type *string `json:"type,omitempty" azure:"ro"`

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -82,7 +82,7 @@ func (p *productArrayPoller) Poll(ctx context.Context) (*http.Response, error) {
 }
 
 func (p *productArrayPoller) FinalResponse(ctx context.Context) (ProductArrayResponse, error) {
-	respType := ProductArrayResponse{ProductArray: []Product{}}
+	respType := ProductArrayResponse{ProductArray: []*Product{}}
 	resp, err := p.pt.FinalResponse(ctx, p.pipeline, &respType.ProductArray)
 	if err != nil {
 		return ProductArrayResponse{}, err
@@ -98,7 +98,7 @@ func (p *productArrayPoller) ResumeToken() (string, error) {
 }
 
 func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error) {
-	respType := ProductArrayResponse{ProductArray: []Product{}}
+	respType := ProductArrayResponse{ProductArray: []*Product{}}
 	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, &respType.ProductArray)
 	if err != nil {
 		return ProductArrayResponse{}, err

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -506,7 +506,7 @@ func (client *ExplicitClient) postRequiredArrayHeaderHandleError(resp *azcore.Re
 }
 
 // PostRequiredArrayParameter - Test explicitly required array. Please put null and the client library should throw before the request is sent.
-func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bodyParameter []string, options *ExplicitPostRequiredArrayParameterOptions) (*http.Response, error) {
+func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bodyParameter []*string, options *ExplicitPostRequiredArrayParameterOptions) (*http.Response, error) {
 	req, err := client.postRequiredArrayParameterCreateRequest(ctx, bodyParameter, options)
 	if err != nil {
 		return nil, err
@@ -522,7 +522,7 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 }
 
 // postRequiredArrayParameterCreateRequest creates the PostRequiredArrayParameter request.
-func (client *ExplicitClient) postRequiredArrayParameterCreateRequest(ctx context.Context, bodyParameter []string, options *ExplicitPostRequiredArrayParameterOptions) (*azcore.Request, error) {
+func (client *ExplicitClient) postRequiredArrayParameterCreateRequest(ctx context.Context, bodyParameter []*string, options *ExplicitPostRequiredArrayParameterOptions) (*azcore.Request, error) {
 	urlPath := "/reqopt/requied/array/parameter"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {

--- a/test/autorest/optionalgroup/zz_generated_models.go
+++ b/test/autorest/optionalgroup/zz_generated_models.go
@@ -10,11 +10,11 @@ package optionalgroup
 import "fmt"
 
 type ArrayOptionalWrapper struct {
-	Value *[]string `json:"value,omitempty"`
+	Value *[]*string `json:"value,omitempty"`
 }
 
 type ArrayWrapper struct {
-	Value *[]string `json:"value,omitempty"`
+	Value *[]*string `json:"value,omitempty"`
 }
 
 type ClassOptionalWrapper struct {
@@ -52,7 +52,7 @@ type ExplicitPostOptionalArrayHeaderOptions struct {
 
 // ExplicitPostOptionalArrayParameterOptions contains the optional parameters for the Explicit.PostOptionalArrayParameter method.
 type ExplicitPostOptionalArrayParameterOptions struct {
-	BodyParameter *[]string
+	BodyParameter *[]*string
 }
 
 // ExplicitPostOptionalArrayPropertyOptions contains the optional parameters for the Explicit.PostOptionalArrayProperty method.

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -22,8 +22,8 @@ type CustomParameterGroup struct {
 }
 
 type OdataProductResult struct {
-	OdataNextLink *string    `json:"odata.nextLink,omitempty"`
-	Values        *[]Product `json:"values,omitempty"`
+	OdataNextLink *string     `json:"odata.nextLink,omitempty"`
+	Values        *[]*Product `json:"values,omitempty"`
 }
 
 // OdataProductResultResponse is the response envelope for operations that return a OdataProductResult type.
@@ -149,8 +149,8 @@ type ProductProperties struct {
 }
 
 type ProductResult struct {
-	NextLink *string    `json:"nextLink,omitempty"`
-	Values   *[]Product `json:"values,omitempty"`
+	NextLink *string     `json:"nextLink,omitempty"`
+	Values   *[]*Product `json:"values,omitempty"`
 }
 
 // ProductResultPagerPollerResponse is the response envelope for operations that asynchronously return a ProductResultPager type.
@@ -174,8 +174,8 @@ type ProductResultResponse struct {
 }
 
 type ProductResultValue struct {
-	NextLink *string    `json:"nextLink,omitempty"`
-	Value    *[]Product `json:"value,omitempty"`
+	NextLink *string     `json:"nextLink,omitempty"`
+	Value    *[]*Product `json:"value,omitempty"`
 }
 
 // ProductResultValueResponse is the response envelope for operations that return a ProductResultValue type.
@@ -187,8 +187,8 @@ type ProductResultValueResponse struct {
 }
 
 type ProductResultValueWithXMSClientName struct {
-	Indexes  *[]Product `json:"values,omitempty"`
-	NextLink *string    `json:"nextLink,omitempty"`
+	Indexes  *[]*Product `json:"values,omitempty"`
+	NextLink *string     `json:"nextLink,omitempty"`
 }
 
 // ProductResultValueWithXMSClientNameResponse is the response envelope for operations that return a ProductResultValueWithXMSClientName type.

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice.go
@@ -59,7 +59,7 @@ func (client *AutoRestReportServiceClient) getOptionalReportCreateRequest(ctx co
 
 // getOptionalReportHandleResponse handles the GetOptionalReport response.
 func (client *AutoRestReportServiceClient) getOptionalReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}
@@ -110,7 +110,7 @@ func (client *AutoRestReportServiceClient) getReportCreateRequest(ctx context.Co
 
 // getReportHandleResponse handles the GetReport response.
 func (client *AutoRestReportServiceClient) getReportHandleResponse(resp *azcore.Response) (MapOfInt32Response, error) {
-	var val map[string]int32
+	var val map[string]*int32
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return MapOfInt32Response{}, err
 	}

--- a/test/autorest/reportgroup/zz_generated_models.go
+++ b/test/autorest/reportgroup/zz_generated_models.go
@@ -46,11 +46,11 @@ func (e Error) Error() string {
 	return msg
 }
 
-// MapOfInt32Response is the response envelope for operations that return a map[string]int32 type.
+// MapOfInt32Response is the response envelope for operations that return a map[string]*int32 type.
 type MapOfInt32Response struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Dictionary of <integer>
-	Value map[string]int32
+	Value map[string]*int32
 }

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -44,7 +44,11 @@ func TestURLMultiArrayStringMultiValid(t *testing.T) {
 	t.Skip("Cannot set nil for string value in string slice")
 	client := newQueriesClient()
 	result, err := client.ArrayStringMultiValid(context.Background(), &QueriesArrayStringMultiValidOptions{
-		ArrayQuery: &[]string{"ArrayQuery1", url.QueryEscape("begin!*'();:@ &=+$,/?#[]end"), "", ""},
+		ArrayQuery: &[]string{
+			"ArrayQuery1",
+			url.QueryEscape("begin!*'();:@ &=+$,/?#[]end"),
+			"",
+			""},
 	})
 	if err != nil {
 		t.Fatalf("ArrayStringMultiValid: %v", err)

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -49,14 +49,14 @@ func TestValidationValidationOfBody(t *testing.T) {
 	client := newAutoRestValidationTestClient()
 	result, err := client.ValidationOfBody(context.Background(), "123", 150, &AutoRestValidationTestValidationOfBodyOptions{
 		Body: &Product{
-			DisplayNames: &[]string{
-				"displayname1",
-				"displayname2",
-				"displayname3",
-				"displayname4",
-				"displayname5",
-				"displayname6",
-				"displayname7"}},
+			DisplayNames: &[]*string{
+				to.StringPtr("displayname1"),
+				to.StringPtr("displayname2"),
+				to.StringPtr("displayname3"),
+				to.StringPtr("displayname4"),
+				to.StringPtr("displayname5"),
+				to.StringPtr("displayname6"),
+				to.StringPtr("displayname7")}},
 	})
 	if err != nil {
 		t.Fatalf("ValidationOfBody: %v", err)

--- a/test/autorest/validationgroup/zz_generated_models.go
+++ b/test/autorest/validationgroup/zz_generated_models.go
@@ -96,7 +96,7 @@ type Product struct {
 	ConstStringAsEnum *string `json:"constStringAsEnum,omitempty"`
 
 	// Non required array of unique items from 0 to 6 elements.
-	DisplayNames *[]string `json:"display_names,omitempty"`
+	DisplayNames *[]*string `json:"display_names,omitempty"`
 
 	// Image URL representing the product.
 	Image *string `json:"image,omitempty"`

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -34,7 +34,7 @@ func TestGetACLs(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := []SignedIdentifier{
+	expected := []*SignedIdentifier{
 		{
 			ID: to.StringPtr("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
 			AccessPolicy: &AccessPolicy{
@@ -169,7 +169,7 @@ func TestGetRootList(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := []Banana{
+	expected := []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),
@@ -195,7 +195,7 @@ func TestGetRootListSingleItem(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
-	expected := []Banana{
+	expected := []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),
@@ -264,13 +264,13 @@ func TestGetSimple(t *testing.T) {
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
 		Title:  to.StringPtr("Sample Slide Show"),
-		Slides: &[]Slide{
+		Slides: &[]*Slide{
 			{
 				Title: to.StringPtr("Wake up to WonderWidgets!"),
 				Type:  to.StringPtr("all"),
 			},
 			{
-				Items: &[]string{"Why WonderWidgets are great", "", "Who buys WonderWidgets"},
+				Items: stringPtrArrayPtr(to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets")),
 				Title: to.StringPtr("Overview"),
 				Type:  to.StringPtr("all"),
 			},
@@ -291,8 +291,8 @@ func TestGetWrappedLists(t *testing.T) {
 		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := &AppleBarrel{
-		BadApples:  &[]string{"Red Delicious"},
-		GoodApples: &[]string{"Fuji", "Gala"},
+		BadApples:  stringPtrArrayPtr(to.StringPtrArray("Red Delicious")),
+		GoodApples: stringPtrArrayPtr(to.StringPtrArray("Fuji", "Gala")),
 	}
 	if r := cmp.Diff(result.AppleBarrel, expected); r != "" {
 		t.Fatal(r)
@@ -342,12 +342,12 @@ func TestListBlobs(t *testing.T) {
 	}
 	expected := ListBlobsResponse{
 		Blobs: &Blobs{
-			Blob: &[]Blob{
+			Blob: &[]*Blob{
 				{
-					Metadata: &map[string]string{
-						"color":            "blue",
-						"blobnumber":       "01",
-						"somemetadataname": "SomeMetadataValue",
+					Metadata: &map[string]*string{
+						"color":            to.StringPtr("blue"),
+						"blobnumber":       to.StringPtr("01"),
+						"somemetadataname": to.StringPtr("SomeMetadataValue"),
 					},
 					Name: to.StringPtr("blob1.txt"),
 					Properties: &BlobProperties{
@@ -364,11 +364,11 @@ func TestListBlobs(t *testing.T) {
 					},
 				},
 				{
-					Metadata: &map[string]string{
-						"color":             "green",
-						"blobnumber":        "02",
-						"somemetadataname":  "SomeMetadataValue",
-						"x-ms-invalid-name": "nasdf$@#$$",
+					Metadata: &map[string]*string{
+						"color":             to.StringPtr("green"),
+						"blobnumber":        to.StringPtr("02"),
+						"somemetadataname":  to.StringPtr("SomeMetadataValue"),
+						"x-ms-invalid-name": to.StringPtr("nasdf$@#$$"),
 					},
 					Name: to.StringPtr("blob2.txt"),
 					Properties: &BlobProperties{
@@ -385,10 +385,10 @@ func TestListBlobs(t *testing.T) {
 					Snapshot: to.StringPtr("2009-09-09T09:20:03.0427659Z"),
 				},
 				{
-					Metadata: &map[string]string{
-						"color":            "green",
-						"blobnumber":       "02",
-						"somemetadataname": "SomeMetadataValue",
+					Metadata: &map[string]*string{
+						"color":            to.StringPtr("green"),
+						"blobnumber":       to.StringPtr("02"),
+						"somemetadataname": to.StringPtr("SomeMetadataValue"),
 					},
 					Name: to.StringPtr("blob2.txt"),
 					Properties: &BlobProperties{
@@ -405,10 +405,10 @@ func TestListBlobs(t *testing.T) {
 					Snapshot: to.StringPtr("2009-09-09T09:20:03.1587543Z"),
 				},
 				{
-					Metadata: &map[string]string{
-						"color":            "green",
-						"blobnumber":       "02",
-						"somemetadataname": "SomeMetadataValue",
+					Metadata: &map[string]*string{
+						"color":            to.StringPtr("green"),
+						"blobnumber":       to.StringPtr("02"),
+						"somemetadataname": to.StringPtr("SomeMetadataValue"),
 					},
 					Name: to.StringPtr("blob2.txt"),
 					Properties: &BlobProperties{
@@ -425,10 +425,10 @@ func TestListBlobs(t *testing.T) {
 					},
 				},
 				{
-					Metadata: &map[string]string{
-						"color":            "yellow",
-						"blobnumber":       "03",
-						"somemetadataname": "SomeMetadataValue",
+					Metadata: &map[string]*string{
+						"color":            to.StringPtr("yellow"),
+						"blobnumber":       to.StringPtr("03"),
+						"somemetadataname": to.StringPtr("SomeMetadataValue"),
 					},
 					Name: to.StringPtr("blob3.txt"),
 					Properties: &BlobProperties{
@@ -468,7 +468,7 @@ func TestListContainers(t *testing.T) {
 		ServiceEndpoint: to.StringPtr("https://myaccount.blob.core.windows.net/"),
 		MaxResults:      to.Int32Ptr(3),
 		NextMarker:      to.StringPtr("video"),
-		Containers: &[]Container{
+		Containers: &[]*Container{
 			{
 				Name: to.StringPtr("audio"),
 				Properties: &ContainerProperties{
@@ -500,7 +500,7 @@ func TestListContainers(t *testing.T) {
 
 func TestPutACLs(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.PutACLs(context.Background(), []SignedIdentifier{
+	result, err := client.PutACLs(context.Background(), []*SignedIdentifier{
 		{
 			ID: to.StringPtr("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
 			AccessPolicy: &AccessPolicy{
@@ -568,7 +568,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 func TestPutEmptyList(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutEmptyList(context.Background(), Slideshow{
-		Slides: &[]Slide{},
+		Slides: &[]*Slide{},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -580,7 +580,7 @@ func TestPutEmptyList(t *testing.T) {
 
 func TestPutEmptyRootList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.PutEmptyRootList(context.Background(), []Banana{}, nil)
+	result, err := client.PutEmptyRootList(context.Background(), []*Banana{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,8 +592,8 @@ func TestPutEmptyRootList(t *testing.T) {
 func TestPutEmptyWrappedLists(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutEmptyWrappedLists(context.Background(), AppleBarrel{
-		BadApples:  &[]string{},
-		GoodApples: &[]string{},
+		BadApples:  &[]*string{},
+		GoodApples: &[]*string{},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -605,7 +605,7 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 
 func TestPutRootList(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.PutRootList(context.Background(), []Banana{
+	result, err := client.PutRootList(context.Background(), []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),
@@ -627,7 +627,7 @@ func TestPutRootList(t *testing.T) {
 
 func TestPutRootListSingleItem(t *testing.T) {
 	client := newXMLClient()
-	result, err := client.PutRootListSingleItem(context.Background(), []Banana{
+	result, err := client.PutRootListSingleItem(context.Background(), []*Banana{
 		{
 			Name:       to.StringPtr("Cavendish"),
 			Flavor:     to.StringPtr("Sweet"),
@@ -688,13 +688,13 @@ func TestPutSimple(t *testing.T) {
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
 		Title:  to.StringPtr("Sample Slide Show"),
-		Slides: &[]Slide{
+		Slides: &[]*Slide{
 			{
 				Title: to.StringPtr("Wake up to WonderWidgets!"),
 				Type:  to.StringPtr("all"),
 			},
 			{
-				Items: &[]string{"Why WonderWidgets are great", "", "Who buys WonderWidgets"},
+				Items: stringPtrArrayPtr(to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets")),
 				Title: to.StringPtr("Overview"),
 				Type:  to.StringPtr("all"),
 			},
@@ -711,8 +711,8 @@ func TestPutSimple(t *testing.T) {
 func TestPutWrappedLists(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutWrappedLists(context.Background(), AppleBarrel{
-		BadApples:  &[]string{"Red Delicious"},
-		GoodApples: &[]string{"Fuji", "Gala"},
+		BadApples:  stringPtrArrayPtr(to.StringPtrArray("Red Delicious")),
+		GoodApples: stringPtrArrayPtr(to.StringPtrArray("Fuji", "Gala")),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -720,4 +720,8 @@ func TestPutWrappedLists(t *testing.T) {
 	if s := result.StatusCode; s != http.StatusCreated {
 		t.Fatalf("unexpected status code %d", s)
 	}
+}
+
+func stringPtrArrayPtr(s []*string) *[]*string {
+	return &s
 }

--- a/test/autorest/xmlgroup/zz_generated_models.go
+++ b/test/autorest/xmlgroup/zz_generated_models.go
@@ -61,8 +61,8 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 
 // A barrel of apples.
 type AppleBarrel struct {
-	BadApples  *[]string `xml:"BadApples>Apple"`
-	GoodApples *[]string `xml:"GoodApples>Apple"`
+	BadApples  *[]*string `xml:"BadApples>Apple"`
+	GoodApples *[]*string `xml:"GoodApples>Apple"`
 }
 
 // AppleBarrelResponse is the response envelope for operations that return a AppleBarrel type.
@@ -112,10 +112,10 @@ func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
-// BananaArrayResponse is the response envelope for operations that return a []Banana type.
+// BananaArrayResponse is the response envelope for operations that return a []*Banana type.
 type BananaArrayResponse struct {
 	// Array of Banana
-	Bananas []Banana `xml:"banana"`
+	Bananas []*Banana `xml:"banana"`
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
@@ -135,8 +135,8 @@ type Blob struct {
 	Deleted *bool `xml:"Deleted"`
 
 	// Dictionary of
-	Metadata *map[string]string `xml:"Metadata"`
-	Name     *string            `xml:"Name"`
+	Metadata *map[string]*string `xml:"Metadata"`
+	Name     *string             `xml:"Name"`
 
 	// Properties of a blob
 	Properties *BlobProperties `xml:"Properties"`
@@ -155,7 +155,7 @@ func (b *Blob) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	b.Metadata = (*map[string]string)(aux.Metadata)
+	b.Metadata = (*map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -235,8 +235,8 @@ func (b *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 }
 
 type Blobs struct {
-	Blob       *[]Blob       `xml:"Blob"`
-	BlobPrefix *[]BlobPrefix `xml:"BlobPrefix"`
+	Blob       *[]*Blob       `xml:"Blob"`
+	BlobPrefix *[]*BlobPrefix `xml:"BlobPrefix"`
 }
 
 // I am a complex type with no XML node
@@ -254,8 +254,8 @@ type ComplexTypeWithMeta struct {
 // An Azure Storage container
 type Container struct {
 	// Dictionary of
-	Metadata *map[string]string `xml:"Metadata"`
-	Name     *string            `xml:"Name"`
+	Metadata *map[string]*string `xml:"Metadata"`
+	Name     *string             `xml:"Name"`
 
 	// Properties of a container
 	Properties *ContainerProperties `xml:"Properties"`
@@ -273,7 +273,7 @@ func (c *Container) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.Metadata = (*map[string]string)(aux.Metadata)
+	c.Metadata = (*map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -399,12 +399,12 @@ type ListBlobsResponseResponse struct {
 
 // An enumeration of containers
 type ListContainersResponse struct {
-	Containers      *[]Container `xml:"Containers>Container"`
-	Marker          *string      `xml:"Marker"`
-	MaxResults      *int32       `xml:"MaxResults"`
-	NextMarker      *string      `xml:"NextMarker"`
-	Prefix          *string      `xml:"Prefix"`
-	ServiceEndpoint *string      `xml:"ServiceEndpoint,attr"`
+	Containers      *[]*Container `xml:"Containers>Container"`
+	Marker          *string       `xml:"Marker"`
+	MaxResults      *int32        `xml:"MaxResults"`
+	NextMarker      *string       `xml:"NextMarker"`
+	Prefix          *string       `xml:"Prefix"`
+	ServiceEndpoint *string       `xml:"ServiceEndpoint,attr"`
 }
 
 // ListContainersResponseResponse is the response envelope for operations that return a ListContainersResponse type.
@@ -520,28 +520,28 @@ type SignedIdentifier struct {
 	ID *string `xml:"Id"`
 }
 
-// SignedIdentifierArrayResponse is the response envelope for operations that return a []SignedIdentifier type.
+// SignedIdentifierArrayResponse is the response envelope for operations that return a []*SignedIdentifier type.
 type SignedIdentifierArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// a collection of signed identifiers
-	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+	SignedIdentifiers []*SignedIdentifier `xml:"SignedIdentifier"`
 }
 
 // A slide in a slideshow
 type Slide struct {
-	Items *[]string `xml:"item"`
-	Title *string   `xml:"title"`
-	Type  *string   `xml:"type,attr"`
+	Items *[]*string `xml:"item"`
+	Title *string    `xml:"title"`
+	Type  *string    `xml:"type,attr"`
 }
 
 // Data about a slideshow
 type Slideshow struct {
-	Author *string  `xml:"author,attr"`
-	Date   *string  `xml:"date,attr"`
-	Slides *[]Slide `xml:"slide"`
-	Title  *string  `xml:"title,attr"`
+	Author *string   `xml:"author,attr"`
+	Date   *string   `xml:"date,attr"`
+	Slides *[]*Slide `xml:"slide"`
+	Title  *string   `xml:"title,attr"`
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Slideshow.
@@ -568,7 +568,7 @@ type SlideshowResponse struct {
 // Storage Service Properties.
 type StorageServiceProperties struct {
 	// The set of CORS rules.
-	Cors *[]CorsRule `xml:"Cors>CorsRule"`
+	Cors *[]*CorsRule `xml:"Cors>CorsRule"`
 
 	// The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27
 	// and all more recent versions

--- a/test/autorest/xmlgroup/zz_generated_xml.go
+++ b/test/autorest/xmlgroup/zz_generated_xml.go
@@ -913,7 +913,7 @@ func (client *XMLClient) listContainersHandleError(resp *azcore.Response) error 
 }
 
 // PutACLs - Puts storage ACLs for a container.
-func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIdentifier, options *XMLPutACLsOptions) (*http.Response, error) {
+func (client *XMLClient) PutACLs(ctx context.Context, properties []*SignedIdentifier, options *XMLPutACLsOptions) (*http.Response, error) {
 	req, err := client.putACLsCreateRequest(ctx, properties, options)
 	if err != nil {
 		return nil, err
@@ -929,7 +929,7 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []SignedIdentif
 }
 
 // putACLsCreateRequest creates the PutACLs request.
-func (client *XMLClient) putACLsCreateRequest(ctx context.Context, properties []SignedIdentifier, options *XMLPutACLsOptions) (*azcore.Request, error) {
+func (client *XMLClient) putACLsCreateRequest(ctx context.Context, properties []*SignedIdentifier, options *XMLPutACLsOptions) (*azcore.Request, error) {
 	urlPath := "/xml/mycontainer"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -941,8 +941,8 @@ func (client *XMLClient) putACLsCreateRequest(ctx context.Context, properties []
 	query.Set("restype", "container")
 	req.URL.RawQuery = query.Encode()
 	type wrapper struct {
-		XMLName    xml.Name            `xml:"SignedIdentifiers"`
-		Properties *[]SignedIdentifier `xml:"SignedIdentifier"`
+		XMLName    xml.Name             `xml:"SignedIdentifiers"`
+		Properties *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
 	return req, req.MarshalAsXML(wrapper{Properties: &properties})
 }
@@ -1116,7 +1116,7 @@ func (client *XMLClient) putEmptyListHandleError(resp *azcore.Response) error {
 }
 
 // PutEmptyRootList - Puts an empty list as the root element.
-func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana, options *XMLPutEmptyRootListOptions) (*http.Response, error) {
+func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []*Banana, options *XMLPutEmptyRootListOptions) (*http.Response, error) {
 	req, err := client.putEmptyRootListCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
@@ -1132,7 +1132,7 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []Banana,
 }
 
 // putEmptyRootListCreateRequest creates the PutEmptyRootList request.
-func (client *XMLClient) putEmptyRootListCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutEmptyRootListOptions) (*azcore.Request, error) {
+func (client *XMLClient) putEmptyRootListCreateRequest(ctx context.Context, bananas []*Banana, options *XMLPutEmptyRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/empty-root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -1140,8 +1140,8 @@ func (client *XMLClient) putEmptyRootListCreateRequest(ctx context.Context, bana
 	}
 	req.Telemetry(telemetryInfo)
 	type wrapper struct {
-		XMLName xml.Name  `xml:"bananas"`
-		Bananas *[]Banana `xml:"banana"`
+		XMLName xml.Name   `xml:"bananas"`
+		Bananas *[]*Banana `xml:"banana"`
 	}
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
@@ -1198,7 +1198,7 @@ func (client *XMLClient) putEmptyWrappedListsHandleError(resp *azcore.Response) 
 }
 
 // PutRootList - Puts a list as the root element.
-func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana, options *XMLPutRootListOptions) (*http.Response, error) {
+func (client *XMLClient) PutRootList(ctx context.Context, bananas []*Banana, options *XMLPutRootListOptions) (*http.Response, error) {
 	req, err := client.putRootListCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
@@ -1214,7 +1214,7 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []Banana, opti
 }
 
 // putRootListCreateRequest creates the PutRootList request.
-func (client *XMLClient) putRootListCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutRootListOptions) (*azcore.Request, error) {
+func (client *XMLClient) putRootListCreateRequest(ctx context.Context, bananas []*Banana, options *XMLPutRootListOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -1222,8 +1222,8 @@ func (client *XMLClient) putRootListCreateRequest(ctx context.Context, bananas [
 	}
 	req.Telemetry(telemetryInfo)
 	type wrapper struct {
-		XMLName xml.Name  `xml:"bananas"`
-		Bananas *[]Banana `xml:"banana"`
+		XMLName xml.Name   `xml:"bananas"`
+		Bananas *[]*Banana `xml:"banana"`
 	}
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }
@@ -1241,7 +1241,7 @@ func (client *XMLClient) putRootListHandleError(resp *azcore.Response) error {
 }
 
 // PutRootListSingleItem - Puts a list with a single item.
-func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Banana, options *XMLPutRootListSingleItemOptions) (*http.Response, error) {
+func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []*Banana, options *XMLPutRootListSingleItemOptions) (*http.Response, error) {
 	req, err := client.putRootListSingleItemCreateRequest(ctx, bananas, options)
 	if err != nil {
 		return nil, err
@@ -1257,7 +1257,7 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []Ba
 }
 
 // putRootListSingleItemCreateRequest creates the PutRootListSingleItem request.
-func (client *XMLClient) putRootListSingleItemCreateRequest(ctx context.Context, bananas []Banana, options *XMLPutRootListSingleItemOptions) (*azcore.Request, error) {
+func (client *XMLClient) putRootListSingleItemCreateRequest(ctx context.Context, bananas []*Banana, options *XMLPutRootListSingleItemOptions) (*azcore.Request, error) {
 	urlPath := "/xml/root-list-single-item"
 	req, err := azcore.NewRequest(ctx, http.MethodPut, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -1265,8 +1265,8 @@ func (client *XMLClient) putRootListSingleItemCreateRequest(ctx context.Context,
 	}
 	req.Telemetry(telemetryInfo)
 	type wrapper struct {
-		XMLName xml.Name  `xml:"bananas"`
-		Bananas *[]Banana `xml:"banana"`
+		XMLName xml.Name   `xml:"bananas"`
+		Bananas *[]*Banana `xml:"banana"`
 	}
 	return req, req.MarshalAsXML(wrapper{Bananas: &bananas})
 }

--- a/test/autorest/xmlgroup/zz_generated_xml_helper.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_helper.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-type additionalProperties map[string]string
+type additionalProperties map[string]*string
 
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -29,7 +29,8 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if *ap == nil {
 				*ap = additionalProperties{}
 			}
-			(*ap)[tokName] = string(tt)
+			s := string(tt)
+			(*ap)[tokName] = &s
 			tokName = ""
 			break
 		}

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -29,7 +29,7 @@ type APIError struct {
 	Code *string `json:"code,omitempty"`
 
 	// The Api error details
-	Details *[]APIErrorBase `json:"details,omitempty"`
+	Details *[]*APIErrorBase `json:"details,omitempty"`
 
 	// The Api inner error
 	Innererror *InnerError `json:"innererror,omitempty"`
@@ -163,7 +163,7 @@ type AvailabilitySetListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of availability sets
-	Value *[]AvailabilitySet `json:"value,omitempty"`
+	Value *[]*AvailabilitySet `json:"value,omitempty"`
 }
 
 // AvailabilitySetListResultResponse is the response envelope for operations that return a AvailabilitySetListResult type.
@@ -188,10 +188,10 @@ type AvailabilitySetProperties struct {
 	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
 
 	// READ-ONLY; The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty" azure:"ro"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty" azure:"ro"`
 
 	// A list of references to all virtual machines in the availability set.
-	VirtualMachines *[]SubResource `json:"virtualMachines,omitempty"`
+	VirtualMachines *[]*SubResource `json:"virtualMachines,omitempty"`
 }
 
 // AvailabilitySetResponse is the response envelope for operations that return a AvailabilitySet type.
@@ -338,7 +338,7 @@ func (e CloudError) Error() string {
 // The List Compute Operation operation response.
 type ComputeOperationListResult struct {
 	// READ-ONLY; The list of compute operations
-	Value *[]ComputeOperationValue `json:"value,omitempty" azure:"ro"`
+	Value *[]*ComputeOperationValue `json:"value,omitempty" azure:"ro"`
 }
 
 // ComputeOperationListResultResponse is the response envelope for operations that return a ComputeOperationListResult type.
@@ -428,7 +428,7 @@ type ContainerServiceListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// the list of container services.
-	Value *[]ContainerService `json:"value,omitempty"`
+	Value *[]*ContainerService `json:"value,omitempty"`
 }
 
 // ContainerServiceListResultResponse is the response envelope for operations that return a ContainerServiceListResult type.
@@ -482,7 +482,7 @@ type ContainerServicePrincipalProfile struct {
 // Properties of the container service.
 type ContainerServiceProperties struct {
 	// Properties of the agent pool.
-	AgentPoolProfiles *[]ContainerServiceAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles *[]*ContainerServiceAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
 
 	// Properties for custom clusters.
 	CustomProfile *ContainerServiceCustomProfile `json:"customProfile,omitempty"`
@@ -521,7 +521,7 @@ type ContainerServiceResponse struct {
 // SSH configuration for Linux-based VMs running on Azure.
 type ContainerServiceSSHConfiguration struct {
 	// the list of SSH public keys used to authenticate with Linux-based VMs.
-	PublicKeys *[]ContainerServiceSSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys *[]*ContainerServiceSSHPublicKey `json:"publicKeys,omitempty"`
 }
 
 // Contains information about SSH certificate public key data.
@@ -699,7 +699,7 @@ type DedicatedHostAllocatableVM struct {
 // Dedicated host unutilized capacity.
 type DedicatedHostAvailableCapacity struct {
 	// The unutilized capacity of the dedicated host represented in terms of each VM size that is allowed to be deployed to the dedicated host.
-	AllocatableVMs *[]DedicatedHostAllocatableVM `json:"allocatableVMs,omitempty"`
+	AllocatableVMs *[]*DedicatedHostAllocatableVM `json:"allocatableVMs,omitempty"`
 }
 
 // Specifies information about the dedicated host group that the dedicated hosts should be assigned to.
@@ -713,7 +713,7 @@ type DedicatedHostGroup struct {
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group
 	// supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // The List Dedicated Host Group with resource group response.
@@ -722,7 +722,7 @@ type DedicatedHostGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of dedicated host groups
-	Value *[]DedicatedHostGroup `json:"value,omitempty"`
+	Value *[]*DedicatedHostGroup `json:"value,omitempty"`
 }
 
 // DedicatedHostGroupListResultResponse is the response envelope for operations that return a DedicatedHostGroupListResult type.
@@ -737,7 +737,7 @@ type DedicatedHostGroupListResultResponse struct {
 // Dedicated Host Group Properties.
 type DedicatedHostGroupProperties struct {
 	// READ-ONLY; A list of references to all dedicated hosts in the dedicated host group.
-	Hosts *[]SubResourceReadOnly `json:"hosts,omitempty" azure:"ro"`
+	Hosts *[]*SubResourceReadOnly `json:"hosts,omitempty" azure:"ro"`
 
 	// Number of fault domains that the host group can span.
 	PlatformFaultDomainCount *int32 `json:"platformFaultDomainCount,omitempty"`
@@ -762,7 +762,7 @@ type DedicatedHostGroupUpdate struct {
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group
 	// supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DedicatedHostGroupUpdate.
@@ -812,7 +812,7 @@ type DedicatedHostInstanceView struct {
 	AvailableCapacity *DedicatedHostAvailableCapacity `json:"availableCapacity,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 }
 
 // The list dedicated host operation response.
@@ -821,7 +821,7 @@ type DedicatedHostListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of dedicated hosts
-	Value *[]DedicatedHost `json:"value,omitempty"`
+	Value *[]*DedicatedHost `json:"value,omitempty"`
 }
 
 // DedicatedHostListResultResponse is the response envelope for operations that return a DedicatedHostListResult type.
@@ -875,7 +875,7 @@ type DedicatedHostProperties struct {
 	ProvisioningTime *time.Time `json:"provisioningTime,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of references to all virtual machines in the Dedicated Host.
-	VirtualMachines *[]SubResourceReadOnly `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines *[]*SubResourceReadOnly `json:"virtualMachines,omitempty" azure:"ro"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DedicatedHostProperties.
@@ -1012,7 +1012,7 @@ type DiffDiskSettings struct {
 // Describes the disallowed disk types.
 type Disallowed struct {
 	// A list of disk types.
-	DiskTypes *[]string `json:"diskTypes,omitempty"`
+	DiskTypes *[]*string `json:"diskTypes,omitempty"`
 }
 
 // Disk resource.
@@ -1023,7 +1023,7 @@ type Disk struct {
 
 	// READ-ONLY; List of relative URIs containing the IDs of the VMs that have the disk attached. maxShares should be set to a value greater than one for disks
 	// to allow attaching them to multiple VMs.
-	ManagedByExtended *[]string `json:"managedByExtended,omitempty" azure:"ro"`
+	ManagedByExtended *[]*string `json:"managedByExtended,omitempty" azure:"ro"`
 
 	// Disk resource properties.
 	Properties *DiskProperties `json:"properties,omitempty"`
@@ -1032,7 +1032,7 @@ type Disk struct {
 	SKU *DiskSKU `json:"sku,omitempty"`
 
 	// The Logical zone list for Disk.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // disk encryption set resource.
@@ -1049,7 +1049,7 @@ type DiskEncryptionSetList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of disk encryption sets.
-	Value *[]DiskEncryptionSet `json:"value,omitempty"`
+	Value *[]*DiskEncryptionSet `json:"value,omitempty"`
 }
 
 // DiskEncryptionSetListResponse is the response envelope for operations that return a DiskEncryptionSetList type.
@@ -1094,7 +1094,7 @@ type DiskEncryptionSetUpdate struct {
 	Properties *DiskEncryptionSetUpdateProperties `json:"properties,omitempty"`
 
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DiskEncryptionSetUpdate.
@@ -1163,13 +1163,13 @@ type DiskImageEncryption struct {
 type DiskInstanceView struct {
 	// Specifies the encryption settings for the OS Disk.
 	// Minimum api-version: 2015-06-15
-	EncryptionSettings *[]DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	EncryptionSettings *[]*DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
 
 	// The disk name.
 	Name *string `json:"name,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 }
 
 // The List Disks operation response.
@@ -1178,7 +1178,7 @@ type DiskList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of disks.
-	Value *[]Disk `json:"value,omitempty"`
+	Value *[]*Disk `json:"value,omitempty"`
 }
 
 // DiskListResponse is the response envelope for operations that return a DiskList type.
@@ -1253,7 +1253,7 @@ type DiskProperties struct {
 
 	// READ-ONLY; Details of the list of all VMs that have the disk attached. maxShares should be set to a value greater than one for disks to allow attaching
 	// them to multiple VMs.
-	ShareInfo *[]ShareInfoElement `json:"shareInfo,omitempty" azure:"ro"`
+	ShareInfo *[]*ShareInfoElement `json:"shareInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The time when the disk was created.
 	TimeCreated *time.Time `json:"timeCreated,omitempty" azure:"ro"`
@@ -1382,7 +1382,7 @@ type DiskUpdate struct {
 	SKU *DiskSKU `json:"sku,omitempty"`
 
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DiskUpdate.
@@ -1481,7 +1481,7 @@ type Encryption struct {
 // Optional. Allows users to provide customer managed keys for encrypting the OS and data disks in the gallery artifact.
 type EncryptionImages struct {
 	// A list of encryption specifications for data disk images.
-	DataDiskImages *[]DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
+	DataDiskImages *[]*DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
 
 	// This is the disk image encryption base class.
 	OSDiskImage *DiskImageEncryption `json:"osDiskImage,omitempty"`
@@ -1508,7 +1508,7 @@ type EncryptionSetProperties struct {
 
 	// READ-ONLY; A readonly collection of key vault keys previously used by this disk encryption set while a key rotation is in progress. It will be empty
 	// if there is no ongoing key rotation.
-	PreviousKeys *[]KeyVaultAndKeyReference `json:"previousKeys,omitempty" azure:"ro"`
+	PreviousKeys *[]*KeyVaultAndKeyReference `json:"previousKeys,omitempty" azure:"ro"`
 
 	// READ-ONLY; The disk encryption set provisioning state.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
@@ -1522,7 +1522,7 @@ type EncryptionSettingsCollection struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// A collection of encryption settings, one for each disk volume.
-	EncryptionSettings *[]EncryptionSettingsElement `json:"encryptionSettings,omitempty"`
+	EncryptionSettings *[]*EncryptionSettingsElement `json:"encryptionSettings,omitempty"`
 
 	// Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption
 	// with AAD app.'1.1' corresponds to Azure Disk
@@ -1590,7 +1590,7 @@ type GalleryApplicationList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Gallery Applications.
-	Value *[]GalleryApplication `json:"value,omitempty"`
+	Value *[]*GalleryApplication `json:"value,omitempty"`
 }
 
 // GalleryApplicationListResponse is the response envelope for operations that return a GalleryApplicationList type.
@@ -1723,7 +1723,7 @@ type GalleryApplicationVersionList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of gallery Application Versions.
-	Value *[]GalleryApplicationVersion `json:"value,omitempty"`
+	Value *[]*GalleryApplicationVersion `json:"value,omitempty"`
 }
 
 // GalleryApplicationVersionListResponse is the response envelope for operations that return a GalleryApplicationVersionList type.
@@ -1899,7 +1899,7 @@ type GalleryArtifactPublishingProfileBase struct {
 	StorageAccountType *StorageAccountType `json:"storageAccountType,omitempty"`
 
 	// The target regions where the Image Version is going to be replicated to. This property is updatable.
-	TargetRegions *[]TargetRegion `json:"targetRegions,omitempty"`
+	TargetRegions *[]*TargetRegion `json:"targetRegions,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type GalleryArtifactPublishingProfileBase.
@@ -2026,7 +2026,7 @@ type GalleryImageList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Shared Image Gallery images.
-	Value *[]GalleryImage `json:"value,omitempty"`
+	Value *[]*GalleryImage `json:"value,omitempty"`
 }
 
 // GalleryImageListResponse is the response envelope for operations that return a GalleryImageList type.
@@ -2208,7 +2208,7 @@ type GalleryImageVersionList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of gallery Image Versions.
-	Value *[]GalleryImageVersion `json:"value,omitempty"`
+	Value *[]*GalleryImageVersion `json:"value,omitempty"`
 }
 
 // GalleryImageVersionListResponse is the response envelope for operations that return a GalleryImageVersionList type.
@@ -2264,7 +2264,7 @@ type GalleryImageVersionResponse struct {
 // This is the storage profile of a Gallery Image Version.
 type GalleryImageVersionStorageProfile struct {
 	// A list of data disk images.
-	DataDiskImages *[]GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
+	DataDiskImages *[]*GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
 
 	// This is the disk image base class.
 	OSDiskImage *GalleryDiskImage `json:"osDiskImage,omitempty"`
@@ -2344,7 +2344,7 @@ type GalleryList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of galleries.
-	Value *[]Gallery `json:"value,omitempty"`
+	Value *[]*Gallery `json:"value,omitempty"`
 }
 
 // GalleryListResponse is the response envelope for operations that return a GalleryList type.
@@ -2502,7 +2502,7 @@ type ImageListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of Images.
-	Value *[]Image `json:"value,omitempty"`
+	Value *[]*Image `json:"value,omitempty"`
 }
 
 // ImageListResultResponse is the response envelope for operations that return a ImageListResult type.
@@ -2609,7 +2609,7 @@ type ImageStorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]ImageDataDisk `json:"dataDisks,omitempty"`
+	DataDisks *[]*ImageDataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the operating system disk used by the virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
@@ -2798,7 +2798,7 @@ type ListUsagesResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of compute resource usages.
-	Value *[]Usage `json:"value,omitempty"`
+	Value *[]*Usage `json:"value,omitempty"`
 }
 
 // ListUsagesResultResponse is the response envelope for operations that return a ListUsagesResult type.
@@ -3049,7 +3049,7 @@ type NetworkInterfaceReferenceProperties struct {
 // Specifies the network interfaces of the virtual machine.
 type NetworkProfile struct {
 	// Specifies the list of resource Ids for the network interfaces associated with the virtual machine.
-	NetworkInterfaces *[]NetworkInterfaceReference `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces *[]*NetworkInterfaceReference `json:"networkInterfaces,omitempty"`
 }
 
 // Specifies information about the operating system disk used by the virtual machine.
@@ -3185,7 +3185,7 @@ type OSProfile struct {
 	RequireGuestProvisionSignal *bool `json:"requireGuestProvisionSignal,omitempty"`
 
 	// Specifies set of certificates that should be installed onto the virtual machine.
-	Secrets *[]VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// Specifies Windows operating system settings on the virtual machine.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
@@ -3246,7 +3246,7 @@ type ProximityPlacementGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of proximity placement groups
-	Value *[]ProximityPlacementGroup `json:"value,omitempty"`
+	Value *[]*ProximityPlacementGroup `json:"value,omitempty"`
 }
 
 // ProximityPlacementGroupListResultResponse is the response envelope for operations that return a ProximityPlacementGroupListResult type.
@@ -3261,7 +3261,7 @@ type ProximityPlacementGroupListResultResponse struct {
 // Describes the properties of a Proximity Placement Group.
 type ProximityPlacementGroupProperties struct {
 	// READ-ONLY; A list of references to all availability sets in the proximity placement group.
-	AvailabilitySets *[]SubResourceWithColocationStatus `json:"availabilitySets,omitempty" azure:"ro"`
+	AvailabilitySets *[]*SubResourceWithColocationStatus `json:"availabilitySets,omitempty" azure:"ro"`
 
 	// Describes colocation status of the Proximity Placement Group.
 	ColocationStatus *InstanceViewStatus `json:"colocationStatus,omitempty"`
@@ -3273,10 +3273,10 @@ type ProximityPlacementGroupProperties struct {
 	ProximityPlacementGroupType *ProximityPlacementGroupType `json:"proximityPlacementGroupType,omitempty"`
 
 	// READ-ONLY; A list of references to all virtual machine scale sets in the proximity placement group.
-	VirtualMachineScaleSets *[]SubResourceWithColocationStatus `json:"virtualMachineScaleSets,omitempty" azure:"ro"`
+	VirtualMachineScaleSets *[]*SubResourceWithColocationStatus `json:"virtualMachineScaleSets,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of references to all virtual machines in the proximity placement group.
-	VirtualMachines *[]SubResourceWithColocationStatus `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines *[]*SubResourceWithColocationStatus `json:"virtualMachines,omitempty" azure:"ro"`
 }
 
 // ProximityPlacementGroupResponse is the response envelope for operations that return a ProximityPlacementGroup type.
@@ -3384,7 +3384,7 @@ type ReplicationStatus struct {
 	AggregatedState *AggregatedReplicationState `json:"aggregatedState,omitempty" azure:"ro"`
 
 	// READ-ONLY; This is a summary of replication status for each region.
-	Summary *[]RegionalReplicationStatus `json:"summary,omitempty" azure:"ro"`
+	Summary *[]*RegionalReplicationStatus `json:"summary,omitempty" azure:"ro"`
 }
 
 // Api request input for LogAnalytics getRequestRateByInterval Api.
@@ -3433,7 +3433,7 @@ type Resource struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -3451,16 +3451,16 @@ type ResourceRange struct {
 // Describes an available Compute SKU.
 type ResourceSKU struct {
 	// READ-ONLY; The api versions that support this SKU.
-	APIVersions *[]string `json:"apiVersions,omitempty" azure:"ro"`
+	APIVersions *[]*string `json:"apiVersions,omitempty" azure:"ro"`
 
 	// READ-ONLY; A name value pair to describe the capability.
-	Capabilities *[]ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities *[]*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
 
 	// READ-ONLY; Specifies the number of virtual machines in the scale set.
 	Capacity *ResourceSKUCapacity `json:"capacity,omitempty" azure:"ro"`
 
 	// READ-ONLY; Metadata for retrieving price info.
-	Costs *[]ResourceSKUCosts `json:"costs,omitempty" azure:"ro"`
+	Costs *[]*ResourceSKUCosts `json:"costs,omitempty" azure:"ro"`
 
 	// READ-ONLY; The Family of this particular SKU.
 	Family *string `json:"family,omitempty" azure:"ro"`
@@ -3469,10 +3469,10 @@ type ResourceSKU struct {
 	Kind *string `json:"kind,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of locations and availability zones in those locations where the SKU is available.
-	LocationInfo *[]ResourceSKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
+	LocationInfo *[]*ResourceSKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The set of locations that the SKU is available.
-	Locations *[]string `json:"locations,omitempty" azure:"ro"`
+	Locations *[]*string `json:"locations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The name of SKU.
 	Name *string `json:"name,omitempty" azure:"ro"`
@@ -3481,7 +3481,7 @@ type ResourceSKU struct {
 	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
 
 	// READ-ONLY; The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
-	Restrictions *[]ResourceSKURestrictions `json:"restrictions,omitempty" azure:"ro"`
+	Restrictions *[]*ResourceSKURestrictions `json:"restrictions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The Size of the SKU.
 	Size *string `json:"size,omitempty" azure:"ro"`
@@ -3534,18 +3534,18 @@ type ResourceSKULocationInfo struct {
 	Location *string `json:"location,omitempty" azure:"ro"`
 
 	// READ-ONLY; Details of capabilities available to a SKU in specific zones.
-	ZoneDetails *[]ResourceSKUZoneDetails `json:"zoneDetails,omitempty" azure:"ro"`
+	ZoneDetails *[]*ResourceSKUZoneDetails `json:"zoneDetails,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of availability zones where the SKU is supported.
-	Zones *[]string `json:"zones,omitempty" azure:"ro"`
+	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
 }
 
 type ResourceSKURestrictionInfo struct {
 	// READ-ONLY; Locations where the SKU is restricted
-	Locations *[]string `json:"locations,omitempty" azure:"ro"`
+	Locations *[]*string `json:"locations,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of availability zones where the SKU is restricted.
-	Zones *[]string `json:"zones,omitempty" azure:"ro"`
+	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
 }
 
 // Describes scaling information of a SKU.
@@ -3560,16 +3560,16 @@ type ResourceSKURestrictions struct {
 	Type *ResourceSKURestrictionsType `json:"type,omitempty" azure:"ro"`
 
 	// READ-ONLY; The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.
-	Values *[]string `json:"values,omitempty" azure:"ro"`
+	Values *[]*string `json:"values,omitempty" azure:"ro"`
 }
 
 // Describes The zonal capabilities of a SKU.
 type ResourceSKUZoneDetails struct {
 	// READ-ONLY; A list of capabilities that are available for the SKU in the specified list of zones.
-	Capabilities *[]ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities *[]*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
 
 	// READ-ONLY; The set of zones that the SKU is available in with the specified capabilities.
-	Name *[]string `json:"name,omitempty" azure:"ro"`
+	Name *[]*string `json:"name,omitempty" azure:"ro"`
 }
 
 // ResourceSKUsListOptions contains the optional parameters for the ResourceSKUs.List method.
@@ -3584,7 +3584,7 @@ type ResourceSKUsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of skus available for the subscription.
-	Value *[]ResourceSKU `json:"value,omitempty"`
+	Value *[]*ResourceSKU `json:"value,omitempty"`
 }
 
 // ResourceSKUsResultResponse is the response envelope for operations that return a ResourceSKUsResult type.
@@ -3740,10 +3740,10 @@ type RollingUpgradeStatusInfoResponse struct {
 type RunCommandDocument struct {
 	RunCommandDocumentBase
 	// The parameters used by the script.
-	Parameters *[]RunCommandParameterDefinition `json:"parameters,omitempty"`
+	Parameters *[]*RunCommandParameterDefinition `json:"parameters,omitempty"`
 
 	// The script to be executed.
-	Script *[]string `json:"script,omitempty"`
+	Script *[]*string `json:"script,omitempty"`
 }
 
 // Describes the properties of a Run Command metadata.
@@ -3779,10 +3779,10 @@ type RunCommandInput struct {
 	CommandID *string `json:"commandId,omitempty"`
 
 	// The run command parameters.
-	Parameters *[]RunCommandInputParameter `json:"parameters,omitempty"`
+	Parameters *[]*RunCommandInputParameter `json:"parameters,omitempty"`
 
 	// Optional. The script to be executed. When this value is given, the given script will override the default script of the command.
-	Script *[]string `json:"script,omitempty"`
+	Script *[]*string `json:"script,omitempty"`
 }
 
 // Describes the properties of a run command parameter.
@@ -3800,7 +3800,7 @@ type RunCommandListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine run commands.
-	Value *[]RunCommandDocumentBase `json:"value,omitempty"`
+	Value *[]*RunCommandDocumentBase `json:"value,omitempty"`
 }
 
 // RunCommandListResultResponse is the response envelope for operations that return a RunCommandListResult type.
@@ -3829,7 +3829,7 @@ type RunCommandParameterDefinition struct {
 
 type RunCommandResult struct {
 	// Run command operation response.
-	Value *[]InstanceViewStatus `json:"value,omitempty"`
+	Value *[]*InstanceViewStatus `json:"value,omitempty"`
 }
 
 // RunCommandResultPollerResponse is the response envelope for operations that asynchronously return a RunCommandResult type.
@@ -3871,7 +3871,7 @@ type SKU struct {
 // SSH configuration for Linux based VMs running on Azure
 type SSHConfiguration struct {
 	// The list of SSH public keys used to authenticate with linux based VMs.
-	PublicKeys *[]SSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys *[]*SSHPublicKey `json:"publicKeys,omitempty"`
 }
 
 // Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
@@ -3973,7 +3973,7 @@ type SSHPublicKeysGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of SSH public keys
-	Value *[]SSHPublicKeyResource `json:"value,omitempty"`
+	Value *[]*SSHPublicKeyResource `json:"value,omitempty"`
 }
 
 // SSHPublicKeysGroupListResultResponse is the response envelope for operations that return a SSHPublicKeysGroupListResult type.
@@ -4013,7 +4013,7 @@ type ScaleInPolicy struct {
 	// NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal.
 	// For zonal virtual machine scale sets, the
 	// scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal.
-	Rules *[]VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
+	Rules *[]*VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
 }
 
 type ScheduledEventsProfile struct {
@@ -4045,7 +4045,7 @@ type SnapshotList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of snapshots.
-	Value *[]Snapshot `json:"value,omitempty"`
+	Value *[]*Snapshot `json:"value,omitempty"`
 }
 
 // SnapshotListResponse is the response envelope for operations that return a SnapshotList type.
@@ -4203,7 +4203,7 @@ type SnapshotUpdate struct {
 	SKU *SnapshotSKU `json:"sku,omitempty"`
 
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SnapshotUpdate.
@@ -4283,7 +4283,7 @@ type StorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]DataDisk `json:"dataDisks,omitempty"`
+	DataDisks *[]*DataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This
 	// element is required when you want to use a platform
@@ -4351,7 +4351,7 @@ type ThrottledRequestsInput struct {
 // The Update Resource model definition.
 type UpdateResource struct {
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type UpdateResource.
@@ -4375,7 +4375,7 @@ type UpdateResourceDefinition struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -4582,7 +4582,7 @@ type VaultSecretGroup struct {
 	SourceVault *SubResource `json:"sourceVault,omitempty"`
 
 	// The list of key vault references in SourceVault which contain certificates.
-	VaultCertificates *[]VaultCertificate `json:"vaultCertificates,omitempty"`
+	VaultCertificates *[]*VaultCertificate `json:"vaultCertificates,omitempty"`
 }
 
 // Describes the uri of a disk.
@@ -4608,19 +4608,19 @@ type VirtualMachine struct {
 	Properties *VirtualMachineProperties `json:"properties,omitempty"`
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources *[]VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources *[]*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
 
 	// The virtual machine zones.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // The instance view of the VM Agent running on the virtual machine.
 type VirtualMachineAgentInstanceView struct {
 	// The virtual machine extension handler instance view.
-	ExtensionHandlers *[]VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
+	ExtensionHandlers *[]*VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent full version.
 	VMAgentVersion *string `json:"vmAgentVersion,omitempty"`
@@ -4701,13 +4701,13 @@ type VirtualMachineExtensionImage struct {
 	Properties *VirtualMachineExtensionImageProperties `json:"properties,omitempty"`
 }
 
-// VirtualMachineExtensionImageArrayResponse is the response envelope for operations that return a []VirtualMachineExtensionImage type.
+// VirtualMachineExtensionImageArrayResponse is the response envelope for operations that return a []*VirtualMachineExtensionImage type.
 type VirtualMachineExtensionImageArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Array of VirtualMachineExtensionImage
-	VirtualMachineExtensionImageArray []VirtualMachineExtensionImage
+	VirtualMachineExtensionImageArray []*VirtualMachineExtensionImage
 }
 
 // Describes the properties of a Virtual Machine Extension Image.
@@ -4763,10 +4763,10 @@ type VirtualMachineExtensionInstanceView struct {
 	Name *string `json:"name,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The resource status information.
-	Substatuses *[]InstanceViewStatus `json:"substatuses,omitempty"`
+	Substatuses *[]*InstanceViewStatus `json:"substatuses,omitempty"`
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string `json:"type,omitempty"`
@@ -4898,7 +4898,7 @@ type VirtualMachineExtensionsListOptions struct {
 // The List Extension operation response
 type VirtualMachineExtensionsListResult struct {
 	// The list of extensions
-	Value *[]VirtualMachineExtension `json:"value,omitempty"`
+	Value *[]*VirtualMachineExtension `json:"value,omitempty"`
 }
 
 // VirtualMachineExtensionsListResultResponse is the response envelope for operations that return a VirtualMachineExtensionsListResult type.
@@ -4931,7 +4931,7 @@ type VirtualMachineIdentity struct {
 
 	// The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]UserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities *map[string]*UserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
 }
 
 // Describes a Virtual Machine Image.
@@ -4945,7 +4945,7 @@ type VirtualMachineImage struct {
 type VirtualMachineImageProperties struct {
 	// Describes automatic OS upgrade properties on the image.
 	AutomaticOSUpgradeProperties *AutomaticOSUpgradeProperties `json:"automaticOSUpgradeProperties,omitempty"`
-	DataDiskImages               *[]DataDiskImage              `json:"dataDiskImages,omitempty"`
+	DataDiskImages               *[]*DataDiskImage             `json:"dataDiskImages,omitempty"`
 
 	// Specifies the HyperVGeneration Type
 	HyperVGeneration *HyperVGenerationTypes `json:"hyperVGeneration,omitempty"`
@@ -4968,16 +4968,16 @@ type VirtualMachineImageResource struct {
 
 	// Specifies the tags that are assigned to the virtual machine. For more information about using tags, see Using tags to organize your Azure resources
 	// [https://docs.microsoft.com/azure/azure-resource-manager/resource-group-using-tags.md].
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
-// VirtualMachineImageResourceArrayResponse is the response envelope for operations that return a []VirtualMachineImageResource type.
+// VirtualMachineImageResourceArrayResponse is the response envelope for operations that return a []*VirtualMachineImageResource type.
 type VirtualMachineImageResourceArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Array of VirtualMachineImageResource
-	VirtualMachineImageResourceArray []VirtualMachineImageResource
+	VirtualMachineImageResourceArray []*VirtualMachineImageResource
 }
 
 // VirtualMachineImageResponse is the response envelope for operations that return a VirtualMachineImage type.
@@ -5028,10 +5028,10 @@ type VirtualMachineInstanceView struct {
 	ComputerName *string `json:"computerName,omitempty"`
 
 	// The virtual machine disk information.
-	Disks *[]DiskInstanceView `json:"disks,omitempty"`
+	Disks *[]*DiskInstanceView `json:"disks,omitempty"`
 
 	// The extensions information.
-	Extensions *[]VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions *[]*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
 
 	// Specifies the HyperVGeneration Type associated with a resource
 	HyperVGeneration *HyperVGenerationType `json:"hyperVGeneration,omitempty"`
@@ -5055,7 +5055,7 @@ type VirtualMachineInstanceView struct {
 	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent running on the virtual machine.
 	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
@@ -5076,7 +5076,7 @@ type VirtualMachineListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machines.
-	Value *[]VirtualMachine `json:"value,omitempty"`
+	Value *[]*VirtualMachine `json:"value,omitempty"`
 }
 
 // VirtualMachineListResultResponse is the response envelope for operations that return a VirtualMachineListResult type.
@@ -5230,7 +5230,7 @@ type VirtualMachineScaleSet struct {
 	SKU *SKU `json:"sku,omitempty"`
 
 	// The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Describes a virtual machine scale set data disk.
@@ -5291,7 +5291,7 @@ type VirtualMachineScaleSetExtensionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of VM scale set extensions.
-	Value *[]VirtualMachineScaleSetExtension `json:"value,omitempty"`
+	Value *[]*VirtualMachineScaleSetExtension `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetExtensionListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetExtensionListResult type.
@@ -5318,7 +5318,7 @@ type VirtualMachineScaleSetExtensionPollerResponse struct {
 // Describes a virtual machine scale set extension profile.
 type VirtualMachineScaleSetExtensionProfile struct {
 	// The virtual machine scale set child extension resources.
-	Extensions *[]VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
+	Extensions *[]*VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
 }
 
 // Describes the properties of a Virtual Machine Scale Set Extension.
@@ -5336,7 +5336,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	ProtectedSettings interface{} `json:"protectedSettings,omitempty"`
 
 	// Collection of extension names after which this extension needs to be provisioned.
-	ProvisionAfterExtensions *[]string `json:"provisionAfterExtensions,omitempty"`
+	ProvisionAfterExtensions *[]*string `json:"provisionAfterExtensions,omitempty"`
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
@@ -5427,20 +5427,20 @@ type VirtualMachineScaleSetIPConfigurationProperties struct {
 	// Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of multiple application
 	// gateways. Multiple scale sets cannot use the
 	// same application gateway.
-	ApplicationGatewayBackendAddressPools *[]SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools *[]*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups *[]SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups *[]*SubResource `json:"applicationSecurityGroups,omitempty"`
 
 	// Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal
 	// load balancer. Multiple scale sets cannot
 	// use the same basic sku load balancer.
-	LoadBalancerBackendAddressPools *[]SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools *[]*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to inbound Nat pools of the load balancers. A scale set can reference inbound nat pools of one public and one internal
 	// load balancer. Multiple scale sets cannot use
 	// the same basic sku load balancer.
-	LoadBalancerInboundNatPools *[]SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools *[]*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
 
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
 	Primary *bool `json:"primary,omitempty"`
@@ -5481,7 +5481,7 @@ type VirtualMachineScaleSetIdentity struct {
 	// The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the
 	// form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities *map[string]*VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
 }
 
 type VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue struct {
@@ -5495,13 +5495,13 @@ type VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue struct {
 // The instance view of a virtual machine scale set.
 type VirtualMachineScaleSetInstanceView struct {
 	// READ-ONLY; The extensions information.
-	Extensions *[]VirtualMachineScaleSetVMExtensionsSummary `json:"extensions,omitempty" azure:"ro"`
+	Extensions *[]*VirtualMachineScaleSetVMExtensionsSummary `json:"extensions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The orchestration services information.
-	OrchestrationServices *[]OrchestrationServiceSummary `json:"orchestrationServices,omitempty" azure:"ro"`
+	OrchestrationServices *[]*OrchestrationServiceSummary `json:"orchestrationServices,omitempty" azure:"ro"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// READ-ONLY; The instance view status summary for the virtual machine scale set.
 	VirtualMachine *VirtualMachineScaleSetInstanceViewStatusesSummary `json:"virtualMachine,omitempty" azure:"ro"`
@@ -5519,7 +5519,7 @@ type VirtualMachineScaleSetInstanceViewResponse struct {
 // Instance view statuses summary for virtual machines of a virtual machine scale set.
 type VirtualMachineScaleSetInstanceViewStatusesSummary struct {
 	// READ-ONLY; The extensions information.
-	StatusesSummary *[]VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary *[]*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
 }
 
 // List of Virtual Machine Scale Set OS Upgrade History operation response.
@@ -5528,7 +5528,7 @@ type VirtualMachineScaleSetListOSUpgradeHistory struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of OS upgrades performed on the virtual machine scale set.
-	Value *[]UpgradeOperationHistoricalStatusInfo `json:"value,omitempty"`
+	Value *[]*UpgradeOperationHistoricalStatusInfo `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetListOSUpgradeHistoryResponse is the response envelope for operations that return a VirtualMachineScaleSetListOSUpgradeHistory type.
@@ -5546,7 +5546,7 @@ type VirtualMachineScaleSetListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets.
-	Value *[]VirtualMachineScaleSet `json:"value,omitempty"`
+	Value *[]*VirtualMachineScaleSet `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListResult type.
@@ -5564,7 +5564,7 @@ type VirtualMachineScaleSetListSKUsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of skus available for the virtual machine scale set.
-	Value *[]VirtualMachineScaleSetSKU `json:"value,omitempty"`
+	Value *[]*VirtualMachineScaleSetSKU `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetListSKUsResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListSKUsResult type.
@@ -5582,7 +5582,7 @@ type VirtualMachineScaleSetListWithLinkResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets.
-	Value *[]VirtualMachineScaleSet `json:"value,omitempty"`
+	Value *[]*VirtualMachineScaleSet `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetListWithLinkResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListWithLinkResult type.
@@ -5616,7 +5616,7 @@ type VirtualMachineScaleSetNetworkConfiguration struct {
 // Describes a virtual machines scale sets network configuration's DNS settings.
 type VirtualMachineScaleSetNetworkConfigurationDNSSettings struct {
 	// List of DNS servers IP addresses
-	DNSServers *[]string `json:"dnsServers,omitempty"`
+	DNSServers *[]*string `json:"dnsServers,omitempty"`
 }
 
 // Describes a virtual machine scale set network profile's IP configuration.
@@ -5631,7 +5631,7 @@ type VirtualMachineScaleSetNetworkConfigurationProperties struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// Specifies the IP configurations of the network interface.
-	IPConfigurations *[]VirtualMachineScaleSetIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*VirtualMachineScaleSetIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// The network security group.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
@@ -5647,7 +5647,7 @@ type VirtualMachineScaleSetNetworkProfile struct {
 	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
 }
 
 // Describes a virtual machine scale set operating system disk.
@@ -5689,7 +5689,7 @@ type VirtualMachineScaleSetOSDisk struct {
 	OSType *OperatingSystemTypes `json:"osType,omitempty"`
 
 	// Specifies the container urls that are used to store operating system disks for the scale set.
-	VhdContainers *[]string `json:"vhdContainers,omitempty"`
+	VhdContainers *[]*string `json:"vhdContainers,omitempty"`
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
@@ -5746,7 +5746,7 @@ type VirtualMachineScaleSetOSProfile struct {
 	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
 
 	// Specifies set of certificates that should be installed onto the virtual machines in the scale set.
-	Secrets *[]VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// Specifies Windows operating system settings on the virtual machine.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
@@ -5835,7 +5835,7 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
 	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings `json:"dnsSettings,omitempty"`
 
 	// The list of IP tags associated with the public IP address.
-	IPTags *[]VirtualMachineScaleSetIPTag `json:"ipTags,omitempty"`
+	IPTags *[]*VirtualMachineScaleSetIPTag `json:"ipTags,omitempty"`
 
 	// The idle timeout of the public IP address.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -5853,7 +5853,7 @@ type VirtualMachineScaleSetReimageParameters struct {
 	VirtualMachineReimageParameters
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual
 	// machines in the virtual machine scale set.
-	InstanceIDs *[]string `json:"instanceIds,omitempty"`
+	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
 }
 
 // VirtualMachineScaleSetResponse is the response envelope for operations that return a VirtualMachineScaleSet type.
@@ -5919,7 +5919,7 @@ type VirtualMachineScaleSetStorageProfile struct {
 	// Specifies the parameters that are used to add data disks to the virtual machines in the scale set.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks *[]*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This
 	// element is required when you want to use a platform
@@ -5973,16 +5973,16 @@ type VirtualMachineScaleSetUpdateIPConfiguration struct {
 // Describes a virtual machine scale set network profile's IP configuration properties.
 type VirtualMachineScaleSetUpdateIPConfigurationProperties struct {
 	// The application gateway backend address pools.
-	ApplicationGatewayBackendAddressPools *[]SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools *[]*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups *[]SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups *[]*SubResource `json:"applicationSecurityGroups,omitempty"`
 
 	// The load balancer backend address pools.
-	LoadBalancerBackendAddressPools *[]SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools *[]*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// The load balancer inbound nat pools.
-	LoadBalancerInboundNatPools *[]SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools *[]*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
 
 	// Specifies the primary IP Configuration in case the network interface has more than one IP Configuration.
 	Primary *bool `json:"primary,omitempty"`
@@ -6020,7 +6020,7 @@ type VirtualMachineScaleSetUpdateNetworkConfigurationProperties struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// The virtual machine scale set IP Configuration.
-	IPConfigurations *[]VirtualMachineScaleSetUpdateIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*VirtualMachineScaleSetUpdateIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// The network security group.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
@@ -6036,7 +6036,7 @@ type VirtualMachineScaleSetUpdateNetworkProfile struct {
 	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
 }
 
 // Describes virtual machine scale set operating system disk Update Object. This should be used for Updating VMSS OS Disk.
@@ -6057,7 +6057,7 @@ type VirtualMachineScaleSetUpdateOSDisk struct {
 	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
 
 	// The list of virtual hard disk container uris.
-	VhdContainers *[]string `json:"vhdContainers,omitempty"`
+	VhdContainers *[]*string `json:"vhdContainers,omitempty"`
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
@@ -6072,7 +6072,7 @@ type VirtualMachineScaleSetUpdateOSProfile struct {
 	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
 
 	// The List of certificates for addition to the VM.
-	Secrets *[]VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// The Windows Configuration of the OS profile.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
@@ -6136,7 +6136,7 @@ type VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties struct {
 // Describes a virtual machine scale set storage profile.
 type VirtualMachineScaleSetUpdateStorageProfile struct {
 	// The data disks.
-	DataDisks *[]VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks *[]*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
 
 	// The image reference.
 	ImageReference *ImageReference `json:"imageReference,omitempty"`
@@ -6190,13 +6190,13 @@ type VirtualMachineScaleSetVM struct {
 	Properties *VirtualMachineScaleSetVMProperties `json:"properties,omitempty"`
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources *[]VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources *[]*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
 
 	// READ-ONLY; The virtual machine SKU.
 	SKU *SKU `json:"sku,omitempty" azure:"ro"`
 
 	// READ-ONLY; The virtual machine zones.
-	Zones *[]string `json:"zones,omitempty" azure:"ro"`
+	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
 }
 
 // VirtualMachineScaleSetVMExtensionsBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.BeginCreateOrUpdate
@@ -6233,20 +6233,20 @@ type VirtualMachineScaleSetVMExtensionsSummary struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// READ-ONLY; The extensions information.
-	StatusesSummary *[]VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary *[]*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
 }
 
 // Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceIDs struct {
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual
 	// machines in the virtual machine scale set.
-	InstanceIDs *[]string `json:"instanceIds,omitempty"`
+	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
 }
 
 // Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceRequiredIDs struct {
 	// The virtual machine scale set instance ids.
-	InstanceIDs *[]string `json:"instanceIds,omitempty"`
+	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
 }
 
 // The instance view of a virtual machine scale set VM.
@@ -6257,10 +6257,10 @@ type VirtualMachineScaleSetVMInstanceView struct {
 	BootDiagnostics *BootDiagnosticsInstanceView `json:"bootDiagnostics,omitempty"`
 
 	// The disks information.
-	Disks *[]DiskInstanceView `json:"disks,omitempty"`
+	Disks *[]*DiskInstanceView `json:"disks,omitempty"`
 
 	// The extensions information.
-	Extensions *[]VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions *[]*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
 
 	// The Maintenance Operation status on the virtual machine.
 	MaintenanceRedeployStatus *MaintenanceRedeployStatus `json:"maintenanceRedeployStatus,omitempty"`
@@ -6278,7 +6278,7 @@ type VirtualMachineScaleSetVMInstanceView struct {
 	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
 
 	// The resource status information.
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent running on the virtual machine.
 	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
@@ -6302,7 +6302,7 @@ type VirtualMachineScaleSetVMListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets VMs.
-	Value *[]VirtualMachineScaleSetVM `json:"value,omitempty"`
+	Value *[]*VirtualMachineScaleSetVM `json:"value,omitempty"`
 }
 
 // VirtualMachineScaleSetVMListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetVMListResult type.
@@ -6317,7 +6317,7 @@ type VirtualMachineScaleSetVMListResultResponse struct {
 // Describes a virtual machine scale set VM network profile.
 type VirtualMachineScaleSetVMNetworkProfileConfiguration struct {
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
 }
 
 // VirtualMachineScaleSetVMPollerResponse is the response envelope for operations that asynchronously return a VirtualMachineScaleSetVM type.
@@ -6701,7 +6701,7 @@ type VirtualMachineSize struct {
 // The List Virtual Machine operation response.
 type VirtualMachineSizeListResult struct {
 	// The list of virtual machine sizes.
-	Value *[]VirtualMachineSize `json:"value,omitempty"`
+	Value *[]*VirtualMachineSize `json:"value,omitempty"`
 }
 
 // VirtualMachineSizeListResultResponse is the response envelope for operations that return a VirtualMachineSizeListResult type.
@@ -6744,7 +6744,7 @@ type VirtualMachineUpdate struct {
 	Properties *VirtualMachineProperties `json:"properties,omitempty"`
 
 	// The virtual machine zones.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type VirtualMachineUpdate.
@@ -6875,7 +6875,7 @@ type VirtualMachinesSimulateEvictionOptions struct {
 // Describes Windows Remote Management configuration of the VM
 type WinRMConfiguration struct {
 	// The list of Windows Remote Management listeners
-	Listeners *[]WinRMListener `json:"listeners,omitempty"`
+	Listeners *[]*WinRMListener `json:"listeners,omitempty"`
 }
 
 // Describes Protocol and thumbprint of Windows Remote Management listener
@@ -6901,7 +6901,7 @@ type WinRMListener struct {
 // Specifies Windows operating system settings on the virtual machine.
 type WindowsConfiguration struct {
 	// Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
-	AdditionalUnattendContent *[]AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
+	AdditionalUnattendContent *[]*AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
 
 	// Indicates whether Automatic Updates is enabled for the Windows virtual machine. Default value is true.
 	// For virtual machine scale sets, this property can be updated and updates will take effect on OS reprovisioning.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages.go
@@ -149,7 +149,7 @@ func (client *VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx co
 
 // listTypesHandleResponse handles the ListTypes response.
 func (client *VirtualMachineExtensionImagesClient) listTypesHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	var val []VirtualMachineExtensionImage
+	var val []*VirtualMachineExtensionImage
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineExtensionImageArrayResponse{}, err
 	}
@@ -226,7 +226,7 @@ func (client *VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx
 
 // listVersionsHandleResponse handles the ListVersions response.
 func (client *VirtualMachineExtensionImagesClient) listVersionsHandleResponse(resp *azcore.Response) (VirtualMachineExtensionImageArrayResponse, error) {
-	var val []VirtualMachineExtensionImage
+	var val []*VirtualMachineExtensionImage
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineExtensionImageArrayResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages.go
@@ -170,7 +170,7 @@ func (client *VirtualMachineImagesClient) listCreateRequest(ctx context.Context,
 
 // listHandleResponse handles the List response.
 func (client *VirtualMachineImagesClient) listHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val []VirtualMachineImageResource
+	var val []*VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -234,7 +234,7 @@ func (client *VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Co
 
 // listOffersHandleResponse handles the ListOffers response.
 func (client *VirtualMachineImagesClient) listOffersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val []VirtualMachineImageResource
+	var val []*VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -294,7 +294,7 @@ func (client *VirtualMachineImagesClient) listPublishersCreateRequest(ctx contex
 
 // listPublishersHandleResponse handles the ListPublishers response.
 func (client *VirtualMachineImagesClient) listPublishersHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val []VirtualMachineImageResource
+	var val []*VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}
@@ -362,7 +362,7 @@ func (client *VirtualMachineImagesClient) listSKUsCreateRequest(ctx context.Cont
 
 // listSKUsHandleResponse handles the ListSKUs response.
 func (client *VirtualMachineImagesClient) listSKUsHandleResponse(resp *azcore.Response) (VirtualMachineImageResourceArrayResponse, error) {
-	var val []VirtualMachineImageResource
+	var val []*VirtualMachineImageResource
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return VirtualMachineImageResourceArrayResponse{}, err
 	}

--- a/test/go.mod
+++ b/test/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.2
-	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.2
+	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4
 	github.com/google/go-cmp v0.5.4
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.2 h1:jBp1eg+iY1S6SEjISakVfHmv
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.2/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.2 h1:TZTVOb/ce7nCmOZYga9+ELtPPVVFG2Px4s/w5OycYS0=
-github.com/Azure/azure-sdk-for-go/sdk/to v0.1.2/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4 h1:3w4gk+uYOwplGhID1fDP305/8bI5Aug3URoC1V493KU=
+github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways.go
@@ -686,7 +686,7 @@ func (client *ApplicationGatewaysClient) listAvailableRequestHeadersCreateReques
 
 // listAvailableRequestHeadersHandleResponse handles the ListAvailableRequestHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableRequestHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -739,7 +739,7 @@ func (client *ApplicationGatewaysClient) listAvailableResponseHeadersCreateReque
 
 // listAvailableResponseHeadersHandleResponse handles the ListAvailableResponseHeaders response.
 func (client *ApplicationGatewaysClient) listAvailableResponseHeadersHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}
@@ -898,7 +898,7 @@ func (client *ApplicationGatewaysClient) listAvailableServerVariablesCreateReque
 
 // listAvailableServerVariablesHandleResponse handles the ListAvailableServerVariables response.
 func (client *ApplicationGatewaysClient) listAvailableServerVariablesHandleResponse(resp *azcore.Response) (StringArrayResponse, error) {
-	var val []string
+	var val []*string
 	if err := resp.UnmarshalAsJSON(&val); err != nil {
 		return StringArrayResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -32,7 +32,7 @@ type AADAuthenticationParameters struct {
 // AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 type AddressSpace struct {
 	// A list of address blocks reserved for this virtual network in CIDR notation.
-	AddressPrefixes *[]string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
 }
 
 // Application gateway resource.
@@ -48,7 +48,7 @@ type ApplicationGateway struct {
 	Properties *ApplicationGatewayPropertiesFormat `json:"properties,omitempty"`
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Authentication certificates of an application gateway.
@@ -95,16 +95,16 @@ type ApplicationGatewayAvailableSSLOptions struct {
 // Properties of ApplicationGatewayAvailableSslOptions.
 type ApplicationGatewayAvailableSSLOptionsPropertiesFormat struct {
 	// List of available Ssl cipher suites.
-	AvailableCipherSuites *[]ApplicationGatewaySSLCipherSuite `json:"availableCipherSuites,omitempty"`
+	AvailableCipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"availableCipherSuites,omitempty"`
 
 	// List of available Ssl protocols.
-	AvailableProtocols *[]ApplicationGatewaySSLProtocol `json:"availableProtocols,omitempty"`
+	AvailableProtocols *[]*ApplicationGatewaySSLProtocol `json:"availableProtocols,omitempty"`
 
 	// Name of the Ssl predefined policy applied by default to application gateway.
 	DefaultPolicy *ApplicationGatewaySSLPolicyName `json:"defaultPolicy,omitempty"`
 
 	// List of available Ssl predefined policy.
-	PredefinedPolicies *[]SubResource `json:"predefinedPolicies,omitempty"`
+	PredefinedPolicies *[]*SubResource `json:"predefinedPolicies,omitempty"`
 }
 
 // ApplicationGatewayAvailableSSLOptionsResponse is the response envelope for operations that return a ApplicationGatewayAvailableSSLOptions type.
@@ -122,7 +122,7 @@ type ApplicationGatewayAvailableSSLPredefinedPolicies struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of available Ssl predefined policy.
-	Value *[]ApplicationGatewaySSLPredefinedPolicy `json:"value,omitempty"`
+	Value *[]*ApplicationGatewaySSLPredefinedPolicy `json:"value,omitempty"`
 }
 
 // ApplicationGatewayAvailableSSLPredefinedPoliciesResponse is the response envelope for operations that return a ApplicationGatewayAvailableSSLPredefinedPolicies
@@ -138,7 +138,7 @@ type ApplicationGatewayAvailableSSLPredefinedPoliciesResponse struct {
 // Response for ApplicationGatewayAvailableWafRuleSets API service call.
 type ApplicationGatewayAvailableWafRuleSetsResult struct {
 	// The list of application gateway rule sets.
-	Value *[]ApplicationGatewayFirewallRuleSet `json:"value,omitempty"`
+	Value *[]*ApplicationGatewayFirewallRuleSet `json:"value,omitempty"`
 }
 
 // ApplicationGatewayAvailableWafRuleSetsResultResponse is the response envelope for operations that return a ApplicationGatewayAvailableWafRuleSetsResult
@@ -179,10 +179,10 @@ type ApplicationGatewayBackendAddressPool struct {
 // Properties of Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
 	// Backend addresses.
-	BackendAddresses *[]ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendAddresses *[]*ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
 
 	// READ-ONLY; Collection of references to IPs defined in network interfaces.
-	BackendIPConfigurations *[]NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -210,7 +210,7 @@ type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
 	AffinityCookieName *string `json:"affinityCookieName,omitempty"`
 
 	// Array of references to application gateway authentication certificates.
-	AuthenticationCertificates *[]SubResource `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates *[]*SubResource `json:"authenticationCertificates,omitempty"`
 
 	// Connection draining of the backend http settings resource.
 	ConnectionDraining *ApplicationGatewayConnectionDraining `json:"connectionDraining,omitempty"`
@@ -247,13 +247,13 @@ type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
 	RequestTimeout *int32 `json:"requestTimeout,omitempty"`
 
 	// Array of references to application gateway trusted root certificates.
-	TrustedRootCertificates *[]SubResource `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates *[]*SubResource `json:"trustedRootCertificates,omitempty"`
 }
 
 // Response for ApplicationGatewayBackendHealth API service call.
 type ApplicationGatewayBackendHealth struct {
 	// A list of ApplicationGatewayBackendHealthPool resources.
-	BackendAddressPools *[]ApplicationGatewayBackendHealthPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools *[]*ApplicationGatewayBackendHealthPool `json:"backendAddressPools,omitempty"`
 }
 
 // Application gateway BackendHealthHttp settings.
@@ -262,7 +262,7 @@ type ApplicationGatewayBackendHealthHTTPSettings struct {
 	BackendHTTPSettings *ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettings,omitempty"`
 
 	// List of ApplicationGatewayBackendHealthServer resources.
-	Servers *[]ApplicationGatewayBackendHealthServer `json:"servers,omitempty"`
+	Servers *[]*ApplicationGatewayBackendHealthServer `json:"servers,omitempty"`
 }
 
 // Result of on demand test probe.
@@ -314,7 +314,7 @@ type ApplicationGatewayBackendHealthPool struct {
 	BackendAddressPool *ApplicationGatewayBackendAddressPool `json:"backendAddressPool,omitempty"`
 
 	// List of ApplicationGatewayBackendHealthHttpSettings resources.
-	BackendHTTPSettingsCollection *[]ApplicationGatewayBackendHealthHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection *[]*ApplicationGatewayBackendHealthHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
 }
 
 // ApplicationGatewayBackendHealthResponse is the response envelope for operations that return a ApplicationGatewayBackendHealth type.
@@ -365,7 +365,7 @@ type ApplicationGatewayFirewallDisabledRuleGroup struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// The list of rules that will be disabled. If null, all rules of the rule group will be disabled.
-	Rules *[]int32 `json:"rules,omitempty"`
+	Rules *[]*int32 `json:"rules,omitempty"`
 }
 
 // Allow to exclude some variable satisfy the condition for the WAF check.
@@ -398,7 +398,7 @@ type ApplicationGatewayFirewallRuleGroup struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// The rules of the web application firewall rule group.
-	Rules *[]ApplicationGatewayFirewallRule `json:"rules,omitempty"`
+	Rules *[]*ApplicationGatewayFirewallRule `json:"rules,omitempty"`
 }
 
 // A web application firewall rule set.
@@ -414,7 +414,7 @@ type ApplicationGatewayFirewallRuleSetPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The rule groups of the web application firewall rule set.
-	RuleGroups *[]ApplicationGatewayFirewallRuleGroup `json:"ruleGroups,omitempty"`
+	RuleGroups *[]*ApplicationGatewayFirewallRuleGroup `json:"ruleGroups,omitempty"`
 
 	// The type of the web application firewall rule set.
 	RuleSetType *string `json:"ruleSetType,omitempty"`
@@ -501,7 +501,7 @@ type ApplicationGatewayHTTPListener struct {
 // Properties of HTTP listener of an application gateway.
 type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 	// Custom error configurations of the HTTP listener.
-	CustomErrorConfigurations *[]ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations *[]*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
 
 	// Reference to the FirewallPolicy resource.
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
@@ -516,7 +516,7 @@ type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 	HostName *string `json:"hostName,omitempty"`
 
 	// List of Host names for HTTP Listener that allows special wildcard characters as well.
-	HostNames *[]string `json:"hostNames,omitempty"`
+	HostNames *[]*string `json:"hostNames,omitempty"`
 
 	// Protocol of the HTTP listener.
 	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
@@ -571,7 +571,7 @@ type ApplicationGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of an application gateways in a resource group.
-	Value *[]ApplicationGateway `json:"value,omitempty"`
+	Value *[]*ApplicationGateway `json:"value,omitempty"`
 }
 
 // ApplicationGatewayListResultResponse is the response envelope for operations that return a ApplicationGatewayListResult type.
@@ -639,7 +639,7 @@ type ApplicationGatewayPathRulePropertiesFormat struct {
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
 
 	// Path rules of URL path map.
-	Paths *[]string `json:"paths,omitempty"`
+	Paths *[]*string `json:"paths,omitempty"`
 
 	// READ-ONLY; The provisioning state of the path rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -685,7 +685,7 @@ type ApplicationGatewayProbeHealthResponseMatch struct {
 	Body *string `json:"body,omitempty"`
 
 	// Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399.
-	StatusCodes *[]string `json:"statusCodes,omitempty"`
+	StatusCodes *[]*string `json:"statusCodes,omitempty"`
 }
 
 // Properties of probe of an application gateway.
@@ -732,21 +732,21 @@ type ApplicationGatewayProbePropertiesFormat struct {
 type ApplicationGatewayPropertiesFormat struct {
 	// Authentication certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	AuthenticationCertificates *[]ApplicationGatewayAuthenticationCertificate `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates *[]*ApplicationGatewayAuthenticationCertificate `json:"authenticationCertificates,omitempty"`
 
 	// Autoscale Configuration.
 	AutoscaleConfiguration *ApplicationGatewayAutoscaleConfiguration `json:"autoscaleConfiguration,omitempty"`
 
 	// Backend address pool of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendAddressPools *[]ApplicationGatewayBackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools *[]*ApplicationGatewayBackendAddressPool `json:"backendAddressPools,omitempty"`
 
 	// Backend http settings of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendHTTPSettingsCollection *[]ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection *[]*ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
 
 	// Custom error configurations of the application gateway resource.
-	CustomErrorConfigurations *[]ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations *[]*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
 
 	// Whether FIPS is enabled on the application gateway resource.
 	EnableFips *bool `json:"enableFips,omitempty"`
@@ -762,55 +762,55 @@ type ApplicationGatewayPropertiesFormat struct {
 
 	// Frontend IP addresses of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendIPConfigurations *[]ApplicationGatewayFrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations *[]*ApplicationGatewayFrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
 
 	// Frontend ports of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendPorts *[]ApplicationGatewayFrontendPort `json:"frontendPorts,omitempty"`
+	FrontendPorts *[]*ApplicationGatewayFrontendPort `json:"frontendPorts,omitempty"`
 
 	// Subnets of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	GatewayIPConfigurations *[]ApplicationGatewayIPConfiguration `json:"gatewayIPConfigurations,omitempty"`
+	GatewayIPConfigurations *[]*ApplicationGatewayIPConfiguration `json:"gatewayIPConfigurations,omitempty"`
 
 	// Http listeners of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	HTTPListeners *[]ApplicationGatewayHTTPListener `json:"httpListeners,omitempty"`
+	HTTPListeners *[]*ApplicationGatewayHTTPListener `json:"httpListeners,omitempty"`
 
 	// READ-ONLY; Operational state of the application gateway resource.
 	OperationalState *ApplicationGatewayOperationalState `json:"operationalState,omitempty" azure:"ro"`
 
 	// Probes of the application gateway resource.
-	Probes *[]ApplicationGatewayProbe `json:"probes,omitempty"`
+	Probes *[]*ApplicationGatewayProbe `json:"probes,omitempty"`
 
 	// READ-ONLY; The provisioning state of the application gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Redirect configurations of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	RedirectConfigurations *[]ApplicationGatewayRedirectConfiguration `json:"redirectConfigurations,omitempty"`
+	RedirectConfigurations *[]*ApplicationGatewayRedirectConfiguration `json:"redirectConfigurations,omitempty"`
 
 	// Request routing rules of the application gateway resource.
-	RequestRoutingRules *[]ApplicationGatewayRequestRoutingRule `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules *[]*ApplicationGatewayRequestRoutingRule `json:"requestRoutingRules,omitempty"`
 
 	// READ-ONLY; The resource GUID property of the application gateway resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// Rewrite rules for the application gateway resource.
-	RewriteRuleSets *[]ApplicationGatewayRewriteRuleSet `json:"rewriteRuleSets,omitempty"`
+	RewriteRuleSets *[]*ApplicationGatewayRewriteRuleSet `json:"rewriteRuleSets,omitempty"`
 
 	// SKU of the application gateway resource.
 	SKU *ApplicationGatewaySKU `json:"sku,omitempty"`
 
 	// SSL certificates of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits]
 	// .
-	SSLCertificates *[]ApplicationGatewaySSLCertificate `json:"sslCertificates,omitempty"`
+	SSLCertificates *[]*ApplicationGatewaySSLCertificate `json:"sslCertificates,omitempty"`
 
 	// SSL policy of the application gateway resource.
 	SSLPolicy *ApplicationGatewaySSLPolicy `json:"sslPolicy,omitempty"`
 
 	// Trusted Root certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	TrustedRootCertificates *[]ApplicationGatewayTrustedRootCertificate `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates *[]*ApplicationGatewayTrustedRootCertificate `json:"trustedRootCertificates,omitempty"`
 
 	// URL path map of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	URLPathMaps *[]ApplicationGatewayURLPathMap `json:"urlPathMaps,omitempty"`
+	URLPathMaps *[]*ApplicationGatewayURLPathMap `json:"urlPathMaps,omitempty"`
 
 	// Web application firewall configuration.
 	WebApplicationFirewallConfiguration *ApplicationGatewayWebApplicationFirewallConfiguration `json:"webApplicationFirewallConfiguration,omitempty"`
@@ -841,13 +841,13 @@ type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	IncludeQueryString *bool `json:"includeQueryString,omitempty"`
 
 	// Path rules specifying redirect configuration.
-	PathRules *[]SubResource `json:"pathRules,omitempty"`
+	PathRules *[]*SubResource `json:"pathRules,omitempty"`
 
 	// HTTP redirection type.
 	RedirectType *ApplicationGatewayRedirectType `json:"redirectType,omitempty"`
 
 	// Request routing specifying redirect configuration.
-	RequestRoutingRules *[]SubResource `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules *[]*SubResource `json:"requestRoutingRules,omitempty"`
 
 	// Reference to a listener to redirect the request to.
 	TargetListener *SubResource `json:"targetListener,omitempty"`
@@ -856,7 +856,7 @@ type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	TargetURL *string `json:"targetUrl,omitempty"`
 
 	// Url path maps specifying default redirect configuration.
-	URLPathMaps *[]SubResource `json:"urlPathMaps,omitempty"`
+	URLPathMaps *[]*SubResource `json:"urlPathMaps,omitempty"`
 }
 
 // Request routing rule of an application gateway.
@@ -920,7 +920,7 @@ type ApplicationGatewayRewriteRule struct {
 	ActionSet *ApplicationGatewayRewriteRuleActionSet `json:"actionSet,omitempty"`
 
 	// Conditions based on which the action set execution will be evaluated.
-	Conditions *[]ApplicationGatewayRewriteRuleCondition `json:"conditions,omitempty"`
+	Conditions *[]*ApplicationGatewayRewriteRuleCondition `json:"conditions,omitempty"`
 
 	// Name of the rewrite rule that is unique within an Application Gateway.
 	Name *string `json:"name,omitempty"`
@@ -932,10 +932,10 @@ type ApplicationGatewayRewriteRule struct {
 // Set of actions in the Rewrite Rule in Application Gateway.
 type ApplicationGatewayRewriteRuleActionSet struct {
 	// Request Header Actions in the Action Set.
-	RequestHeaderConfigurations *[]ApplicationGatewayHeaderConfiguration `json:"requestHeaderConfigurations,omitempty"`
+	RequestHeaderConfigurations *[]*ApplicationGatewayHeaderConfiguration `json:"requestHeaderConfigurations,omitempty"`
 
 	// Response Header Actions in the Action Set.
-	ResponseHeaderConfigurations *[]ApplicationGatewayHeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
+	ResponseHeaderConfigurations *[]*ApplicationGatewayHeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
 
 	// Url Configuration Action in the Action Set.
 	URLConfiguration *ApplicationGatewayURLConfiguration `json:"urlConfiguration,omitempty"`
@@ -975,7 +975,7 @@ type ApplicationGatewayRewriteRuleSetPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Rewrite rules in the rewrite rule set.
-	RewriteRules *[]ApplicationGatewayRewriteRule `json:"rewriteRules,omitempty"`
+	RewriteRules *[]*ApplicationGatewayRewriteRule `json:"rewriteRules,omitempty"`
 }
 
 // SKU of an application gateway.
@@ -1027,10 +1027,10 @@ type ApplicationGatewaySSLCertificatePropertiesFormat struct {
 // Application Gateway Ssl policy.
 type ApplicationGatewaySSLPolicy struct {
 	// Ssl cipher suites to be enabled in the specified order to application gateway.
-	CipherSuites *[]ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
 
 	// Ssl protocols to be disabled on application gateway.
-	DisabledSSLProtocols *[]ApplicationGatewaySSLProtocol `json:"disabledSslProtocols,omitempty"`
+	DisabledSSLProtocols *[]*ApplicationGatewaySSLProtocol `json:"disabledSslProtocols,omitempty"`
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
 	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
@@ -1055,7 +1055,7 @@ type ApplicationGatewaySSLPredefinedPolicy struct {
 // Properties of ApplicationGatewaySslPredefinedPolicy.
 type ApplicationGatewaySSLPredefinedPolicyPropertiesFormat struct {
 	// Ssl cipher suites to be enabled in the specified order for application gateway.
-	CipherSuites *[]ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
 	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
@@ -1141,7 +1141,7 @@ type ApplicationGatewayURLPathMapPropertiesFormat struct {
 	DefaultRewriteRuleSet *SubResource `json:"defaultRewriteRuleSet,omitempty"`
 
 	// Path rule of URL path map resource.
-	PathRules *[]ApplicationGatewayPathRule `json:"pathRules,omitempty"`
+	PathRules *[]*ApplicationGatewayPathRule `json:"pathRules,omitempty"`
 
 	// READ-ONLY; The provisioning state of the URL path map resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -1150,13 +1150,13 @@ type ApplicationGatewayURLPathMapPropertiesFormat struct {
 // Application gateway web application firewall configuration.
 type ApplicationGatewayWebApplicationFirewallConfiguration struct {
 	// The disabled rule groups.
-	DisabledRuleGroups *[]ApplicationGatewayFirewallDisabledRuleGroup `json:"disabledRuleGroups,omitempty"`
+	DisabledRuleGroups *[]*ApplicationGatewayFirewallDisabledRuleGroup `json:"disabledRuleGroups,omitempty"`
 
 	// Whether the web application firewall is enabled or not.
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// The exclusion list.
-	Exclusions *[]ApplicationGatewayFirewallExclusion `json:"exclusions,omitempty"`
+	Exclusions *[]*ApplicationGatewayFirewallExclusion `json:"exclusions,omitempty"`
 
 	// Maximum file upload size in Mb for WAF.
 	FileUploadLimitInMb *int32 `json:"fileUploadLimitInMb,omitempty"`
@@ -1272,22 +1272,22 @@ type ApplicationGatewaysUpdateTagsOptions struct {
 type ApplicationRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
 
 	// List of FQDN Tags for this rule condition.
-	FqdnTags *[]string `json:"fqdnTags,omitempty"`
+	FqdnTags *[]*string `json:"fqdnTags,omitempty"`
 
 	// Array of Application Protocols.
-	Protocols *[]FirewallPolicyRuleConditionApplicationProtocol `json:"protocols,omitempty"`
+	Protocols *[]*FirewallPolicyRuleConditionApplicationProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 
 	// List of FQDNs for this rule condition.
-	TargetFqdns *[]string `json:"targetFqdns,omitempty"`
+	TargetFqdns *[]*string `json:"targetFqdns,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ApplicationRuleCondition.
@@ -1353,7 +1353,7 @@ type ApplicationSecurityGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of application security groups.
-	Value *[]ApplicationSecurityGroup `json:"value,omitempty"`
+	Value *[]*ApplicationSecurityGroup `json:"value,omitempty"`
 }
 
 // ApplicationSecurityGroupListResultResponse is the response envelope for operations that return a ApplicationSecurityGroupListResult type.
@@ -1433,7 +1433,7 @@ type AuthorizationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The authorizations in an ExpressRoute Circuit.
-	Value *[]ExpressRouteCircuitAuthorization `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitAuthorization `json:"value,omitempty"`
 }
 
 // AuthorizationListResultResponse is the response envelope for operations that return a AuthorizationListResult type.
@@ -1469,7 +1469,7 @@ type AutoApprovedPrivateLinkServicesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of auto approved private link service.
-	Value *[]AutoApprovedPrivateLinkService `json:"value,omitempty"`
+	Value *[]*AutoApprovedPrivateLinkService `json:"value,omitempty"`
 }
 
 // AutoApprovedPrivateLinkServicesResultResponse is the response envelope for operations that return a AutoApprovedPrivateLinkServicesResult type.
@@ -1496,7 +1496,7 @@ type Availability struct {
 // The serviceName of an AvailableDelegation indicates a possible delegation for a subnet.
 type AvailableDelegation struct {
 	// The actions permitted to the service upon delegation.
-	Actions *[]string `json:"actions,omitempty"`
+	Actions *[]*string `json:"actions,omitempty"`
 
 	// A unique identifier of the AvailableDelegation resource.
 	ID *string `json:"id,omitempty"`
@@ -1522,7 +1522,7 @@ type AvailableDelegationsResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available delegations.
-	Value *[]AvailableDelegation `json:"value,omitempty"`
+	Value *[]*AvailableDelegation `json:"value,omitempty"`
 }
 
 // AvailableDelegationsResultResponse is the response envelope for operations that return a AvailableDelegationsResult type.
@@ -1570,7 +1570,7 @@ type AvailablePrivateEndpointTypesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available privateEndpoint type.
-	Value *[]AvailablePrivateEndpointType `json:"value,omitempty"`
+	Value *[]*AvailablePrivateEndpointType `json:"value,omitempty"`
 }
 
 // AvailablePrivateEndpointTypesResultResponse is the response envelope for operations that return a AvailablePrivateEndpointTypesResult type.
@@ -1585,7 +1585,7 @@ type AvailablePrivateEndpointTypesResultResponse struct {
 // List of available countries with details.
 type AvailableProvidersList struct {
 	// List of available countries.
-	Countries *[]AvailableProvidersListCountry `json:"countries,omitempty"`
+	Countries *[]*AvailableProvidersListCountry `json:"countries,omitempty"`
 }
 
 // City or town details.
@@ -1594,7 +1594,7 @@ type AvailableProvidersListCity struct {
 	CityName *string `json:"cityName,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]string `json:"providers,omitempty"`
+	Providers *[]*string `json:"providers,omitempty"`
 }
 
 // Country details.
@@ -1603,16 +1603,16 @@ type AvailableProvidersListCountry struct {
 	CountryName *string `json:"countryName,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]string `json:"providers,omitempty"`
+	Providers *[]*string `json:"providers,omitempty"`
 
 	// List of available states in the country.
-	States *[]AvailableProvidersListState `json:"states,omitempty"`
+	States *[]*AvailableProvidersListState `json:"states,omitempty"`
 }
 
 // Constraints that determine the list of available Internet service providers.
 type AvailableProvidersListParameters struct {
 	// A list of Azure regions.
-	AzureLocations *[]string `json:"azureLocations,omitempty"`
+	AzureLocations *[]*string `json:"azureLocations,omitempty"`
 
 	// The city or town for available providers list.
 	City *string `json:"city,omitempty"`
@@ -1648,10 +1648,10 @@ type AvailableProvidersListResponse struct {
 // State details.
 type AvailableProvidersListState struct {
 	// List of available cities or towns in the state.
-	Cities *[]AvailableProvidersListCity `json:"cities,omitempty"`
+	Cities *[]*AvailableProvidersListCity `json:"cities,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]string `json:"providers,omitempty"`
+	Providers *[]*string `json:"providers,omitempty"`
 
 	// The state name.
 	StateName *string `json:"stateName,omitempty"`
@@ -1693,7 +1693,7 @@ type AvailableServiceAliasesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available service aliases.
-	Value *[]AvailableServiceAlias `json:"value,omitempty"`
+	Value *[]*AvailableServiceAlias `json:"value,omitempty"`
 }
 
 // AvailableServiceAliasesResultResponse is the response envelope for operations that return a AvailableServiceAliasesResult type.
@@ -1728,7 +1728,7 @@ type AzureFirewall struct {
 	Properties *AzureFirewallPropertiesFormat `json:"properties,omitempty"`
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Properties of an application rule.
@@ -1737,22 +1737,22 @@ type AzureFirewallApplicationRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of FQDN Tags for this rule.
-	FqdnTags *[]string `json:"fqdnTags,omitempty"`
+	FqdnTags *[]*string `json:"fqdnTags,omitempty"`
 
 	// Name of the application rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of ApplicationRuleProtocols.
-	Protocols *[]AzureFirewallApplicationRuleProtocol `json:"protocols,omitempty"`
+	Protocols *[]*AzureFirewallApplicationRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 
 	// List of FQDNs for this rule.
-	TargetFqdns *[]string `json:"targetFqdns,omitempty"`
+	TargetFqdns *[]*string `json:"targetFqdns,omitempty"`
 }
 
 // Application rule collection resource.
@@ -1780,7 +1780,7 @@ type AzureFirewallApplicationRuleCollectionPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a application rule collection.
-	Rules *[]AzureFirewallApplicationRule `json:"rules,omitempty"`
+	Rules *[]*AzureFirewallApplicationRule `json:"rules,omitempty"`
 }
 
 // Properties of the application rule protocol.
@@ -1808,7 +1808,7 @@ type AzureFirewallFqdnTagListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Azure Firewall FQDN Tags in a resource group.
-	Value *[]AzureFirewallFqdnTag `json:"value,omitempty"`
+	Value *[]*AzureFirewallFqdnTag `json:"value,omitempty"`
 }
 
 // AzureFirewallFqdnTagListResultResponse is the response envelope for operations that return a AzureFirewallFqdnTagListResult type.
@@ -1880,7 +1880,7 @@ type AzureFirewallListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Azure Firewalls in a resource group.
-	Value *[]AzureFirewall `json:"value,omitempty"`
+	Value *[]*AzureFirewall `json:"value,omitempty"`
 }
 
 // AzureFirewallListResultResponse is the response envelope for operations that return a AzureFirewallListResult type.
@@ -1904,22 +1904,22 @@ type AzureFirewallNatRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of destination IP addresses for this rule. Supports IP ranges, prefixes, and service tags.
-	DestinationAddresses *[]string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]string `json:"destinationPorts,omitempty"`
+	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
 
 	// Name of the NAT rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule.
-	Protocols *[]AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols *[]*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 
 	// The translated address for this NAT rule.
 	TranslatedAddress *string `json:"translatedAddress,omitempty"`
@@ -1956,7 +1956,7 @@ type AzureFirewallNatRuleCollectionProperties struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a NAT rule collection.
-	Rules *[]AzureFirewallNatRule `json:"rules,omitempty"`
+	Rules *[]*AzureFirewallNatRule `json:"rules,omitempty"`
 }
 
 // Properties of the network rule.
@@ -1965,28 +1965,28 @@ type AzureFirewallNetworkRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of destination IP addresses.
-	DestinationAddresses *[]string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination FQDNs.
-	DestinationFqdns *[]string `json:"destinationFqdns,omitempty"`
+	DestinationFqdns *[]*string `json:"destinationFqdns,omitempty"`
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups *[]string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups *[]*string `json:"destinationIpGroups,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]string `json:"destinationPorts,omitempty"`
+	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
 
 	// Name of the network rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of AzureFirewallNetworkRuleProtocols.
-	Protocols *[]AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols *[]*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 }
 
 // Network rule collection resource.
@@ -2014,7 +2014,7 @@ type AzureFirewallNetworkRuleCollectionPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a network rule collection.
-	Rules *[]AzureFirewallNetworkRule `json:"rules,omitempty"`
+	Rules *[]*AzureFirewallNetworkRule `json:"rules,omitempty"`
 }
 
 // AzureFirewallPollerResponse is the response envelope for operations that asynchronously return a AzureFirewall type.
@@ -2032,10 +2032,10 @@ type AzureFirewallPollerResponse struct {
 // Properties of the Azure Firewall.
 type AzureFirewallPropertiesFormat struct {
 	// The additional properties used to further config this azure firewall.
-	AdditionalProperties *map[string]string `json:"additionalProperties,omitempty"`
+	AdditionalProperties *map[string]*string `json:"additionalProperties,omitempty"`
 
 	// Collection of application rule collections used by Azure Firewall.
-	ApplicationRuleCollections *[]AzureFirewallApplicationRuleCollection `json:"applicationRuleCollections,omitempty"`
+	ApplicationRuleCollections *[]*AzureFirewallApplicationRuleCollection `json:"applicationRuleCollections,omitempty"`
 
 	// The firewallPolicy associated with this azure firewall.
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
@@ -2044,19 +2044,19 @@ type AzureFirewallPropertiesFormat struct {
 	HubIPAddresses *HubIPAddresses `json:"hubIpAddresses,omitempty" azure:"ro"`
 
 	// IP configuration of the Azure Firewall resource.
-	IPConfigurations *[]AzureFirewallIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*AzureFirewallIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; IpGroups associated with AzureFirewall.
-	IPGroups *[]AzureFirewallIPGroups `json:"ipGroups,omitempty" azure:"ro"`
+	IPGroups *[]*AzureFirewallIPGroups `json:"ipGroups,omitempty" azure:"ro"`
 
 	// IP configuration of the Azure Firewall used for management traffic.
 	ManagementIPConfiguration *AzureFirewallIPConfiguration `json:"managementIpConfiguration,omitempty"`
 
 	// Collection of NAT rule collections used by Azure Firewall.
-	NatRuleCollections *[]AzureFirewallNatRuleCollection `json:"natRuleCollections,omitempty"`
+	NatRuleCollections *[]*AzureFirewallNatRuleCollection `json:"natRuleCollections,omitempty"`
 
 	// Collection of network rule collections used by Azure Firewall.
-	NetworkRuleCollections *[]AzureFirewallNetworkRuleCollection `json:"networkRuleCollections,omitempty"`
+	NetworkRuleCollections *[]*AzureFirewallNetworkRuleCollection `json:"networkRuleCollections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the Azure firewall resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -2140,7 +2140,7 @@ type AzureReachabilityReport struct {
 	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
 
 	// List of Azure reachability report items.
-	ReachabilityReport *[]AzureReachabilityReportItem `json:"reachabilityReport,omitempty"`
+	ReachabilityReport *[]*AzureReachabilityReportItem `json:"reachabilityReport,omitempty"`
 }
 
 // Azure reachability report details for a given provider location.
@@ -2149,7 +2149,7 @@ type AzureReachabilityReportItem struct {
 	AzureLocation *string `json:"azureLocation,omitempty"`
 
 	// List of latency details for each of the time series.
-	Latencies *[]AzureReachabilityReportLatencyInfo `json:"latencies,omitempty"`
+	Latencies *[]*AzureReachabilityReportLatencyInfo `json:"latencies,omitempty"`
 
 	// The Internet service provider.
 	Provider *string `json:"provider,omitempty"`
@@ -2212,7 +2212,7 @@ type AzureReachabilityReportLocation struct {
 // Geographic and time constraints for Azure reachability report.
 type AzureReachabilityReportParameters struct {
 	// Optional Azure regions to scope the query to.
-	AzureLocations *[]string `json:"azureLocations,omitempty"`
+	AzureLocations *[]*string `json:"azureLocations,omitempty"`
 
 	// The end time for the Azure reachability report.
 	EndTime *time.Time `json:"endTime,omitempty"`
@@ -2221,7 +2221,7 @@ type AzureReachabilityReportParameters struct {
 	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
 
 	// List of Internet service providers.
-	Providers *[]string `json:"providers,omitempty"`
+	Providers *[]*string `json:"providers,omitempty"`
 
 	// The start time for the Azure reachability report.
 	StartTime *time.Time `json:"startTime,omitempty"`
@@ -2301,7 +2301,7 @@ type BGPCommunity struct {
 	CommunityName *string `json:"communityName,omitempty"`
 
 	// The prefixes that the bgp community contains.
-	CommunityPrefixes *[]string `json:"communityPrefixes,omitempty"`
+	CommunityPrefixes *[]*string `json:"communityPrefixes,omitempty"`
 
 	// The value of the bgp community. For more information: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing.
 	CommunityValue *string `json:"communityValue,omitempty"`
@@ -2335,16 +2335,16 @@ type BackendAddressPool struct {
 // Properties of the backend address pool.
 type BackendAddressPoolPropertiesFormat struct {
 	// READ-ONLY; An array of references to IP addresses defined in network interfaces.
-	BackendIPConfigurations *[]NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to load balancing rules that use this backend address pool.
-	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; A reference to an outbound rule that uses this backend address pool.
 	OutboundRule *SubResource `json:"outboundRule,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to outbound rules that use this backend address pool.
-	OutboundRules *[]SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules *[]*SubResource `json:"outboundRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -2401,7 +2401,7 @@ type BastionActiveSessionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of active sessions on the bastion.
-	Value *[]BastionActiveSession `json:"value,omitempty"`
+	Value *[]*BastionActiveSession `json:"value,omitempty"`
 }
 
 // BastionActiveSessionListResultPagerPollerResponse is the response envelope for operations that asynchronously return a BastionActiveSessionListResultPager
@@ -2473,7 +2473,7 @@ type BastionHostListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Bastion Hosts in a resource group.
-	Value *[]BastionHost `json:"value,omitempty"`
+	Value *[]*BastionHost `json:"value,omitempty"`
 }
 
 // BastionHostListResultResponse is the response envelope for operations that return a BastionHostListResult type.
@@ -2503,7 +2503,7 @@ type BastionHostPropertiesFormat struct {
 	DNSName *string `json:"dnsName,omitempty"`
 
 	// IP configuration of the Bastion Host resource.
-	IPConfigurations *[]BastionHostIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*BastionHostIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the bastion host resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -2549,7 +2549,7 @@ type BastionSessionDeleteResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of sessions with their corresponding state.
-	Value *[]BastionSessionState `json:"value,omitempty"`
+	Value *[]*BastionSessionState `json:"value,omitempty"`
 }
 
 // BastionSessionDeleteResultResponse is the response envelope for operations that return a BastionSessionDeleteResult type.
@@ -2591,7 +2591,7 @@ type BastionShareableLink struct {
 // Post request for all the Bastion Shareable Link endpoints.
 type BastionShareableLinkListRequest struct {
 	// List of VM references.
-	VMs *[]BastionShareableLink `json:"vms,omitempty"`
+	VMs *[]*BastionShareableLink `json:"vms,omitempty"`
 }
 
 // Response for all the Bastion Shareable Link endpoints.
@@ -2600,7 +2600,7 @@ type BastionShareableLinkListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Bastion Shareable Links for the request.
-	Value *[]BastionShareableLink `json:"value,omitempty"`
+	Value *[]*BastionShareableLink `json:"value,omitempty"`
 }
 
 // BastionShareableLinkListResultPagerPollerResponse is the response envelope for operations that asynchronously return a BastionShareableLinkListResultPager
@@ -2655,7 +2655,7 @@ type BgpPeerStatus struct {
 // Response for list BGP peer status API service call.
 type BgpPeerStatusListResult struct {
 	// List of BGP peers.
-	Value *[]BgpPeerStatus `json:"value,omitempty"`
+	Value *[]*BgpPeerStatus `json:"value,omitempty"`
 }
 
 // BgpPeerStatusListResultPollerResponse is the response envelope for operations that asynchronously return a BgpPeerStatusListResult type.
@@ -2697,7 +2697,7 @@ type BgpServiceCommunityListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of service community resources.
-	Value *[]BgpServiceCommunity `json:"value,omitempty"`
+	Value *[]*BgpServiceCommunity `json:"value,omitempty"`
 }
 
 // BgpServiceCommunityListResultResponse is the response envelope for operations that return a BgpServiceCommunityListResult type.
@@ -2712,7 +2712,7 @@ type BgpServiceCommunityListResultResponse struct {
 // Properties of Service Community.
 type BgpServiceCommunityPropertiesFormat struct {
 	// A list of bgp communities.
-	BgpCommunities *[]BGPCommunity `json:"bgpCommunities,omitempty"`
+	BgpCommunities *[]*BGPCommunity `json:"bgpCommunities,omitempty"`
 
 	// The name of the bgp community. e.g. Skype.
 	ServiceName *string `json:"serviceName,omitempty"`
@@ -2727,7 +2727,7 @@ type BgpSettings struct {
 	BgpPeeringAddress *string `json:"bgpPeeringAddress,omitempty"`
 
 	// BGP peering address with IP configuration ID for virtual network gateway.
-	BgpPeeringAddresses *[]IPConfigurationBgpPeeringAddress `json:"bgpPeeringAddresses,omitempty"`
+	BgpPeeringAddresses *[]*IPConfigurationBgpPeeringAddress `json:"bgpPeeringAddresses,omitempty"`
 
 	// The weight added to routes learned from this BGP speaker.
 	PeerWeight *int32 `json:"peerWeight,omitempty"`
@@ -2775,7 +2775,7 @@ type CloudErrorBody struct {
 	Code *string `json:"code,omitempty"`
 
 	// A list of additional details about the error.
-	Details *[]CloudErrorBody `json:"details,omitempty"`
+	Details *[]*CloudErrorBody `json:"details,omitempty"`
 
 	// A message describing the error, intended to be suitable for display in a user interface.
 	Message *string `json:"message,omitempty"`
@@ -2801,7 +2801,7 @@ type ConnectionMonitor struct {
 	Properties *ConnectionMonitorParameters `json:"properties,omitempty"`
 
 	// Connection monitor tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // Describes the destination of connection monitor.
@@ -2834,7 +2834,7 @@ type ConnectionMonitorEndpoint struct {
 // Describes the connection monitor endpoint filter.
 type ConnectionMonitorEndpointFilter struct {
 	// List of items in the filter.
-	Items *[]ConnectionMonitorEndpointFilterItem `json:"items,omitempty"`
+	Items *[]*ConnectionMonitorEndpointFilterItem `json:"items,omitempty"`
 
 	// The behavior of the endpoint filter. Currently only 'Include' is supported.
 	Type *ConnectionMonitorEndpointFilterType `json:"type,omitempty"`
@@ -2864,10 +2864,10 @@ type ConnectionMonitorHTTPConfiguration struct {
 	PreferHTTPS *bool `json:"preferHTTPS,omitempty"`
 
 	// The HTTP headers to transmit with the request.
-	RequestHeaders *[]HTTPHeader `json:"requestHeaders,omitempty"`
+	RequestHeaders *[]*HTTPHeader `json:"requestHeaders,omitempty"`
 
 	// HTTP status codes to consider successful. For instance, "2xx,301-304,418".
-	ValidStatusCodeRanges *[]string `json:"validStatusCodeRanges,omitempty"`
+	ValidStatusCodeRanges *[]*string `json:"validStatusCodeRanges,omitempty"`
 }
 
 // Describes the ICMP configuration.
@@ -2879,7 +2879,7 @@ type ConnectionMonitorIcmpConfiguration struct {
 // List of connection monitors.
 type ConnectionMonitorListResult struct {
 	// Information about connection monitors.
-	Value *[]ConnectionMonitorResult `json:"value,omitempty"`
+	Value *[]*ConnectionMonitorResult `json:"value,omitempty"`
 }
 
 // ConnectionMonitorListResultResponse is the response envelope for operations that return a ConnectionMonitorListResult type.
@@ -2909,7 +2909,7 @@ type ConnectionMonitorParameters struct {
 	Destination *ConnectionMonitorDestination `json:"destination,omitempty"`
 
 	// List of connection monitor endpoints.
-	Endpoints *[]ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
+	Endpoints *[]*ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
 
 	// Monitoring interval in seconds.
 	MonitoringIntervalInSeconds *int32 `json:"monitoringIntervalInSeconds,omitempty"`
@@ -2918,16 +2918,16 @@ type ConnectionMonitorParameters struct {
 	Notes *string `json:"notes,omitempty"`
 
 	// List of connection monitor outputs.
-	Outputs *[]ConnectionMonitorOutput `json:"outputs,omitempty"`
+	Outputs *[]*ConnectionMonitorOutput `json:"outputs,omitempty"`
 
 	// Describes the source of connection monitor.
 	Source *ConnectionMonitorSource `json:"source,omitempty"`
 
 	// List of connection monitor test configurations.
-	TestConfigurations *[]ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
+	TestConfigurations *[]*ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
 
 	// List of connection monitor test groups.
-	TestGroups *[]ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
+	TestGroups *[]*ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
 }
 
 func (c ConnectionMonitorParameters) marshalInternal() map[string]interface{} {
@@ -2989,7 +2989,7 @@ type ConnectionMonitorQueryResult struct {
 	SourceStatus *ConnectionMonitorSourceStatus `json:"sourceStatus,omitempty"`
 
 	// Information about connection states.
-	States *[]ConnectionStateSnapshot `json:"states,omitempty"`
+	States *[]*ConnectionStateSnapshot `json:"states,omitempty"`
 }
 
 // ConnectionMonitorQueryResultPollerResponse is the response envelope for operations that asynchronously return a ConnectionMonitorQueryResult type.
@@ -3031,7 +3031,7 @@ type ConnectionMonitorResult struct {
 	Properties *ConnectionMonitorResultProperties `json:"properties,omitempty"`
 
 	// Connection monitor tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Connection monitor type.
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -3172,7 +3172,7 @@ type ConnectionMonitorTestConfiguration struct {
 // Describes the connection monitor test group.
 type ConnectionMonitorTestGroup struct {
 	// List of destination endpoint names.
-	Destinations *[]string `json:"destinations,omitempty"`
+	Destinations *[]*string `json:"destinations,omitempty"`
 
 	// Value indicating whether test group is disabled.
 	Disable *bool `json:"disable,omitempty"`
@@ -3181,10 +3181,10 @@ type ConnectionMonitorTestGroup struct {
 	Name *string `json:"name,omitempty"`
 
 	// List of source endpoint names.
-	Sources *[]string `json:"sources,omitempty"`
+	Sources *[]*string `json:"sources,omitempty"`
 
 	// List of test configuration names.
-	TestConfigurations *[]string `json:"testConfigurations,omitempty"`
+	TestConfigurations *[]*string `json:"testConfigurations,omitempty"`
 }
 
 // Describes the settings for producing output into a log analytics workspace.
@@ -3303,7 +3303,7 @@ type ConnectionStateSnapshot struct {
 	EvaluationState *EvaluationState `json:"evaluationState,omitempty"`
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops *[]ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops *[]*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
 
 	// Maximum latency in ms.
 	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty"`
@@ -3409,10 +3409,10 @@ type ConnectivityHop struct {
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of issues.
-	Issues *[]ConnectivityIssue `json:"issues,omitempty" azure:"ro"`
+	Issues *[]*ConnectivityIssue `json:"issues,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of next hop identifiers.
-	NextHopIDs *[]string `json:"nextHopIds,omitempty" azure:"ro"`
+	NextHopIDs *[]*string `json:"nextHopIds,omitempty" azure:"ro"`
 
 	// READ-ONLY; The ID of the resource corresponding to this hop.
 	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
@@ -3430,7 +3430,7 @@ type ConnectivityInformation struct {
 	ConnectionStatus *ConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops *[]ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops *[]*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
 
 	// READ-ONLY; Maximum latency in milliseconds.
 	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty" azure:"ro"`
@@ -3469,7 +3469,7 @@ type ConnectivityInformationResponse struct {
 // Information about an issue encountered in the process of checking for connectivity.
 type ConnectivityIssue struct {
 	// READ-ONLY; Provides additional context on the issue.
-	Context *[]map[string]string `json:"context,omitempty" azure:"ro"`
+	Context *[]map[string]*string `json:"context,omitempty" azure:"ro"`
 
 	// READ-ONLY; The origin of the issue.
 	Origin *Origin `json:"origin,omitempty" azure:"ro"`
@@ -3548,10 +3548,10 @@ type ContainerNetworkInterfaceConfiguration struct {
 // Container network interface configuration properties.
 type ContainerNetworkInterfaceConfigurationPropertiesFormat struct {
 	// A list of container network interfaces created from this container network interface configuration.
-	ContainerNetworkInterfaces *[]SubResource `json:"containerNetworkInterfaces,omitempty"`
+	ContainerNetworkInterfaces *[]*SubResource `json:"containerNetworkInterfaces,omitempty"`
 
 	// A list of ip configurations of the container network interface configuration.
-	IPConfigurations *[]IPConfigurationProfile `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*IPConfigurationProfile `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the container network interface configuration resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -3587,7 +3587,7 @@ type ContainerNetworkInterfacePropertiesFormat struct {
 	ContainerNetworkInterfaceConfiguration *ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfiguration,omitempty" azure:"ro"`
 
 	// READ-ONLY; Reference to the ip configuration on this container nic.
-	IPConfigurations *[]ContainerNetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations *[]*ContainerNetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the container network interface resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -3599,7 +3599,7 @@ type CustomDNSConfigPropertiesFormat struct {
 	Fqdn *string `json:"fqdn,omitempty"`
 
 	// A list of private ip addresses of the private endpoint.
-	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
 }
 
 // Response for the CheckDnsNameAvailability API service call.
@@ -3662,13 +3662,13 @@ type DdosCustomPolicyPollerResponse struct {
 // DDoS custom policy properties.
 type DdosCustomPolicyPropertiesFormat struct {
 	// The protocol-specific DDoS policy customization parameters.
-	ProtocolCustomSettings *[]ProtocolCustomSettingsFormat `json:"protocolCustomSettings,omitempty"`
+	ProtocolCustomSettings *[]*ProtocolCustomSettingsFormat `json:"protocolCustomSettings,omitempty"`
 
 	// READ-ONLY; The provisioning state of the DDoS custom policy resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of public IPs associated with the DDoS custom policy resource. This list is read-only.
-	PublicIPAddresses *[]SubResource `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses *[]*SubResource `json:"publicIPAddresses,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the DDoS custom policy resource. It uniquely identifies the resource, even if the user changes its name or migrate
 	// the resource across subscriptions or resource groups.
@@ -3702,7 +3702,7 @@ type DdosProtectionPlan struct {
 	Properties *DdosProtectionPlanPropertiesFormat `json:"properties,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -3714,7 +3714,7 @@ type DdosProtectionPlanListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of DDoS protection plans.
-	Value *[]DdosProtectionPlan `json:"value,omitempty"`
+	Value *[]*DdosProtectionPlan `json:"value,omitempty"`
 }
 
 // DdosProtectionPlanListResultResponse is the response envelope for operations that return a DdosProtectionPlanListResult type.
@@ -3748,7 +3748,7 @@ type DdosProtectionPlanPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of virtual networks associated with the DDoS protection plan resource. This list is read-only.
-	VirtualNetworks *[]SubResource `json:"virtualNetworks,omitempty" azure:"ro"`
+	VirtualNetworks *[]*SubResource `json:"virtualNetworks,omitempty" azure:"ro"`
 }
 
 // DdosProtectionPlanResponse is the response envelope for operations that return a DdosProtectionPlan type.
@@ -3841,7 +3841,7 @@ type DeviceProperties struct {
 // options.
 type DhcpOptions struct {
 	// The list of DNS servers IP addresses.
-	DNSServers *[]string `json:"dnsServers,omitempty"`
+	DNSServers *[]*string `json:"dnsServers,omitempty"`
 }
 
 // Dimension of the metric.
@@ -3862,7 +3862,7 @@ type EffectiveNetworkSecurityGroup struct {
 	Association *EffectiveNetworkSecurityGroupAssociation `json:"association,omitempty"`
 
 	// A collection of effective security rules.
-	EffectiveSecurityRules *[]EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules *[]*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
 
 	// The ID of network security group that is applied.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
@@ -3886,7 +3886,7 @@ type EffectiveNetworkSecurityGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of effective network security groups.
-	Value *[]EffectiveNetworkSecurityGroup `json:"value,omitempty"`
+	Value *[]*EffectiveNetworkSecurityGroup `json:"value,omitempty"`
 }
 
 // EffectiveNetworkSecurityGroupListResultPollerResponse is the response envelope for operations that asynchronously return a EffectiveNetworkSecurityGroupListResult
@@ -3921,23 +3921,23 @@ type EffectiveNetworkSecurityRule struct {
 
 	// The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and
 	// the asterisk (*).
-	DestinationAddressPrefixes *[]string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes *[]*string `json:"destinationAddressPrefixes,omitempty"`
 
 	// The destination port or range.
 	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
 
 	// The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk
 	// (*).
-	DestinationPortRanges *[]string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges *[]*string `json:"destinationPortRanges,omitempty"`
 
 	// The direction of the rule.
 	Direction *SecurityRuleDirection `json:"direction,omitempty"`
 
 	// Expanded destination address prefix.
-	ExpandedDestinationAddressPrefix *[]string `json:"expandedDestinationAddressPrefix,omitempty"`
+	ExpandedDestinationAddressPrefix *[]*string `json:"expandedDestinationAddressPrefix,omitempty"`
 
 	// The expanded source address prefix.
-	ExpandedSourceAddressPrefix *[]string `json:"expandedSourceAddressPrefix,omitempty"`
+	ExpandedSourceAddressPrefix *[]*string `json:"expandedSourceAddressPrefix,omitempty"`
 
 	// The name of the security rule specified by the user (if created by the user).
 	Name *string `json:"name,omitempty"`
@@ -3953,19 +3953,19 @@ type EffectiveNetworkSecurityRule struct {
 
 	// The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the
 	// asterisk (*).
-	SourceAddressPrefixes *[]string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes *[]*string `json:"sourceAddressPrefixes,omitempty"`
 
 	// The source port or range.
 	SourcePortRange *string `json:"sourcePortRange,omitempty"`
 
 	// The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*).
-	SourcePortRanges *[]string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges *[]*string `json:"sourcePortRanges,omitempty"`
 }
 
 // Effective Route.
 type EffectiveRoute struct {
 	// The address prefixes of the effective routes in CIDR notation.
-	AddressPrefix *[]string `json:"addressPrefix,omitempty"`
+	AddressPrefix *[]*string `json:"addressPrefix,omitempty"`
 
 	// If true, on-premises routes are not propagated to the network interfaces in the subnet.
 	DisableBgpRoutePropagation *bool `json:"disableBgpRoutePropagation,omitempty"`
@@ -3974,7 +3974,7 @@ type EffectiveRoute struct {
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the next hop of the effective route.
-	NextHopIPAddress *[]string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress *[]*string `json:"nextHopIpAddress,omitempty"`
 
 	// The type of Azure hop the packet should be sent to.
 	NextHopType *RouteNextHopType `json:"nextHopType,omitempty"`
@@ -3992,7 +3992,7 @@ type EffectiveRouteListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of effective routes.
-	Value *[]EffectiveRoute `json:"value,omitempty"`
+	Value *[]*EffectiveRoute `json:"value,omitempty"`
 }
 
 // EffectiveRouteListResultPollerResponse is the response envelope for operations that asynchronously return a EffectiveRouteListResult type.
@@ -4032,7 +4032,7 @@ type EndpointServicesListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of available endpoint services in a region.
-	Value *[]EndpointServiceResult `json:"value,omitempty"`
+	Value *[]*EndpointServiceResult `json:"value,omitempty"`
 }
 
 // EndpointServicesListResultResponse is the response envelope for operations that return a EndpointServicesListResult type.
@@ -4050,7 +4050,7 @@ type Error struct {
 	Code *string `json:"code,omitempty"`
 
 	// Error details.
-	Details *[]ErrorDetails `json:"details,omitempty"`
+	Details *[]*ErrorDetails `json:"details,omitempty"`
 
 	// Inner error message.
 	InnerError *string `json:"innerError,omitempty"`
@@ -4137,7 +4137,7 @@ type EvaluatedNetworkSecurityGroup struct {
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty"`
 
 	// READ-ONLY; List of network security rules evaluation results.
-	RulesEvaluationResult *[]NetworkSecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
+	RulesEvaluationResult *[]*NetworkSecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
 }
 
 // ExpressRouteCircuit resource.
@@ -4249,7 +4249,7 @@ type ExpressRouteCircuitConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The global reach connection associated with Private Peering in an ExpressRoute Circuit.
-	Value *[]ExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitConnection `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitConnectionListResultResponse is the response envelope for operations that return a ExpressRouteCircuitConnectionListResult type.
@@ -4333,7 +4333,7 @@ type ExpressRouteCircuitListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRouteCircuits in a resource group.
-	Value *[]ExpressRouteCircuit `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuit `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitListResultResponse is the response envelope for operations that return a ExpressRouteCircuitListResult type.
@@ -4364,10 +4364,10 @@ type ExpressRouteCircuitPeering struct {
 // Specifies the peering configuration.
 type ExpressRouteCircuitPeeringConfig struct {
 	// The communities of bgp peering. Specified for microsoft peering.
-	AdvertisedCommunities *[]string `json:"advertisedCommunities,omitempty"`
+	AdvertisedCommunities *[]*string `json:"advertisedCommunities,omitempty"`
 
 	// The reference to AdvertisedPublicPrefixes.
-	AdvertisedPublicPrefixes *[]string `json:"advertisedPublicPrefixes,omitempty"`
+	AdvertisedPublicPrefixes *[]*string `json:"advertisedPublicPrefixes,omitempty"`
 
 	// READ-ONLY; The advertised public prefix state of the Peering resource.
 	AdvertisedPublicPrefixesState *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState `json:"advertisedPublicPrefixesState,omitempty" azure:"ro"`
@@ -4394,7 +4394,7 @@ type ExpressRouteCircuitPeeringListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The peerings in an express route circuit.
-	Value *[]ExpressRouteCircuitPeering `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitPeering `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitPeeringListResultResponse is the response envelope for operations that return a ExpressRouteCircuitPeeringListResult type.
@@ -4424,7 +4424,7 @@ type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	AzureASN *int32 `json:"azureASN,omitempty"`
 
 	// The list of circuit connections associated with Azure Private Peering for this circuit.
-	Connections *[]ExpressRouteCircuitConnection `json:"connections,omitempty"`
+	Connections *[]*ExpressRouteCircuitConnection `json:"connections,omitempty"`
 
 	// The ExpressRoute connection.
 	ExpressRouteConnection *ExpressRouteConnectionID `json:"expressRouteConnection,omitempty"`
@@ -4445,7 +4445,7 @@ type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	PeerASN *int64 `json:"peerASN,omitempty"`
 
 	// READ-ONLY; The list of peered circuit connections associated with Azure Private Peering for this circuit.
-	PeeredConnections *[]PeerExpressRouteCircuitConnection `json:"peeredConnections,omitempty" azure:"ro"`
+	PeeredConnections *[]*PeerExpressRouteCircuitConnection `json:"peeredConnections,omitempty" azure:"ro"`
 
 	// The peering type.
 	PeeringType *ExpressRoutePeeringType `json:"peeringType,omitempty"`
@@ -4528,7 +4528,7 @@ type ExpressRouteCircuitPropertiesFormat struct {
 	AllowClassicOperations *bool `json:"allowClassicOperations,omitempty"`
 
 	// The list of authorizations.
-	Authorizations *[]ExpressRouteCircuitAuthorization `json:"authorizations,omitempty"`
+	Authorizations *[]*ExpressRouteCircuitAuthorization `json:"authorizations,omitempty"`
 
 	// The bandwidth of the circuit when the circuit is provisioned on an ExpressRoutePort resource.
 	BandwidthInGbps *float32 `json:"bandwidthInGbps,omitempty"`
@@ -4546,7 +4546,7 @@ type ExpressRouteCircuitPropertiesFormat struct {
 	GlobalReachEnabled *bool `json:"globalReachEnabled,omitempty"`
 
 	// The list of peerings.
-	Peerings *[]ExpressRouteCircuitPeering `json:"peerings,omitempty"`
+	Peerings *[]*ExpressRouteCircuitPeering `json:"peerings,omitempty"`
 
 	// READ-ONLY; The provisioning state of the express route circuit resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -4672,7 +4672,7 @@ type ExpressRouteCircuitsArpTableListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of the ARP tables.
-	Value *[]ExpressRouteCircuitArpTable `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitArpTable `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitsArpTableListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsArpTableListResult
@@ -4753,7 +4753,7 @@ type ExpressRouteCircuitsRoutesTableListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of routes table.
-	Value *[]ExpressRouteCircuitRoutesTable `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitRoutesTable `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitsRoutesTableListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsRoutesTableListResult
@@ -4784,7 +4784,7 @@ type ExpressRouteCircuitsRoutesTableSummaryListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of the routes table.
-	Value *[]ExpressRouteCircuitRoutesTableSummary `json:"value,omitempty"`
+	Value *[]*ExpressRouteCircuitRoutesTableSummary `json:"value,omitempty"`
 }
 
 // ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsRoutesTableSummaryListResult
@@ -4834,7 +4834,7 @@ type ExpressRouteConnectionID struct {
 // ExpressRouteConnection list.
 type ExpressRouteConnectionList struct {
 	// The list of ExpressRoute connections.
-	Value *[]ExpressRouteConnection `json:"value,omitempty"`
+	Value *[]*ExpressRouteConnection `json:"value,omitempty"`
 }
 
 // ExpressRouteConnectionListResponse is the response envelope for operations that return a ExpressRouteConnectionList type.
@@ -4921,7 +4921,7 @@ type ExpressRouteCrossConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ExpressRouteCrossConnection resources.
-	Value *[]ExpressRouteCrossConnection `json:"value,omitempty"`
+	Value *[]*ExpressRouteCrossConnection `json:"value,omitempty"`
 }
 
 // ExpressRouteCrossConnectionListResultResponse is the response envelope for operations that return a ExpressRouteCrossConnectionListResult type.
@@ -4952,7 +4952,7 @@ type ExpressRouteCrossConnectionPeeringList struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The peerings in an express route cross connection.
-	Value *[]ExpressRouteCrossConnectionPeering `json:"value,omitempty"`
+	Value *[]*ExpressRouteCrossConnectionPeering `json:"value,omitempty"`
 }
 
 // ExpressRouteCrossConnectionPeeringListResponse is the response envelope for operations that return a ExpressRouteCrossConnectionPeeringList type.
@@ -5079,7 +5079,7 @@ type ExpressRouteCrossConnectionProperties struct {
 	PeeringLocation *string `json:"peeringLocation,omitempty"`
 
 	// The list of peerings.
-	Peerings *[]ExpressRouteCrossConnectionPeering `json:"peerings,omitempty"`
+	Peerings *[]*ExpressRouteCrossConnectionPeering `json:"peerings,omitempty"`
 
 	// READ-ONLY; The name of the primary port.
 	PrimaryAzurePort *string `json:"primaryAzurePort,omitempty" azure:"ro"`
@@ -5166,7 +5166,7 @@ type ExpressRouteCrossConnectionsRoutesTableSummaryListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of the routes table.
-	Value *[]ExpressRouteCrossConnectionRoutesTableSummary `json:"value,omitempty"`
+	Value *[]*ExpressRouteCrossConnectionRoutesTableSummary `json:"value,omitempty"`
 }
 
 // ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCrossConnectionsRoutesTableSummaryListResult
@@ -5210,7 +5210,7 @@ type ExpressRouteGateway struct {
 // List of ExpressRoute gateways.
 type ExpressRouteGatewayList struct {
 	// List of ExpressRoute gateways.
-	Value *[]ExpressRouteGateway `json:"value,omitempty"`
+	Value *[]*ExpressRouteGateway `json:"value,omitempty"`
 }
 
 // ExpressRouteGatewayListResponse is the response envelope for operations that return a ExpressRouteGatewayList type.
@@ -5240,7 +5240,7 @@ type ExpressRouteGatewayProperties struct {
 	AutoScaleConfiguration *ExpressRouteGatewayPropertiesAutoScaleConfiguration `json:"autoScaleConfiguration,omitempty"`
 
 	// READ-ONLY; List of ExpressRoute connections to the ExpressRoute gateway.
-	ExpressRouteConnections *[]ExpressRouteConnection `json:"expressRouteConnections,omitempty" azure:"ro"`
+	ExpressRouteConnections *[]*ExpressRouteConnection `json:"expressRouteConnections,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the express route gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -5317,7 +5317,7 @@ type ExpressRouteLinkListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of ExpressRouteLink sub-resources.
-	Value *[]ExpressRouteLink `json:"value,omitempty"`
+	Value *[]*ExpressRouteLink `json:"value,omitempty"`
 }
 
 // ExpressRouteLinkListResultResponse is the response envelope for operations that return a ExpressRouteLinkListResult type.
@@ -5406,7 +5406,7 @@ type ExpressRoutePortListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRoutePort resources.
-	Value *[]ExpressRoutePort `json:"value,omitempty"`
+	Value *[]*ExpressRoutePort `json:"value,omitempty"`
 }
 
 // ExpressRoutePortListResultResponse is the response envelope for operations that return a ExpressRoutePortListResult type.
@@ -5439,7 +5439,7 @@ type ExpressRoutePortPropertiesFormat struct {
 	BandwidthInGbps *int32 `json:"bandwidthInGbps,omitempty"`
 
 	// READ-ONLY; Reference the ExpressRoute circuit(s) that are provisioned on this ExpressRoutePort resource.
-	Circuits *[]SubResource `json:"circuits,omitempty" azure:"ro"`
+	Circuits *[]*SubResource `json:"circuits,omitempty" azure:"ro"`
 
 	// Encapsulation method on physical ports.
 	Encapsulation *ExpressRoutePortsEncapsulation `json:"encapsulation,omitempty"`
@@ -5448,7 +5448,7 @@ type ExpressRoutePortPropertiesFormat struct {
 	EtherType *string `json:"etherType,omitempty" azure:"ro"`
 
 	// The set of physical links of the ExpressRoutePort resource.
-	Links *[]ExpressRouteLink `json:"links,omitempty"`
+	Links *[]*ExpressRouteLink `json:"links,omitempty"`
 
 	// READ-ONLY; Maximum transmission unit of the physical port pair(s).
 	Mtu *string `json:"mtu,omitempty" azure:"ro"`
@@ -5522,7 +5522,7 @@ type ExpressRoutePortsLocationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of all ExpressRoutePort peering locations.
-	Value *[]ExpressRoutePortsLocation `json:"value,omitempty"`
+	Value *[]*ExpressRoutePortsLocation `json:"value,omitempty"`
 }
 
 // ExpressRoutePortsLocationListResultResponse is the response envelope for operations that return a ExpressRoutePortsLocationListResult type.
@@ -5540,7 +5540,7 @@ type ExpressRoutePortsLocationPropertiesFormat struct {
 	Address *string `json:"address,omitempty" azure:"ro"`
 
 	// The inventory of available ExpressRoutePort bandwidths.
-	AvailableBandwidths *[]ExpressRoutePortsLocationBandwidths `json:"availableBandwidths,omitempty"`
+	AvailableBandwidths *[]*ExpressRoutePortsLocationBandwidths `json:"availableBandwidths,omitempty"`
 
 	// READ-ONLY; Contact details of peering locations.
 	Contact *string `json:"contact,omitempty" azure:"ro"`
@@ -5595,7 +5595,7 @@ type ExpressRouteServiceProviderListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRouteResourceProvider resources.
-	Value *[]ExpressRouteServiceProvider `json:"value,omitempty"`
+	Value *[]*ExpressRouteServiceProvider `json:"value,omitempty"`
 }
 
 // ExpressRouteServiceProviderListResultResponse is the response envelope for operations that return a ExpressRouteServiceProviderListResult type.
@@ -5610,10 +5610,10 @@ type ExpressRouteServiceProviderListResultResponse struct {
 // Properties of ExpressRouteServiceProvider.
 type ExpressRouteServiceProviderPropertiesFormat struct {
 	// A list of bandwidths offered.
-	BandwidthsOffered *[]ExpressRouteServiceProviderBandwidthsOffered `json:"bandwidthsOffered,omitempty"`
+	BandwidthsOffered *[]*ExpressRouteServiceProviderBandwidthsOffered `json:"bandwidthsOffered,omitempty"`
 
 	// A list of peering locations.
-	PeeringLocations *[]string `json:"peeringLocations,omitempty"`
+	PeeringLocations *[]*string `json:"peeringLocations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the express route service provider resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -5713,7 +5713,7 @@ type FirewallPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Firewall Policies in a resource group.
-	Value *[]FirewallPolicy `json:"value,omitempty"`
+	Value *[]*FirewallPolicy `json:"value,omitempty"`
 }
 
 // FirewallPolicyListResultResponse is the response envelope for operations that return a FirewallPolicyListResult type.
@@ -5804,16 +5804,16 @@ type FirewallPolicyPropertiesFormat struct {
 	BasePolicy *SubResource `json:"basePolicy,omitempty"`
 
 	// READ-ONLY; List of references to Child Firewall Policies.
-	ChildPolicies *[]SubResource `json:"childPolicies,omitempty" azure:"ro"`
+	ChildPolicies *[]*SubResource `json:"childPolicies,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of references to Azure Firewalls that this Firewall Policy is associated with.
-	Firewalls *[]SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls *[]*SubResource `json:"firewalls,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the firewall policy resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of references to FirewallPolicyRuleGroups.
-	RuleGroups *[]SubResource `json:"ruleGroups,omitempty" azure:"ro"`
+	RuleGroups *[]*SubResource `json:"ruleGroups,omitempty" azure:"ro"`
 
 	// The operation mode for Threat Intelligence.
 	ThreatIntelMode *AzureFirewallThreatIntelMode `json:"threatIntelMode,omitempty"`
@@ -5987,7 +5987,7 @@ type FirewallPolicyRuleGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of FirewallPolicyRuleGroups in a FirewallPolicy.
-	Value *[]FirewallPolicyRuleGroup `json:"value,omitempty"`
+	Value *[]*FirewallPolicyRuleGroup `json:"value,omitempty"`
 }
 
 // FirewallPolicyRuleGroupListResultResponse is the response envelope for operations that return a FirewallPolicyRuleGroupListResult type.
@@ -6136,7 +6136,7 @@ type FlowLogListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// Information about flow log resource.
-	Value *[]FlowLog `json:"value,omitempty"`
+	Value *[]*FlowLog `json:"value,omitempty"`
 }
 
 // FlowLogListResultResponse is the response envelope for operations that return a FlowLogListResult type.
@@ -6253,22 +6253,22 @@ type FrontendIPConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Properties of Frontend IP Configuration of the load balancer.
 type FrontendIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; An array of references to inbound pools that use this frontend IP.
-	InboundNatPools *[]SubResource `json:"inboundNatPools,omitempty" azure:"ro"`
+	InboundNatPools *[]*SubResource `json:"inboundNatPools,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to inbound rules that use this frontend IP.
-	InboundNatRules *[]SubResource `json:"inboundNatRules,omitempty" azure:"ro"`
+	InboundNatRules *[]*SubResource `json:"inboundNatRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to load balancing rules that use this frontend IP.
-	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to outbound rules that use this frontend IP.
-	OutboundRules *[]SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules *[]*SubResource `json:"outboundRules,omitempty" azure:"ro"`
 
 	// The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
@@ -6328,7 +6328,7 @@ type GatewayRoute struct {
 // List of virtual network gateway routes.
 type GatewayRouteListResult struct {
 	// List of gateway routes.
-	Value *[]GatewayRoute `json:"value,omitempty"`
+	Value *[]*GatewayRoute `json:"value,omitempty"`
 }
 
 // GatewayRouteListResultPollerResponse is the response envelope for operations that asynchronously return a GatewayRouteListResult type.
@@ -6358,19 +6358,19 @@ type GetVPNSitesConfigurationRequest struct {
 	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
 
 	// List of resource-ids of the vpn-sites for which config is to be downloaded.
-	VPNSites *[]string `json:"vpnSites,omitempty"`
+	VPNSites *[]*string `json:"vpnSites,omitempty"`
 }
 
 // HTTP configuration of the connectivity check.
 type HTTPConfiguration struct {
 	// List of HTTP headers.
-	Headers *[]HTTPHeader `json:"headers,omitempty"`
+	Headers *[]*HTTPHeader `json:"headers,omitempty"`
 
 	// HTTP method.
 	Method *HTTPMethod `json:"method,omitempty"`
 
 	// Valid status codes.
-	ValidStatusCodes *[]int32 `json:"validStatusCodes,omitempty"`
+	ValidStatusCodes *[]*int32 `json:"validStatusCodes,omitempty"`
 }
 
 // The HTTP header.
@@ -6400,7 +6400,7 @@ type HubIPAddresses struct {
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
 
 	// List of Public IP addresses associated with azure firewall.
-	PublicIPAddresses *[]AzureFirewallPublicIPAddress `json:"publicIPAddresses,omitempty"`
+	PublicIPAddresses *[]*AzureFirewallPublicIPAddress `json:"publicIPAddresses,omitempty"`
 }
 
 // HubVirtualNetworkConnection Resource.
@@ -6459,7 +6459,7 @@ type IPAddressAvailabilityResult struct {
 	Available *bool `json:"available,omitempty"`
 
 	// Contains other available private IP addresses if the asked for address is taken.
-	AvailableIPAddresses *[]string `json:"availableIPAddresses,omitempty"`
+	AvailableIPAddresses *[]*string `json:"availableIPAddresses,omitempty"`
 }
 
 // IPAddressAvailabilityResultResponse is the response envelope for operations that return a IPAddressAvailabilityResult type.
@@ -6487,7 +6487,7 @@ type IPAllocationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of IpAllocation resources.
-	Value *[]IPAllocation `json:"value,omitempty"`
+	Value *[]*IPAllocation `json:"value,omitempty"`
 }
 
 // IPAllocationListResultResponse is the response envelope for operations that return a IPAllocationListResult type.
@@ -6514,7 +6514,7 @@ type IPAllocationPollerResponse struct {
 // Properties of the IpAllocation.
 type IPAllocationPropertiesFormat struct {
 	// IpAllocation tags.
-	AllocationTags *map[string]string `json:"allocationTags,omitempty"`
+	AllocationTags *map[string]*string `json:"allocationTags,omitempty"`
 
 	// The IPAM allocation ID.
 	IpamAllocationID *string `json:"ipamAllocationId,omitempty"`
@@ -6594,16 +6594,16 @@ type IPConfiguration struct {
 // Properties of IPConfigurationBgpPeeringAddress.
 type IPConfigurationBgpPeeringAddress struct {
 	// The list of custom BGP peering addresses which belong to IP configuration.
-	CustomBgpIPAddresses *[]string `json:"customBgpIpAddresses,omitempty"`
+	CustomBgpIPAddresses *[]*string `json:"customBgpIpAddresses,omitempty"`
 
 	// READ-ONLY; The list of default BGP peering addresses which belong to IP configuration.
-	DefaultBgpIPAddresses *[]string `json:"defaultBgpIpAddresses,omitempty" azure:"ro"`
+	DefaultBgpIPAddresses *[]*string `json:"defaultBgpIpAddresses,omitempty" azure:"ro"`
 
 	// The ID of IP configuration which belongs to gateway.
 	IPConfigurationID *string `json:"ipconfigurationId,omitempty"`
 
 	// READ-ONLY; The list of tunnel public IP addresses which belong to IP configuration.
-	TunnelIPAddresses *[]string `json:"tunnelIpAddresses,omitempty" azure:"ro"`
+	TunnelIPAddresses *[]*string `json:"tunnelIpAddresses,omitempty" azure:"ro"`
 }
 
 // IP configuration profile child resource.
@@ -6665,7 +6665,7 @@ type IPGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of IpGroups information resources.
-	Value *[]IPGroup `json:"value,omitempty"`
+	Value *[]*IPGroup `json:"value,omitempty"`
 }
 
 // IPGroupListResultResponse is the response envelope for operations that return a IPGroupListResult type.
@@ -6692,10 +6692,10 @@ type IPGroupPollerResponse struct {
 // The IpGroups property information.
 type IPGroupPropertiesFormat struct {
 	// READ-ONLY; List of references to Azure resources that this IpGroups is associated with.
-	Firewalls *[]SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls *[]*SubResource `json:"firewalls,omitempty" azure:"ro"`
 
 	// IpAddresses/IpAddressPrefixes in the IpGroups resource.
-	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
 
 	// READ-ONLY; The provisioning state of the IpGroups resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -6878,7 +6878,7 @@ type InboundNatRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of inbound nat rules in a load balancer.
-	Value *[]InboundNatRule `json:"value,omitempty"`
+	Value *[]*InboundNatRule `json:"value,omitempty"`
 }
 
 // InboundNatRuleListResultResponse is the response envelope for operations that return a InboundNatRuleListResult type.
@@ -6973,7 +6973,7 @@ type ListHubVirtualNetworkConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of HubVirtualNetworkConnections.
-	Value *[]HubVirtualNetworkConnection `json:"value,omitempty"`
+	Value *[]*HubVirtualNetworkConnection `json:"value,omitempty"`
 }
 
 // ListHubVirtualNetworkConnectionsResultResponse is the response envelope for operations that return a ListHubVirtualNetworkConnectionsResult type.
@@ -6991,7 +6991,7 @@ type ListP2SVPNGatewaysResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of P2SVpnGateways.
-	Value *[]P2SVPNGateway `json:"value,omitempty"`
+	Value *[]*P2SVPNGateway `json:"value,omitempty"`
 }
 
 // ListP2SVPNGatewaysResultResponse is the response envelope for operations that return a ListP2SVPNGatewaysResult type.
@@ -7010,7 +7010,7 @@ type ListVPNConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Vpn Connections.
-	Value *[]VPNConnection `json:"value,omitempty"`
+	Value *[]*VPNConnection `json:"value,omitempty"`
 }
 
 // ListVPNConnectionsResultResponse is the response envelope for operations that return a ListVPNConnectionsResult type.
@@ -7029,7 +7029,7 @@ type ListVPNGatewaysResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnGateways.
-	Value *[]VPNGateway `json:"value,omitempty"`
+	Value *[]*VPNGateway `json:"value,omitempty"`
 }
 
 // ListVPNGatewaysResultResponse is the response envelope for operations that return a ListVPNGatewaysResult type.
@@ -7047,7 +7047,7 @@ type ListVPNServerConfigurationsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnServerConfigurations.
-	Value *[]VPNServerConfiguration `json:"value,omitempty"`
+	Value *[]*VPNServerConfiguration `json:"value,omitempty"`
 }
 
 // ListVPNServerConfigurationsResultResponse is the response envelope for operations that return a ListVPNServerConfigurationsResult type.
@@ -7066,7 +7066,7 @@ type ListVPNSiteLinkConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSiteLinkConnections.
-	Value *[]VPNSiteLinkConnection `json:"value,omitempty"`
+	Value *[]*VPNSiteLinkConnection `json:"value,omitempty"`
 }
 
 // ListVPNSiteLinkConnectionsResultResponse is the response envelope for operations that return a ListVPNSiteLinkConnectionsResult type.
@@ -7085,7 +7085,7 @@ type ListVPNSiteLinksResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSitesLinks.
-	Value *[]VPNSiteLink `json:"value,omitempty"`
+	Value *[]*VPNSiteLink `json:"value,omitempty"`
 }
 
 // ListVPNSiteLinksResultResponse is the response envelope for operations that return a ListVPNSiteLinksResult type.
@@ -7103,7 +7103,7 @@ type ListVPNSitesResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSites.
-	Value *[]VPNSite `json:"value,omitempty"`
+	Value *[]*VPNSite `json:"value,omitempty"`
 }
 
 // ListVPNSitesResultResponse is the response envelope for operations that return a ListVPNSitesResult type.
@@ -7121,7 +7121,7 @@ type ListVirtualHubRouteTableV2SResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualHubRouteTableV2s.
-	Value *[]VirtualHubRouteTableV2 `json:"value,omitempty"`
+	Value *[]*VirtualHubRouteTableV2 `json:"value,omitempty"`
 }
 
 // ListVirtualHubRouteTableV2SResultResponse is the response envelope for operations that return a ListVirtualHubRouteTableV2SResult type.
@@ -7139,7 +7139,7 @@ type ListVirtualHubsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualHubs.
-	Value *[]VirtualHub `json:"value,omitempty"`
+	Value *[]*VirtualHub `json:"value,omitempty"`
 }
 
 // ListVirtualHubsResultResponse is the response envelope for operations that return a ListVirtualHubsResult type.
@@ -7157,7 +7157,7 @@ type ListVirtualWANsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualWANs.
-	Value *[]VirtualWAN `json:"value,omitempty"`
+	Value *[]*VirtualWAN `json:"value,omitempty"`
 }
 
 // ListVirtualWANsResultResponse is the response envelope for operations that return a ListVirtualWANsResult type.
@@ -7188,7 +7188,7 @@ type LoadBalancerBackendAddressPoolListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of backend address pools in a load balancer.
-	Value *[]BackendAddressPool `json:"value,omitempty"`
+	Value *[]*BackendAddressPool `json:"value,omitempty"`
 }
 
 // LoadBalancerBackendAddressPoolListResultResponse is the response envelope for operations that return a LoadBalancerBackendAddressPoolListResult type.
@@ -7216,7 +7216,7 @@ type LoadBalancerFrontendIPConfigurationListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of frontend IP configurations in a load balancer.
-	Value *[]FrontendIPConfiguration `json:"value,omitempty"`
+	Value *[]*FrontendIPConfiguration `json:"value,omitempty"`
 }
 
 // LoadBalancerFrontendIPConfigurationListResultResponse is the response envelope for operations that return a LoadBalancerFrontendIPConfigurationListResult
@@ -7245,7 +7245,7 @@ type LoadBalancerListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancers in a resource group.
-	Value *[]LoadBalancer `json:"value,omitempty"`
+	Value *[]*LoadBalancer `json:"value,omitempty"`
 }
 
 // LoadBalancerListResultResponse is the response envelope for operations that return a LoadBalancerListResult type.
@@ -7263,7 +7263,7 @@ type LoadBalancerLoadBalancingRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancing rules in a load balancer.
-	Value *[]LoadBalancingRule `json:"value,omitempty"`
+	Value *[]*LoadBalancingRule `json:"value,omitempty"`
 }
 
 // LoadBalancerLoadBalancingRuleListResultResponse is the response envelope for operations that return a LoadBalancerLoadBalancingRuleListResult type.
@@ -7296,7 +7296,7 @@ type LoadBalancerOutboundRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of outbound rules in a load balancer.
-	Value *[]OutboundRule `json:"value,omitempty"`
+	Value *[]*OutboundRule `json:"value,omitempty"`
 }
 
 // LoadBalancerOutboundRuleListResultResponse is the response envelope for operations that return a LoadBalancerOutboundRuleListResult type.
@@ -7336,7 +7336,7 @@ type LoadBalancerProbeListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of probes in a load balancer.
-	Value *[]Probe `json:"value,omitempty"`
+	Value *[]*Probe `json:"value,omitempty"`
 }
 
 // LoadBalancerProbeListResultResponse is the response envelope for operations that return a LoadBalancerProbeListResult type.
@@ -7361,10 +7361,10 @@ type LoadBalancerProbesListOptions struct {
 // Properties of the load balancer.
 type LoadBalancerPropertiesFormat struct {
 	// Collection of backend address pools used by a load balancer.
-	BackendAddressPools *[]BackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools *[]*BackendAddressPool `json:"backendAddressPools,omitempty"`
 
 	// Object representing the frontend IPs to be used for the load balancer.
-	FrontendIPConfigurations *[]FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations *[]*FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
 
 	// Defines an external port range for inbound NAT to a single backend port on NICs associated with a load balancer. Inbound NAT rules are created automatically
 	// for each NIC associated with the Load
@@ -7372,22 +7372,22 @@ type LoadBalancerPropertiesFormat struct {
 	// Inbound NAT pools are referenced from virtual
 	// machine scale sets. NICs that are associated with individual virtual machines cannot reference an inbound NAT pool. They have to reference individual
 	// inbound NAT rules.
-	InboundNatPools *[]InboundNatPool `json:"inboundNatPools,omitempty"`
+	InboundNatPools *[]*InboundNatPool `json:"inboundNatPools,omitempty"`
 
 	// Collection of inbound NAT Rules used by a load balancer. Defining inbound NAT rules on your load balancer is mutually exclusive with defining an inbound
 	// NAT pool. Inbound NAT pools are referenced from
 	// virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an Inbound NAT pool. They have to reference individual
 	// inbound NAT rules.
-	InboundNatRules *[]InboundNatRule `json:"inboundNatRules,omitempty"`
+	InboundNatRules *[]*InboundNatRule `json:"inboundNatRules,omitempty"`
 
 	// Object collection representing the load balancing rules Gets the provisioning.
-	LoadBalancingRules *[]LoadBalancingRule `json:"loadBalancingRules,omitempty"`
+	LoadBalancingRules *[]*LoadBalancingRule `json:"loadBalancingRules,omitempty"`
 
 	// The outbound rules.
-	OutboundRules *[]OutboundRule `json:"outboundRules,omitempty"`
+	OutboundRules *[]*OutboundRule `json:"outboundRules,omitempty"`
 
 	// Collection of probe objects used in the load balancer.
-	Probes *[]Probe `json:"probes,omitempty"`
+	Probes *[]*Probe `json:"probes,omitempty"`
 
 	// READ-ONLY; The provisioning state of the load balancer resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -7527,7 +7527,7 @@ type LocalNetworkGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of local network gateways that exists in a resource group.
-	Value *[]LocalNetworkGateway `json:"value,omitempty"`
+	Value *[]*LocalNetworkGateway `json:"value,omitempty"`
 }
 
 // LocalNetworkGatewayListResultResponse is the response envelope for operations that return a LocalNetworkGatewayListResult type.
@@ -7624,7 +7624,7 @@ type ManagedRuleGroupOverride struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// List of rules that will be disabled. If none specified, all rules in the group will be disabled.
-	Rules *[]ManagedRuleOverride `json:"rules,omitempty"`
+	Rules *[]*ManagedRuleOverride `json:"rules,omitempty"`
 }
 
 // Defines a managed rule group override setting.
@@ -7639,7 +7639,7 @@ type ManagedRuleOverride struct {
 // Defines a managed rule set.
 type ManagedRuleSet struct {
 	// Defines the rule group overrides to apply to the rule set.
-	RuleGroupOverrides *[]ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
+	RuleGroupOverrides *[]*ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
 
 	// Defines the rule set type to use.
 	RuleSetType *string `json:"ruleSetType,omitempty"`
@@ -7651,10 +7651,10 @@ type ManagedRuleSet struct {
 // Allow to exclude some variable satisfy the condition for the WAF check.
 type ManagedRulesDefinition struct {
 	// The Exclusions that are applied on the policy.
-	Exclusions *[]OwaspCrsExclusionEntry `json:"exclusions,omitempty"`
+	Exclusions *[]*OwaspCrsExclusionEntry `json:"exclusions,omitempty"`
 
 	// The managed rule sets that are associated with the policy.
-	ManagedRuleSets *[]ManagedRuleSet `json:"managedRuleSets,omitempty"`
+	ManagedRuleSets *[]*ManagedRuleSet `json:"managedRuleSets,omitempty"`
 }
 
 // Identity for the resource.
@@ -7672,16 +7672,16 @@ type ManagedServiceIdentity struct {
 
 	// The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities *map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties `json:"userAssignedIdentities,omitempty"`
 }
 
 // Define match conditions.
 type MatchCondition struct {
 	// Match value.
-	MatchValues *[]string `json:"matchValues,omitempty"`
+	MatchValues *[]*string `json:"matchValues,omitempty"`
 
 	// List of match variables.
-	MatchVariables *[]MatchVariable `json:"matchVariables,omitempty"`
+	MatchVariables *[]*MatchVariable `json:"matchVariables,omitempty"`
 
 	// Whether this is negate condition or not.
 	NegationConditon *bool `json:"negationConditon,omitempty"`
@@ -7690,7 +7690,7 @@ type MatchCondition struct {
 	Operator *WebApplicationFirewallOperator `json:"operator,omitempty"`
 
 	// List of transforms.
-	Transforms *[]WebApplicationFirewallTransform `json:"transforms,omitempty"`
+	Transforms *[]*WebApplicationFirewallTransform `json:"transforms,omitempty"`
 }
 
 // Define match variables.
@@ -7717,10 +7717,10 @@ type MetricSpecification struct {
 	AggregationType *string `json:"aggregationType,omitempty"`
 
 	// List of availability.
-	Availabilities *[]Availability `json:"availabilities,omitempty"`
+	Availabilities *[]*Availability `json:"availabilities,omitempty"`
 
 	// List of dimensions.
-	Dimensions *[]Dimension `json:"dimensions,omitempty"`
+	Dimensions *[]*Dimension `json:"dimensions,omitempty"`
 
 	// The description of the metric.
 	DisplayDescription *string `json:"displayDescription,omitempty"`
@@ -7769,7 +7769,7 @@ type NatGateway struct {
 	SKU *NatGatewaySKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the zone in which Nat Gateway should be deployed.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Response for ListNatGateways API service call.
@@ -7778,7 +7778,7 @@ type NatGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Nat Gateways that exists in a resource group.
-	Value *[]NatGateway `json:"value,omitempty"`
+	Value *[]*NatGateway `json:"value,omitempty"`
 }
 
 // NatGatewayListResultResponse is the response envelope for operations that return a NatGatewayListResult type.
@@ -7811,16 +7811,16 @@ type NatGatewayPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// An array of public ip addresses associated with the nat gateway resource.
-	PublicIPAddresses *[]SubResource `json:"publicIpAddresses,omitempty"`
+	PublicIPAddresses *[]*SubResource `json:"publicIpAddresses,omitempty"`
 
 	// An array of public ip prefixes associated with the nat gateway resource.
-	PublicIPPrefixes *[]SubResource `json:"publicIpPrefixes,omitempty"`
+	PublicIPPrefixes *[]*SubResource `json:"publicIpPrefixes,omitempty"`
 
 	// READ-ONLY; The resource GUID property of the NAT gateway resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the subnets using this nat gateway resource.
-	Subnets *[]SubResource `json:"subnets,omitempty" azure:"ro"`
+	Subnets *[]*SubResource `json:"subnets,omitempty" azure:"ro"`
 }
 
 // NatGatewayResponse is the response envelope for operations that return a NatGateway type.
@@ -7873,19 +7873,19 @@ type NatGatewaysUpdateTagsOptions struct {
 type NatRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]string `json:"destinationPorts,omitempty"`
+	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols *[]FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols *[]*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NatRuleCondition.
@@ -7934,7 +7934,7 @@ func (n *NatRuleCondition) UnmarshalJSON(data []byte) error {
 // Parameters to get network configuration diagnostic.
 type NetworkConfigurationDiagnosticParameters struct {
 	// List of network configuration diagnostic profiles.
-	Profiles *[]NetworkConfigurationDiagnosticProfile `json:"profiles,omitempty"`
+	Profiles *[]*NetworkConfigurationDiagnosticProfile `json:"profiles,omitempty"`
 
 	// The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application
 	// Gateway.
@@ -7965,7 +7965,7 @@ type NetworkConfigurationDiagnosticProfile struct {
 // Results of network configuration diagnostic on the target resource.
 type NetworkConfigurationDiagnosticResponse struct {
 	// READ-ONLY; List of network configuration diagnostic results.
-	Results *[]NetworkConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
+	Results *[]*NetworkConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
 }
 
 // NetworkConfigurationDiagnosticResponsePollerResponse is the response envelope for operations that asynchronously return a NetworkConfigurationDiagnosticResponse
@@ -8031,7 +8031,7 @@ type NetworkInterfaceAssociation struct {
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// Collection of custom security rules.
-	SecurityRules *[]SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
 }
 
 // DNS settings of a network interface.
@@ -8039,12 +8039,12 @@ type NetworkInterfaceDNSSettings struct {
 	// READ-ONLY; If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are
 	// part of the Availability Set. This property is what is
 	// configured on each of those VMs.
-	AppliedDNSServers *[]string `json:"appliedDnsServers,omitempty" azure:"ro"`
+	AppliedDNSServers *[]*string `json:"appliedDnsServers,omitempty" azure:"ro"`
 
 	// List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with
 	// other IPs, it must be the only value in dnsServers
 	// collection.
-	DNSServers *[]string `json:"dnsServers,omitempty"`
+	DNSServers *[]*string `json:"dnsServers,omitempty"`
 
 	// Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
 	InternalDNSNameLabel *string `json:"internalDnsNameLabel,omitempty"`
@@ -8077,7 +8077,7 @@ type NetworkInterfaceIPConfigurationListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ip configurations.
-	Value *[]NetworkInterfaceIPConfiguration `json:"value,omitempty"`
+	Value *[]*NetworkInterfaceIPConfiguration `json:"value,omitempty"`
 }
 
 // NetworkInterfaceIPConfigurationListResultResponse is the response envelope for operations that return a NetworkInterfaceIPConfigurationListResult type.
@@ -8092,7 +8092,7 @@ type NetworkInterfaceIPConfigurationListResultResponse struct {
 // PrivateLinkConnection properties for the network interface.
 type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
 	// READ-ONLY; List of FQDNs for current private link connection.
-	Fqdns *[]string `json:"fqdns,omitempty" azure:"ro"`
+	Fqdns *[]*string `json:"fqdns,omitempty" azure:"ro"`
 
 	// READ-ONLY; The group ID for current private link connection.
 	GroupID *string `json:"groupId,omitempty" azure:"ro"`
@@ -8104,16 +8104,16 @@ type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
 // Properties of IP configuration.
 type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 	// The reference to ApplicationGatewayBackendAddressPool resource.
-	ApplicationGatewayBackendAddressPools *[]ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools *[]*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Application security groups in which the IP configuration is included.
-	ApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
 
 	// The reference to LoadBalancerBackendAddressPool resource.
-	LoadBalancerBackendAddressPools *[]BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools *[]*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// A list of references of LoadBalancerInboundNatRules.
-	LoadBalancerInboundNatRules *[]InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
+	LoadBalancerInboundNatRules *[]*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
 
 	// Whether this is a primary customer address on the network interface.
 	Primary *bool `json:"primary,omitempty"`
@@ -8140,7 +8140,7 @@ type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 	Subnet *Subnet `json:"subnet,omitempty"`
 
 	// The reference to Virtual Network Taps.
-	VirtualNetworkTaps *[]VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
+	VirtualNetworkTaps *[]*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
 }
 
 // NetworkInterfaceIPConfigurationResponse is the response envelope for operations that return a NetworkInterfaceIPConfiguration type.
@@ -8168,7 +8168,7 @@ type NetworkInterfaceListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of network interfaces in a resource group.
-	Value *[]NetworkInterface `json:"value,omitempty"`
+	Value *[]*NetworkInterface `json:"value,omitempty"`
 }
 
 // NetworkInterfaceListResultResponse is the response envelope for operations that return a NetworkInterfaceListResult type.
@@ -8186,7 +8186,7 @@ type NetworkInterfaceLoadBalancerListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancers.
-	Value *[]LoadBalancer `json:"value,omitempty"`
+	Value *[]*LoadBalancer `json:"value,omitempty"`
 }
 
 // NetworkInterfaceLoadBalancerListResultResponse is the response envelope for operations that return a NetworkInterfaceLoadBalancerListResult type.
@@ -8227,10 +8227,10 @@ type NetworkInterfacePropertiesFormat struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// READ-ONLY; A list of references to linked BareMetal resources.
-	HostedWorkloads *[]string `json:"hostedWorkloads,omitempty" azure:"ro"`
+	HostedWorkloads *[]*string `json:"hostedWorkloads,omitempty" azure:"ro"`
 
 	// A list of IPConfigurations of the network interface.
-	IPConfigurations *[]NetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The MAC address of the network interface.
 	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
@@ -8251,7 +8251,7 @@ type NetworkInterfacePropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of TapConfigurations of the network interface.
-	TapConfigurations *[]NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
+	TapConfigurations *[]*NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The reference to a virtual machine.
 	VirtualMachine *SubResource `json:"virtualMachine,omitempty" azure:"ro"`
@@ -8288,7 +8288,7 @@ type NetworkInterfaceTapConfigurationListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of tap configurations.
-	Value *[]NetworkInterfaceTapConfiguration `json:"value,omitempty"`
+	Value *[]*NetworkInterfaceTapConfiguration `json:"value,omitempty"`
 }
 
 // NetworkInterfaceTapConfigurationListResultResponse is the response envelope for operations that return a NetworkInterfaceTapConfigurationListResult type.
@@ -8487,7 +8487,7 @@ type NetworkProfileListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of network profiles that exist in a resource group.
-	Value *[]NetworkProfile `json:"value,omitempty"`
+	Value *[]*NetworkProfile `json:"value,omitempty"`
 }
 
 // NetworkProfileListResultResponse is the response envelope for operations that return a NetworkProfileListResult type.
@@ -8502,10 +8502,10 @@ type NetworkProfileListResultResponse struct {
 // Network profile properties.
 type NetworkProfilePropertiesFormat struct {
 	// List of chid container network interface configurations.
-	ContainerNetworkInterfaceConfigurations *[]ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
+	ContainerNetworkInterfaceConfigurations *[]*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
 
 	// READ-ONLY; List of child container network interfaces.
-	ContainerNetworkInterfaces *[]ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
+	ContainerNetworkInterfaces *[]*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the network profile resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -8558,22 +8558,22 @@ type NetworkProfilesUpdateTagsOptions struct {
 type NetworkRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups *[]string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups *[]*string `json:"destinationIpGroups,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]string `json:"destinationPorts,omitempty"`
+	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols *[]FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols *[]*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]string `json:"sourceAddresses,omitempty"`
+	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NetworkRuleCondition.
@@ -8639,7 +8639,7 @@ type NetworkSecurityGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of NetworkSecurityGroup resources.
-	Value *[]NetworkSecurityGroup `json:"value,omitempty"`
+	Value *[]*NetworkSecurityGroup `json:"value,omitempty"`
 }
 
 // NetworkSecurityGroupListResultResponse is the response envelope for operations that return a NetworkSecurityGroupListResult type.
@@ -8666,13 +8666,13 @@ type NetworkSecurityGroupPollerResponse struct {
 // Network Security Group resource.
 type NetworkSecurityGroupPropertiesFormat struct {
 	// READ-ONLY; The default security rules of network security group.
-	DefaultSecurityRules *[]SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
+	DefaultSecurityRules *[]*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to flow log resources.
-	FlowLogs *[]FlowLog `json:"flowLogs,omitempty" azure:"ro"`
+	FlowLogs *[]*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to network interfaces.
-	NetworkInterfaces *[]NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the network security group resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -8681,10 +8681,10 @@ type NetworkSecurityGroupPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A collection of security rules of the network security group.
-	SecurityRules *[]SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
 }
 
 // NetworkSecurityGroupResponse is the response envelope for operations that return a NetworkSecurityGroup type.
@@ -8699,7 +8699,7 @@ type NetworkSecurityGroupResponse struct {
 // Network configuration diagnostic result corresponded provided traffic query.
 type NetworkSecurityGroupResult struct {
 	// READ-ONLY; List of results network security groups diagnostic.
-	EvaluatedNetworkSecurityGroups *[]EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
+	EvaluatedNetworkSecurityGroups *[]*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
 
 	// The network traffic is allowed or denied.
 	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
@@ -8779,7 +8779,7 @@ type NetworkVirtualApplianceListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Network Virtual Appliances.
-	Value *[]NetworkVirtualAppliance `json:"value,omitempty"`
+	Value *[]*NetworkVirtualAppliance `json:"value,omitempty"`
 }
 
 // NetworkVirtualApplianceListResultResponse is the response envelope for operations that return a NetworkVirtualApplianceListResult type.
@@ -8806,10 +8806,10 @@ type NetworkVirtualAppliancePollerResponse struct {
 // Network Virtual Appliance definition.
 type NetworkVirtualAppliancePropertiesFormat struct {
 	// BootStrapConfigurationBlob storage URLs.
-	BootStrapConfigurationBlob *[]string `json:"bootStrapConfigurationBlob,omitempty"`
+	BootStrapConfigurationBlob *[]*string `json:"bootStrapConfigurationBlob,omitempty"`
 
 	// CloudInitConfigurationBlob storage URLs.
-	CloudInitConfigurationBlob *[]string `json:"cloudInitConfigurationBlob,omitempty"`
+	CloudInitConfigurationBlob *[]*string `json:"cloudInitConfigurationBlob,omitempty"`
 
 	// READ-ONLY; The provisioning state of the resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -8818,7 +8818,7 @@ type NetworkVirtualAppliancePropertiesFormat struct {
 	VirtualApplianceAsn *int64 `json:"virtualApplianceAsn,omitempty"`
 
 	// READ-ONLY; List of Virtual Appliance Network Interfaces.
-	VirtualApplianceNics *[]VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
+	VirtualApplianceNics *[]*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
 
 	// The Virtual Hub where Network Virtual Appliance is being deployed.
 	VirtualHub *SubResource `json:"virtualHub,omitempty"`
@@ -8877,7 +8877,7 @@ type NetworkWatcher struct {
 // Response for ListNetworkWatchers API service call.
 type NetworkWatcherListResult struct {
 	// List of network watcher resources.
-	Value *[]NetworkWatcher `json:"value,omitempty"`
+	Value *[]*NetworkWatcher `json:"value,omitempty"`
 }
 
 // NetworkWatcherListResultResponse is the response envelope for operations that return a NetworkWatcherListResult type.
@@ -9081,7 +9081,7 @@ type OperationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Network operations supported by the Network resource provider.
-	Value *[]Operation `json:"value,omitempty"`
+	Value *[]*Operation `json:"value,omitempty"`
 }
 
 // OperationListResultResponse is the response envelope for operations that return a OperationListResult type.
@@ -9102,10 +9102,10 @@ type OperationPropertiesFormat struct {
 // Specification of the service.
 type OperationPropertiesFormatServiceSpecification struct {
 	// Operation log specification.
-	LogSpecifications *[]LogSpecification `json:"logSpecifications,omitempty"`
+	LogSpecifications *[]*LogSpecification `json:"logSpecifications,omitempty"`
 
 	// Operation service specification.
-	MetricSpecifications *[]MetricSpecification `json:"metricSpecifications,omitempty"`
+	MetricSpecifications *[]*MetricSpecification `json:"metricSpecifications,omitempty"`
 }
 
 // OperationsListOptions contains the optional parameters for the Operations.List method.
@@ -9142,7 +9142,7 @@ type OutboundRulePropertiesFormat struct {
 	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
 
 	// The Frontend IP addresses of the load balancer.
-	FrontendIPConfigurations *[]SubResource `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations *[]*SubResource `json:"frontendIPConfigurations,omitempty"`
 
 	// The timeout for the TCP idle connection.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -9221,7 +9221,7 @@ type P2SVPNConnectionHealthRequest struct {
 	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
 
 	// The list of p2s vpn user names whose p2s vpn connection detailed health to retrieve for.
-	VPNUserNamesFilter *[]string `json:"vpnUserNamesFilter,omitempty"`
+	VPNUserNamesFilter *[]*string `json:"vpnUserNamesFilter,omitempty"`
 }
 
 // P2SVPNConnectionHealthResponse is the response envelope for operations that return a P2SVPNConnectionHealth type.
@@ -9236,7 +9236,7 @@ type P2SVPNConnectionHealthResponse struct {
 // List of p2s vpn connections to be disconnected.
 type P2SVPNConnectionRequest struct {
 	// List of p2s vpn connection Ids.
-	VPNConnectionIDs *[]string `json:"vpnConnectionIds,omitempty"`
+	VPNConnectionIDs *[]*string `json:"vpnConnectionIds,omitempty"`
 }
 
 // P2SVpnGateway Resource.
@@ -9264,7 +9264,7 @@ type P2SVPNGatewayPollerResponse struct {
 // Parameters for P2SVpnGateway.
 type P2SVPNGatewayProperties struct {
 	// List of all p2s connection configurations of the gateway.
-	P2SConnectionConfigurations *[]P2SConnectionConfiguration `json:"p2SConnectionConfigurations,omitempty"`
+	P2SConnectionConfigurations *[]*P2SConnectionConfiguration `json:"p2SConnectionConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the P2S VPN gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -9383,7 +9383,7 @@ type PacketCaptureFilter struct {
 // List of packet capture sessions.
 type PacketCaptureListResult struct {
 	// Information about packet capture sessions.
-	Value *[]PacketCaptureResult `json:"value,omitempty"`
+	Value *[]*PacketCaptureResult `json:"value,omitempty"`
 }
 
 // PacketCaptureListResultResponse is the response envelope for operations that return a PacketCaptureListResult type.
@@ -9401,7 +9401,7 @@ type PacketCaptureParameters struct {
 	BytesToCapturePerPacket *int32 `json:"bytesToCapturePerPacket,omitempty"`
 
 	// A list of packet capture filters.
-	Filters *[]PacketCaptureFilter `json:"filters,omitempty"`
+	Filters *[]*PacketCaptureFilter `json:"filters,omitempty"`
 
 	// The storage location for a packet capture session.
 	StorageLocation *PacketCaptureStorageLocation `json:"storageLocation,omitempty"`
@@ -9428,7 +9428,7 @@ type PacketCaptureQueryStatusResult struct {
 	Name *string `json:"name,omitempty"`
 
 	// List of errors of packet capture session.
-	PacketCaptureError *[]PcError `json:"packetCaptureError,omitempty"`
+	PacketCaptureError *[]*PcError `json:"packetCaptureError,omitempty"`
 
 	// The status of the packet capture session.
 	PacketCaptureStatus *PcStatus `json:"packetCaptureStatus,omitempty"`
@@ -9607,7 +9607,7 @@ type PatchRouteFilter struct {
 	Properties *RouteFilterPropertiesFormat `json:"properties,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -9648,7 +9648,7 @@ type PeerExpressRouteCircuitConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The global reach peer circuit connection associated with Private Peering in an ExpressRoute Circuit.
-	Value *[]PeerExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value *[]*PeerExpressRouteCircuitConnection `json:"value,omitempty"`
 }
 
 // PeerExpressRouteCircuitConnectionListResultResponse is the response envelope for operations that return a PeerExpressRouteCircuitConnectionListResult
@@ -9725,7 +9725,7 @@ type PolicySettings struct {
 // Details of PrepareNetworkPolicies for Subnet.
 type PrepareNetworkPoliciesRequest struct {
 	// A list of NetworkIntentPolicyConfiguration.
-	NetworkIntentPolicyConfigurations *[]NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
+	NetworkIntentPolicyConfigurations *[]*NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
 
 	// The name of the service for which subnet is being prepared for.
 	ServiceName *string `json:"serviceName,omitempty"`
@@ -9759,7 +9759,7 @@ type PrivateDNSZoneGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of private dns zone group resources in a private endpoint.
-	Value *[]PrivateDNSZoneGroup `json:"value,omitempty"`
+	Value *[]*PrivateDNSZoneGroup `json:"value,omitempty"`
 }
 
 // PrivateDNSZoneGroupListResultResponse is the response envelope for operations that return a PrivateDNSZoneGroupListResult type.
@@ -9786,7 +9786,7 @@ type PrivateDNSZoneGroupPollerResponse struct {
 // Properties of the private dns zone group.
 type PrivateDNSZoneGroupPropertiesFormat struct {
 	// A collection of private dns zone configurations of the private dns zone group.
-	PrivateDNSZoneConfigs *[]PrivateDNSZoneConfig `json:"privateDnsZoneConfigs,omitempty"`
+	PrivateDNSZoneConfigs *[]*PrivateDNSZoneConfig `json:"privateDnsZoneConfigs,omitempty"`
 
 	// READ-ONLY; The provisioning state of the private dns zone group resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -9827,7 +9827,7 @@ type PrivateDNSZonePropertiesFormat struct {
 	PrivateDNSZoneID *string `json:"privateDnsZoneId,omitempty"`
 
 	// READ-ONLY; A collection of information regarding a recordSet, holding information to identify private resources.
-	RecordSets *[]RecordSet `json:"recordSets,omitempty" azure:"ro"`
+	RecordSets *[]*RecordSet `json:"recordSets,omitempty" azure:"ro"`
 }
 
 // Private endpoint resource.
@@ -9862,7 +9862,7 @@ type PrivateEndpointConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of PrivateEndpointConnection resources for a specific private link service.
-	Value *[]PrivateEndpointConnection `json:"value,omitempty"`
+	Value *[]*PrivateEndpointConnection `json:"value,omitempty"`
 }
 
 // PrivateEndpointConnectionListResultResponse is the response envelope for operations that return a PrivateEndpointConnectionListResult type.
@@ -9904,7 +9904,7 @@ type PrivateEndpointListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of private endpoint resources in a resource group.
-	Value *[]PrivateEndpoint `json:"value,omitempty"`
+	Value *[]*PrivateEndpoint `json:"value,omitempty"`
 }
 
 // PrivateEndpointListResultResponse is the response envelope for operations that return a PrivateEndpointListResult type.
@@ -9931,17 +9931,17 @@ type PrivateEndpointPollerResponse struct {
 // Properties of the private endpoint.
 type PrivateEndpointProperties struct {
 	// An array of custom dns configurations.
-	CustomDNSConfigs *[]CustomDNSConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomDNSConfigs *[]*CustomDNSConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
 
 	// A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the
 	// remote resource.
-	ManualPrivateLinkServiceConnections *[]PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+	ManualPrivateLinkServiceConnections *[]*PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private endpoint.
-	NetworkInterfaces *[]NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// A grouping of information about the connection to the remote resource.
-	PrivateLinkServiceConnections *[]PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
+	PrivateLinkServiceConnections *[]*PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the private endpoint resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10014,7 +10014,7 @@ type PrivateLinkServiceConnection struct {
 // Properties of the PrivateLinkServiceConnection.
 type PrivateLinkServiceConnectionProperties struct {
 	// The ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.
-	GroupIDs *[]string `json:"groupIds,omitempty"`
+	GroupIDs *[]*string `json:"groupIds,omitempty"`
 
 	// A collection of read-only information about the state of the connection to the remote resource.
 	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
@@ -10084,7 +10084,7 @@ type PrivateLinkServiceListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of PrivateLinkService resources in a resource group.
-	Value *[]PrivateLinkService `json:"value,omitempty"`
+	Value *[]*PrivateLinkService `json:"value,omitempty"`
 }
 
 // PrivateLinkServiceListResultResponse is the response envelope for operations that return a PrivateLinkServiceListResult type.
@@ -10120,19 +10120,19 @@ type PrivateLinkServiceProperties struct {
 	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty"`
 
 	// The list of Fqdn.
-	Fqdns *[]string `json:"fqdns,omitempty"`
+	Fqdns *[]*string `json:"fqdns,omitempty"`
 
 	// An array of private link service IP configurations.
-	IPConfigurations *[]PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// An array of references to the load balancer IP configurations.
-	LoadBalancerFrontendIPConfigurations *[]FrontendIPConfiguration `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations *[]*FrontendIPConfiguration `json:"loadBalancerFrontendIpConfigurations,omitempty"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private link service.
-	NetworkInterfaces *[]NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of list about connections to the private endpoint.
-	PrivateEndpointConnections *[]PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
+	PrivateEndpointConnections *[]*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the private link service resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10285,7 +10285,7 @@ type ProbePropertiesFormat struct {
 	IntervalInSeconds *int32 `json:"intervalInSeconds,omitempty"`
 
 	// READ-ONLY; The load balancer rules that use this probe.
-	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// The number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints
 	// to be taken out of rotation faster or slower than
@@ -10353,7 +10353,7 @@ type PublicIPAddress struct {
 	SKU *PublicIPAddressSKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Contains FQDN of the DNS record associated with the public IP address.
@@ -10379,7 +10379,7 @@ type PublicIPAddressListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of public IP addresses that exists in a resource group.
-	Value *[]PublicIPAddress `json:"value,omitempty"`
+	Value *[]*PublicIPAddress `json:"value,omitempty"`
 }
 
 // PublicIPAddressListResultResponse is the response envelope for operations that return a PublicIPAddressListResult type.
@@ -10418,7 +10418,7 @@ type PublicIPAddressPropertiesFormat struct {
 	IPConfiguration *IPConfiguration `json:"ipConfiguration,omitempty" azure:"ro"`
 
 	// The list of tags associated with the public IP address.
-	IPTags *[]IPTag `json:"ipTags,omitempty"`
+	IPTags *[]*IPTag `json:"ipTags,omitempty"`
 
 	// The idle timeout of the public IP address.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -10517,7 +10517,7 @@ type PublicIPPrefix struct {
 	SKU *PublicIPPrefixSKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]string `json:"zones,omitempty"`
+	Zones *[]*string `json:"zones,omitempty"`
 }
 
 // Response for ListPublicIpPrefixes API service call.
@@ -10526,7 +10526,7 @@ type PublicIPPrefixListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of public IP prefixes that exists in a resource group.
-	Value *[]PublicIPPrefix `json:"value,omitempty"`
+	Value *[]*PublicIPPrefix `json:"value,omitempty"`
 }
 
 // PublicIPPrefixListResultResponse is the response envelope for operations that return a PublicIPPrefixListResult type.
@@ -10556,7 +10556,7 @@ type PublicIPPrefixPropertiesFormat struct {
 	IPPrefix *string `json:"ipPrefix,omitempty" azure:"ro"`
 
 	// The list of tags associated with the public IP prefix.
-	IPTags *[]IPTag `json:"ipTags,omitempty"`
+	IPTags *[]*IPTag `json:"ipTags,omitempty"`
 
 	// READ-ONLY; The reference to load balancer frontend IP configuration associated with the public IP prefix.
 	LoadBalancerFrontendIPConfiguration *SubResource `json:"loadBalancerFrontendIpConfiguration,omitempty" azure:"ro"`
@@ -10571,7 +10571,7 @@ type PublicIPPrefixPropertiesFormat struct {
 	PublicIPAddressVersion *IPVersion `json:"publicIPAddressVersion,omitempty"`
 
 	// READ-ONLY; The list of all referenced PublicIPAddresses.
-	PublicIPAddresses *[]ReferencedPublicIPAddress `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses *[]*ReferencedPublicIPAddress `json:"publicIPAddresses,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the public IP prefix resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
@@ -10647,7 +10647,7 @@ type RecordSet struct {
 	Fqdn *string `json:"fqdn,omitempty"`
 
 	// The private ip address of the private endpoint.
-	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
 
 	// READ-ONLY; The provisioning state of the recordset.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10680,7 +10680,7 @@ type Resource struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
@@ -10725,7 +10725,7 @@ type ResourceNavigationLinksListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The resource navigation links in a subnet.
-	Value *[]ResourceNavigationLink `json:"value,omitempty"`
+	Value *[]*ResourceNavigationLink `json:"value,omitempty"`
 }
 
 // ResourceNavigationLinksListResultResponse is the response envelope for operations that return a ResourceNavigationLinksListResult type.
@@ -10740,7 +10740,7 @@ type ResourceNavigationLinksListResultResponse struct {
 // The base resource set for visibility and auto-approval.
 type ResourceSet struct {
 	// The list of subscriptions.
-	Subscriptions *[]string `json:"subscriptions,omitempty"`
+	Subscriptions *[]*string `json:"subscriptions,omitempty"`
 }
 
 // Parameters that define the retention policy for flow log.
@@ -10781,7 +10781,7 @@ type RouteFilterListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of route filters in a resource group.
-	Value *[]RouteFilter `json:"value,omitempty"`
+	Value *[]*RouteFilter `json:"value,omitempty"`
 }
 
 // RouteFilterListResultResponse is the response envelope for operations that return a RouteFilterListResult type.
@@ -10808,16 +10808,16 @@ type RouteFilterPollerResponse struct {
 // Route Filter Resource.
 type RouteFilterPropertiesFormat struct {
 	// READ-ONLY; A collection of references to express route circuit ipv6 peerings.
-	IPv6Peerings *[]ExpressRouteCircuitPeering `json:"ipv6Peerings,omitempty" azure:"ro"`
+	IPv6Peerings *[]*ExpressRouteCircuitPeering `json:"ipv6Peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to express route circuit peerings.
-	Peerings *[]ExpressRouteCircuitPeering `json:"peerings,omitempty" azure:"ro"`
+	Peerings *[]*ExpressRouteCircuitPeering `json:"peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the route filter resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of RouteFilterRules contained within a route filter.
-	Rules *[]RouteFilterRule `json:"rules,omitempty"`
+	Rules *[]*RouteFilterRule `json:"rules,omitempty"`
 }
 
 // RouteFilterResponse is the response envelope for operations that return a RouteFilter type.
@@ -10851,7 +10851,7 @@ type RouteFilterRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of RouteFilterRules in a resource group.
-	Value *[]RouteFilterRule `json:"value,omitempty"`
+	Value *[]*RouteFilterRule `json:"value,omitempty"`
 }
 
 // RouteFilterRuleListResultResponse is the response envelope for operations that return a RouteFilterRuleListResult type.
@@ -10881,7 +10881,7 @@ type RouteFilterRulePropertiesFormat struct {
 	Access *Access `json:"access,omitempty"`
 
 	// The collection for bgp community values to filter on. e.g. ['12076:5010','12076:5020'].
-	Communities *[]string `json:"communities,omitempty"`
+	Communities *[]*string `json:"communities,omitempty"`
 
 	// READ-ONLY; The provisioning state of the route filter rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10956,7 +10956,7 @@ type RouteListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of routes in a resource group.
-	Value *[]Route `json:"value,omitempty"`
+	Value *[]*Route `json:"value,omitempty"`
 }
 
 // RouteListResultResponse is the response envelope for operations that return a RouteListResult type.
@@ -11020,7 +11020,7 @@ type RouteTableListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of route tables in a resource group.
-	Value *[]RouteTable `json:"value,omitempty"`
+	Value *[]*RouteTable `json:"value,omitempty"`
 }
 
 // RouteTableListResultResponse is the response envelope for operations that return a RouteTableListResult type.
@@ -11053,10 +11053,10 @@ type RouteTablePropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of routes contained within a route table.
-	Routes *[]Route `json:"routes,omitempty"`
+	Routes *[]*Route `json:"routes,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
 }
 
 // RouteTableResponse is the response envelope for operations that return a RouteTable type.
@@ -11137,7 +11137,7 @@ type SecurityGroupViewParameters struct {
 // The information about security rules applied to the specified VM.
 type SecurityGroupViewResult struct {
 	// List of network interfaces on the specified VM.
-	NetworkInterfaces *[]SecurityGroupNetworkInterface `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces *[]*SecurityGroupNetworkInterface `json:"networkInterfaces,omitempty"`
 }
 
 // SecurityGroupViewResultPollerResponse is the response envelope for operations that asynchronously return a SecurityGroupViewResult type.
@@ -11177,7 +11177,7 @@ type SecurityPartnerProviderListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Security Partner Providers in a resource group.
-	Value *[]SecurityPartnerProvider `json:"value,omitempty"`
+	Value *[]*SecurityPartnerProvider `json:"value,omitempty"`
 }
 
 // SecurityPartnerProviderListResultResponse is the response envelope for operations that return a SecurityPartnerProviderListResult type.
@@ -11271,10 +11271,10 @@ type SecurityRule struct {
 // All security rules associated with the network interface.
 type SecurityRuleAssociations struct {
 	// Collection of default security rules of the network security group.
-	DefaultSecurityRules *[]SecurityRule `json:"defaultSecurityRules,omitempty"`
+	DefaultSecurityRules *[]*SecurityRule `json:"defaultSecurityRules,omitempty"`
 
 	// Collection of effective security rules.
-	EffectiveSecurityRules *[]EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules *[]*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
 
 	// Network interface and it's custom security rules.
 	NetworkInterfaceAssociation *NetworkInterfaceAssociation `json:"networkInterfaceAssociation,omitempty"`
@@ -11289,7 +11289,7 @@ type SecurityRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The security rules in a network security group.
-	Value *[]SecurityRule `json:"value,omitempty"`
+	Value *[]*SecurityRule `json:"value,omitempty"`
 }
 
 // SecurityRuleListResultResponse is the response envelope for operations that return a SecurityRuleListResult type.
@@ -11327,16 +11327,16 @@ type SecurityRulePropertiesFormat struct {
 	DestinationAddressPrefix *string `json:"destinationAddressPrefix,omitempty"`
 
 	// The destination address prefixes. CIDR or destination IP ranges.
-	DestinationAddressPrefixes *[]string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes *[]*string `json:"destinationAddressPrefixes,omitempty"`
 
 	// The application security group specified as destination.
-	DestinationApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
 
 	// The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
 	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
 
 	// The destination port ranges.
-	DestinationPortRanges *[]string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges *[]*string `json:"destinationPortRanges,omitempty"`
 
 	// The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 	Direction *SecurityRuleDirection `json:"direction,omitempty"`
@@ -11357,16 +11357,16 @@ type SecurityRulePropertiesFormat struct {
 	SourceAddressPrefix *string `json:"sourceAddressPrefix,omitempty"`
 
 	// The CIDR or source IP ranges.
-	SourceAddressPrefixes *[]string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes *[]*string `json:"sourceAddressPrefixes,omitempty"`
 
 	// The application security group specified as source.
-	SourceApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourceApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
 
 	// The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
 	SourcePortRange *string `json:"sourcePortRange,omitempty"`
 
 	// The source port ranges.
-	SourcePortRanges *[]string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges *[]*string `json:"sourcePortRanges,omitempty"`
 }
 
 // SecurityRuleResponse is the response envelope for operations that return a SecurityRule type.
@@ -11426,7 +11426,7 @@ type ServiceAssociationLinkPropertiesFormat struct {
 	LinkedResourceType *string `json:"linkedResourceType,omitempty"`
 
 	// A list of locations.
-	Locations *[]string `json:"locations,omitempty"`
+	Locations *[]*string `json:"locations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the service association link resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -11443,7 +11443,7 @@ type ServiceAssociationLinksListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The service association links in a subnet.
-	Value *[]ServiceAssociationLink `json:"value,omitempty"`
+	Value *[]*ServiceAssociationLink `json:"value,omitempty"`
 }
 
 // ServiceAssociationLinksListResultResponse is the response envelope for operations that return a ServiceAssociationLinksListResult type.
@@ -11458,7 +11458,7 @@ type ServiceAssociationLinksListResultResponse struct {
 // Properties of a service delegation.
 type ServiceDelegationPropertiesFormat struct {
 	// READ-ONLY; The actions permitted to the service upon delegation.
-	Actions *[]string `json:"actions,omitempty" azure:"ro"`
+	Actions *[]*string `json:"actions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the service delegation resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -11528,7 +11528,7 @@ type ServiceEndpointPolicyDefinitionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The service endpoint policy definition in a service endpoint policy.
-	Value *[]ServiceEndpointPolicyDefinition `json:"value,omitempty"`
+	Value *[]*ServiceEndpointPolicyDefinition `json:"value,omitempty"`
 }
 
 // ServiceEndpointPolicyDefinitionListResultResponse is the response envelope for operations that return a ServiceEndpointPolicyDefinitionListResult type.
@@ -11565,7 +11565,7 @@ type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
 	Service *string `json:"service,omitempty"`
 
 	// A list of service resources.
-	ServiceResources *[]string `json:"serviceResources,omitempty"`
+	ServiceResources *[]*string `json:"serviceResources,omitempty"`
 }
 
 // ServiceEndpointPolicyDefinitionResponse is the response envelope for operations that return a ServiceEndpointPolicyDefinition type.
@@ -11605,7 +11605,7 @@ type ServiceEndpointPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ServiceEndpointPolicy resources.
-	Value *[]ServiceEndpointPolicy `json:"value,omitempty"`
+	Value *[]*ServiceEndpointPolicy `json:"value,omitempty"`
 }
 
 // ServiceEndpointPolicyListResultResponse is the response envelope for operations that return a ServiceEndpointPolicyListResult type.
@@ -11638,10 +11638,10 @@ type ServiceEndpointPolicyPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A collection of service endpoint policy definitions of the service endpoint policy.
-	ServiceEndpointPolicyDefinitions *[]ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	ServiceEndpointPolicyDefinitions *[]*ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
 }
 
 // ServiceEndpointPolicyResponse is the response envelope for operations that return a ServiceEndpointPolicy type.
@@ -11656,7 +11656,7 @@ type ServiceEndpointPolicyResponse struct {
 // The service endpoint properties.
 type ServiceEndpointPropertiesFormat struct {
 	// A list of locations.
-	Locations *[]string `json:"locations,omitempty"`
+	Locations *[]*string `json:"locations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the service endpoint resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -11680,7 +11680,7 @@ type ServiceTagInformation struct {
 // Properties of the service tag information.
 type ServiceTagInformationPropertiesFormat struct {
 	// READ-ONLY; The list of IP address prefixes.
-	AddressPrefixes *[]string `json:"addressPrefixes,omitempty" azure:"ro"`
+	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty" azure:"ro"`
 
 	// READ-ONLY; The iteration number of service tag.
 	ChangeNumber *string `json:"changeNumber,omitempty" azure:"ro"`
@@ -11715,7 +11715,7 @@ type ServiceTagsListResult struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of service tag information resources.
-	Values *[]ServiceTagInformation `json:"values,omitempty" azure:"ro"`
+	Values *[]*ServiceTagInformation `json:"values,omitempty" azure:"ro"`
 }
 
 // ServiceTagsListResultResponse is the response envelope for operations that return a ServiceTagsListResult type.
@@ -11730,16 +11730,16 @@ type ServiceTagsListResultResponse struct {
 // List of session IDs.
 type SessionIDs struct {
 	// List of session IDs.
-	SessionIDs *[]string `json:"sessionIds,omitempty"`
+	SessionIDs *[]*string `json:"sessionIds,omitempty"`
 }
 
-// StringArrayResponse is the response envelope for operations that return a []string type.
+// StringArrayResponse is the response envelope for operations that return a []*string type.
 type StringArrayResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 
 	// Response for ApplicationGatewayAvailableServerVariables API service call.
-	StringArray []string
+	StringArray []*string
 }
 
 // StringPollerResponse is the response envelope for operations that asynchronously return a string type.
@@ -11786,7 +11786,7 @@ type SubnetAssociation struct {
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// Collection of custom security rules.
-	SecurityRules *[]SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
 }
 
 // Response for ListSubnets API service callRetrieves all subnet that belongs to a virtual network.
@@ -11795,7 +11795,7 @@ type SubnetListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The subnets in a virtual network.
-	Value *[]Subnet `json:"value,omitempty"`
+	Value *[]*Subnet `json:"value,omitempty"`
 }
 
 // SubnetListResultResponse is the response envelope for operations that return a SubnetListResult type.
@@ -11825,19 +11825,19 @@ type SubnetPropertiesFormat struct {
 	AddressPrefix *string `json:"addressPrefix,omitempty"`
 
 	// List of address prefixes for the subnet.
-	AddressPrefixes *[]string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
 
 	// An array of references to the delegations on the subnet.
-	Delegations *[]Delegation `json:"delegations,omitempty"`
+	Delegations *[]*Delegation `json:"delegations,omitempty"`
 
 	// Array of IpAllocation which reference this subnet.
-	IPAllocations *[]SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations *[]*SubResource `json:"ipAllocations,omitempty"`
 
 	// READ-ONLY; Array of IP configuration profiles which reference this subnet.
-	IPConfigurationProfiles *[]IPConfigurationProfile `json:"ipConfigurationProfiles,omitempty" azure:"ro"`
+	IPConfigurationProfiles *[]*IPConfigurationProfile `json:"ipConfigurationProfiles,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the network interface IP configurations using subnet.
-	IPConfigurations *[]IPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations *[]*IPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
 
 	// Nat gateway associated with this subnet.
 	NatGateway *SubResource `json:"natGateway,omitempty"`
@@ -11849,7 +11849,7 @@ type SubnetPropertiesFormat struct {
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty"`
 
 	// READ-ONLY; An array of references to private endpoints.
-	PrivateEndpoints *[]PrivateEndpoint `json:"privateEndpoints,omitempty" azure:"ro"`
+	PrivateEndpoints *[]*PrivateEndpoint `json:"privateEndpoints,omitempty" azure:"ro"`
 
 	// Enable or Disable apply network policies on private link service in the subnet.
 	PrivateLinkServiceNetworkPolicies *string `json:"privateLinkServiceNetworkPolicies,omitempty"`
@@ -11861,19 +11861,19 @@ type SubnetPropertiesFormat struct {
 	Purpose *string `json:"purpose,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the external resources using subnet.
-	ResourceNavigationLinks *[]ResourceNavigationLink `json:"resourceNavigationLinks,omitempty" azure:"ro"`
+	ResourceNavigationLinks *[]*ResourceNavigationLink `json:"resourceNavigationLinks,omitempty" azure:"ro"`
 
 	// The reference to the RouteTable resource.
 	RouteTable *RouteTable `json:"routeTable,omitempty"`
 
 	// READ-ONLY; An array of references to services injecting into this subnet.
-	ServiceAssociationLinks *[]ServiceAssociationLink `json:"serviceAssociationLinks,omitempty" azure:"ro"`
+	ServiceAssociationLinks *[]*ServiceAssociationLink `json:"serviceAssociationLinks,omitempty" azure:"ro"`
 
 	// An array of service endpoint policies.
-	ServiceEndpointPolicies *[]ServiceEndpointPolicy `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpointPolicies *[]*ServiceEndpointPolicy `json:"serviceEndpointPolicies,omitempty"`
 
 	// An array of service endpoints.
-	ServiceEndpoints *[]ServiceEndpointPropertiesFormat `json:"serviceEndpoints,omitempty"`
+	ServiceEndpoints *[]*ServiceEndpointPropertiesFormat `json:"serviceEndpoints,omitempty"`
 }
 
 // SubnetResponse is the response envelope for operations that return a Subnet type.
@@ -11919,7 +11919,7 @@ type SubnetsListOptions struct {
 // Tags object for patch operations.
 type TagsObject struct {
 	// Resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type TagsObject.
@@ -11941,7 +11941,7 @@ type Topology struct {
 	LastModified *time.Time `json:"lastModified,omitempty" azure:"ro"`
 
 	// A list of topology resources.
-	Resources *[]TopologyResource `json:"resources,omitempty"`
+	Resources *[]*TopologyResource `json:"resources,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type Topology.
@@ -12014,7 +12014,7 @@ type TopologyParameters struct {
 // The network resource topology information for the given resource group.
 type TopologyResource struct {
 	// Holds the associations the resource has with other resources in the resource group.
-	Associations *[]TopologyAssociation `json:"associations,omitempty"`
+	Associations *[]*TopologyAssociation `json:"associations,omitempty"`
 
 	// ID of the resource.
 	ID *string `json:"id,omitempty"`
@@ -12062,10 +12062,10 @@ type TrafficAnalyticsProperties struct {
 // An traffic selector policy for a virtual network gateway connection.
 type TrafficSelectorPolicy struct {
 	// A collection of local address spaces in CIDR format.
-	LocalAddressRanges *[]string `json:"localAddressRanges,omitempty"`
+	LocalAddressRanges *[]*string `json:"localAddressRanges,omitempty"`
 
 	// A collection of remote address spaces in CIDR format.
-	RemoteAddressRanges *[]string `json:"remoteAddressRanges,omitempty"`
+	RemoteAddressRanges *[]*string `json:"remoteAddressRanges,omitempty"`
 }
 
 // Information gained from troubleshooting of specified resource.
@@ -12080,7 +12080,7 @@ type TroubleshootingDetails struct {
 	ReasonType *string `json:"reasonType,omitempty"`
 
 	// List of recommended actions.
-	RecommendedActions *[]TroubleshootingRecommendedActions `json:"recommendedActions,omitempty"`
+	RecommendedActions *[]*TroubleshootingRecommendedActions `json:"recommendedActions,omitempty"`
 
 	// A summary of troubleshooting.
 	Summary *string `json:"summary,omitempty"`
@@ -12128,7 +12128,7 @@ type TroubleshootingResult struct {
 	EndTime *time.Time `json:"endTime,omitempty"`
 
 	// Information from troubleshooting.
-	Results *[]TroubleshootingDetails `json:"results,omitempty"`
+	Results *[]*TroubleshootingDetails `json:"results,omitempty"`
 
 	// The start time of the troubleshooting.
 	StartTime *time.Time `json:"startTime,omitempty"`
@@ -12260,7 +12260,7 @@ type UsagesListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list network resource usages.
-	Value *[]Usage `json:"value,omitempty"`
+	Value *[]*Usage `json:"value,omitempty"`
 }
 
 // UsagesListResultResponse is the response envelope for operations that return a UsagesListResult type.
@@ -12295,28 +12295,28 @@ type VPNClientConfiguration struct {
 	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
 
 	// The radiusServers property for multiple radius server configuration.
-	RadiusServers *[]RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers *[]*RadiusServer `json:"radiusServers,omitempty"`
 
 	// The reference to the address space resource which represents Address space for P2S VpnClient.
 	VPNClientAddressPool *AddressSpace `json:"vpnClientAddressPool,omitempty"`
 
 	// VpnClientIpsecPolicies for virtual network gateway P2S client.
-	VPNClientIPSecPolicies *[]IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies *[]*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
 
 	// VpnClientProtocols for Virtual network gateway.
-	VPNClientProtocols *[]VPNClientProtocol `json:"vpnClientProtocols,omitempty"`
+	VPNClientProtocols *[]*VPNClientProtocol `json:"vpnClientProtocols,omitempty"`
 
 	// VpnClientRevokedCertificate for Virtual network gateway.
-	VPNClientRevokedCertificates *[]VPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates *[]*VPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
 
 	// VpnClientRootCertificate for virtual network gateway.
-	VPNClientRootCertificates *[]VPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates *[]*VPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
 }
 
 // VpnClientConnectionHealth properties.
 type VPNClientConnectionHealth struct {
 	// List of allocated ip addresses to the connected p2s vpn clients.
-	AllocatedIPAddresses *[]string `json:"allocatedIpAddresses,omitempty"`
+	AllocatedIPAddresses *[]*string `json:"allocatedIpAddresses,omitempty"`
 
 	// READ-ONLY; Total of the Egress Bytes Transferred in this connection.
 	TotalEgressBytesTransferred *int64 `json:"totalEgressBytesTransferred,omitempty" azure:"ro"`
@@ -12370,7 +12370,7 @@ type VPNClientConnectionHealthDetail struct {
 // List of virtual network gateway vpn client connection health.
 type VPNClientConnectionHealthDetailListResult struct {
 	// List of vpn client connection health.
-	Value *[]VPNClientConnectionHealthDetail `json:"value,omitempty"`
+	Value *[]*VPNClientConnectionHealthDetail `json:"value,omitempty"`
 }
 
 // VPNClientConnectionHealthDetailListResultPollerResponse is the response envelope for operations that asynchronously return a VPNClientConnectionHealthDetailListResult
@@ -12450,7 +12450,7 @@ type VPNClientParameters struct {
 
 	// A list of client root certificates public certificate data encoded as Base-64 strings. Optional parameter for external radius based authentication with
 	// EAPTLS.
-	ClientRootCertificates *[]string `json:"clientRootCertificates,omitempty"`
+	ClientRootCertificates *[]*string `json:"clientRootCertificates,omitempty"`
 
 	// VPN client Processor Architecture.
 	ProcessorArchitecture *ProcessorArchitecture `json:"processorArchitecture,omitempty"`
@@ -12554,7 +12554,7 @@ type VPNConnectionProperties struct {
 	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; Ingress bytes transferred.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -12581,7 +12581,7 @@ type VPNConnectionProperties struct {
 	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol `json:"vpnConnectionProtocolType,omitempty"`
 
 	// List of all vpn site link connections to the gateway.
-	VPNLinkConnections *[]VPNSiteLinkConnection `json:"vpnLinkConnections,omitempty"`
+	VPNLinkConnections *[]*VPNSiteLinkConnection `json:"vpnLinkConnections,omitempty"`
 }
 
 // VPNConnectionResponse is the response envelope for operations that return a VPNConnection type.
@@ -12653,7 +12653,7 @@ type VPNGatewayProperties struct {
 	BgpSettings *BgpSettings `json:"bgpSettings,omitempty"`
 
 	// List of all vpn connections to the gateway.
-	Connections *[]VPNConnection `json:"connections,omitempty"`
+	Connections *[]*VPNConnection `json:"connections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the VPN gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -12841,40 +12841,40 @@ type VPNServerConfigurationProperties struct {
 	Name *string `json:"name,omitempty"`
 
 	// READ-ONLY; List of references to P2SVpnGateways.
-	P2SVPNGateways *[]P2SVPNGateway `json:"p2SVpnGateways,omitempty" azure:"ro"`
+	P2SVPNGateways *[]*P2SVPNGateway `json:"p2SVpnGateways,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the VpnServerConfiguration resource. Possible values are: 'Updating', 'Deleting', and 'Failed'.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Radius client root certificate of VpnServerConfiguration.
-	RadiusClientRootCertificates *[]VPNServerConfigRadiusClientRootCertificate `json:"radiusClientRootCertificates,omitempty"`
+	RadiusClientRootCertificates *[]*VPNServerConfigRadiusClientRootCertificate `json:"radiusClientRootCertificates,omitempty"`
 
 	// The radius server address property of the VpnServerConfiguration resource for point to site client connection.
 	RadiusServerAddress *string `json:"radiusServerAddress,omitempty"`
 
 	// Radius Server root certificate of VpnServerConfiguration.
-	RadiusServerRootCertificates *[]VPNServerConfigRadiusServerRootCertificate `json:"radiusServerRootCertificates,omitempty"`
+	RadiusServerRootCertificates *[]*VPNServerConfigRadiusServerRootCertificate `json:"radiusServerRootCertificates,omitempty"`
 
 	// The radius secret property of the VpnServerConfiguration resource for point to site client connection.
 	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
 
 	// Multiple Radius Server configuration for VpnServerConfiguration.
-	RadiusServers *[]RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers *[]*RadiusServer `json:"radiusServers,omitempty"`
 
 	// VPN authentication types for the VpnServerConfiguration.
-	VPNAuthenticationTypes *[]VPNAuthenticationType `json:"vpnAuthenticationTypes,omitempty"`
+	VPNAuthenticationTypes *[]*VPNAuthenticationType `json:"vpnAuthenticationTypes,omitempty"`
 
 	// VpnClientIpsecPolicies for VpnServerConfiguration.
-	VPNClientIPSecPolicies *[]IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies *[]*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
 
 	// VPN client revoked certificate of VpnServerConfiguration.
-	VPNClientRevokedCertificates *[]VPNServerConfigVPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates *[]*VPNServerConfigVPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
 
 	// VPN client root certificate of VpnServerConfiguration.
-	VPNClientRootCertificates *[]VPNServerConfigVPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates *[]*VPNServerConfigVPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
 
 	// VPN protocols for the VpnServerConfiguration.
-	VPNProtocols *[]VPNGatewayTunnelingProtocol `json:"vpnProtocols,omitempty"`
+	VPNProtocols *[]*VPNGatewayTunnelingProtocol `json:"vpnProtocols,omitempty"`
 }
 
 // VPNServerConfigurationResponse is the response envelope for operations that return a VPNServerConfiguration type.
@@ -12920,7 +12920,7 @@ type VPNServerConfigurationsListOptions struct {
 // VpnServerConfigurations list associated with VirtualWan Response.
 type VPNServerConfigurationsResponse struct {
 	// List of VpnServerConfigurations associated with VirtualWan.
-	VPNServerConfigurationResourceIDs *[]string `json:"vpnServerConfigurationResourceIds,omitempty"`
+	VPNServerConfigurationResourceIDs *[]*string `json:"vpnServerConfigurationResourceIds,omitempty"`
 }
 
 // VPNServerConfigurationsResponsePollerResponse is the response envelope for operations that asynchronously return a VPNServerConfigurationsResponse type.
@@ -13015,7 +13015,7 @@ type VPNSiteLinkConnectionProperties struct {
 	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; Ingress bytes transferred.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -13129,7 +13129,7 @@ type VPNSiteProperties struct {
 	SiteKey *string `json:"siteKey,omitempty"`
 
 	// List of all vpn site links.
-	VPNSiteLinks *[]VPNSiteLink `json:"vpnSiteLinks,omitempty"`
+	VPNSiteLinks *[]*VPNSiteLink `json:"vpnSiteLinks,omitempty"`
 
 	// The VirtualWAN to which the vpnSite belongs.
 	VirtualWan *SubResource `json:"virtualWan,omitempty"`
@@ -13322,10 +13322,10 @@ type VirtualHubProperties struct {
 	VPNGateway *SubResource `json:"vpnGateway,omitempty"`
 
 	// List of all virtual hub route table v2s associated with this VirtualHub.
-	VirtualHubRouteTableV2S *[]VirtualHubRouteTableV2 `json:"virtualHubRouteTableV2s,omitempty"`
+	VirtualHubRouteTableV2S *[]*VirtualHubRouteTableV2 `json:"virtualHubRouteTableV2s,omitempty"`
 
 	// List of all vnet connections with this VirtualHub.
-	VirtualNetworkConnections *[]HubVirtualNetworkConnection `json:"virtualNetworkConnections,omitempty"`
+	VirtualNetworkConnections *[]*HubVirtualNetworkConnection `json:"virtualNetworkConnections,omitempty"`
 
 	// The VirtualWAN to which the VirtualHub belongs.
 	VirtualWan *SubResource `json:"virtualWan,omitempty"`
@@ -13343,7 +13343,7 @@ type VirtualHubResponse struct {
 // VirtualHub route.
 type VirtualHubRoute struct {
 	// List of all addressPrefixes.
-	AddressPrefixes *[]string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
 
 	// NextHop ip address.
 	NextHopIPAddress *string `json:"nextHopIpAddress,omitempty"`
@@ -13352,7 +13352,7 @@ type VirtualHubRoute struct {
 // VirtualHub route table.
 type VirtualHubRouteTable struct {
 	// List of all routes.
-	Routes *[]VirtualHubRoute `json:"routes,omitempty"`
+	Routes *[]*VirtualHubRoute `json:"routes,omitempty"`
 }
 
 // VirtualHubRouteTableV2 Resource.
@@ -13383,13 +13383,13 @@ type VirtualHubRouteTableV2PollerResponse struct {
 // Parameters for VirtualHubRouteTableV2.
 type VirtualHubRouteTableV2Properties struct {
 	// List of all connections attached to this route table v2.
-	AttachedConnections *[]string `json:"attachedConnections,omitempty"`
+	AttachedConnections *[]*string `json:"attachedConnections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the virtual hub route table v2 resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// List of all routes.
-	Routes *[]VirtualHubRouteV2 `json:"routes,omitempty"`
+	Routes *[]*VirtualHubRouteV2 `json:"routes,omitempty"`
 }
 
 // VirtualHubRouteTableV2Response is the response envelope for operations that return a VirtualHubRouteTableV2 type.
@@ -13427,13 +13427,13 @@ type VirtualHubRouteV2 struct {
 	DestinationType *string `json:"destinationType,omitempty"`
 
 	// List of all destinations.
-	Destinations *[]string `json:"destinations,omitempty"`
+	Destinations *[]*string `json:"destinations,omitempty"`
 
 	// The type of next hops.
 	NextHopType *string `json:"nextHopType,omitempty"`
 
 	// NextHops ip address.
-	NextHops *[]string `json:"nextHops,omitempty"`
+	NextHops *[]*string `json:"nextHops,omitempty"`
 }
 
 // VirtualHubsBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubs.BeginCreateOrUpdate method.
@@ -13545,7 +13545,7 @@ type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -13569,10 +13569,10 @@ type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	SharedKey *string `json:"sharedKey,omitempty"`
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies *[]TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies *[]*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus *[]TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus *[]*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
 
 	// Enable policy-based traffic selectors.
 	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
@@ -13590,7 +13590,7 @@ type VirtualNetworkGatewayConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value *[]VirtualNetworkGatewayConnection `json:"value,omitempty"`
+	Value *[]*VirtualNetworkGatewayConnection `json:"value,omitempty"`
 }
 
 // VirtualNetworkGatewayConnectionListResultResponse is the response envelope for operations that return a VirtualNetworkGatewayConnectionListResult type.
@@ -13641,7 +13641,7 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -13665,10 +13665,10 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	SharedKey *string `json:"sharedKey,omitempty"`
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies *[]TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies *[]*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus *[]TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus *[]*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
 
 	// Use private local Azure IP for the connection.
 	UseLocalAzureIPAddress *bool `json:"useLocalAzureIpAddress,omitempty"`
@@ -13785,7 +13785,7 @@ type VirtualNetworkGatewayListConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value *[]VirtualNetworkGatewayConnectionListEntity `json:"value,omitempty"`
+	Value *[]*VirtualNetworkGatewayConnectionListEntity `json:"value,omitempty"`
 }
 
 // VirtualNetworkGatewayListConnectionsResultResponse is the response envelope for operations that return a VirtualNetworkGatewayListConnectionsResult type.
@@ -13803,7 +13803,7 @@ type VirtualNetworkGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGateway resources that exists in a resource group.
-	Value *[]VirtualNetworkGateway `json:"value,omitempty"`
+	Value *[]*VirtualNetworkGateway `json:"value,omitempty"`
 }
 
 // VirtualNetworkGatewayListResultResponse is the response envelope for operations that return a VirtualNetworkGatewayListResult type.
@@ -13856,7 +13856,7 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 	GatewayType *VirtualNetworkGatewayType `json:"gatewayType,omitempty"`
 
 	// IP configurations for virtual network gateway.
-	IPConfigurations *[]VirtualNetworkGatewayIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations *[]*VirtualNetworkGatewayIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The IP address allocated by the gateway to which dns requests can be sent.
 	InboundDNSForwardingEndpoint *string `json:"inboundDnsForwardingEndpoint,omitempty" azure:"ro"`
@@ -14028,7 +14028,7 @@ type VirtualNetworkListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of VirtualNetwork resources in a resource group.
-	Value *[]VirtualNetwork `json:"value,omitempty"`
+	Value *[]*VirtualNetwork `json:"value,omitempty"`
 }
 
 // VirtualNetworkListResultResponse is the response envelope for operations that return a VirtualNetworkListResult type.
@@ -14046,7 +14046,7 @@ type VirtualNetworkListUsageResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// READ-ONLY; VirtualNetwork usage stats.
-	Value *[]VirtualNetworkUsage `json:"value,omitempty" azure:"ro"`
+	Value *[]*VirtualNetworkUsage `json:"value,omitempty" azure:"ro"`
 }
 
 // VirtualNetworkListUsageResultResponse is the response envelope for operations that return a VirtualNetworkListUsageResult type.
@@ -14077,7 +14077,7 @@ type VirtualNetworkPeeringListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The peerings in a virtual network.
-	Value *[]VirtualNetworkPeering `json:"value,omitempty"`
+	Value *[]*VirtualNetworkPeering `json:"value,omitempty"`
 }
 
 // VirtualNetworkPeeringListResultResponse is the response envelope for operations that return a VirtualNetworkPeeringListResult type.
@@ -14195,7 +14195,7 @@ type VirtualNetworkPropertiesFormat struct {
 	EnableVMProtection *bool `json:"enableVmProtection,omitempty"`
 
 	// Array of IpAllocation which reference this VNET.
-	IPAllocations *[]SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations *[]*SubResource `json:"ipAllocations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the virtual network resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -14204,10 +14204,10 @@ type VirtualNetworkPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A list of subnets in a Virtual Network.
-	Subnets *[]Subnet `json:"subnets,omitempty"`
+	Subnets *[]*Subnet `json:"subnets,omitempty"`
 
 	// A list of peerings in a Virtual Network.
-	VirtualNetworkPeerings *[]VirtualNetworkPeering `json:"virtualNetworkPeerings,omitempty"`
+	VirtualNetworkPeerings *[]*VirtualNetworkPeering `json:"virtualNetworkPeerings,omitempty"`
 }
 
 // VirtualNetworkResponse is the response envelope for operations that return a VirtualNetwork type.
@@ -14235,7 +14235,7 @@ type VirtualNetworkTapListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of VirtualNetworkTaps in a resource group.
-	Value *[]VirtualNetworkTap `json:"value,omitempty"`
+	Value *[]*VirtualNetworkTap `json:"value,omitempty"`
 }
 
 // VirtualNetworkTapListResultResponse is the response envelope for operations that return a VirtualNetworkTapListResult type.
@@ -14271,7 +14271,7 @@ type VirtualNetworkTapPropertiesFormat struct {
 	DestinationPort *int32 `json:"destinationPort,omitempty"`
 
 	// READ-ONLY; Specifies the list of resource IDs for the network interface IP configuration that needs to be tapped.
-	NetworkInterfaceTapConfigurations *[]NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
+	NetworkInterfaceTapConfigurations *[]*NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the virtual network tap resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -14403,7 +14403,7 @@ type VirtualRouterListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Virtual Routers.
-	Value *[]VirtualRouter `json:"value,omitempty"`
+	Value *[]*VirtualRouter `json:"value,omitempty"`
 }
 
 // VirtualRouterListResultResponse is the response envelope for operations that return a VirtualRouterListResult type.
@@ -14437,7 +14437,7 @@ type VirtualRouterPeeringListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualRouterPeerings in a VirtualRouter.
-	Value *[]VirtualRouterPeering `json:"value,omitempty"`
+	Value *[]*VirtualRouterPeering `json:"value,omitempty"`
 }
 
 // VirtualRouterPeeringListResultResponse is the response envelope for operations that return a VirtualRouterPeeringListResult type.
@@ -14523,7 +14523,7 @@ type VirtualRouterPropertiesFormat struct {
 	HostedSubnet *SubResource `json:"hostedSubnet,omitempty"`
 
 	// READ-ONLY; List of references to VirtualRouterPeerings.
-	Peerings *[]SubResource `json:"peerings,omitempty" azure:"ro"`
+	Peerings *[]*SubResource `json:"peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -14532,7 +14532,7 @@ type VirtualRouterPropertiesFormat struct {
 	VirtualRouterAsn *int64 `json:"virtualRouterAsn,omitempty"`
 
 	// VirtualRouter IPs.
-	VirtualRouterIPs *[]string `json:"virtualRouterIps,omitempty"`
+	VirtualRouterIPs *[]*string `json:"virtualRouterIps,omitempty"`
 }
 
 // VirtualRouterResponse is the response envelope for operations that return a VirtualRouter type.
@@ -14622,10 +14622,10 @@ type VirtualWanProperties struct {
 	Type *string `json:"type,omitempty"`
 
 	// READ-ONLY; List of VpnSites in the VirtualWAN.
-	VPNSites *[]SubResource `json:"vpnSites,omitempty" azure:"ro"`
+	VPNSites *[]*SubResource `json:"vpnSites,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of VirtualHubs in the VirtualWAN.
-	VirtualHubs *[]SubResource `json:"virtualHubs,omitempty" azure:"ro"`
+	VirtualHubs *[]*SubResource `json:"virtualHubs,omitempty" azure:"ro"`
 }
 
 // Collection of SecurityProviders.
@@ -14643,7 +14643,7 @@ type VirtualWanSecurityProvider struct {
 // Collection of SecurityProviders.
 type VirtualWanSecurityProviders struct {
 	// List of VirtualWAN security providers.
-	SupportedProviders *[]VirtualWanSecurityProvider `json:"supportedProviders,omitempty"`
+	SupportedProviders *[]*VirtualWanSecurityProvider `json:"supportedProviders,omitempty"`
 }
 
 // VirtualWanSecurityProvidersResponse is the response envelope for operations that return a VirtualWanSecurityProviders type.
@@ -14703,7 +14703,7 @@ type WebApplicationFirewallCustomRule struct {
 	Etag *string `json:"etag,omitempty" azure:"ro"`
 
 	// List of match conditions.
-	MatchConditions *[]MatchCondition `json:"matchConditions,omitempty"`
+	MatchConditions *[]*MatchCondition `json:"matchConditions,omitempty"`
 
 	// The name of the resource that is unique within a policy. This name can be used to access the resource.
 	Name *string `json:"name,omitempty"`
@@ -14757,7 +14757,7 @@ type WebApplicationFirewallPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of WebApplicationFirewallPolicies within a resource group.
-	Value *[]WebApplicationFirewallPolicy `json:"value,omitempty" azure:"ro"`
+	Value *[]*WebApplicationFirewallPolicy `json:"value,omitempty" azure:"ro"`
 }
 
 // WebApplicationFirewallPolicyListResultResponse is the response envelope for operations that return a WebApplicationFirewallPolicyListResult type.
@@ -14773,19 +14773,19 @@ type WebApplicationFirewallPolicyListResultResponse struct {
 // Defines web application firewall policy properties.
 type WebApplicationFirewallPolicyPropertiesFormat struct {
 	// READ-ONLY; A collection of references to application gateways.
-	ApplicationGateways *[]ApplicationGateway `json:"applicationGateways,omitempty" azure:"ro"`
+	ApplicationGateways *[]*ApplicationGateway `json:"applicationGateways,omitempty" azure:"ro"`
 
 	// The custom rules inside the policy.
-	CustomRules *[]WebApplicationFirewallCustomRule `json:"customRules,omitempty"`
+	CustomRules *[]*WebApplicationFirewallCustomRule `json:"customRules,omitempty"`
 
 	// READ-ONLY; A collection of references to application gateway http listeners.
-	HTTPListeners *[]SubResource `json:"httpListeners,omitempty" azure:"ro"`
+	HTTPListeners *[]*SubResource `json:"httpListeners,omitempty" azure:"ro"`
 
 	// Describes the managedRules structure.
 	ManagedRules *ManagedRulesDefinition `json:"managedRules,omitempty"`
 
 	// READ-ONLY; A collection of references to application gateway path rules.
-	PathBasedRules *[]SubResource `json:"pathBasedRules,omitempty" azure:"ro"`
+	PathBasedRules *[]*SubResource `json:"pathBasedRules,omitempty" azure:"ro"`
 
 	// The PolicySettings for policy.
 	PolicySettings *PolicySettings `json:"policySettings,omitempty"`

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -1159,8 +1159,8 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 	}
 	req.Header.Set("Accept", "application/xml")
 	type wrapper struct {
-		XMLName      xml.Name            `xml:"SignedIdentifiers"`
-		ContainerACL *[]SignedIdentifier `xml:"SignedIdentifier"`
+		XMLName      xml.Name             `xml:"SignedIdentifiers"`
+		ContainerACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
 	if containerSetAccessPolicyOptions != nil {
 		return req, req.MarshalAsXML(wrapper{ContainerACL: containerSetAccessPolicyOptions.ContainerACL})

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -643,7 +643,7 @@ type BlobDownloadResponse struct {
 }
 
 type BlobFlatListSegment struct {
-	BlobItems *[]BlobItem `xml:"Blob"`
+	BlobItems *[]*BlobItem `xml:"Blob"`
 }
 
 // BlobGetAccessControlOptions contains the optional parameters for the Blob.GetAccessControl method.
@@ -869,8 +869,8 @@ type BlobHTTPHeaders struct {
 }
 
 type BlobHierarchyListSegment struct {
-	BlobItems    *[]BlobItem   `xml:"Blob"`
-	BlobPrefixes *[]BlobPrefix `xml:"BlobPrefix"`
+	BlobItems    *[]*BlobItem   `xml:"Blob"`
+	BlobPrefixes *[]*BlobPrefix `xml:"BlobPrefix"`
 }
 
 // An Azure Storage blob
@@ -886,7 +886,7 @@ type BlobItem struct {
 
 type BlobMetadata struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]string
+	AdditionalProperties *map[string]*string
 	Encrypted            *string `xml:"Encrypted,attr"`
 }
 
@@ -1553,8 +1553,8 @@ type BlockBlobUploadResponse struct {
 }
 
 type BlockList struct {
-	CommittedBlocks   *[]Block `xml:"CommittedBlocks>Block"`
-	UncommittedBlocks *[]Block `xml:"UncommittedBlocks>Block"`
+	CommittedBlocks   *[]*Block `xml:"CommittedBlocks>Block"`
+	UncommittedBlocks *[]*Block `xml:"UncommittedBlocks>Block"`
 }
 
 // BlockListResponse is the response envelope for operations that return a BlockList type.
@@ -1589,9 +1589,9 @@ type BlockListResponse struct {
 }
 
 type BlockLookupList struct {
-	Committed   *[]string `xml:"Committed"`
-	Latest      *[]string `xml:"Latest"`
-	Uncommitted *[]string `xml:"Uncommitted"`
+	Committed   *[]*string `xml:"Committed"`
+	Latest      *[]*string `xml:"Latest"`
+	Uncommitted *[]*string `xml:"Uncommitted"`
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlockLookupList.
@@ -1906,8 +1906,8 @@ type ContainerGetPropertiesResponse struct {
 // An Azure Storage container
 type ContainerItem struct {
 	// Dictionary of
-	Metadata *map[string]string `xml:"Metadata"`
-	Name     *string            `xml:"Name"`
+	Metadata *map[string]*string `xml:"Metadata"`
+	Name     *string             `xml:"Name"`
 
 	// Properties of a container
 	Properties *ContainerProperties `xml:"Properties"`
@@ -1925,7 +1925,7 @@ func (c *ContainerItem) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.Metadata = (*map[string]string)(aux.Metadata)
+	c.Metadata = (*map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -2090,7 +2090,7 @@ type ContainerSetAccessPolicyOptions struct {
 	// Specifies whether data in the container may be accessed publicly and the level of access
 	Access *PublicAccessType
 	// the acls for the container
-	ContainerACL *[]SignedIdentifier
+	ContainerACL *[]*SignedIdentifier
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.
 	RequestID *string
 	// The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting
@@ -2603,12 +2603,12 @@ type ListBlobsHierarchySegmentResponseResponse struct {
 
 // An enumeration of containers
 type ListContainersSegmentResponse struct {
-	ContainerItems  *[]ContainerItem `xml:"Containers>Container"`
-	Marker          *string          `xml:"Marker"`
-	MaxResults      *int32           `xml:"MaxResults"`
-	NextMarker      *string          `xml:"NextMarker"`
-	Prefix          *string          `xml:"Prefix"`
-	ServiceEndpoint *string          `xml:"ServiceEndpoint,attr"`
+	ContainerItems  *[]*ContainerItem `xml:"Containers>Container"`
+	Marker          *string           `xml:"Marker"`
+	MaxResults      *int32            `xml:"MaxResults"`
+	NextMarker      *string           `xml:"NextMarker"`
+	Prefix          *string           `xml:"Prefix"`
+	ServiceEndpoint *string           `xml:"ServiceEndpoint,attr"`
 }
 
 // ListContainersSegmentResponseResponse is the response envelope for operations that return a ListContainersSegmentResponse type.
@@ -3036,8 +3036,8 @@ type PageBlobUploadPagesResponse struct {
 
 // the list of pages
 type PageList struct {
-	ClearRange *[]ClearRange `xml:"ClearRange"`
-	PageRange  *[]PageRange  `xml:"PageRange"`
+	ClearRange *[]*ClearRange `xml:"ClearRange"`
+	PageRange  *[]*PageRange  `xml:"PageRange"`
 }
 
 // PageListResponse is the response envelope for operations that return a PageList type.
@@ -3232,7 +3232,7 @@ type SignedIdentifier struct {
 	ID *string `xml:"Id"`
 }
 
-// SignedIdentifierArrayResponse is the response envelope for operations that return a []SignedIdentifier type.
+// SignedIdentifierArrayResponse is the response envelope for operations that return a []*SignedIdentifier type.
 type SignedIdentifierArrayResponse struct {
 	// BlobPublicAccess contains the information returned from the x-ms-blob-public-access header response.
 	BlobPublicAccess *PublicAccessType `xml:"BlobPublicAccess"`
@@ -3256,7 +3256,7 @@ type SignedIdentifierArrayResponse struct {
 	RequestID *string `xml:"RequestID"`
 
 	// a collection of signed identifiers
-	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+	SignedIdentifiers []*SignedIdentifier `xml:"SignedIdentifier"`
 
 	// Version contains the information returned from the x-ms-version header response.
 	Version *string `xml:"Version"`
@@ -3305,7 +3305,7 @@ func (e StorageError) Error() string {
 // Storage Service Properties.
 type StorageServiceProperties struct {
 	// The set of CORS rules.
-	Cors *[]CorsRule `xml:"Cors>CorsRule"`
+	Cors *[]*CorsRule `xml:"Cors>CorsRule"`
 
 	// The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27
 	// and all more recent versions

--- a/test/storage/2019-07-07/azblob/zz_generated_xml_helper.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_xml_helper.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-type additionalProperties map[string]string
+type additionalProperties map[string]*string
 
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
@@ -29,7 +29,8 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if *ap == nil {
 				*ap = additionalProperties{}
 			}
-			(*ap)[tokName] = string(tt)
+			s := string(tt)
+			(*ap)[tokName] = &s
 			tokName = ""
 			break
 		}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -39,7 +39,7 @@ type Activity struct {
 	AdditionalProperties *map[string]interface{}
 
 	// Activity depends on condition.
-	DependsOn *[]ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn *[]*ActivityDependency `json:"dependsOn,omitempty"`
 
 	// Activity description.
 	Description *string `json:"description,omitempty"`
@@ -51,7 +51,7 @@ type Activity struct {
 	Type *string `json:"type,omitempty"`
 
 	// Activity user properties.
-	UserProperties *[]UserProperty `json:"userProperties,omitempty"`
+	UserProperties *[]*UserProperty `json:"userProperties,omitempty"`
 }
 
 // GetActivity implements the ActivityClassification interface for type Activity.
@@ -128,7 +128,7 @@ type ActivityDependency struct {
 	AdditionalProperties *map[string]interface{}
 
 	// Match-Condition for the dependency.
-	DependencyConditions *[]DependencyCondition `json:"dependencyConditions,omitempty"`
+	DependencyConditions *[]*DependencyCondition `json:"dependencyConditions,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ActivityDependency.
@@ -401,7 +401,7 @@ type ActivityRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of activity runs.
-	Value *[]ActivityRun `json:"value,omitempty"`
+	Value *[]*ActivityRun `json:"value,omitempty"`
 }
 
 // ActivityRunsQueryResponseResponse is the response envelope for operations that return a ActivityRunsQueryResponse type.
@@ -3121,12 +3121,12 @@ type AzureMLBatchExecutionActivityTypeProperties struct {
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Inputs to AzureMLWebServiceFile objects specifying the input Blob locations.. This
 	// information will be passed in the
 	// WebServiceInputs property of the Azure ML batch execution request.
-	WebServiceInputs *map[string]AzureMLWebServiceFile `json:"webServiceInputs,omitempty"`
+	WebServiceInputs *map[string]*AzureMLWebServiceFile `json:"webServiceInputs,omitempty"`
 
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Outputs to AzureMLWebServiceFile objects specifying the output Blob locations.
 	// This information will be passed in the
 	// WebServiceOutputs property of the Azure ML batch execution request.
-	WebServiceOutputs *map[string]AzureMLWebServiceFile `json:"webServiceOutputs,omitempty"`
+	WebServiceOutputs *map[string]*AzureMLWebServiceFile `json:"webServiceOutputs,omitempty"`
 }
 
 // Azure ML Execute Pipeline activity.
@@ -4265,7 +4265,7 @@ type AzureSQLSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -4335,7 +4335,7 @@ type AzureSQLSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLSource.
@@ -4815,7 +4815,7 @@ type BigDataPoolResourceInfoListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Big Data pools
-	Value *[]BigDataPoolResourceInfo `json:"value,omitempty"`
+	Value *[]*BigDataPoolResourceInfo `json:"value,omitempty"`
 }
 
 // BigDataPoolResourceInfoListResultResponse is the response envelope for operations that return a BigDataPoolResourceInfoListResult type.
@@ -4851,7 +4851,7 @@ type BigDataPoolResourceProperties struct {
 	CreationDate *time.Time `json:"creationDate,omitempty"`
 
 	// List of custom libraries/packages associated with the spark pool.
-	CustomLibraries *[]LibraryInfo `json:"customLibraries,omitempty"`
+	CustomLibraries *[]*LibraryInfo `json:"customLibraries,omitempty"`
 
 	// The default folder where Spark logs will be written.
 	DefaultSparkLogFolder *string `json:"defaultSparkLogFolder,omitempty"`
@@ -5183,7 +5183,7 @@ type BlobEventsTriggerTypeProperties struct {
 	BlobPathEndsWith *string `json:"blobPathEndsWith,omitempty"`
 
 	// The type of events that cause this trigger to fire.
-	Events *[]BlobEventType `json:"events,omitempty"`
+	Events *[]*BlobEventType `json:"events,omitempty"`
 
 	// If set to true, blobs with zero bytes will be ignored.
 	IgnoreEmptyBlobs *bool `json:"ignoreEmptyBlobs,omitempty"`
@@ -5565,7 +5565,7 @@ func (c *ChainingTrigger) UnmarshalJSON(data []byte) error {
 // Chaining Trigger properties.
 type ChainingTriggerTypeProperties struct {
 	// Upstream Pipelines.
-	DependsOn *[]PipelineReference `json:"dependsOn,omitempty"`
+	DependsOn *[]*PipelineReference `json:"dependsOn,omitempty"`
 
 	// Run Dimension property that needs to be emitted by upstream pipelines.
 	RunDimension *string `json:"runDimension,omitempty"`
@@ -5637,7 +5637,7 @@ type CloudErrorBody struct {
 	Code *string `json:"code,omitempty"`
 
 	// Array with additional error details.
-	Details *[]CloudError `json:"details,omitempty"`
+	Details *[]*CloudError `json:"details,omitempty"`
 
 	// Error message.
 	Message *string `json:"message,omitempty"`
@@ -5652,7 +5652,7 @@ type CloudErrorBodyAutoGenerated struct {
 	Code *string `json:"code,omitempty"`
 
 	// Array with additional error details.
-	Details *[]CloudErrorAutoGenerated `json:"details,omitempty"`
+	Details *[]*CloudErrorAutoGenerated `json:"details,omitempty"`
 
 	// Error message.
 	Message *string `json:"message,omitempty"`
@@ -6107,10 +6107,10 @@ func (c ControlActivity) MarshalJSON() ([]byte, error) {
 type CopyActivity struct {
 	ExecutionActivity
 	// List of inputs for the activity.
-	Inputs *[]DatasetReference `json:"inputs,omitempty"`
+	Inputs *[]*DatasetReference `json:"inputs,omitempty"`
 
 	// List of outputs for the activity.
-	Outputs *[]DatasetReference `json:"outputs,omitempty"`
+	Outputs *[]*DatasetReference `json:"outputs,omitempty"`
 
 	// Copy activity properties.
 	TypeProperties *CopyActivityTypeProperties `json:"typeProperties,omitempty"`
@@ -7061,10 +7061,10 @@ func (c *CustomActivity) UnmarshalJSON(data []byte) error {
 // Reference objects for custom activity
 type CustomActivityReferenceObject struct {
 	// Dataset references.
-	Datasets *[]DatasetReference `json:"datasets,omitempty"`
+	Datasets *[]*DatasetReference `json:"datasets,omitempty"`
 
 	// Linked service references.
-	LinkedServices *[]LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices *[]*LinkedServiceReference `json:"linkedServices,omitempty"`
 }
 
 // Custom activity properties.
@@ -7229,12 +7229,12 @@ type DWCopyCommandSettings struct {
 	// Additional options directly passed to SQL DW in Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object).
 	// Example: "additionalOptions": { "MAXERRORS":
 	// "1000", "DATEFORMAT": "'ymd'" }
-	AdditionalOptions *map[string]string `json:"additionalOptions,omitempty"`
+	AdditionalOptions *map[string]*string `json:"additionalOptions,omitempty"`
 
 	// Specifies the default values for each target column in SQL DW. The default values in the property overwrite the DEFAULT constraint set in the DB, and
 	// identity column cannot have a default value. Type:
 	// array of objects (or Expression with resultType array of objects).
-	DefaultValues *[]DWCopyCommandDefaultValue `json:"defaultValues,omitempty"`
+	DefaultValues *[]*DWCopyCommandDefaultValue `json:"defaultValues,omitempty"`
 }
 
 // DataFlowClassification provides polymorphic access to related types.
@@ -7377,13 +7377,13 @@ type DataFlowDebugPackage struct {
 	DataFlow *DataFlowDebugResource `json:"dataFlow,omitempty"`
 
 	// List of datasets.
-	Datasets *[]DatasetDebugResource `json:"datasets,omitempty"`
+	Datasets *[]*DatasetDebugResource `json:"datasets,omitempty"`
 
 	// Data flow debug settings.
 	DebugSettings *DataFlowDebugPackageDebugSettings `json:"debugSettings,omitempty"`
 
 	// List of linked services.
-	LinkedServices *[]LinkedServiceDebugResource `json:"linkedServices,omitempty"`
+	LinkedServices *[]*LinkedServiceDebugResource `json:"linkedServices,omitempty"`
 
 	// The ID of data flow debug session.
 	SessionID *string `json:"sessionId,omitempty"`
@@ -7463,7 +7463,7 @@ type DataFlowDebugPackageDebugSettings struct {
 	Parameters *map[string]interface{} `json:"parameters,omitempty"`
 
 	// Source setting for data flow debug.
-	SourceSettings *[]DataFlowSourceSetting `json:"sourceSettings,omitempty"`
+	SourceSettings *[]*DataFlowSourceSetting `json:"sourceSettings,omitempty"`
 }
 
 // Request body structure for data flow preview data.
@@ -7640,7 +7640,7 @@ type DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions struct {
 // Request body structure for data flow statistics.
 type DataFlowDebugStatisticsRequest struct {
 	// List of column names.
-	Columns *[]string `json:"columns,omitempty"`
+	Columns *[]*string `json:"columns,omitempty"`
 
 	// The data flow which contains the debug session.
 	DataFlowName *string `json:"dataFlowName,omitempty"`
@@ -7676,7 +7676,7 @@ type DataFlowListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of data flows.
-	Value *[]DataFlowResource `json:"value,omitempty"`
+	Value *[]*DataFlowResource `json:"value,omitempty"`
 }
 
 // DataFlowListResponseResponse is the response envelope for operations that return a DataFlowListResponse type.
@@ -8114,7 +8114,7 @@ type Dataset struct {
 	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
 
 	// Parameters for dataset.
-	Parameters *map[string]ParameterSpecification `json:"parameters,omitempty"`
+	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType: DatasetSchemaDataElement.
 	Schema interface{} `json:"schema,omitempty"`
@@ -8405,7 +8405,7 @@ type DatasetListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of datasets.
-	Value *[]DatasetResource `json:"value,omitempty"`
+	Value *[]*DatasetResource `json:"value,omitempty"`
 }
 
 // DatasetListResponseResponse is the response envelope for operations that return a DatasetListResponse type.
@@ -10477,13 +10477,13 @@ func (e ErrorContract) Error() string {
 // format.)
 type ErrorResponse struct {
 	// READ-ONLY; The error additional info.
-	AdditionalInfo *[]ErrorAdditionalInfo `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo *[]*ErrorAdditionalInfo `json:"additionalInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error code.
 	Code *string `json:"code,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error details.
-	Details *[]ErrorResponse `json:"details,omitempty" azure:"ro"`
+	Details *[]*ErrorResponse `json:"details,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error message.
 	Message *string `json:"message,omitempty" azure:"ro"`
@@ -10666,22 +10666,22 @@ type ExecuteSSISPackageActivityTypeProperties struct {
 	LoggingLevel interface{} `json:"loggingLevel,omitempty"`
 
 	// The package level connection managers to execute the SSIS package.
-	PackageConnectionManagers *map[string]map[string]SSISExecutionParameter `json:"packageConnectionManagers,omitempty"`
+	PackageConnectionManagers *map[string]map[string]*SSISExecutionParameter `json:"packageConnectionManagers,omitempty"`
 
 	// SSIS package location.
 	PackageLocation *SSISPackageLocation `json:"packageLocation,omitempty"`
 
 	// The package level parameters to execute the SSIS package.
-	PackageParameters *map[string]SSISExecutionParameter `json:"packageParameters,omitempty"`
+	PackageParameters *map[string]*SSISExecutionParameter `json:"packageParameters,omitempty"`
 
 	// The project level connection managers to execute the SSIS package.
-	ProjectConnectionManagers *map[string]map[string]SSISExecutionParameter `json:"projectConnectionManagers,omitempty"`
+	ProjectConnectionManagers *map[string]map[string]*SSISExecutionParameter `json:"projectConnectionManagers,omitempty"`
 
 	// The project level parameters to execute the SSIS package.
-	ProjectParameters *map[string]SSISExecutionParameter `json:"projectParameters,omitempty"`
+	ProjectParameters *map[string]*SSISExecutionParameter `json:"projectParameters,omitempty"`
 
 	// The property overrides to execute the SSIS package.
-	PropertyOverrides *map[string]SSISPropertyOverride `json:"propertyOverrides,omitempty"`
+	PropertyOverrides *map[string]*SSISPropertyOverride `json:"propertyOverrides,omitempty"`
 
 	// Specifies the runtime to execute SSIS package. The value should be "x86" or "x64". Type: string (or Expression with resultType string).
 	Runtime interface{} `json:"runtime,omitempty"`
@@ -12496,7 +12496,7 @@ type HDInsightHiveActivityTypeProperties struct {
 	ScriptPath interface{} `json:"scriptPath,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
 
 	// User specified arguments under hivevar namespace.
 	Variables *[]interface{} `json:"variables,omitempty"`
@@ -12622,7 +12622,7 @@ type HDInsightMapReduceActivityTypeProperties struct {
 	JarLinkedService *LinkedServiceReference `json:"jarLinkedService,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
 }
 
 // HDInsight ondemand linked service.
@@ -12662,7 +12662,7 @@ func (h *HDInsightOnDemandLinkedService) UnmarshalJSON(data []byte) error {
 // HDInsight ondemand linked service properties.
 type HDInsightOnDemandLinkedServiceTypeProperties struct {
 	// Specifies additional storage accounts for the HDInsight linked service so that the Data Factory service can register them on your behalf.
-	AdditionalLinkedServiceNames *[]LinkedServiceReference `json:"additionalLinkedServiceNames,omitempty"`
+	AdditionalLinkedServiceNames *[]*LinkedServiceReference `json:"additionalLinkedServiceNames,omitempty"`
 
 	// The prefix of cluster name, postfix will be distinct with timestamp. Type: string (or Expression with resultType string).
 	ClusterNamePrefix interface{} `json:"clusterNamePrefix,omitempty"`
@@ -12728,7 +12728,7 @@ type HDInsightOnDemandLinkedServiceTypeProperties struct {
 
 	// Custom script actions to run on HDI ondemand cluster once it's up. Please refer to
 	// https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-customize-cluster-linux?toc=%2Fen-us%2Fazure%2Fhdinsight%2Fr-server%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json#understanding-script-actions.
-	ScriptActions *[]ScriptAction `json:"scriptActions,omitempty"`
+	ScriptActions *[]*ScriptAction `json:"scriptActions,omitempty"`
 
 	// The service principal id for the hostSubscriptionId. Type: string (or Expression with resultType string).
 	ServicePrincipalID interface{} `json:"servicePrincipalId,omitempty"`
@@ -12819,7 +12819,7 @@ type HDInsightPigActivityTypeProperties struct {
 	ScriptPath interface{} `json:"scriptPath,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
 }
 
 // HDInsight Spark activity.
@@ -12953,7 +12953,7 @@ type HDInsightStreamingActivityTypeProperties struct {
 	Reducer interface{} `json:"reducer,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
 }
 
 // Linked service for an HTTP source.
@@ -14555,7 +14555,7 @@ type IntegrationRuntimeListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of integration runtimes.
-	Value *[]IntegrationRuntimeResource `json:"value,omitempty"`
+	Value *[]*IntegrationRuntimeResource `json:"value,omitempty"`
 }
 
 // IntegrationRuntimeListResponseResponse is the response envelope for operations that return a IntegrationRuntimeListResponse type.
@@ -14759,7 +14759,7 @@ type IntegrationRuntimeVNetProperties struct {
 	AdditionalProperties *map[string]interface{}
 
 	// Resource IDs of the public IP addresses that this integration runtime will use.
-	PublicIPs *[]string `json:"publicIPs,omitempty"`
+	PublicIPs *[]*string `json:"publicIPs,omitempty"`
 
 	// The name of the subnet this integration runtime will join.
 	Subnet *string `json:"subnet,omitempty"`
@@ -15372,7 +15372,7 @@ type LibraryListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Library.
-	Value *[]LibraryResource `json:"value,omitempty"`
+	Value *[]*LibraryResource `json:"value,omitempty"`
 }
 
 // LibraryListResponseResponse is the response envelope for operations that return a LibraryListResponse type.
@@ -15686,7 +15686,7 @@ type LinkedService struct {
 	Description *string `json:"description,omitempty"`
 
 	// Parameters for linked service.
-	Parameters *map[string]ParameterSpecification `json:"parameters,omitempty"`
+	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Type of linked service.
 	Type *string `json:"type,omitempty"`
@@ -15798,7 +15798,7 @@ type LinkedServiceListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of linked services.
-	Value *[]LinkedServiceResource `json:"value,omitempty"`
+	Value *[]*LinkedServiceResource `json:"value,omitempty"`
 }
 
 // LinkedServiceListResponseResponse is the response envelope for operations that return a LinkedServiceListResponse type.
@@ -16179,7 +16179,7 @@ type ManagedIntegrationRuntimeTypeProperties struct {
 // Managed Virtual Network Settings
 type ManagedVirtualNetworkSettings struct {
 	// Allowed Aad Tenant Ids For Linking
-	AllowedAADTenantIDsForLinking *[]string `json:"allowedAadTenantIdsForLinking,omitempty"`
+	AllowedAADTenantIDsForLinking *[]*string `json:"allowedAadTenantIdsForLinking,omitempty"`
 
 	// Linked Access Check On Target Resource
 	LinkedAccessCheckOnTargetResource *bool `json:"linkedAccessCheckOnTargetResource,omitempty"`
@@ -16228,13 +16228,13 @@ type MappingDataFlowTypeProperties struct {
 	Script *string `json:"script,omitempty"`
 
 	// List of sinks in data flow.
-	Sinks *[]DataFlowSink `json:"sinks,omitempty"`
+	Sinks *[]*DataFlowSink `json:"sinks,omitempty"`
 
 	// List of sources in data flow.
-	Sources *[]DataFlowSource `json:"sources,omitempty"`
+	Sources *[]*DataFlowSource `json:"sources,omitempty"`
 
 	// List of transformations in data flow.
-	Transformations *[]Transformation `json:"transformations,omitempty"`
+	Transformations *[]*Transformation `json:"transformations,omitempty"`
 }
 
 // MariaDB server linked service.
@@ -17140,7 +17140,7 @@ type MultiplePipelineTriggerClassification interface {
 type MultiplePipelineTrigger struct {
 	Trigger
 	// Pipelines that need to be started.
-	Pipelines *[]TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines *[]*TriggerPipelineReference `json:"pipelines,omitempty"`
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type MultiplePipelineTrigger.
@@ -17467,7 +17467,7 @@ type Notebook struct {
 	BigDataPool *BigDataPoolReference `json:"bigDataPool,omitempty"`
 
 	// Array of cells of the current notebook.
-	Cells *[]NotebookCell `json:"cells,omitempty"`
+	Cells *[]*NotebookCell `json:"cells,omitempty"`
 
 	// The description of the notebook.
 	Description *string `json:"description,omitempty"`
@@ -17582,10 +17582,10 @@ type NotebookCell struct {
 	Metadata interface{} `json:"metadata,omitempty"`
 
 	// Cell-level output items.
-	Outputs *[]NotebookCellOutputItem `json:"outputs,omitempty"`
+	Outputs *[]*NotebookCellOutputItem `json:"outputs,omitempty"`
 
 	// Contents of the cell, represented as an array of lines.
-	Source *[]string `json:"source,omitempty"`
+	Source *[]*string `json:"source,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NotebookCell.
@@ -17806,7 +17806,7 @@ type NotebookListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Notebooks.
-	Value *[]NotebookResource `json:"value,omitempty"`
+	Value *[]*NotebookResource `json:"value,omitempty"`
 }
 
 // NotebookListResponseResponse is the response envelope for operations that return a NotebookListResponse type.
@@ -19607,13 +19607,13 @@ type Pipeline struct {
 	Folder *PipelineFolder `json:"folder,omitempty"`
 
 	// List of parameters for pipeline.
-	Parameters *map[string]ParameterSpecification `json:"parameters,omitempty"`
+	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Dimensions emitted by Pipeline.
 	RunDimensions *map[string]interface{} `json:"runDimensions,omitempty"`
 
 	// List of variables for pipeline.
-	Variables *map[string]VariableSpecification `json:"variables,omitempty"`
+	Variables *map[string]*VariableSpecification `json:"variables,omitempty"`
 }
 
 // PipelineBeginCreateOrUpdatePipelineOptions contains the optional parameters for the Pipeline.BeginCreateOrUpdatePipeline method.
@@ -19668,7 +19668,7 @@ type PipelineListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of pipelines.
-	Value *[]PipelineResource `json:"value,omitempty"`
+	Value *[]*PipelineResource `json:"value,omitempty"`
 }
 
 // PipelineListResponseResponse is the response envelope for operations that return a PipelineListResponse type.
@@ -19794,7 +19794,7 @@ type PipelineRun struct {
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// READ-ONLY; The full or partial list of parameter name, value pair used in the pipeline run.
-	Parameters *map[string]string `json:"parameters,omitempty" azure:"ro"`
+	Parameters *map[string]*string `json:"parameters,omitempty" azure:"ro"`
 
 	// READ-ONLY; The pipeline name.
 	PipelineName *string `json:"pipelineName,omitempty" azure:"ro"`
@@ -19955,7 +19955,7 @@ type PipelineRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of pipeline runs.
-	Value *[]PipelineRun `json:"value,omitempty"`
+	Value *[]*PipelineRun `json:"value,omitempty"`
 }
 
 // PipelineRunsQueryResponseResponse is the response envelope for operations that return a PipelineRunsQueryResponse type.
@@ -20445,7 +20445,7 @@ type QueryDataFlowDebugSessionsResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// Array with all active debug sessions.
-	Value *[]DataFlowDebugSessionInfo `json:"value,omitempty"`
+	Value *[]*DataFlowDebugSessionInfo `json:"value,omitempty"`
 }
 
 // QueryDataFlowDebugSessionsResponseResponse is the response envelope for operations that return a QueryDataFlowDebugSessionsResponse type.
@@ -20634,19 +20634,19 @@ type RecurrenceSchedule struct {
 	AdditionalProperties *map[string]interface{}
 
 	// The hours.
-	Hours *[]int32 `json:"hours,omitempty"`
+	Hours *[]*int32 `json:"hours,omitempty"`
 
 	// The minutes.
-	Minutes *[]int32 `json:"minutes,omitempty"`
+	Minutes *[]*int32 `json:"minutes,omitempty"`
 
 	// The month days.
-	MonthDays *[]int32 `json:"monthDays,omitempty"`
+	MonthDays *[]*int32 `json:"monthDays,omitempty"`
 
 	// The monthly occurrences.
-	MonthlyOccurrences *[]RecurrenceScheduleOccurrence `json:"monthlyOccurrences,omitempty"`
+	MonthlyOccurrences *[]*RecurrenceScheduleOccurrence `json:"monthlyOccurrences,omitempty"`
 
 	// The days of the week.
-	WeekDays *[]DayOfWeek `json:"weekDays,omitempty"`
+	WeekDays *[]*DayOfWeek `json:"weekDays,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RecurrenceSchedule.
@@ -20918,7 +20918,7 @@ type RerunTriggerListResponse struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// List of rerun triggers.
-	Value *[]RerunTriggerResource `json:"value,omitempty"`
+	Value *[]*RerunTriggerResource `json:"value,omitempty"`
 }
 
 // RerunTrigger resource type.
@@ -21534,7 +21534,7 @@ type RunFilterParameters struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of filters.
-	Filters *[]RunQueryFilter `json:"filters,omitempty"`
+	Filters *[]*RunQueryFilter `json:"filters,omitempty"`
 
 	// The time at or after which the run event was updated in 'ISO 8601' format.
 	LastUpdatedAfter *time.Time `json:"lastUpdatedAfter,omitempty"`
@@ -21543,7 +21543,7 @@ type RunFilterParameters struct {
 	LastUpdatedBefore *time.Time `json:"lastUpdatedBefore,omitempty"`
 
 	// List of OrderBy option.
-	OrderBy *[]RunQueryOrderBy `json:"orderBy,omitempty"`
+	OrderBy *[]*RunQueryOrderBy `json:"orderBy,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RunFilterParameters.
@@ -21604,7 +21604,7 @@ type RunQueryFilter struct {
 	Operator *RunQueryFilterOperator `json:"operator,omitempty"`
 
 	// List of filter values.
-	Values *[]string `json:"values,omitempty"`
+	Values *[]*string `json:"values,omitempty"`
 }
 
 // An object to provide order by options for listing runs.
@@ -21820,7 +21820,7 @@ type SQLMISink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -21890,7 +21890,7 @@ type SQLMISource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLMISource.
@@ -21948,7 +21948,7 @@ type SQLPoolInfoListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of SQL pools
-	Value *[]SQLPool `json:"value,omitempty"`
+	Value *[]*SQLPool `json:"value,omitempty"`
 }
 
 // SQLPoolInfoListResultResponse is the response envelope for operations that return a SQLPoolInfoListResult type.
@@ -22116,7 +22116,7 @@ type SQLPoolStoredProcedureActivityTypeProperties struct {
 	StoredProcedureName interface{} `json:"storedProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // SQLPoolsGetOptions contains the optional parameters for the SQLPools.Get method.
@@ -22383,7 +22383,7 @@ type SQLScriptsListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of sql scripts.
-	Value *[]SQLScriptResource `json:"value,omitempty"`
+	Value *[]*SQLScriptResource `json:"value,omitempty"`
 }
 
 // SQLScriptsListResponseResponse is the response envelope for operations that return a SQLScriptsListResponse type.
@@ -22487,7 +22487,7 @@ type SQLServerSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -22557,7 +22557,7 @@ type SQLServerSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLServerSource.
@@ -22639,7 +22639,7 @@ type SQLServerStoredProcedureActivityTypeProperties struct {
 	StoredProcedureName interface{} `json:"storedProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // The on-premises SQL Server dataset.
@@ -22701,7 +22701,7 @@ type SQLSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -22768,7 +22768,7 @@ type SQLSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLSource.
@@ -22916,7 +22916,7 @@ type SSISPackageLocationTypeProperties struct {
 	AccessCredential *SSISAccessCredential `json:"accessCredential,omitempty"`
 
 	// The embedded child package list.
-	ChildPackages *[]SSISChildPackage `json:"childPackages,omitempty"`
+	ChildPackages *[]*SSISChildPackage `json:"childPackages,omitempty"`
 
 	// The configuration file of the package execution. Type: string (or Expression with resultType string).
 	ConfigurationPath interface{} `json:"configurationPath,omitempty"`
@@ -25666,13 +25666,13 @@ type SparkBatchJob struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// The detailed application info.
-	AppInfo *map[string]string `json:"appInfo,omitempty"`
+	AppInfo *map[string]*string `json:"appInfo,omitempty"`
 
 	// The artifact identifier.
 	ArtifactID *string `json:"artifactId,omitempty"`
 
 	// The error information.
-	Errors *[]SparkServiceError `json:"errorInfo,omitempty"`
+	Errors *[]*SparkServiceError `json:"errorInfo,omitempty"`
 
 	// The session Id.
 	ID *int32 `json:"id,omitempty"`
@@ -25682,7 +25682,7 @@ type SparkBatchJob struct {
 	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
 
 	// The log lines.
-	LogLines *[]string `json:"log,omitempty"`
+	LogLines *[]*string `json:"log,omitempty"`
 
 	// The batch name.
 	Name *string `json:"name,omitempty"`
@@ -25709,7 +25709,7 @@ type SparkBatchJob struct {
 	SubmitterName *string `json:"submitterName,omitempty"`
 
 	// The tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// The workspace name.
 	WorkspaceName *string `json:"workspaceName,omitempty"`
@@ -26000,7 +26000,7 @@ type SparkJobDefinitionsListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of spark job definitions.
-	Value *[]SparkJobDefinitionResource `json:"value,omitempty"`
+	Value *[]*SparkJobDefinitionResource `json:"value,omitempty"`
 }
 
 // SparkJobDefinitionsListResponseResponse is the response envelope for operations that return a SparkJobDefinitionsListResponse type.
@@ -26018,10 +26018,10 @@ type SparkJobProperties struct {
 	AdditionalProperties *map[string]interface{}
 
 	// Archives to be used in this job.
-	Archives *[]string `json:"archives,omitempty"`
+	Archives *[]*string `json:"archives,omitempty"`
 
 	// Command line arguments for the application.
-	Args *[]string `json:"args,omitempty"`
+	Args *[]*string `json:"args,omitempty"`
 
 	// Main class for Java/Scala application.
 	ClassName *string `json:"className,omitempty"`
@@ -26045,10 +26045,10 @@ type SparkJobProperties struct {
 	File *string `json:"file,omitempty"`
 
 	// files to be used in this job.
-	Files *[]string `json:"files,omitempty"`
+	Files *[]*string `json:"files,omitempty"`
 
 	// Jars to be used in this job.
-	Jars *[]string `json:"jars,omitempty"`
+	Jars *[]*string `json:"jars,omitempty"`
 
 	// The name of the job.
 	Name *string `json:"name,omitempty"`
@@ -26323,22 +26323,22 @@ func (s *SparkObjectDataset) UnmarshalJSON(data []byte) error {
 }
 
 type SparkRequest struct {
-	Archives  *[]string `json:"archives,omitempty"`
-	Arguments *[]string `json:"args,omitempty"`
-	ClassName *string   `json:"className,omitempty"`
+	Archives  *[]*string `json:"archives,omitempty"`
+	Arguments *[]*string `json:"args,omitempty"`
+	ClassName *string    `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          *[]string          `json:"files,omitempty"`
-	Jars           *[]string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    *[]string          `json:"pyFiles,omitempty"`
+	Configuration  *map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32              `json:"driverCores,omitempty"`
+	DriverMemory   *string             `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32              `json:"executorCores,omitempty"`
+	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
+	ExecutorMemory *string             `json:"executorMemory,omitempty"`
+	File           *string             `json:"file,omitempty"`
+	Files          *[]*string          `json:"files,omitempty"`
+	Jars           *[]*string          `json:"jars,omitempty"`
+	Name           *string             `json:"name,omitempty"`
+	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
 }
 
 type SparkScheduler struct {
@@ -26764,7 +26764,7 @@ type StartDataFlowDebugSessionRequest struct {
 	DataFlow *DataFlowResource `json:"dataFlow,omitempty"`
 
 	// List of datasets.
-	Datasets *[]DatasetResource `json:"datasets,omitempty"`
+	Datasets *[]*DatasetResource `json:"datasets,omitempty"`
 
 	// Data flow debug settings.
 	DebugSettings interface{} `json:"debugSettings,omitempty"`
@@ -26773,7 +26773,7 @@ type StartDataFlowDebugSessionRequest struct {
 	IncrementalDebug *bool `json:"incrementalDebug,omitempty"`
 
 	// List of linked services.
-	LinkedServices *[]LinkedServiceResource `json:"linkedServices,omitempty"`
+	LinkedServices *[]*LinkedServiceResource `json:"linkedServices,omitempty"`
 
 	// The ID of data flow debug session.
 	SessionID *string `json:"sessionId,omitempty"`
@@ -27026,7 +27026,7 @@ func (s *SwitchActivity) UnmarshalJSON(data []byte) error {
 type SwitchActivityTypeProperties struct {
 	// List of cases that correspond to expected values of the 'on' property. This is an optional property and if not provided, the activity will execute activities
 	// provided in defaultActivities.
-	Cases *[]SwitchCase `json:"cases,omitempty"`
+	Cases *[]*SwitchCase `json:"cases,omitempty"`
 
 	// List of activities to execute if no case condition is satisfied. This is an optional property and if not provided, the activity will exit without any
 	// action.
@@ -27795,7 +27795,7 @@ type TrackedResource struct {
 	Location *string `json:"location,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // A data flow transformation.
@@ -28017,7 +28017,7 @@ type TriggerListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of triggers.
-	Value *[]TriggerResource `json:"value,omitempty"`
+	Value *[]*TriggerResource `json:"value,omitempty"`
 }
 
 // TriggerListResponseResponse is the response envelope for operations that return a TriggerListResponse type.
@@ -28084,7 +28084,7 @@ type TriggerRun struct {
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of property name and value related to trigger run. Name, value pair depends on type of trigger.
-	Properties *map[string]string `json:"properties,omitempty" azure:"ro"`
+	Properties *map[string]*string `json:"properties,omitempty" azure:"ro"`
 
 	// READ-ONLY; Trigger run status.
 	Status *TriggerRunStatus `json:"status,omitempty" azure:"ro"`
@@ -28102,7 +28102,7 @@ type TriggerRun struct {
 	TriggerType *string `json:"triggerType,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of pipeline name and run Id triggered by the trigger run.
-	TriggeredPipelines *map[string]string `json:"triggeredPipelines,omitempty" azure:"ro"`
+	TriggeredPipelines *map[string]*string `json:"triggeredPipelines,omitempty" azure:"ro"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type TriggerRun.
@@ -28198,7 +28198,7 @@ type TriggerRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of trigger runs.
-	Value *[]TriggerRun `json:"value,omitempty"`
+	Value *[]*TriggerRun `json:"value,omitempty"`
 }
 
 // TriggerRunsQueryResponseResponse is the response envelope for operations that return a TriggerRunsQueryResponse type.
@@ -28831,7 +28831,7 @@ type WebActivityTypeProperties struct {
 	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
 
 	// List of datasets passed to web endpoint.
-	Datasets *[]DatasetReference `json:"datasets,omitempty"`
+	Datasets *[]*DatasetReference `json:"datasets,omitempty"`
 
 	// Represents the headers that will be sent to the request. For example, to set the language and type on a request: "headers" : { "Accept-Language": "en-us",
 	// "Content-Type": "application/json" }. Type:
@@ -28839,7 +28839,7 @@ type WebActivityTypeProperties struct {
 	Headers interface{} `json:"headers,omitempty"`
 
 	// List of linked services passed to web endpoint.
-	LinkedServices *[]LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices *[]*LinkedServiceReference `json:"linkedServices,omitempty"`
 
 	// Rest API method for target endpoint.
 	Method *WebActivityMethod `json:"method,omitempty"`
@@ -29200,7 +29200,7 @@ type WorkspaceProperties struct {
 	AdlaResourceID *string `json:"adlaResourceId,omitempty" azure:"ro"`
 
 	// Connectivity endpoints
-	ConnectivityEndpoints *map[string]string `json:"connectivityEndpoints,omitempty"`
+	ConnectivityEndpoints *map[string]*string `json:"connectivityEndpoints,omitempty"`
 
 	// Workspace default data lake storage account details
 	DefaultDataLakeStorage *DataLakeStorageAccountDetails `json:"defaultDataLakeStorage,omitempty"`
@@ -29223,7 +29223,7 @@ type WorkspaceProperties struct {
 	ManagedVirtualNetworkSettings *ManagedVirtualNetworkSettings `json:"managedVirtualNetworkSettings,omitempty"`
 
 	// Private endpoint connections to the workspace
-	PrivateEndpointConnections *[]PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	PrivateEndpointConnections *[]*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
 
 	// READ-ONLY; Resource provisioning state
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
@@ -29292,7 +29292,7 @@ type WorkspaceUpdateParameters struct {
 	Identity *WorkspaceIdentity `json:"identity,omitempty"`
 
 	// The resource tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // Xero Service linked service.

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -48,13 +48,13 @@ type SparkBatchJob struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// The detailed application info.
-	AppInfo *map[string]string `json:"appInfo,omitempty"`
+	AppInfo *map[string]*string `json:"appInfo,omitempty"`
 
 	// The artifact identifier.
 	ArtifactID *string `json:"artifactId,omitempty"`
 
 	// The error information.
-	Errors *[]SparkServiceError `json:"errorInfo,omitempty"`
+	Errors *[]*SparkServiceError `json:"errorInfo,omitempty"`
 
 	// The session Id.
 	ID *int32 `json:"id,omitempty"`
@@ -64,7 +64,7 @@ type SparkBatchJob struct {
 	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
 
 	// The log lines.
-	LogLines *[]string `json:"log,omitempty"`
+	LogLines *[]*string `json:"log,omitempty"`
 
 	// The batch name.
 	Name *string `json:"name,omitempty"`
@@ -91,7 +91,7 @@ type SparkBatchJob struct {
 	SubmitterName *string `json:"submitterName,omitempty"`
 
 	// The tags.
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 
 	// The workspace name.
 	WorkspaceName *string `json:"workspaceName,omitempty"`
@@ -103,7 +103,7 @@ type SparkBatchJobCollection struct {
 	From *int32 `json:"from,omitempty"`
 
 	// Batch list
-	Sessions *[]SparkBatchJob `json:"sessions,omitempty"`
+	Sessions *[]*SparkBatchJob `json:"sessions,omitempty"`
 
 	// Number of sessions fetched.
 	Total *int32 `json:"total,omitempty"`
@@ -119,26 +119,26 @@ type SparkBatchJobCollectionResponse struct {
 }
 
 type SparkBatchJobOptions struct {
-	Archives   *[]string `json:"archives,omitempty"`
-	Arguments  *[]string `json:"args,omitempty"`
-	ArtifactID *string   `json:"artifactId,omitempty"`
-	ClassName  *string   `json:"className,omitempty"`
+	Archives   *[]*string `json:"archives,omitempty"`
+	Arguments  *[]*string `json:"args,omitempty"`
+	ArtifactID *string    `json:"artifactId,omitempty"`
+	ClassName  *string    `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          *[]string          `json:"files,omitempty"`
-	Jars           *[]string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    *[]string          `json:"pyFiles,omitempty"`
+	Configuration  *map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32              `json:"driverCores,omitempty"`
+	DriverMemory   *string             `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32              `json:"executorCores,omitempty"`
+	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
+	ExecutorMemory *string             `json:"executorMemory,omitempty"`
+	File           *string             `json:"file,omitempty"`
+	Files          *[]*string          `json:"files,omitempty"`
+	Jars           *[]*string          `json:"jars,omitempty"`
+	Name           *string             `json:"name,omitempty"`
+	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
 
 	// Dictionary of
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // SparkBatchJobResponse is the response envelope for operations that return a SparkBatchJob type.
@@ -249,22 +249,22 @@ func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
 }
 
 type SparkRequest struct {
-	Archives  *[]string `json:"archives,omitempty"`
-	Arguments *[]string `json:"args,omitempty"`
-	ClassName *string   `json:"className,omitempty"`
+	Archives  *[]*string `json:"archives,omitempty"`
+	Arguments *[]*string `json:"args,omitempty"`
+	ClassName *string    `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          *[]string          `json:"files,omitempty"`
-	Jars           *[]string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    *[]string          `json:"pyFiles,omitempty"`
+	Configuration  *map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32              `json:"driverCores,omitempty"`
+	DriverMemory   *string             `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32              `json:"executorCores,omitempty"`
+	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
+	ExecutorMemory *string             `json:"executorMemory,omitempty"`
+	File           *string             `json:"file,omitempty"`
+	Files          *[]*string          `json:"files,omitempty"`
+	Jars           *[]*string          `json:"jars,omitempty"`
+	Name           *string             `json:"name,omitempty"`
+	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
 }
 
 type SparkScheduler struct {
@@ -402,15 +402,15 @@ type SparkSession struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// Dictionary of
-	AppInfo    *map[string]string   `json:"appInfo,omitempty"`
-	ArtifactID *string              `json:"artifactId,omitempty"`
-	Errors     *[]SparkServiceError `json:"errorInfo,omitempty"`
-	ID         *int32               `json:"id,omitempty"`
+	AppInfo    *map[string]*string   `json:"appInfo,omitempty"`
+	ArtifactID *string               `json:"artifactId,omitempty"`
+	Errors     *[]*SparkServiceError `json:"errorInfo,omitempty"`
+	ID         *int32                `json:"id,omitempty"`
 
 	// The job type.
 	JobType       *SparkJobType           `json:"jobType,omitempty"`
 	LivyInfo      *SparkSessionState      `json:"livyInfo,omitempty"`
-	LogLines      *[]string               `json:"log,omitempty"`
+	LogLines      *[]*string              `json:"log,omitempty"`
 	Name          *string                 `json:"name,omitempty"`
 	Plugin        *SparkServicePlugin     `json:"pluginInfo,omitempty"`
 	Result        *SparkSessionResultType `json:"result,omitempty"`
@@ -421,8 +421,8 @@ type SparkSession struct {
 	SubmitterName *string                 `json:"submitterName,omitempty"`
 
 	// Dictionary of
-	Tags          *map[string]string `json:"tags,omitempty"`
-	WorkspaceName *string            `json:"workspaceName,omitempty"`
+	Tags          *map[string]*string `json:"tags,omitempty"`
+	WorkspaceName *string             `json:"workspaceName,omitempty"`
 }
 
 // SparkSessionCancelSparkSessionOptions contains the optional parameters for the SparkSession.CancelSparkSession method.
@@ -436,9 +436,9 @@ type SparkSessionCancelSparkStatementOptions struct {
 }
 
 type SparkSessionCollection struct {
-	From     *int32          `json:"from,omitempty"`
-	Sessions *[]SparkSession `json:"sessions,omitempty"`
-	Total    *int32          `json:"total,omitempty"`
+	From     *int32           `json:"from,omitempty"`
+	Sessions *[]*SparkSession `json:"sessions,omitempty"`
+	Total    *int32           `json:"total,omitempty"`
 }
 
 // SparkSessionCollectionResponse is the response envelope for operations that return a SparkSessionCollection type.
@@ -487,26 +487,26 @@ type SparkSessionGetSparkStatementsOptions struct {
 }
 
 type SparkSessionOptions struct {
-	Archives   *[]string `json:"archives,omitempty"`
-	Arguments  *[]string `json:"args,omitempty"`
-	ArtifactID *string   `json:"artifactId,omitempty"`
-	ClassName  *string   `json:"className,omitempty"`
+	Archives   *[]*string `json:"archives,omitempty"`
+	Arguments  *[]*string `json:"args,omitempty"`
+	ArtifactID *string    `json:"artifactId,omitempty"`
+	ClassName  *string    `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          *[]string          `json:"files,omitempty"`
-	Jars           *[]string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    *[]string          `json:"pyFiles,omitempty"`
+	Configuration  *map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32              `json:"driverCores,omitempty"`
+	DriverMemory   *string             `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32              `json:"executorCores,omitempty"`
+	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
+	ExecutorMemory *string             `json:"executorMemory,omitempty"`
+	File           *string             `json:"file,omitempty"`
+	Files          *[]*string          `json:"files,omitempty"`
+	Jars           *[]*string          `json:"jars,omitempty"`
+	Name           *string             `json:"name,omitempty"`
+	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
 
 	// Dictionary of
-	Tags *map[string]string `json:"tags,omitempty"`
+	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
 // SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the SparkSession.ResetSparkSessionTimeout method.
@@ -640,8 +640,8 @@ type SparkStatementCancellationResultResponse struct {
 }
 
 type SparkStatementCollection struct {
-	Statements *[]SparkStatement `json:"statements,omitempty"`
-	Total      *int32            `json:"total_statements,omitempty"`
+	Statements *[]*SparkStatement `json:"statements,omitempty"`
+	Total      *int32             `json:"total_statements,omitempty"`
 }
 
 // SparkStatementCollectionResponse is the response envelope for operations that return a SparkStatementCollection type.
@@ -663,7 +663,7 @@ type SparkStatementOutput struct {
 	ErrorValue     *string     `json:"evalue,omitempty"`
 	ExecutionCount *int32      `json:"execution_count,omitempty"`
 	Status         *string     `json:"status,omitempty"`
-	Traceback      *[]string   `json:"traceback,omitempty"`
+	Traceback      *[]*string  `json:"traceback,omitempty"`
 }
 
 // SparkStatementResponse is the response envelope for operations that return a SparkStatement type.

--- a/test/tables/2019-02-02/aztables/zz_generated_models.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_models.go
@@ -259,7 +259,7 @@ type SignedIdentifier struct {
 	ID *string `xml:"Id"`
 }
 
-// SignedIdentifierArrayResponse is the response envelope for operations that return a []SignedIdentifier type.
+// SignedIdentifierArrayResponse is the response envelope for operations that return a []*SignedIdentifier type.
 type SignedIdentifierArrayResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string `xml:"ClientRequestID"`
@@ -274,7 +274,7 @@ type SignedIdentifierArrayResponse struct {
 	RequestID *string `xml:"RequestID"`
 
 	// A collection of signed identifiers.
-	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+	SignedIdentifiers []*SignedIdentifier `xml:"SignedIdentifier"`
 
 	// Version contains the information returned from the x-ms-version header response.
 	Version *string `xml:"Version"`
@@ -517,7 +517,7 @@ type TableQueryResponse struct {
 	OdataMetadata *string `json:"odata.metadata,omitempty"`
 
 	// List of tables.
-	Value *[]TableResponseProperties `json:"value,omitempty"`
+	Value *[]*TableResponseProperties `json:"value,omitempty"`
 }
 
 // TableQueryResponseResponse is the response envelope for operations that return a TableQueryResponse type.
@@ -611,7 +611,7 @@ func (e TableServiceError) Error() string {
 // Table Service Properties.
 type TableServiceProperties struct {
 	// The set of CORS rules.
-	Cors *[]CorsRule `xml:"Cors>CorsRule"`
+	Cors *[]*CorsRule `xml:"Cors>CorsRule"`
 
 	// A summary of request statistics grouped by API in hourly aggregates for tables.
 	HourMetrics *Metrics `xml:"HourMetrics"`
@@ -685,7 +685,7 @@ type TableSetAccessPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics logging is enabled.
 	RequestID *string
 	// The acls for the table.
-	TableACL *[]SignedIdentifier
+	TableACL *[]*SignedIdentifier
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_table.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_table.go
@@ -936,8 +936,8 @@ func (client *TableClient) setAccessPolicyCreateRequest(ctx context.Context, tab
 	}
 	req.Header.Set("Accept", "application/xml")
 	type wrapper struct {
-		XMLName  xml.Name            `xml:"SignedIdentifiers"`
-		TableACL *[]SignedIdentifier `xml:"SignedIdentifier"`
+		XMLName  xml.Name             `xml:"SignedIdentifiers"`
+		TableACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
 	if options != nil {
 		return req, req.MarshalAsXML(wrapper{TableACL: options.TableACL})


### PR DESCRIPTION
Applicable to arrays and maps.  However we don't do this for arrays that
are used as header/path/query params as it doesn't make sense.