### PR TITLE
Update autorest.core and M4 to latest versions

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -79,7 +79,7 @@ function generate(inputFile, outputDir, additionalArgs) {
     sem.take(function() {
         console.log('generating ' + inputFile);
         cleanGeneratedFiles(outputDir);
-        exec('autorest --version:3.0.6375 --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, inputFile));
+        exec('autorest --version:3.2.1 --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, inputFile));
     });
 }
 
@@ -87,7 +87,7 @@ function generateFromReadme(readme, tag, outputDir, additionalArgs) {
     sem.take(function() {
         console.log('generating ' + readme);
         cleanGeneratedFiles(outputDir);
-        exec('autorest --version:3.0.6375 --use=. ' + readme + ' --tag=' + tag + ' --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, readme));
+        exec('autorest --version:3.2.1 --use=. ' + readme + ' --tag=' + tag + ' --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs, autorestCallback(outputDir, readme));
     });
 }
 

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -10,7 +10,7 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 ``` yaml !isLoaded('@autorest/remodeler') 
 use-extension:
-  "@autorest/modelerfour" : "4.15.440" 
+  "@autorest/modelerfour" : "4.18.0"
 
 modelerfour:
   resolve-schema-name-collisons: true

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -6,7 +6,7 @@
 import { Session } from '@autorest/extension-base';
 import { values } from '@azure-tools/linq';
 import { comment } from '@azure-tools/codegen';
-import { aggregateParameters, isArraySchema, isDictionarySchema, isSchemaResponse } from '../common/helpers';
+import { aggregateParameters, isSchemaResponse } from '../common/helpers';
 import { ArraySchema, CodeModel, DictionarySchema, Language, Parameter, Schema, SchemaType, Operation, GroupProperty, ImplementationLocation, SerializationStyle, ByteArraySchema, ConstantSchema, NumberSchema, DateTimeSchema } from '@azure-tools/codemodel';
 import { ImportManager } from './imports';
 

--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -55,6 +55,9 @@ export class ImportManager {
       case SchemaType.Array:
         this.addImportForSchemaType((<ArraySchema>schema).elementType);
         break;
+      case SchemaType.Binary:
+        this.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+        break;
       case SchemaType.Dictionary:
         this.addImportForSchemaType((<DictionarySchema>schema).elementType);
         break;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -467,7 +467,6 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
         text += '\tunencodedParams := []string{}\n';
       }
       for (const qp of values(unencodedParams)) {
-        // TODO: unused?
         let setter: string;
         if (qp.protocol.http?.explode === true) {
           setter = `\tfor _, qv := range ${getParamName(qp, true)} {\n`;
@@ -476,7 +475,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
         } else {
           setter = `unencodedParams = append(unencodedParams, "${qp.language.go!.serializedName}="+${formatParamValue(qp, imports)})`;
         }
-        text += emitQueryParam(qp, `unencodedParams = append(unencodedParams, "${qp.language.go!.serializedName}="+${formatParamValue(qp, imports)})`);
+        text += emitQueryParam(qp, setter);
       }
       text += '\treq.URL.RawQuery = strings.Join(unencodedParams, "&")\n';
     }

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -386,7 +386,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
         return false;
       }
       if (pp.schema.type === SchemaType.String || choiceIsString(pp.schema)) {
-        const paramName = getParamName(pp);
+        const paramName = getParamName(pp, true);
         imports.add('errors');
         text += `\tif ${paramName} == "" {\n`;
         text += `\t\treturn nil, errors.New("parameter ${paramName} cannot be empty")\n`;
@@ -448,7 +448,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
       for (const qp of values(encodedParams)) {
         let setter: string;
         if (qp.protocol.http?.explode === true) {
-          setter = `\tfor _, qv := range ${getParamName(qp)} {\n`;
+          setter = `\tfor _, qv := range ${getParamName(qp, true)} {\n`;
           setter += `\t\tquery.Add("${qp.language.go!.serializedName}", qv)\n`;
           setter += '\t}';
         } else {
@@ -467,9 +467,10 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
         text += '\tunencodedParams := []string{}\n';
       }
       for (const qp of values(unencodedParams)) {
+        // TODO: unused?
         let setter: string;
         if (qp.protocol.http?.explode === true) {
-          setter = `\tfor _, qv := range ${getParamName(qp)} {\n`;
+          setter = `\tfor _, qv := range ${getParamName(qp, true)} {\n`;
           setter += `\t\tunencodedParams = append(unencodedParams, "${qp.language.go!.serializedName}="+qv)\n`;
           setter += '\t}';
         } else {
@@ -489,7 +490,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
   headerParam.forEach(header => {
     const emitHeaderSet = function (headerParam: Parameter, prefix: string): string {
       if (header.schema.language.go!.headerCollectionPrefix) {
-        let headerText = `${prefix}for k, v := range ${getParamName(headerParam)} {\n`;
+        let headerText = `${prefix}for k, v := range ${getParamName(headerParam, true)} {\n`;
         headerText += `${prefix}\treq.Header.Set("${header.schema.language.go!.headerCollectionPrefix}"+k, v)\n`;
         headerText += `${prefix}}\n`;
         return headerText;
@@ -509,11 +510,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
   if (mediaType === 'JSON' || mediaType === 'XML') {
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
     // default to the body param name
-    let body = bodyParam!.language.go!.name;
-    if (bodyParam!.language.go!.paramGroup) {
-      const paramGroup = <GroupProperty>bodyParam!.language.go!.paramGroup;
-      body = `${(<string>paramGroup.language.go!.name).uncapitalize()}.${(<string>bodyParam!.language.go!.name).capitalize()}`;
-    }
+    let body = getParamName(bodyParam!, false);
     if (bodyParam!.schema.type === SchemaType.Constant) {
       // if the value is constant, embed it directly
       body = formatConstantValue(<ConstantSchema>bodyParam!.schema);
@@ -566,8 +563,7 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
     if (bodyParam!.required || bodyParam!.schema.type === SchemaType.Constant) {
       text += `\treturn req, req.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, body)}\n`;
     } else {
-      const paramGroup = <GroupProperty>bodyParam!.language.go!.paramGroup;
-      text += `\tif ${(<string>paramGroup.language.go!.name).uncapitalize()} != nil {\n`;
+      text += emitParamGroupCheck(<GroupProperty>bodyParam!.language.go!.paramGroup, bodyParam!);
       text += `\t\treturn req, req.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, body)}\n`;
       text += '\t}\n';
       text += '\treturn req, nil\n';
@@ -584,17 +580,27 @@ function createProtocolRequest(codeModel: CodeModel, op: Operation, imports: Imp
       }
     }
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
-    text += `\treturn req, req.SetBody(${bodyParam?.language.go!.name}, ${contentType})\n`;
+    if (bodyParam!.required) {
+      text += `\treturn req, req.SetBody(${bodyParam?.language.go!.name}, ${contentType})\n`;
+    } else {
+      text += emitParamGroupCheck(<GroupProperty>bodyParam!.language.go!.paramGroup, bodyParam!);
+      text += `\treturn req, req.SetBody(${getParamName(bodyParam!, false)}, ${contentType})\n`;
+      text += '\t}\n';
+      text += '\treturn req, nil\n';
+    }
   } else if (mediaType === 'text') {
     imports.add('strings');
-    let bodyParam = '';
-    for (const param of values(op.requests![0].parameters)) {
-      if (param.protocol.http!.in === 'body') {
-        bodyParam = param.language.go!.name;
-      }
+    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+    if (bodyParam!.required) {
+      text += `\tbody := azcore.NopCloser(strings.NewReader(${bodyParam}))\n`;
+      text += `\treturn req, req.SetBody(body, "text/plain; encoding=UTF-8")\n`;
+    } else {
+      text += emitParamGroupCheck(<GroupProperty>bodyParam!.language.go!.paramGroup, bodyParam!);
+      text += `\tbody := azcore.NopCloser(strings.NewReader(${getParamName(bodyParam!, true)}))\n`;
+      text += `\treturn req, req.SetBody(body, "text/plain; encoding=UTF-8")\n`;
+      text += '\t}\n';
+      text += '\treturn req, nil\n';
     }
-    text += `\tbody := azcore.NopCloser(strings.NewReader(${bodyParam}))\n`;
-    text += `\treturn req, req.SetBody(body, "text/plain; encoding=UTF-8")\n`;
   } else {
     text += `\treturn req, nil\n`;
   }

--- a/src/test/namer-test.ts
+++ b/src/test/namer-test.ts
@@ -2,14 +2,3 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-
-import { suite, test } from 'mocha-typescript';
-import * as assert from 'assert';
-
-@suite class TestNamer {
-  @test async 'test something'() {
-    assert.equal(1, 1, 'works for me kids!');
-
-  }
-
-}

--- a/test/autorest/extenumsgroup/zz_generated_pet.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet.go
@@ -54,7 +54,7 @@ func (client *PetClient) addPetCreateRequest(ctx context.Context, options *PetAd
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.PetParam != nil {
 		return req, req.MarshalAsJSON(options.PetParam)
 	}
 	return req, nil

--- a/test/autorest/lrogroup/zz_generated_lroretrys.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys.go
@@ -329,7 +329,7 @@ func (client *LRORetrysClient) post202Retry200CreateRequest(ctx context.Context,
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -410,7 +410,7 @@ func (client *LRORetrysClient) postAsyncRelativeRetrySucceededCreateRequest(ctx 
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -491,7 +491,7 @@ func (client *LRORetrysClient) put201CreatingSucceeded200CreateRequest(ctx conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -581,7 +581,7 @@ func (client *LRORetrysClient) putAsyncRelativeRetrySucceededCreateRequest(ctx c
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil

--- a/test/autorest/lrogroup/zz_generated_lros.go
+++ b/test/autorest/lrogroup/zz_generated_lros.go
@@ -1220,7 +1220,7 @@ func (client *LROsClient) post202NoRetry204CreateRequest(ctx context.Context, op
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1308,7 +1308,7 @@ func (client *LROsClient) post202Retry200CreateRequest(ctx context.Context, opti
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1389,7 +1389,7 @@ func (client *LROsClient) postAsyncNoRetrySucceededCreateRequest(ctx context.Con
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1479,7 +1479,7 @@ func (client *LROsClient) postAsyncRetryFailedCreateRequest(ctx context.Context,
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1560,7 +1560,7 @@ func (client *LROsClient) postAsyncRetrySucceededCreateRequest(ctx context.Conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1650,7 +1650,7 @@ func (client *LROsClient) postAsyncRetrycanceledCreateRequest(ctx context.Contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1988,7 +1988,7 @@ func (client *LROsClient) put200Acceptedcanceled200CreateRequest(ctx context.Con
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2074,7 +2074,7 @@ func (client *LROsClient) put200SucceededCreateRequest(ctx context.Context, opti
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2160,7 +2160,7 @@ func (client *LROsClient) put200SucceededNoStateCreateRequest(ctx context.Contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2250,7 +2250,7 @@ func (client *LROsClient) put200UpdatingSucceeded204CreateRequest(ctx context.Co
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2340,7 +2340,7 @@ func (client *LROsClient) put201CreatingFailed200CreateRequest(ctx context.Conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2430,7 +2430,7 @@ func (client *LROsClient) put201CreatingSucceeded200CreateRequest(ctx context.Co
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2516,7 +2516,7 @@ func (client *LROsClient) put201SucceededCreateRequest(ctx context.Context, opti
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2604,7 +2604,7 @@ func (client *LROsClient) put202Retry200CreateRequest(ctx context.Context, optio
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2692,7 +2692,7 @@ func (client *LROsClient) putAsyncNoHeaderInRetryCreateRequest(ctx context.Conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2782,7 +2782,7 @@ func (client *LROsClient) putAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2872,7 +2872,7 @@ func (client *LROsClient) putAsyncNoRetrycanceledCreateRequest(ctx context.Conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2958,7 +2958,7 @@ func (client *LROsClient) putAsyncNonResourceCreateRequest(ctx context.Context, 
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.SKU != nil {
 		return req, req.MarshalAsJSON(options.SKU)
 	}
 	return req, nil
@@ -3048,7 +3048,7 @@ func (client *LROsClient) putAsyncRetryFailedCreateRequest(ctx context.Context, 
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -3138,7 +3138,7 @@ func (client *LROsClient) putAsyncRetrySucceededCreateRequest(ctx context.Contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -3224,7 +3224,7 @@ func (client *LROsClient) putAsyncSubResourceCreateRequest(ctx context.Context, 
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -3312,7 +3312,7 @@ func (client *LROsClient) putNoHeaderInRetryCreateRequest(ctx context.Context, o
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -3398,7 +3398,7 @@ func (client *LROsClient) putNonResourceCreateRequest(ctx context.Context, optio
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.SKU != nil {
 		return req, req.MarshalAsJSON(options.SKU)
 	}
 	return req, nil
@@ -3484,7 +3484,7 @@ func (client *LROsClient) putSubResourceCreateRequest(ctx context.Context, optio
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil

--- a/test/autorest/lrogroup/zz_generated_lrosads.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads.go
@@ -690,7 +690,7 @@ func (client *LROSADsClient) post202NoLocationCreateRequest(ctx context.Context,
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -767,7 +767,7 @@ func (client *LROSADsClient) post202NonRetry400CreateRequest(ctx context.Context
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -844,7 +844,7 @@ func (client *LROSADsClient) post202RetryInvalidHeaderCreateRequest(ctx context.
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -923,7 +923,7 @@ func (client *LROSADsClient) postAsyncRelativeRetry400CreateRequest(ctx context.
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1004,7 +1004,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidHeaderCreateRequest(ct
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1085,7 +1085,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidJSONPollingCreateReque
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1166,7 +1166,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryNoPayloadCreateRequest(ctx co
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1243,7 +1243,7 @@ func (client *LROSADsClient) postNonRetry400CreateRequest(ctx context.Context, o
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1320,7 +1320,7 @@ func (client *LROSADsClient) put200InvalidJSONCreateRequest(ctx context.Context,
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1408,7 +1408,7 @@ func (client *LROSADsClient) putAsyncRelativeRetry400CreateRequest(ctx context.C
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1496,7 +1496,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidHeaderCreateRequest(ctx
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1586,7 +1586,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPollingCreateReques
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1676,7 +1676,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusCreateRequest(ctx cont
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1766,7 +1766,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayloadCreateRequest(c
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1852,7 +1852,7 @@ func (client *LROSADsClient) putError201NoProvisioningStatePayloadCreateRequest(
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -1938,7 +1938,7 @@ func (client *LROSADsClient) putNonRetry201Creating400CreateRequest(ctx context.
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2025,7 +2025,7 @@ func (client *LROSADsClient) putNonRetry201Creating400InvalidJSONCreateRequest(c
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -2111,7 +2111,7 @@ func (client *LROSADsClient) putNonRetry400CreateRequest(ctx context.Context, op
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader.go
@@ -92,7 +92,7 @@ func (client *LROsCustomHeaderClient) post202Retry200CreateRequest(ctx context.C
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -173,7 +173,7 @@ func (client *LROsCustomHeaderClient) postAsyncRetrySucceededCreateRequest(ctx c
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -254,7 +254,7 @@ func (client *LROsCustomHeaderClient) put201CreatingSucceeded200CreateRequest(ct
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
@@ -344,7 +344,7 @@ func (client *LROsCustomHeaderClient) putAsyncRetrySucceededCreateRequest(ctx co
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Product != nil {
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -20,7 +20,9 @@ func newMediaTypesClient() *MediaTypesClient {
 func TestAnalyzeBody(t *testing.T) {
 	client := newMediaTypesClient()
 	body := azcore.NopCloser(bytes.NewReader([]byte("PDF")))
-	result, err := client.AnalyzeBody(context.Background(), ContentTypeApplicationPDF, body, nil)
+	result, err := client.AnalyzeBody(context.Background(), ContentTypeApplicationPDF, &MediaTypesClientAnalyzeBodyOptions{
+		Input: body,
+	})
 	if err != nil {
 		t.Fatalf("AnalyzeBody: %v", err)
 	}
@@ -45,7 +47,9 @@ func TestAnalyzeBodyWithSourcePath(t *testing.T) {
 
 func TestContentTypeWithEncoding(t *testing.T) {
 	client := newMediaTypesClient()
-	result, err := client.ContentTypeWithEncoding(context.Background(), "foo", nil)
+	result, err := client.ContentTypeWithEncoding(context.Background(), &MediaTypesClientContentTypeWithEncodingOptions{
+		Input: to.StringPtr("foo"),
+	})
 	if err != nil {
 		t.Fatalf("ContentTypeWithEncoding: %v", err)
 	}

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient.go
@@ -29,8 +29,8 @@ func NewMediaTypesClient(con *Connection) *MediaTypesClient {
 }
 
 // AnalyzeBody - Analyze body, that could be different media types.
-func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser, options *MediaTypesClientAnalyzeBodyOptions) (StringResponse, error) {
-	req, err := client.analyzeBodyCreateRequest(ctx, contentType, input, options)
+func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType ContentType, options *MediaTypesClientAnalyzeBodyOptions) (StringResponse, error) {
+	req, err := client.analyzeBodyCreateRequest(ctx, contentType, options)
 	if err != nil {
 		return StringResponse{}, err
 	}
@@ -45,7 +45,7 @@ func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType Con
 }
 
 // analyzeBodyCreateRequest creates the AnalyzeBody request.
-func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, contentType ContentType, input azcore.ReadSeekCloser, options *MediaTypesClientAnalyzeBodyOptions) (*azcore.Request, error) {
+func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, contentType ContentType, options *MediaTypesClientAnalyzeBodyOptions) (*azcore.Request, error) {
 	urlPath := "/mediatypes/analyze"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -54,7 +54,10 @@ func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, co
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Content-Type", string(contentType))
 	req.Header.Set("Accept", "application/json")
-	return req, req.SetBody(input, string(contentType))
+	if options != nil && options.Input != nil {
+		return req, req.SetBody(options.Input, string(contentType))
+	}
+	return req, nil
 }
 
 // analyzeBodyHandleResponse handles the AnalyzeBody response.
@@ -103,7 +106,7 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathCreateRequest(ctx conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Input != nil {
 		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil
@@ -131,8 +134,8 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleError(resp *azcor
 }
 
 // ContentTypeWithEncoding - Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter
-func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, input string, options *MediaTypesClientContentTypeWithEncodingOptions) (StringResponse, error) {
-	req, err := client.contentTypeWithEncodingCreateRequest(ctx, input, options)
+func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, options *MediaTypesClientContentTypeWithEncodingOptions) (StringResponse, error) {
+	req, err := client.contentTypeWithEncodingCreateRequest(ctx, options)
 	if err != nil {
 		return StringResponse{}, err
 	}
@@ -147,7 +150,7 @@ func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, inp
 }
 
 // contentTypeWithEncodingCreateRequest creates the ContentTypeWithEncoding request.
-func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context.Context, input string, options *MediaTypesClientContentTypeWithEncodingOptions) (*azcore.Request, error) {
+func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context.Context, options *MediaTypesClientContentTypeWithEncodingOptions) (*azcore.Request, error) {
 	urlPath := "/mediatypes/contentTypeWithEncoding"
 	req, err := azcore.NewRequest(ctx, http.MethodPost, azcore.JoinPaths(client.con.Endpoint(), urlPath))
 	if err != nil {
@@ -155,8 +158,11 @@ func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	body := azcore.NopCloser(strings.NewReader(input))
-	return req, req.SetBody(body, "text/plain; encoding=UTF-8")
+	if options != nil && options.Input != nil {
+		body := azcore.NopCloser(strings.NewReader(*options.Input))
+		return req, req.SetBody(body, "text/plain; encoding=UTF-8")
+	}
+	return req, nil
 }
 
 // contentTypeWithEncodingHandleResponse handles the ContentTypeWithEncoding response.

--- a/test/autorest/mediatypesgroup/zz_generated_models.go
+++ b/test/autorest/mediatypesgroup/zz_generated_models.go
@@ -7,11 +7,15 @@
 
 package mediatypesgroup
 
-import "net/http"
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
+)
 
 // MediaTypesClientAnalyzeBodyOptions contains the optional parameters for the MediaTypesClient.AnalyzeBody method.
 type MediaTypesClientAnalyzeBodyOptions struct {
-	// placeholder for future optional parameters
+	// Input parameter.
+	Input azcore.ReadSeekCloser
 }
 
 // MediaTypesClientAnalyzeBodyWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithSourcePath method.
@@ -22,7 +26,8 @@ type MediaTypesClientAnalyzeBodyWithSourcePathOptions struct {
 
 // MediaTypesClientContentTypeWithEncodingOptions contains the optional parameters for the MediaTypesClient.ContentTypeWithEncoding method.
 type MediaTypesClientContentTypeWithEncodingOptions struct {
-	// placeholder for future optional parameters
+	// Input parameter.
+	Input *string
 }
 
 // Uri or local path to source data.

--- a/test/autorest/nonstringenumgroup/zz_generated_float.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float.go
@@ -101,7 +101,7 @@ func (client *FloatClient) putCreateRequest(ctx context.Context, options *FloatP
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Input != nil {
 		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil

--- a/test/autorest/nonstringenumgroup/zz_generated_int.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int.go
@@ -101,7 +101,7 @@ func (client *IntClient) putCreateRequest(ctx context.Context, options *IntPutOp
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Input != nil {
 		return req, req.MarshalAsJSON(options.Input)
 	}
 	return req, nil

--- a/test/autorest/optionalgroup/zz_generated_explicit.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit.go
@@ -91,7 +91,7 @@ func (client *ExplicitClient) postOptionalArrayParameterCreateRequest(ctx contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -131,7 +131,7 @@ func (client *ExplicitClient) postOptionalArrayPropertyCreateRequest(ctx context
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -171,7 +171,7 @@ func (client *ExplicitClient) postOptionalClassParameterCreateRequest(ctx contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -211,7 +211,7 @@ func (client *ExplicitClient) postOptionalClassPropertyCreateRequest(ctx context
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -291,7 +291,7 @@ func (client *ExplicitClient) postOptionalIntegerParameterCreateRequest(ctx cont
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -331,7 +331,7 @@ func (client *ExplicitClient) postOptionalIntegerPropertyCreateRequest(ctx conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -411,7 +411,7 @@ func (client *ExplicitClient) postOptionalStringParameterCreateRequest(ctx conte
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil
@@ -451,7 +451,7 @@ func (client *ExplicitClient) postOptionalStringPropertyCreateRequest(ctx contex
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil

--- a/test/autorest/optionalgroup/zz_generated_implicit.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit.go
@@ -220,7 +220,7 @@ func (client *ImplicitClient) putOptionalBodyCreateRequest(ctx context.Context, 
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.BodyParameter != nil {
 		return req, req.MarshalAsJSON(options.BodyParameter)
 	}
 	return req, nil

--- a/test/autorest/stringgroup/zz_generated_string.go
+++ b/test/autorest/stringgroup/zz_generated_string.go
@@ -528,7 +528,7 @@ func (client *StringClient) putNullCreateRequest(ctx context.Context, options *S
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.StringBody != nil {
 		return req, req.MarshalAsJSON(options.StringBody)
 	}
 	return req, nil

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest.go
@@ -95,7 +95,7 @@ func (client *AutoRestValidationTestClient) postWithConstantInBodyCreateRequest(
 	}
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Body != nil {
 		return req, req.MarshalAsJSON(options.Body)
 	}
 	return req, nil
@@ -159,7 +159,7 @@ func (client *AutoRestValidationTestClient) validationOfBodyCreateRequest(ctx co
 	query.Set("apiVersion", "1.0.0")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Body != nil {
 		return req, req.MarshalAsJSON(options.Body)
 	}
 	return req, nil

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics.go
@@ -130,7 +130,7 @@ func (client *LogAnalyticsClient) exportRequestRateByIntervalHandleError(resp *a
 }
 
 // BeginExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.
-func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsBeginExportThrottledRequestsOptions) (LogAnalyticsOperationResultPollerResponse, error) {
+func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Context, location string, parameters ThrottledRequestsInput, options *LogAnalyticsBeginExportThrottledRequestsOptions) (LogAnalyticsOperationResultPollerResponse, error) {
 	resp, err := client.exportThrottledRequests(ctx, location, parameters, options)
 	if err != nil {
 		return LogAnalyticsOperationResultPollerResponse{}, err
@@ -167,7 +167,7 @@ func (client *LogAnalyticsClient) ResumeExportThrottledRequests(token string) (L
 }
 
 // ExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.
-func (client *LogAnalyticsClient) exportThrottledRequests(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsBeginExportThrottledRequestsOptions) (*azcore.Response, error) {
+func (client *LogAnalyticsClient) exportThrottledRequests(ctx context.Context, location string, parameters ThrottledRequestsInput, options *LogAnalyticsBeginExportThrottledRequestsOptions) (*azcore.Response, error) {
 	req, err := client.exportThrottledRequestsCreateRequest(ctx, location, parameters, options)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (client *LogAnalyticsClient) exportThrottledRequests(ctx context.Context, l
 }
 
 // exportThrottledRequestsCreateRequest creates the ExportThrottledRequests request.
-func (client *LogAnalyticsClient) exportThrottledRequestsCreateRequest(ctx context.Context, location string, parameters LogAnalyticsInputBase, options *LogAnalyticsBeginExportThrottledRequestsOptions) (*azcore.Request, error) {
+func (client *LogAnalyticsClient) exportThrottledRequestsCreateRequest(ctx context.Context, location string, parameters ThrottledRequestsInput, options *LogAnalyticsBeginExportThrottledRequestsOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getThrottledRequests"
 	if location == "" {
 		return nil, errors.New("parameter location cannot be empty")

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -1483,8 +1483,8 @@ type EncryptionImages struct {
 	// A list of encryption specifications for data disk images.
 	DataDiskImages *[]*DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
 
-	// This is the disk image encryption base class.
-	OSDiskImage *DiskImageEncryption `json:"osDiskImage,omitempty"`
+	// Contains encryption settings for an OS disk image.
+	OSDiskImage *OSDiskImageEncryption `json:"osDiskImage,omitempty"`
 }
 
 // The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
@@ -2237,8 +2237,8 @@ type GalleryImageVersionProperties struct {
 	// READ-ONLY; The provisioning state, which only appears in the response.
 	ProvisioningState *GalleryImageVersionPropertiesProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
-	// Describes the basic gallery artifact publishing profile.
-	PublishingProfile *GalleryArtifactPublishingProfileBase `json:"publishingProfile,omitempty"`
+	// The publishing profile of a gallery Image Version.
+	PublishingProfile *GalleryImageVersionPublishingProfile `json:"publishingProfile,omitempty"`
 
 	// READ-ONLY; This is the replication status of the gallery Image Version.
 	ReplicationStatus *ReplicationStatus `json:"replicationStatus,omitempty" azure:"ro"`
@@ -2266,8 +2266,8 @@ type GalleryImageVersionStorageProfile struct {
 	// A list of data disk images.
 	DataDiskImages *[]*GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
 
-	// This is the disk image base class.
-	OSDiskImage *GalleryDiskImage `json:"osDiskImage,omitempty"`
+	// This is the OS disk image.
+	OSDiskImage *GalleryOSDiskImage `json:"osDiskImage,omitempty"`
 
 	// The gallery artifact version source.
 	Source *GalleryArtifactVersionSource `json:"source,omitempty"`
@@ -2470,7 +2470,7 @@ type ImageDisk struct {
 	Caching *CachingTypes `json:"caching,omitempty"`
 
 	// Specifies the customer managed disk encryption set resource id for the managed image disk.
-	DiskEncryptionSet *SubResource `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
 
 	// Specifies the size of empty data disks in gigabytes. This element can be used to overwrite the name of the disk in a virtual machine image.
 	// This value cannot be larger than 1023 GB
@@ -3027,7 +3027,7 @@ type ManagedArtifact struct {
 type ManagedDiskParameters struct {
 	SubResource
 	// Specifies the customer managed disk encryption set resource id for the managed disk.
-	DiskEncryptionSet *SubResource `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.
 	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
@@ -4354,12 +4354,6 @@ type UpdateResource struct {
 	Tags *map[string]*string `json:"tags,omitempty"`
 }
 
-// MarshalJSON implements the json.Marshaller interface for type UpdateResource.
-func (u UpdateResource) MarshalJSON() ([]byte, error) {
-	objectMap := u.marshalInternal()
-	return json.Marshal(objectMap)
-}
-
 func (u UpdateResource) marshalInternal() map[string]interface{} {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "tags", u.Tags)
@@ -5597,7 +5591,7 @@ type VirtualMachineScaleSetListWithLinkResultResponse struct {
 // Describes the parameters of a ScaleSet managed disk.
 type VirtualMachineScaleSetManagedDiskParameters struct {
 	// Specifies the customer managed disk encryption set resource id for the managed disk.
-	DiskEncryptionSet *SubResource `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot be used with OS Disk.
 	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
@@ -5850,7 +5844,7 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
 
 // Describes a Virtual Machine Scale Set VM Reimage Parameters.
 type VirtualMachineScaleSetReimageParameters struct {
-	VirtualMachineReimageParameters
+	VirtualMachineScaleSetVMReimageParameters
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual
 	// machines in the virtual machine scale set.
 	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
@@ -6503,7 +6497,7 @@ type VirtualMachineScaleSetVMsBeginReimageAllOptions struct {
 // VirtualMachineScaleSetVMsBeginReimageOptions contains the optional parameters for the VirtualMachineScaleSetVMs.BeginReimage method.
 type VirtualMachineScaleSetVMsBeginReimageOptions struct {
 	// Parameters for the Reimaging Virtual machine in ScaleSet.
-	VMScaleSetVMReimageInput *VirtualMachineReimageParameters
+	VMScaleSetVMReimageInput *VirtualMachineScaleSetVMReimageParameters
 }
 
 // VirtualMachineScaleSetVMsBeginRestartOptions contains the optional parameters for the VirtualMachineScaleSetVMs.BeginRestart method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups.go
@@ -333,7 +333,7 @@ func (client *ProximityPlacementGroupsClient) listBySubscriptionHandleError(resp
 }
 
 // Update - Update a proximity placement group.
-func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource, options *ProximityPlacementGroupsUpdateOptions) (ProximityPlacementGroupResponse, error) {
+func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroupUpdate, options *ProximityPlacementGroupsUpdateOptions) (ProximityPlacementGroupResponse, error) {
 	req, err := client.updateCreateRequest(ctx, resourceGroupName, proximityPlacementGroupName, parameters, options)
 	if err != nil {
 		return ProximityPlacementGroupResponse{}, err
@@ -349,7 +349,7 @@ func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resour
 }
 
 // updateCreateRequest creates the Update request.
-func (client *ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters UpdateResource, options *ProximityPlacementGroupsUpdateOptions) (*azcore.Request, error) {
+func (client *ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Context, resourceGroupName string, proximityPlacementGroupName string, parameters ProximityPlacementGroupUpdate, options *ProximityPlacementGroupsUpdateOptions) (*azcore.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/proximityPlacementGroups/{proximityPlacementGroupName}"
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines.go
@@ -1396,7 +1396,7 @@ func (client *VirtualMachinesClient) reimageCreateRequest(ctx context.Context, r
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.Parameters != nil {
 		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets.go
@@ -268,7 +268,7 @@ func (client *VirtualMachineScaleSetsClient) deallocateCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -988,7 +988,7 @@ func (client *VirtualMachineScaleSetsClient) performMaintenanceCreateRequest(ctx
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -1089,7 +1089,7 @@ func (client *VirtualMachineScaleSetsClient) powerOffCreateRequest(ctx context.C
 	}
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -1183,7 +1183,7 @@ func (client *VirtualMachineScaleSetsClient) redeployCreateRequest(ctx context.C
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -1281,7 +1281,7 @@ func (client *VirtualMachineScaleSetsClient) reimageCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMScaleSetReimageInput != nil {
 		return req, req.MarshalAsJSON(options.VMScaleSetReimageInput)
 	}
 	return req, nil
@@ -1377,7 +1377,7 @@ func (client *VirtualMachineScaleSetsClient) reimageAllCreateRequest(ctx context
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -1471,7 +1471,7 @@ func (client *VirtualMachineScaleSetsClient) restartCreateRequest(ctx context.Co
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil
@@ -1656,7 +1656,7 @@ func (client *VirtualMachineScaleSetsClient) startCreateRequest(ctx context.Cont
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMInstanceIDs != nil {
 		return req, req.MarshalAsJSON(options.VMInstanceIDs)
 	}
 	return req, nil

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms.go
@@ -813,7 +813,7 @@ func (client *VirtualMachineScaleSetVMsClient) reimageCreateRequest(ctx context.
 	query := req.URL.Query()
 	query.Set("api-version", "2019-12-01")
 	req.URL.RawQuery = query.Encode()
-	if options != nil {
+	if options != nil && options.VMScaleSetVMReimageInput != nil {
 		return req, req.MarshalAsJSON(options.VMScaleSetVMReimageInput)
 	}
 	return req, nil

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -2585,7 +2585,7 @@ type BastionShareableLink struct {
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// Reference of the virtual machine resource.
-	VM *Resource `json:"vm,omitempty"`
+	VM *VM `json:"vm,omitempty"`
 }
 
 // Post request for all the Bastion Shareable Link endpoints.
@@ -3581,7 +3581,7 @@ type ContainerNetworkInterfaceIPConfigurationPropertiesFormat struct {
 // Properties of container network interface.
 type ContainerNetworkInterfacePropertiesFormat struct {
 	// Reference to the container to which this container network interface is attached.
-	Container *SubResource `json:"container,omitempty"`
+	Container *Container `json:"container,omitempty"`
 
 	// READ-ONLY; Container network interface configuration from which this container network interface is created.
 	ContainerNetworkInterfaceConfiguration *ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfiguration,omitempty" azure:"ro"`
@@ -10114,7 +10114,7 @@ type PrivateLinkServiceProperties struct {
 	Alias *string `json:"alias,omitempty" azure:"ro"`
 
 	// The auto-approval list of the private link service.
-	AutoApproval *ResourceSet `json:"autoApproval,omitempty"`
+	AutoApproval *PrivateLinkServicePropertiesAutoApproval `json:"autoApproval,omitempty"`
 
 	// Whether the private link service is enabled for proxy protocol or not.
 	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty"`
@@ -10138,7 +10138,7 @@ type PrivateLinkServiceProperties struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The visibility list of the private link service.
-	Visibility *ResourceSet `json:"visibility,omitempty"`
+	Visibility *PrivateLinkServicePropertiesVisibility `json:"visibility,omitempty"`
 }
 
 // The auto-approval list of the private link service.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections.go
@@ -678,7 +678,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureCreateRe
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Parameters != nil {
 		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways.go
@@ -1650,7 +1650,7 @@ func (client *VirtualNetworkGatewaysClient) startPacketCaptureCreateRequest(ctx 
 	query.Set("api-version", "2020-03-01")
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Parameters != nil {
 		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil

--- a/test/storage/2019-07-07/azblob/zz_generated_container.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container.go
@@ -1162,7 +1162,7 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 		XMLName      xml.Name             `xml:"SignedIdentifiers"`
 		ContainerACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
-	if containerSetAccessPolicyOptions != nil {
+	if containerSetAccessPolicyOptions != nil && containerSetAccessPolicyOptions.ContainerACL != nil {
 		return req, req.MarshalAsXML(wrapper{ContainerACL: containerSetAccessPolicyOptions.ContainerACL})
 	}
 	return req, nil

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -993,14 +993,14 @@ func (a *AmazonS3ReadSettings) UnmarshalJSON(data []byte) error {
 
 // Append value for a Variable of type Array.
 type AppendVariableActivity struct {
-	Activity
+	ControlActivity
 	// Append Variable activity properties.
 	TypeProperties *AppendVariableActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AppendVariableActivity.
 func (a AppendVariableActivity) MarshalJSON() ([]byte, error) {
-	objectMap := a.Activity.marshalInternal("AppendVariable")
+	objectMap := a.ControlActivity.marshalInternal("AppendVariable")
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -1022,7 +1022,7 @@ func (a *AppendVariableActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return a.Activity.unmarshalInternal(rawMsg)
+	return a.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // AppendVariable activity properties.
@@ -6092,15 +6092,38 @@ func (c *ConcurSource) UnmarshalJSON(data []byte) error {
 	return c.TabularSource.unmarshalInternal(rawMsg)
 }
 
+// ControlActivityClassification provides polymorphic access to related types.
+// Call the interface's GetControlActivity() method to access the common type.
+// Use a type switch to determine the concrete type.  The possible types are:
+// - *ControlActivity, *AppendVariableActivity, *ExecutePipelineActivity, *FilterActivity, *ForEachActivity, *IfConditionActivity,
+// - *SetVariableActivity, *SwitchActivity, *UntilActivity, *ValidationActivity, *WaitActivity, *WebHookActivity
+type ControlActivityClassification interface {
+	ActivityClassification
+	// GetControlActivity() returns the ControlActivity content of the underlying type.
+	GetControlActivity() *ControlActivity
+}
+
 // Base class for all control activities like IfCondition, ForEach , Until.
 type ControlActivity struct {
 	Activity
 }
 
+// GetControlActivity implements the ControlActivityClassification interface for type ControlActivity.
+func (c *ControlActivity) GetControlActivity() *ControlActivity { return c }
+
 // MarshalJSON implements the json.Marshaller interface for type ControlActivity.
 func (c ControlActivity) MarshalJSON() ([]byte, error) {
-	objectMap := c.Activity.marshalInternal("Container")
+	objectMap := c.marshalInternal("Container")
 	return json.Marshal(objectMap)
+}
+
+func (c ControlActivity) marshalInternal(discValue string) map[string]interface{} {
+	objectMap := c.Activity.marshalInternal(discValue)
+	return objectMap
+}
+
+func (c *ControlActivity) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	return c.Activity.unmarshalInternal(rawMsg)
 }
 
 // Copy activity.
@@ -7755,7 +7778,7 @@ func (d *DataFlowReference) UnmarshalJSON(data []byte) error {
 
 // Data flow resource type.
 type DataFlowResource struct {
-	AzureEntityResource
+	SubResource
 	// Data flow properties.
 	Properties DataFlowClassification `json:"properties,omitempty"`
 }
@@ -8513,7 +8536,7 @@ type DatasetReference struct {
 
 // Dataset resource type.
 type DatasetResource struct {
-	AzureEntityResource
+	SubResource
 	// Dataset properties.
 	Properties DatasetClassification `json:"properties,omitempty"`
 }
@@ -10570,14 +10593,14 @@ type ExecuteDataFlowActivityTypePropertiesCompute struct {
 
 // Execute pipeline activity.
 type ExecutePipelineActivity struct {
-	Activity
+	ControlActivity
 	// Execute pipeline activity properties.
 	TypeProperties *ExecutePipelineActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ExecutePipelineActivity.
 func (e ExecutePipelineActivity) MarshalJSON() ([]byte, error) {
-	objectMap := e.Activity.marshalInternal("ExecutePipeline")
+	objectMap := e.ControlActivity.marshalInternal("ExecutePipeline")
 	populate(objectMap, "typeProperties", e.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -10599,7 +10622,7 @@ func (e *ExecutePipelineActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return e.Activity.unmarshalInternal(rawMsg)
+	return e.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Execute pipeline activity properties.
@@ -11022,14 +11045,14 @@ func (f *FileSystemSource) UnmarshalJSON(data []byte) error {
 
 // Filter and return results from input array based on the conditions.
 type FilterActivity struct {
-	Activity
+	ControlActivity
 	// Filter activity properties.
 	TypeProperties *FilterActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type FilterActivity.
 func (f FilterActivity) MarshalJSON() ([]byte, error) {
-	objectMap := f.Activity.marshalInternal("Filter")
+	objectMap := f.ControlActivity.marshalInternal("Filter")
 	populate(objectMap, "typeProperties", f.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -11051,7 +11074,7 @@ func (f *FilterActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return f.Activity.unmarshalInternal(rawMsg)
+	return f.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Filter activity properties.
@@ -11065,14 +11088,14 @@ type FilterActivityTypeProperties struct {
 
 // This activity is used for iterating over a collection and execute given activities.
 type ForEachActivity struct {
-	Activity
+	ControlActivity
 	// ForEach activity properties.
 	TypeProperties *ForEachActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ForEachActivity.
 func (f ForEachActivity) MarshalJSON() ([]byte, error) {
-	objectMap := f.Activity.marshalInternal("ForEach")
+	objectMap := f.ControlActivity.marshalInternal("ForEach")
 	populate(objectMap, "typeProperties", f.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -11094,7 +11117,7 @@ func (f *ForEachActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return f.Activity.unmarshalInternal(rawMsg)
+	return f.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // ForEach activity properties.
@@ -13827,14 +13850,14 @@ func (h *HubspotSource) UnmarshalJSON(data []byte) error {
 // This activity evaluates a boolean expression and executes either the activities under the ifTrueActivities property or the ifFalseActivities property
 // depending on the result of the expression.
 type IfConditionActivity struct {
-	Activity
+	ControlActivity
 	// IfCondition activity properties.
 	TypeProperties *IfConditionActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type IfConditionActivity.
 func (i IfConditionActivity) MarshalJSON() ([]byte, error) {
-	objectMap := i.Activity.marshalInternal("IfCondition")
+	objectMap := i.ControlActivity.marshalInternal("IfCondition")
 	populate(objectMap, "typeProperties", i.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -13856,7 +13879,7 @@ func (i *IfConditionActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return i.Activity.unmarshalInternal(rawMsg)
+	return i.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // IfCondition activity properties.
@@ -14581,7 +14604,7 @@ type IntegrationRuntimeReference struct {
 
 // Integration runtime resource type.
 type IntegrationRuntimeResource struct {
-	AzureEntityResource
+	SubResource
 	// Integration runtime properties.
 	Properties IntegrationRuntimeClassification `json:"properties,omitempty"`
 }
@@ -15435,7 +15458,7 @@ func (l *LibraryRequirements) UnmarshalJSON(data []byte) error {
 
 // Library response details
 type LibraryResource struct {
-	AzureEntityResource
+	SubResource
 	// Library/package properties.
 	Properties *LibraryResourceProperties `json:"properties,omitempty"`
 }
@@ -15824,7 +15847,7 @@ type LinkedServiceReference struct {
 
 // Linked service resource type.
 type LinkedServiceResource struct {
-	AzureEntityResource
+	SubResource
 	// Properties of linked service.
 	Properties LinkedServiceClassification `json:"properties,omitempty"`
 }
@@ -19694,7 +19717,7 @@ type PipelineReference struct {
 
 // Pipeline resource type.
 type PipelineResource struct {
-	AzureEntityResource
+	SubResource
 	// Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties *map[string]interface{}
 
@@ -19704,7 +19727,7 @@ type PipelineResource struct {
 
 // MarshalJSON implements the json.Marshaller interface for type PipelineResource.
 func (p PipelineResource) MarshalJSON() ([]byte, error) {
-	objectMap := p.AzureEntityResource.marshalInternal()
+	objectMap := p.SubResource.marshalInternal()
 	populate(objectMap, "properties", p.Properties)
 	if p.AdditionalProperties != nil {
 		for key, val := range *p.AdditionalProperties {
@@ -19731,7 +19754,7 @@ func (p *PipelineResource) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	if err := p.AzureEntityResource.unmarshalInternal(rawMsg); err != nil {
+	if err := p.SubResource.unmarshalInternal(rawMsg); err != nil {
 		return err
 	}
 	for key, val := range rawMsg {
@@ -20399,7 +20422,7 @@ type PrivateEndpoint struct {
 
 // A private endpoint connection
 type PrivateEndpointConnection struct {
-	Resource
+	ProxyResource
 	// Private endpoint connection properties.
 	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
 }
@@ -20923,7 +20946,7 @@ type RerunTriggerListResponse struct {
 
 // RerunTrigger resource type.
 type RerunTriggerResource struct {
-	AzureEntityResource
+	SubResource
 	// Properties of the rerun trigger.
 	Properties *RerunTumblingWindowTrigger `json:"properties,omitempty"`
 }
@@ -25226,14 +25249,14 @@ func (s *ServiceNowSource) UnmarshalJSON(data []byte) error {
 
 // Set value for a Variable.
 type SetVariableActivity struct {
-	Activity
+	ControlActivity
 	// Set Variable activity properties.
 	TypeProperties *SetVariableActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SetVariableActivity.
 func (s SetVariableActivity) MarshalJSON() ([]byte, error) {
-	objectMap := s.Activity.marshalInternal("SetVariable")
+	objectMap := s.ControlActivity.marshalInternal("SetVariable")
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -25255,7 +25278,7 @@ func (s *SetVariableActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return s.Activity.unmarshalInternal(rawMsg)
+	return s.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // SetVariable activity properties.
@@ -25968,7 +25991,7 @@ type SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceOptions struct {
 
 // Spark job definition resource type.
 type SparkJobDefinitionResource struct {
-	AzureEntityResource
+	SubResource
 	// Properties of spark job definition.
 	Properties *SparkJobDefinition `json:"properties,omitempty"`
 }
@@ -26960,6 +26983,15 @@ type SubResource struct {
 	AzureEntityResource
 }
 
+func (s SubResource) marshalInternal() map[string]interface{} {
+	objectMap := s.AzureEntityResource.marshalInternal()
+	return objectMap
+}
+
+func (s *SubResource) unmarshalInternal(rawMsg map[string]*json.RawMessage) error {
+	return s.AzureEntityResource.unmarshalInternal(rawMsg)
+}
+
 // Azure Synapse nested debug resource.
 type SubResourceDebugResource struct {
 	// The resource name.
@@ -26990,14 +27022,14 @@ func (s *SubResourceDebugResource) unmarshalInternal(rawMsg map[string]*json.Raw
 // This activity evaluates an expression and executes activities under the cases property that correspond to the expression evaluation expected in the equals
 // property.
 type SwitchActivity struct {
-	Activity
+	ControlActivity
 	// Switch activity properties.
 	TypeProperties *SwitchActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SwitchActivity.
 func (s SwitchActivity) MarshalJSON() ([]byte, error) {
-	objectMap := s.Activity.marshalInternal("Switch")
+	objectMap := s.ControlActivity.marshalInternal("Switch")
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -27019,7 +27051,7 @@ func (s *SwitchActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return s.Activity.unmarshalInternal(rawMsg)
+	return s.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Switch activity properties.
@@ -28049,7 +28081,7 @@ type TriggerReference struct {
 
 // Trigger resource type.
 type TriggerResource struct {
-	AzureEntityResource
+	SubResource
 	// Properties of the trigger.
 	Properties TriggerClassification `json:"properties,omitempty"`
 }
@@ -28414,14 +28446,14 @@ func (t *TumblingWindowTriggerTypeProperties) UnmarshalJSON(data []byte) error {
 
 // This activity executes inner activities until the specified boolean expression results to true or timeout is reached, whichever is earlier.
 type UntilActivity struct {
-	Activity
+	ControlActivity
 	// Until activity properties.
 	TypeProperties *UntilActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type UntilActivity.
 func (u UntilActivity) MarshalJSON() ([]byte, error) {
-	objectMap := u.Activity.marshalInternal("Until")
+	objectMap := u.ControlActivity.marshalInternal("Until")
 	populate(objectMap, "typeProperties", u.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -28443,7 +28475,7 @@ func (u *UntilActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return u.Activity.unmarshalInternal(rawMsg)
+	return u.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Until activity properties.
@@ -28497,14 +28529,14 @@ type UserProperty struct {
 
 // This activity verifies that an external resource exists.
 type ValidationActivity struct {
-	Activity
+	ControlActivity
 	// Validation activity properties.
 	TypeProperties *ValidationActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ValidationActivity.
 func (v ValidationActivity) MarshalJSON() ([]byte, error) {
-	objectMap := v.Activity.marshalInternal("Validation")
+	objectMap := v.ControlActivity.marshalInternal("Validation")
 	populate(objectMap, "typeProperties", v.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -28526,7 +28558,7 @@ func (v *ValidationActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return v.Activity.unmarshalInternal(rawMsg)
+	return v.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Validation activity properties.
@@ -28696,14 +28728,14 @@ type VirtualNetworkProfile struct {
 
 // This activity suspends pipeline execution for the specified interval.
 type WaitActivity struct {
-	Activity
+	ControlActivity
 	// Wait activity properties.
 	TypeProperties *WaitActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type WaitActivity.
 func (w WaitActivity) MarshalJSON() ([]byte, error) {
-	objectMap := w.Activity.marshalInternal("Wait")
+	objectMap := w.ControlActivity.marshalInternal("Wait")
 	populate(objectMap, "typeProperties", w.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -28725,7 +28757,7 @@ func (w *WaitActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return w.Activity.unmarshalInternal(rawMsg)
+	return w.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // Wait activity properties.
@@ -28945,14 +28977,14 @@ func (w *WebClientCertificateAuthentication) UnmarshalJSON(data []byte) error {
 
 // WebHook activity.
 type WebHookActivity struct {
-	Activity
+	ControlActivity
 	// WebHook activity properties.
 	TypeProperties *WebHookActivityTypeProperties `json:"typeProperties,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type WebHookActivity.
 func (w WebHookActivity) MarshalJSON() ([]byte, error) {
-	objectMap := w.Activity.marshalInternal("WebHook")
+	objectMap := w.ControlActivity.marshalInternal("WebHook")
 	populate(objectMap, "typeProperties", w.TypeProperties)
 	return json.Marshal(objectMap)
 }
@@ -28974,7 +29006,7 @@ func (w *WebHookActivity) UnmarshalJSON(data []byte) error {
 			return err
 		}
 	}
-	return w.Activity.unmarshalInternal(rawMsg)
+	return w.ControlActivity.unmarshalInternal(rawMsg)
 }
 
 // WebHook activity type properties.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline.go
@@ -118,7 +118,7 @@ func (client *pipelineClient) createPipelineRunCreateRequest(ctx context.Context
 	}
 	req.URL.RawQuery = query.Encode()
 	req.Header.Set("Accept", "application/json")
-	if options != nil {
+	if options != nil && options.Parameters != nil {
 		return req, req.MarshalAsJSON(options.Parameters)
 	}
 	return req, nil

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
@@ -122,6 +122,63 @@ func unmarshalActivityClassificationArray(rawMsg *json.RawMessage) (*[]ActivityC
 	return &fArray, nil
 }
 
+func unmarshalControlActivityClassification(rawMsg *json.RawMessage) (ControlActivityClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(*rawMsg, &m); err != nil {
+		return nil, err
+	}
+	var b ControlActivityClassification
+	switch m["type"] {
+	case "AppendVariable":
+		b = &AppendVariableActivity{}
+	case "ExecutePipeline":
+		b = &ExecutePipelineActivity{}
+	case "Filter":
+		b = &FilterActivity{}
+	case "ForEach":
+		b = &ForEachActivity{}
+	case "IfCondition":
+		b = &IfConditionActivity{}
+	case "SetVariable":
+		b = &SetVariableActivity{}
+	case "Switch":
+		b = &SwitchActivity{}
+	case "Until":
+		b = &UntilActivity{}
+	case "Validation":
+		b = &ValidationActivity{}
+	case "Wait":
+		b = &WaitActivity{}
+	case "WebHook":
+		b = &WebHookActivity{}
+	default:
+		b = &ControlActivity{}
+	}
+	return b, json.Unmarshal(*rawMsg, &b)
+}
+
+func unmarshalControlActivityClassificationArray(rawMsg *json.RawMessage) (*[]ControlActivityClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []*json.RawMessage
+	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]ControlActivityClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalControlActivityClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return &fArray, nil
+}
+
 func unmarshalExecutionActivityClassification(rawMsg *json.RawMessage) (ExecutionActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil

--- a/test/tables/2019-02-02/aztables/zz_generated_table.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_table.go
@@ -413,7 +413,7 @@ func (client *TableClient) insertEntityCreateRequest(ctx context.Context, table 
 		req.Header.Set("Prefer", string(*tableInsertEntityOptions.ResponsePreference))
 	}
 	req.Header.Set("Accept", "application/json;odata=minimalmetadata")
-	if tableInsertEntityOptions != nil {
+	if tableInsertEntityOptions != nil && tableInsertEntityOptions.TableEntityProperties != nil {
 		return req, req.MarshalAsJSON(tableInsertEntityOptions.TableEntityProperties)
 	}
 	return req, nil
@@ -555,7 +555,7 @@ func (client *TableClient) mergeEntityCreateRequest(ctx context.Context, table s
 		req.Header.Set("If-Match", *tableMergeEntityOptions.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
-	if tableMergeEntityOptions != nil {
+	if tableMergeEntityOptions != nil && tableMergeEntityOptions.TableEntityProperties != nil {
 		return req, req.MarshalAsJSON(tableMergeEntityOptions.TableEntityProperties)
 	}
 	return req, nil
@@ -939,7 +939,7 @@ func (client *TableClient) setAccessPolicyCreateRequest(ctx context.Context, tab
 		XMLName  xml.Name             `xml:"SignedIdentifiers"`
 		TableACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
-	if options != nil {
+	if options != nil && options.TableACL != nil {
 		return req, req.MarshalAsXML(wrapper{TableACL: options.TableACL})
 	}
 	return req, nil
@@ -1029,7 +1029,7 @@ func (client *TableClient) updateEntityCreateRequest(ctx context.Context, table 
 		req.Header.Set("If-Match", *tableUpdateEntityOptions.IfMatch)
 	}
 	req.Header.Set("Accept", "application/json")
-	if tableUpdateEntityOptions != nil {
+	if tableUpdateEntityOptions != nil && tableUpdateEntityOptions.TableEntityProperties != nil {
 		return req, req.MarshalAsJSON(tableUpdateEntityOptions.TableEntityProperties)
 	}
 	return req, nil

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,8 @@
     "declaration": true,
     "stripInternal": true,
     "noEmitHelpers": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "target": "es2018",
     "types": [
       "node"


### PR DESCRIPTION
Removed workaround for header collection support as it's now natively
supported by M4.
Added ability to emit map value types by value.
Fixed up handling of optional body params.
Handle case of types in the hierarchy that don't contain fields.