### PR TITLE
Simplify injecting custom pipeline policies

### DIFF
--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -19,7 +19,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3';
   if (<boolean>session.model.language.go!.azureARM) {
     text += 'require (\n';
-    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0\n';
+    text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0\n';
     text += `\t${azcore}\n`;
     text += ')\n'
   } else {

--- a/test/autorest/custombaseurlgroup/zz_generated_connection.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_connection.go
@@ -25,6 +25,12 @@ type ConnectionOptions struct {
 	Telemetry azcore.TelemetryOptions
 	// Logging configures the built-in logging policy behavior.
 	Logging azcore.LogOptions
+	// PerCallPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request.
+	PerCallPolicies []azcore.Policy
+	// PerRetryPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request, and for each retry request.
+	PerRetryPolicies []azcore.Policy
 }
 
 func (c *ConnectionOptions) telemetryOptions() *azcore.TelemetryOptions {
@@ -49,17 +55,15 @@ func NewConnection(host *string, options *ConnectionOptions) *Connection {
 	if options == nil {
 		options = &ConnectionOptions{}
 	}
-	p := azcore.NewPipeline(options.HTTPClient,
+	policies := []azcore.Policy{
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
-		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewLogPolicy(&options.Logging))
-	return NewConnectionWithPipeline(host, p)
-}
-
-// NewConnectionWithPipeline creates an instance of the Connection type with the specified endpoint and pipeline.
-func NewConnectionWithPipeline(host *string, p azcore.Pipeline) *Connection {
+	}
+	policies = append(policies, options.PerCallPolicies...)
+	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
+	policies = append(policies, options.PerRetryPolicies...)
+	policies = append(policies, azcore.NewLogPolicy(&options.Logging))
 	client := &Connection{
-		p:    p,
+		p:    azcore.NewPipeline(options.HTTPClient, policies...),
 		host: "host",
 	}
 	if host != nil {

--- a/test/autorest/morecustombaseurigroup/zz_generated_connection.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_connection.go
@@ -25,6 +25,12 @@ type ConnectionOptions struct {
 	Telemetry azcore.TelemetryOptions
 	// Logging configures the built-in logging policy behavior.
 	Logging azcore.LogOptions
+	// PerCallPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request.
+	PerCallPolicies []azcore.Policy
+	// PerRetryPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request, and for each retry request.
+	PerRetryPolicies []azcore.Policy
 }
 
 func (c *ConnectionOptions) telemetryOptions() *azcore.TelemetryOptions {
@@ -49,17 +55,15 @@ func NewConnection(dnsSuffix *string, options *ConnectionOptions) *Connection {
 	if options == nil {
 		options = &ConnectionOptions{}
 	}
-	p := azcore.NewPipeline(options.HTTPClient,
+	policies := []azcore.Policy{
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
-		azcore.NewRetryPolicy(&options.Retry),
-		azcore.NewLogPolicy(&options.Logging))
-	return NewConnectionWithPipeline(dnsSuffix, p)
-}
-
-// NewConnectionWithPipeline creates an instance of the Connection type with the specified endpoint and pipeline.
-func NewConnectionWithPipeline(dnsSuffix *string, p azcore.Pipeline) *Connection {
+	}
+	policies = append(policies, options.PerCallPolicies...)
+	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
+	policies = append(policies, options.PerRetryPolicies...)
+	policies = append(policies, azcore.NewLogPolicy(&options.Logging))
 	client := &Connection{
-		p:         p,
+		p:         azcore.NewPipeline(options.HTTPClient, policies...),
 		dnsSuffix: "host",
 	}
 	if dnsSuffix != nil {

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -3,6 +3,6 @@ module armcompute
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
 )

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0 h1:mAQkeMH5c0NUAfkYqhpzdLIXEsw1LI+A/Oq4DNMGxSg=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbtu9SoHYRmZPgLHjbSuOk=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -3,6 +3,6 @@ module armnetwork
 go 1.13
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
 )

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0 h1:mAQkeMH5c0NUAfkYqhpzdLIXEsw1LI+A/Oq4DNMGxSg=
-github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbtu9SoHYRmZPgLHjbSuOk=
+github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=

--- a/test/storage/2019-07-07/azblob/zz_generated_connection.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_connection.go
@@ -26,6 +26,12 @@ type connectionOptions struct {
 	Telemetry azcore.TelemetryOptions
 	// Logging configures the built-in logging policy behavior.
 	Logging azcore.LogOptions
+	// PerCallPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request.
+	PerCallPolicies []azcore.Policy
+	// PerRetryPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request, and for each retry request.
+	PerRetryPolicies []azcore.Policy
 }
 
 func (c *connectionOptions) telemetryOptions() *azcore.TelemetryOptions {
@@ -49,17 +55,15 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	if options == nil {
 		options = &connectionOptions{}
 	}
-	p := azcore.NewPipeline(options.HTTPClient,
+	policies := []azcore.Policy{
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
-		azcore.NewRetryPolicy(&options.Retry),
-		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewLogPolicy(&options.Logging))
-	return newConnectionWithPipeline(endpoint, p)
-}
-
-// newConnectionWithPipeline creates an instance of the connection type with the specified endpoint and pipeline.
-func newConnectionWithPipeline(endpoint string, p azcore.Pipeline) *connection {
-	return &connection{u: endpoint, p: p}
+	}
+	policies = append(policies, options.PerCallPolicies...)
+	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
+	policies = append(policies, options.PerRetryPolicies...)
+	policies = append(policies, cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}))
+	policies = append(policies, azcore.NewLogPolicy(&options.Logging))
+	return &connection{u: endpoint, p: azcore.NewPipeline(options.HTTPClient, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
@@ -26,6 +26,12 @@ type connectionOptions struct {
 	Telemetry azcore.TelemetryOptions
 	// Logging configures the built-in logging policy behavior.
 	Logging azcore.LogOptions
+	// PerCallPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request.
+	PerCallPolicies []azcore.Policy
+	// PerRetryPolicies contains custom policies to inject into the pipeline.
+	// Each policy is executed once per request, and for each retry request.
+	PerRetryPolicies []azcore.Policy
 }
 
 func (c *connectionOptions) telemetryOptions() *azcore.TelemetryOptions {
@@ -49,17 +55,15 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	if options == nil {
 		options = &connectionOptions{}
 	}
-	p := azcore.NewPipeline(options.HTTPClient,
+	policies := []azcore.Policy{
 		azcore.NewTelemetryPolicy(options.telemetryOptions()),
-		azcore.NewRetryPolicy(&options.Retry),
-		cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}),
-		azcore.NewLogPolicy(&options.Logging))
-	return newConnectionWithPipeline(endpoint, p)
-}
-
-// newConnectionWithPipeline creates an instance of the connection type with the specified endpoint and pipeline.
-func newConnectionWithPipeline(endpoint string, p azcore.Pipeline) *connection {
-	return &connection{u: endpoint, p: p}
+	}
+	policies = append(policies, options.PerCallPolicies...)
+	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
+	policies = append(policies, options.PerRetryPolicies...)
+	policies = append(policies, cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: []string{scope}}}))
+	policies = append(policies, azcore.NewLogPolicy(&options.Logging))
+	return &connection{u: endpoint, p: azcore.NewPipeline(options.HTTPClient, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.


### PR DESCRIPTION
Removed NewConnectionWithPipeline() in favor of policy slices in
ConnectionOptions.  The slices are to control where the policies are
injected in the pipeline, either before or after the retry policy.
Update armcore to latest version.