### PR TITLE
Capture build and vet failures

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -76,7 +76,7 @@ jobs:
               $exit = 1
             }
           }
-          return $exit
+          exit $exit
         displayName: 'Build'
 
       - pwsh: |
@@ -90,7 +90,7 @@ jobs:
               $exit = 1
             }
           }
-          return $exit
+          exit $exit
         displayName: 'Vet'
 
       - pwsh: |

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -67,20 +67,30 @@ jobs:
 
       - pwsh: |
           $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(goTestPath))
+          $exit = 0
           foreach ($md in $modDirs) {
             pushd $md
             Write-Host "##[command]Executing go build -v ./... in $md"
             go build -v ./...
+            if (!$?) {
+              $exit = 1
+            }
           }
+          return $exit
         displayName: 'Build'
 
       - pwsh: |
           $modDirs = (./eng/scripts/get_module_dirs.ps1 -serviceDir $(goTestPath))
+          $exit = 0
           foreach ($md in $modDirs) {
             pushd $md
             Write-Host "##[command]Executing go vet ./... in $md"
             go vet ./...
+            if (!$?) {
+              $exit = 1
+            }
           }
+          return $exit
         displayName: 'Vet'
 
       - pwsh: |


### PR DESCRIPTION
Some packages were failing to build but didn't fail CI.
Ensure any build/vet failures are propagated.