### PR TITLE
Misc fixes

### DIFF
--- a/src/generator/arm_pollers.ts
+++ b/src/generator/arm_pollers.ts
@@ -102,6 +102,8 @@ export async function generateARMPollers(session: Session<CodeModel>): Promise<s
       if (isScalar) {
         respType = `respType := ${responseType}{}\n`;
         reference = '&';
+      } else if (poller.respType.type === SchemaType.Any) {
+        respType = `respType := ${responseType}{}\n`;
       }
       pollUntilDone = `${respType}
 		resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, ${reference}respType.${poller.respField})

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -385,7 +385,8 @@ function generateStructs(objects?: ObjectSchema[]): StructDef[] {
     }
     // we check needsPatchMarshaller separately from other
     // states since it's not mutually exclusive with them.
-    if (obj.language.go!.needsPatchMarshaller === true) {
+    // be sure to skip this for root discriminators.
+    if (obj.language.go!.needsPatchMarshaller === true && !obj.language.go!.rootDiscriminator) {
       needsM = true;
     }
     if (needsIntM) {
@@ -539,7 +540,12 @@ function generateInternalMarshaller(obj: ObjectSchema, structDef: StructDef, par
   }
   let marshalInteral = `func (${receiver} ${typeName}) marshalInternal(${paramName}${paramType}) map[string]interface{} {\n`;
   if (parentType) {
-    marshalInteral += `\tobjectMap := ${receiver}.${parentType.language.go!.name}.marshalInternal(${paramName})\n`;
+    // if the parent isn't a discriminator it won't have a param
+    let parentParam = '';
+    if (parentType.discriminator) {
+      parentParam = paramName;
+    }
+    marshalInteral += `\tobjectMap := ${receiver}.${parentType.language.go!.name}.marshalInternal(${parentParam})\n`;
   } else {
     marshalInteral += '\tobjectMap := make(map[string]interface{})\n';
   }

--- a/src/generator/polymorphics.ts
+++ b/src/generator/polymorphics.ts
@@ -20,75 +20,71 @@ export async function generatePolymorphicHelpers(session: Session<CodeModel>): P
   imports.add('encoding/json');
   text += imports.text();
   const discriminators = <Array<ObjectSchema>>session.model.language.go!.discriminators;
-  discriminators.sort((a: ObjectSchema, b: ObjectSchema) => { return sortAscending(a.language.go!.discriminatorInterface, b.language.go!.discriminatorInterface) });
+  // add any sub-hierarchies (SalmonType, SharkType in the test server) to the list
   for (const disc of values(discriminators)) {
-    // this is used to track any sub-hierarchies (SalmonType, SharkType in the test server)
-    const roots = new Array<ObjectSchema>();
-    roots.push(disc);
-
-    // add sub-hierarchies
     for (const val of values(disc.discriminator!.all)) {
       const objSchema = <ObjectSchema>val;
-      if (objSchema.discriminator) {
-        roots.push(objSchema);
+      // some hierarchies can overlap, so conditionally add
+      if (objSchema.discriminator && !discriminators.includes(objSchema)) {
+        discriminators.push(objSchema);
       }
     }
-
+  }
+  discriminators.sort((a: ObjectSchema, b: ObjectSchema) => { return sortAscending(a.language.go!.discriminatorInterface, b.language.go!.discriminatorInterface) });
+  for (const disc of values(discriminators)) {
     // generate unmarshallers for each discriminator
-    for (const root of values(roots)) {
-      const discName = root.language.go!.discriminatorInterface;
-      if (root.language.go!.errorType) {
-        text += `type ${root.language.go!.internalErrorType} struct {\n`;
-        text += `\twrapped ${discName}\n`;
-        text += '}\n\n';
-        const receiver = <string>root.language.go!.internalErrorType[0];
-        text += `func (${receiver} *${root.language.go!.internalErrorType}) UnmarshalJSON(data []byte) (err error) {\n`;
-        text += `\t${receiver}.wrapped, err = unmarshal${discName}((*json.RawMessage)(&data))\n`;
-        text += '\treturn\n';
-        text += '}\n\n';
-      }
-      // scalar unmarshaller
-      text += `func unmarshal${discName}(rawMsg *json.RawMessage) (${discName}, error) {\n`;
-      text += '\tif rawMsg == nil {\n';
-      text += '\t\treturn nil, nil\n';
-      text += '\t}\n';
-      text += '\tvar m map[string]interface{}\n';
-      text += '\tif err := json.Unmarshal(*rawMsg, &m); err != nil {\n';
-      text += '\t\treturn nil, err\n';
-      text += '\t}\n';
-      text += `\tvar b ${discName}\n`;
-      text += `\tswitch m["${root.discriminator!.property.serializedName}"] {\n`;
-      for (const val of values(root.discriminator!.all)) {
-        const objSchema = <ObjectSchema>val;
-        text += `\tcase ${objSchema.discriminatorValue}:\n`;
-        text += `\t\tb = &${val.language.go!.name}{}\n`;
-      }
-      text += '\tdefault:\n';
-      text += `\t\tb = &${root.language.go!.name}{}\n`;
-      text += '\t}\n';
-      text += '\treturn b, json.Unmarshal(*rawMsg, &b)\n';
+    const discName = disc.language.go!.discriminatorInterface;
+    if (disc.language.go!.errorType) {
+      text += `type ${disc.language.go!.internalErrorType} struct {\n`;
+      text += `\twrapped ${discName}\n`;
       text += '}\n\n';
-
-      // array unmarshaller
-      text += `func unmarshal${discName}Array(rawMsg *json.RawMessage) (*[]${discName}, error) {\n`;
-      text += '\tif rawMsg == nil {\n';
-      text += '\t\treturn nil, nil\n';
-      text += '\t}\n';
-      text += '\tvar rawMessages []*json.RawMessage\n';
-      text += '\tif err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {\n';
-      text += '\t\treturn nil, err\n';
-      text += '\t}\n';
-      text += `\tfArray := make([]${discName}, len(rawMessages))\n`;
-      text += '\tfor index, rawMessage := range rawMessages {\n';
-      text += `\t\tf, err := unmarshal${discName}(rawMessage)\n`;
-      text += '\t\tif err != nil {\n';
-      text += '\t\t\treturn nil, err\n';
-      text += '\t\t}\n';
-      text += '\t\tfArray[index] = f\n';
-      text += '\t}\n';
-      text += '\treturn &fArray, nil\n';
+      const receiver = <string>disc.language.go!.internalErrorType[0];
+      text += `func (${receiver} *${disc.language.go!.internalErrorType}) UnmarshalJSON(data []byte) (err error) {\n`;
+      text += `\t${receiver}.wrapped, err = unmarshal${discName}((*json.RawMessage)(&data))\n`;
+      text += '\treturn\n';
       text += '}\n\n';
     }
+    // scalar unmarshaller
+    text += `func unmarshal${discName}(rawMsg *json.RawMessage) (${discName}, error) {\n`;
+    text += '\tif rawMsg == nil {\n';
+    text += '\t\treturn nil, nil\n';
+    text += '\t}\n';
+    text += '\tvar m map[string]interface{}\n';
+    text += '\tif err := json.Unmarshal(*rawMsg, &m); err != nil {\n';
+    text += '\t\treturn nil, err\n';
+    text += '\t}\n';
+    text += `\tvar b ${discName}\n`;
+    text += `\tswitch m["${disc.discriminator!.property.serializedName}"] {\n`;
+    for (const val of values(disc.discriminator!.all)) {
+      const objSchema = <ObjectSchema>val;
+      text += `\tcase ${objSchema.discriminatorValue}:\n`;
+      text += `\t\tb = &${val.language.go!.name}{}\n`;
+    }
+    text += '\tdefault:\n';
+    text += `\t\tb = &${disc.language.go!.name}{}\n`;
+    text += '\t}\n';
+    text += '\treturn b, json.Unmarshal(*rawMsg, &b)\n';
+    text += '}\n\n';
+
+    // array unmarshaller
+    text += `func unmarshal${discName}Array(rawMsg *json.RawMessage) (*[]${discName}, error) {\n`;
+    text += '\tif rawMsg == nil {\n';
+    text += '\t\treturn nil, nil\n';
+    text += '\t}\n';
+    text += '\tvar rawMessages []*json.RawMessage\n';
+    text += '\tif err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {\n';
+    text += '\t\treturn nil, err\n';
+    text += '\t}\n';
+    text += `\tfArray := make([]${discName}, len(rawMessages))\n`;
+    text += '\tfor index, rawMessage := range rawMessages {\n';
+    text += `\t\tf, err := unmarshal${discName}(rawMessage)\n`;
+    text += '\t\tif err != nil {\n';
+    text += '\t\t\treturn nil, err\n';
+    text += '\t\t}\n';
+    text += '\t\tfArray[index] = f\n';
+    text += '\t}\n';
+    text += '\treturn &fArray, nil\n';
+    text += '}\n\n';
   }
   // helper used in discriminator marshallers
   text += 'func strptr(s string) *string {\n';

--- a/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
@@ -93,6 +93,43 @@ func unmarshalFishClassificationArray(rawMsg *json.RawMessage) (*[]FishClassific
 	return &fArray, nil
 }
 
+func unmarshalMyBaseTypeClassification(rawMsg *json.RawMessage) (MyBaseTypeClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(*rawMsg, &m); err != nil {
+		return nil, err
+	}
+	var b MyBaseTypeClassification
+	switch m["kind"] {
+	case MyKindKind1:
+		b = &MyDerivedType{}
+	default:
+		b = &MyBaseType{}
+	}
+	return b, json.Unmarshal(*rawMsg, &b)
+}
+
+func unmarshalMyBaseTypeClassificationArray(rawMsg *json.RawMessage) (*[]MyBaseTypeClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []*json.RawMessage
+	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]MyBaseTypeClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalMyBaseTypeClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return &fArray, nil
+}
+
 func unmarshalSalmonClassification(rawMsg *json.RawMessage) (SalmonClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
@@ -163,43 +200,6 @@ func unmarshalSharkClassificationArray(rawMsg *json.RawMessage) (*[]SharkClassif
 	fArray := make([]SharkClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
 		f, err := unmarshalSharkClassification(rawMessage)
-		if err != nil {
-			return nil, err
-		}
-		fArray[index] = f
-	}
-	return &fArray, nil
-}
-
-func unmarshalMyBaseTypeClassification(rawMsg *json.RawMessage) (MyBaseTypeClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(*rawMsg, &m); err != nil {
-		return nil, err
-	}
-	var b MyBaseTypeClassification
-	switch m["kind"] {
-	case MyKindKind1:
-		b = &MyDerivedType{}
-	default:
-		b = &MyBaseType{}
-	}
-	return b, json.Unmarshal(*rawMsg, &b)
-}
-
-func unmarshalMyBaseTypeClassificationArray(rawMsg *json.RawMessage) (*[]MyBaseTypeClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var rawMessages []*json.RawMessage
-	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
-		return nil, err
-	}
-	fArray := make([]MyBaseTypeClassification, len(rawMessages))
-	for index, rawMessage := range rawMessages {
-		f, err := unmarshalMyBaseTypeClassification(rawMessage)
 		if err != nil {
 			return nil, err
 		}

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
@@ -179,91 +179,6 @@ func unmarshalControlActivityClassificationArray(rawMsg *json.RawMessage) (*[]Co
 	return &fArray, nil
 }
 
-func unmarshalExecutionActivityClassification(rawMsg *json.RawMessage) (ExecutionActivityClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(*rawMsg, &m); err != nil {
-		return nil, err
-	}
-	var b ExecutionActivityClassification
-	switch m["type"] {
-	case "AzureDataExplorerCommand":
-		b = &AzureDataExplorerCommandActivity{}
-	case "AzureFunctionActivity":
-		b = &AzureFunctionActivity{}
-	case "AzureMLBatchExecution":
-		b = &AzureMLBatchExecutionActivity{}
-	case "AzureMLExecutePipeline":
-		b = &AzureMLExecutePipelineActivity{}
-	case "AzureMLUpdateResource":
-		b = &AzureMLUpdateResourceActivity{}
-	case "Copy":
-		b = &CopyActivity{}
-	case "Custom":
-		b = &CustomActivity{}
-	case "DataLakeAnalyticsU-SQL":
-		b = &DataLakeAnalyticsUSQLActivity{}
-	case "DatabricksNotebook":
-		b = &DatabricksNotebookActivity{}
-	case "DatabricksSparkJar":
-		b = &DatabricksSparkJarActivity{}
-	case "DatabricksSparkPython":
-		b = &DatabricksSparkPythonActivity{}
-	case "Delete":
-		b = &DeleteActivity{}
-	case "ExecuteDataFlow":
-		b = &ExecuteDataFlowActivity{}
-	case "ExecuteSSISPackage":
-		b = &ExecuteSSISPackageActivity{}
-	case "GetMetadata":
-		b = &GetMetadataActivity{}
-	case "HDInsightHive":
-		b = &HDInsightHiveActivity{}
-	case "HDInsightMapReduce":
-		b = &HDInsightMapReduceActivity{}
-	case "HDInsightPig":
-		b = &HDInsightPigActivity{}
-	case "HDInsightSpark":
-		b = &HDInsightSparkActivity{}
-	case "HDInsightStreaming":
-		b = &HDInsightStreamingActivity{}
-	case "Lookup":
-		b = &LookupActivity{}
-	case "SparkJob":
-		b = &SynapseSparkJobDefinitionActivity{}
-	case "SqlServerStoredProcedure":
-		b = &SQLServerStoredProcedureActivity{}
-	case "SynapseNotebook":
-		b = &SynapseNotebookActivity{}
-	case "WebActivity":
-		b = &WebActivity{}
-	default:
-		b = &ExecutionActivity{}
-	}
-	return b, json.Unmarshal(*rawMsg, &b)
-}
-
-func unmarshalExecutionActivityClassificationArray(rawMsg *json.RawMessage) (*[]ExecutionActivityClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var rawMessages []*json.RawMessage
-	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
-		return nil, err
-	}
-	fArray := make([]ExecutionActivityClassification, len(rawMessages))
-	for index, rawMessage := range rawMessages {
-		f, err := unmarshalExecutionActivityClassification(rawMessage)
-		if err != nil {
-			return nil, err
-		}
-		fArray[index] = f
-	}
-	return &fArray, nil
-}
-
 func unmarshalCopySinkClassification(rawMsg *json.RawMessage) (CopySinkClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
@@ -568,155 +483,6 @@ func unmarshalCopySourceClassificationArray(rawMsg *json.RawMessage) (*[]CopySou
 	fArray := make([]CopySourceClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
 		f, err := unmarshalCopySourceClassification(rawMessage)
-		if err != nil {
-			return nil, err
-		}
-		fArray[index] = f
-	}
-	return &fArray, nil
-}
-
-func unmarshalTabularSourceClassification(rawMsg *json.RawMessage) (TabularSourceClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal(*rawMsg, &m); err != nil {
-		return nil, err
-	}
-	var b TabularSourceClassification
-	switch m["type"] {
-	case "AmazonMWSSource":
-		b = &AmazonMWSSource{}
-	case "AmazonRedshiftSource":
-		b = &AmazonRedshiftSource{}
-	case "AzureMariaDBSource":
-		b = &AzureMariaDBSource{}
-	case "AzureMySqlSource":
-		b = &AzureMySQLSource{}
-	case "AzurePostgreSqlSource":
-		b = &AzurePostgreSQLSource{}
-	case "AzureSqlSource":
-		b = &AzureSQLSource{}
-	case "AzureTableSource":
-		b = &AzureTableSource{}
-	case "CassandraSource":
-		b = &CassandraSource{}
-	case "ConcurSource":
-		b = &ConcurSource{}
-	case "CouchbaseSource":
-		b = &CouchbaseSource{}
-	case "Db2Source":
-		b = &Db2Source{}
-	case "DrillSource":
-		b = &DrillSource{}
-	case "DynamicsAXSource":
-		b = &DynamicsAXSource{}
-	case "EloquaSource":
-		b = &EloquaSource{}
-	case "GoogleAdWordsSource":
-		b = &GoogleAdWordsSource{}
-	case "GoogleBigQuerySource":
-		b = &GoogleBigQuerySource{}
-	case "GreenplumSource":
-		b = &GreenplumSource{}
-	case "HBaseSource":
-		b = &HBaseSource{}
-	case "HiveSource":
-		b = &HiveSource{}
-	case "HubspotSource":
-		b = &HubspotSource{}
-	case "ImpalaSource":
-		b = &ImpalaSource{}
-	case "InformixSource":
-		b = &InformixSource{}
-	case "JiraSource":
-		b = &JiraSource{}
-	case "MagentoSource":
-		b = &MagentoSource{}
-	case "MariaDBSource":
-		b = &MariaDBSource{}
-	case "MarketoSource":
-		b = &MarketoSource{}
-	case "MySqlSource":
-		b = &MySQLSource{}
-	case "NetezzaSource":
-		b = &NetezzaSource{}
-	case "OdbcSource":
-		b = &OdbcSource{}
-	case "OracleServiceCloudSource":
-		b = &OracleServiceCloudSource{}
-	case "PaypalSource":
-		b = &PaypalSource{}
-	case "PhoenixSource":
-		b = &PhoenixSource{}
-	case "PostgreSqlSource":
-		b = &PostgreSQLSource{}
-	case "PrestoSource":
-		b = &PrestoSource{}
-	case "QuickBooksSource":
-		b = &QuickBooksSource{}
-	case "ResponsysSource":
-		b = &ResponsysSource{}
-	case "SalesforceMarketingCloudSource":
-		b = &SalesforceMarketingCloudSource{}
-	case "SalesforceSource":
-		b = &SalesforceSource{}
-	case "SapBwSource":
-		b = &SapBwSource{}
-	case "SapCloudForCustomerSource":
-		b = &SapCloudForCustomerSource{}
-	case "SapEccSource":
-		b = &SapEccSource{}
-	case "SapHanaSource":
-		b = &SapHanaSource{}
-	case "SapOpenHubSource":
-		b = &SapOpenHubSource{}
-	case "SapTableSource":
-		b = &SapTableSource{}
-	case "ServiceNowSource":
-		b = &ServiceNowSource{}
-	case "ShopifySource":
-		b = &ShopifySource{}
-	case "SparkSource":
-		b = &SparkSource{}
-	case "SqlDWSource":
-		b = &SQLDWSource{}
-	case "SqlMISource":
-		b = &SQLMISource{}
-	case "SqlServerSource":
-		b = &SQLServerSource{}
-	case "SqlSource":
-		b = &SQLSource{}
-	case "SquareSource":
-		b = &SquareSource{}
-	case "SybaseSource":
-		b = &SybaseSource{}
-	case "TeradataSource":
-		b = &TeradataSource{}
-	case "VerticaSource":
-		b = &VerticaSource{}
-	case "XeroSource":
-		b = &XeroSource{}
-	case "ZohoSource":
-		b = &ZohoSource{}
-	default:
-		b = &TabularSource{}
-	}
-	return b, json.Unmarshal(*rawMsg, &b)
-}
-
-func unmarshalTabularSourceClassificationArray(rawMsg *json.RawMessage) (*[]TabularSourceClassification, error) {
-	if rawMsg == nil {
-		return nil, nil
-	}
-	var rawMessages []*json.RawMessage
-	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
-		return nil, err
-	}
-	fArray := make([]TabularSourceClassification, len(rawMessages))
-	for index, rawMessage := range rawMessages {
-		f, err := unmarshalTabularSourceClassification(rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -1217,7 +983,7 @@ func unmarshalDependencyReferenceClassificationArray(rawMsg *json.RawMessage) (*
 	return &fArray, nil
 }
 
-func unmarshalTriggerDependencyReferenceClassification(rawMsg *json.RawMessage) (TriggerDependencyReferenceClassification, error) {
+func unmarshalExecutionActivityClassification(rawMsg *json.RawMessage) (ExecutionActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1225,17 +991,65 @@ func unmarshalTriggerDependencyReferenceClassification(rawMsg *json.RawMessage) 
 	if err := json.Unmarshal(*rawMsg, &m); err != nil {
 		return nil, err
 	}
-	var b TriggerDependencyReferenceClassification
+	var b ExecutionActivityClassification
 	switch m["type"] {
-	case "TumblingWindowTriggerDependencyReference":
-		b = &TumblingWindowTriggerDependencyReference{}
+	case "AzureDataExplorerCommand":
+		b = &AzureDataExplorerCommandActivity{}
+	case "AzureFunctionActivity":
+		b = &AzureFunctionActivity{}
+	case "AzureMLBatchExecution":
+		b = &AzureMLBatchExecutionActivity{}
+	case "AzureMLExecutePipeline":
+		b = &AzureMLExecutePipelineActivity{}
+	case "AzureMLUpdateResource":
+		b = &AzureMLUpdateResourceActivity{}
+	case "Copy":
+		b = &CopyActivity{}
+	case "Custom":
+		b = &CustomActivity{}
+	case "DataLakeAnalyticsU-SQL":
+		b = &DataLakeAnalyticsUSQLActivity{}
+	case "DatabricksNotebook":
+		b = &DatabricksNotebookActivity{}
+	case "DatabricksSparkJar":
+		b = &DatabricksSparkJarActivity{}
+	case "DatabricksSparkPython":
+		b = &DatabricksSparkPythonActivity{}
+	case "Delete":
+		b = &DeleteActivity{}
+	case "ExecuteDataFlow":
+		b = &ExecuteDataFlowActivity{}
+	case "ExecuteSSISPackage":
+		b = &ExecuteSSISPackageActivity{}
+	case "GetMetadata":
+		b = &GetMetadataActivity{}
+	case "HDInsightHive":
+		b = &HDInsightHiveActivity{}
+	case "HDInsightMapReduce":
+		b = &HDInsightMapReduceActivity{}
+	case "HDInsightPig":
+		b = &HDInsightPigActivity{}
+	case "HDInsightSpark":
+		b = &HDInsightSparkActivity{}
+	case "HDInsightStreaming":
+		b = &HDInsightStreamingActivity{}
+	case "Lookup":
+		b = &LookupActivity{}
+	case "SparkJob":
+		b = &SynapseSparkJobDefinitionActivity{}
+	case "SqlServerStoredProcedure":
+		b = &SQLServerStoredProcedureActivity{}
+	case "SynapseNotebook":
+		b = &SynapseNotebookActivity{}
+	case "WebActivity":
+		b = &WebActivity{}
 	default:
-		b = &TriggerDependencyReference{}
+		b = &ExecutionActivity{}
 	}
 	return b, json.Unmarshal(*rawMsg, &b)
 }
 
-func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg *json.RawMessage) (*[]TriggerDependencyReferenceClassification, error) {
+func unmarshalExecutionActivityClassificationArray(rawMsg *json.RawMessage) (*[]ExecutionActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1243,9 +1057,9 @@ func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg *json.RawMess
 	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]TriggerDependencyReferenceClassification, len(rawMessages))
+	fArray := make([]ExecutionActivityClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalTriggerDependencyReferenceClassification(rawMessage)
+		f, err := unmarshalExecutionActivityClassification(rawMessage)
 		if err != nil {
 			return nil, err
 		}
@@ -1633,6 +1447,47 @@ func unmarshalLinkedServiceClassificationArray(rawMsg *json.RawMessage) (*[]Link
 	return &fArray, nil
 }
 
+func unmarshalMultiplePipelineTriggerClassification(rawMsg *json.RawMessage) (MultiplePipelineTriggerClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(*rawMsg, &m); err != nil {
+		return nil, err
+	}
+	var b MultiplePipelineTriggerClassification
+	switch m["type"] {
+	case "BlobEventsTrigger":
+		b = &BlobEventsTrigger{}
+	case "BlobTrigger":
+		b = &BlobTrigger{}
+	case "ScheduleTrigger":
+		b = &ScheduleTrigger{}
+	default:
+		b = &MultiplePipelineTrigger{}
+	}
+	return b, json.Unmarshal(*rawMsg, &b)
+}
+
+func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg *json.RawMessage) (*[]MultiplePipelineTriggerClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []*json.RawMessage
+	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]MultiplePipelineTriggerClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalMultiplePipelineTriggerClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return &fArray, nil
+}
+
 func unmarshalSecretBaseClassification(rawMsg *json.RawMessage) (SecretBaseClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
@@ -1774,6 +1629,155 @@ func unmarshalStoreWriteSettingsClassificationArray(rawMsg *json.RawMessage) (*[
 	return &fArray, nil
 }
 
+func unmarshalTabularSourceClassification(rawMsg *json.RawMessage) (TabularSourceClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(*rawMsg, &m); err != nil {
+		return nil, err
+	}
+	var b TabularSourceClassification
+	switch m["type"] {
+	case "AmazonMWSSource":
+		b = &AmazonMWSSource{}
+	case "AmazonRedshiftSource":
+		b = &AmazonRedshiftSource{}
+	case "AzureMariaDBSource":
+		b = &AzureMariaDBSource{}
+	case "AzureMySqlSource":
+		b = &AzureMySQLSource{}
+	case "AzurePostgreSqlSource":
+		b = &AzurePostgreSQLSource{}
+	case "AzureSqlSource":
+		b = &AzureSQLSource{}
+	case "AzureTableSource":
+		b = &AzureTableSource{}
+	case "CassandraSource":
+		b = &CassandraSource{}
+	case "ConcurSource":
+		b = &ConcurSource{}
+	case "CouchbaseSource":
+		b = &CouchbaseSource{}
+	case "Db2Source":
+		b = &Db2Source{}
+	case "DrillSource":
+		b = &DrillSource{}
+	case "DynamicsAXSource":
+		b = &DynamicsAXSource{}
+	case "EloquaSource":
+		b = &EloquaSource{}
+	case "GoogleAdWordsSource":
+		b = &GoogleAdWordsSource{}
+	case "GoogleBigQuerySource":
+		b = &GoogleBigQuerySource{}
+	case "GreenplumSource":
+		b = &GreenplumSource{}
+	case "HBaseSource":
+		b = &HBaseSource{}
+	case "HiveSource":
+		b = &HiveSource{}
+	case "HubspotSource":
+		b = &HubspotSource{}
+	case "ImpalaSource":
+		b = &ImpalaSource{}
+	case "InformixSource":
+		b = &InformixSource{}
+	case "JiraSource":
+		b = &JiraSource{}
+	case "MagentoSource":
+		b = &MagentoSource{}
+	case "MariaDBSource":
+		b = &MariaDBSource{}
+	case "MarketoSource":
+		b = &MarketoSource{}
+	case "MySqlSource":
+		b = &MySQLSource{}
+	case "NetezzaSource":
+		b = &NetezzaSource{}
+	case "OdbcSource":
+		b = &OdbcSource{}
+	case "OracleServiceCloudSource":
+		b = &OracleServiceCloudSource{}
+	case "PaypalSource":
+		b = &PaypalSource{}
+	case "PhoenixSource":
+		b = &PhoenixSource{}
+	case "PostgreSqlSource":
+		b = &PostgreSQLSource{}
+	case "PrestoSource":
+		b = &PrestoSource{}
+	case "QuickBooksSource":
+		b = &QuickBooksSource{}
+	case "ResponsysSource":
+		b = &ResponsysSource{}
+	case "SalesforceMarketingCloudSource":
+		b = &SalesforceMarketingCloudSource{}
+	case "SalesforceSource":
+		b = &SalesforceSource{}
+	case "SapBwSource":
+		b = &SapBwSource{}
+	case "SapCloudForCustomerSource":
+		b = &SapCloudForCustomerSource{}
+	case "SapEccSource":
+		b = &SapEccSource{}
+	case "SapHanaSource":
+		b = &SapHanaSource{}
+	case "SapOpenHubSource":
+		b = &SapOpenHubSource{}
+	case "SapTableSource":
+		b = &SapTableSource{}
+	case "ServiceNowSource":
+		b = &ServiceNowSource{}
+	case "ShopifySource":
+		b = &ShopifySource{}
+	case "SparkSource":
+		b = &SparkSource{}
+	case "SqlDWSource":
+		b = &SQLDWSource{}
+	case "SqlMISource":
+		b = &SQLMISource{}
+	case "SqlServerSource":
+		b = &SQLServerSource{}
+	case "SqlSource":
+		b = &SQLSource{}
+	case "SquareSource":
+		b = &SquareSource{}
+	case "SybaseSource":
+		b = &SybaseSource{}
+	case "TeradataSource":
+		b = &TeradataSource{}
+	case "VerticaSource":
+		b = &VerticaSource{}
+	case "XeroSource":
+		b = &XeroSource{}
+	case "ZohoSource":
+		b = &ZohoSource{}
+	default:
+		b = &TabularSource{}
+	}
+	return b, json.Unmarshal(*rawMsg, &b)
+}
+
+func unmarshalTabularSourceClassificationArray(rawMsg *json.RawMessage) (*[]TabularSourceClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []*json.RawMessage
+	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]TabularSourceClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalTabularSourceClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return &fArray, nil
+}
+
 func unmarshalTriggerClassification(rawMsg *json.RawMessage) (TriggerClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
@@ -1823,7 +1827,7 @@ func unmarshalTriggerClassificationArray(rawMsg *json.RawMessage) (*[]TriggerCla
 	return &fArray, nil
 }
 
-func unmarshalMultiplePipelineTriggerClassification(rawMsg *json.RawMessage) (MultiplePipelineTriggerClassification, error) {
+func unmarshalTriggerDependencyReferenceClassification(rawMsg *json.RawMessage) (TriggerDependencyReferenceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1831,21 +1835,17 @@ func unmarshalMultiplePipelineTriggerClassification(rawMsg *json.RawMessage) (Mu
 	if err := json.Unmarshal(*rawMsg, &m); err != nil {
 		return nil, err
 	}
-	var b MultiplePipelineTriggerClassification
+	var b TriggerDependencyReferenceClassification
 	switch m["type"] {
-	case "BlobEventsTrigger":
-		b = &BlobEventsTrigger{}
-	case "BlobTrigger":
-		b = &BlobTrigger{}
-	case "ScheduleTrigger":
-		b = &ScheduleTrigger{}
+	case "TumblingWindowTriggerDependencyReference":
+		b = &TumblingWindowTriggerDependencyReference{}
 	default:
-		b = &MultiplePipelineTrigger{}
+		b = &TriggerDependencyReference{}
 	}
 	return b, json.Unmarshal(*rawMsg, &b)
 }
 
-func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg *json.RawMessage) (*[]MultiplePipelineTriggerClassification, error) {
+func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg *json.RawMessage) (*[]TriggerDependencyReferenceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1853,9 +1853,9 @@ func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg *json.RawMessage
 	if err := json.Unmarshal(*rawMsg, &rawMessages); err != nil {
 		return nil, err
 	}
-	fArray := make([]MultiplePipelineTriggerClassification, len(rawMessages))
+	fArray := make([]TriggerDependencyReferenceClassification, len(rawMessages))
 	for index, rawMessage := range rawMessages {
-		f, err := unmarshalMultiplePipelineTriggerClassification(rawMessage)
+		f, err := unmarshalTriggerDependencyReferenceClassification(rawMessage)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixed pollers that return interface{} types.
Fixed discriminators with non-discriminator parents.
Fixed comment generation for multi-response operations.
Improved polymorphic hierarchy building and sorting.
Handle odd case of intermediate types that aren't discriminators.
Fixed response envelope name collisions.
Ensure response envelope is hooked up to response types when the
response type is the same but the object ref is not.
Don't double-quote strings that are already quoted.