### PR TITLE
Use case-insensitive comparison for header prefix

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -109,12 +109,13 @@ function formatHeaderResponseValue(propName: string, header: string, schema: Sch
   // dictionaries are handled slightly different so we do that first
   if (schema.type === SchemaType.Dictionary) {
     imports.add('strings');
-    let text = '\tfor hh := range resp.Header {\n';
-    text += `\t\tif strings.HasPrefix(hh, "${schema.language.go!.headerCollectionPrefix}") {\n`;
+    let text = `\tprefix := strings.ToUpper("${schema.language.go!.headerCollectionPrefix}")\n`;
+    text += '\tfor hh := range resp.Header {\n';
+    text += `\t\tif strings.HasPrefix(strings.ToUpper(hh), prefix) {\n`;
     text += `\t\t\tif ${respObj}.Metadata == nil {\n`;
     text += `\t\t\t\t${respObj}.Metadata = map[string]string{}\n`;
     text += '\t\t\t}\n';
-    text += `\t\t\t${respObj}.Metadata[hh[len("${schema.language.go!.headerCollectionPrefix}"):]] = resp.Header.Get(hh)\n`;
+    text += `\t\t\t${respObj}.Metadata[hh[len(prefix):]] = resp.Header.Get(hh)\n`;
     text += '\t\t}\n';
     text += '\t}\n';
     return text;

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -440,11 +440,11 @@ type DotFishResponse struct {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type DotFishResponse.
 func (d *DotFishResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalDotFishClassification((*json.RawMessage)(&data))
+	res, err := unmarshalDotFishClassification((*json.RawMessage)(&data))
 	if err != nil {
 		return err
 	}
-	d.DotFish = t
+	d.DotFish = res
 	return nil
 }
 
@@ -602,11 +602,11 @@ type FishResponse struct {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type FishResponse.
 func (f *FishResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalFishClassification((*json.RawMessage)(&data))
+	res, err := unmarshalFishClassification((*json.RawMessage)(&data))
 	if err != nil {
 		return err
 	}
-	f.Fish = t
+	f.Fish = res
 	return nil
 }
 
@@ -773,11 +773,11 @@ type MyBaseTypeResponse struct {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type MyBaseTypeResponse.
 func (m *MyBaseTypeResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalMyBaseTypeClassification((*json.RawMessage)(&data))
+	res, err := unmarshalMyBaseTypeClassification((*json.RawMessage)(&data))
 	if err != nil {
 		return err
 	}
-	m.MyBaseType = t
+	m.MyBaseType = res
 	return nil
 }
 
@@ -1074,11 +1074,11 @@ type SalmonResponse struct {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SalmonResponse.
 func (s *SalmonResponse) UnmarshalJSON(data []byte) error {
-	t, err := unmarshalSalmonClassification((*json.RawMessage)(&data))
+	res, err := unmarshalSalmonClassification((*json.RawMessage)(&data))
 	if err != nil {
 		return err
 	}
-	s.Salmon = t
+	s.Salmon = res
 	return nil
 }
 

--- a/test/storage/2019-07-07/azblob/zz_generated_blob_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_blob_client.go
@@ -833,12 +833,13 @@ func (client *blobClient) downloadHandleResponse(resp *azcore.Response) (BlobDow
 		}
 		result.LastModified = &lastModified
 	}
+	prefix := strings.ToUpper("x-ms-meta-")
 	for hh := range resp.Header {
-		if strings.HasPrefix(hh, "x-ms-meta-") {
+		if strings.HasPrefix(strings.ToUpper(hh), prefix) {
 			if result.Metadata == nil {
 				result.Metadata = map[string]string{}
 			}
-			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len(prefix):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("Content-Length"); val != "" {
@@ -1238,12 +1239,13 @@ func (client *blobClient) getPropertiesHandleResponse(resp *azcore.Response) (Bl
 		}
 		result.CreationTime = &creationTime
 	}
+	prefix := strings.ToUpper("x-ms-meta-")
 	for hh := range resp.Header {
-		if strings.HasPrefix(hh, "x-ms-meta-") {
+		if strings.HasPrefix(strings.ToUpper(hh), prefix) {
 			if result.Metadata == nil {
 				result.Metadata = map[string]string{}
 			}
-			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len(prefix):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("x-ms-blob-type"); val != "" {

--- a/test/storage/2019-07-07/azblob/zz_generated_container_client.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_container_client.go
@@ -675,12 +675,13 @@ func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, c
 // getPropertiesHandleResponse handles the GetProperties response.
 func (client *containerClient) getPropertiesHandleResponse(resp *azcore.Response) (ContainerGetPropertiesResponse, error) {
 	result := ContainerGetPropertiesResponse{RawResponse: resp.Response}
+	prefix := strings.ToUpper("x-ms-meta-")
 	for hh := range resp.Header {
-		if strings.HasPrefix(hh, "x-ms-meta-") {
+		if strings.HasPrefix(strings.ToUpper(hh), prefix) {
 			if result.Metadata == nil {
 				result.Metadata = map[string]string{}
 			}
-			result.Metadata[hh[len("x-ms-meta-"):]] = resp.Header.Get(hh)
+			result.Metadata[hh[len(prefix):]] = resp.Header.Get(hh)
 		}
 	}
 	if val := resp.Header.Get("ETag"); val != "" {


### PR DESCRIPTION
Canonicalization of header keys means a case-insensitive comparison must
be used.
Renamed variable t to res to avoid collision with receivers.
Fixed a case of missing internal marshaller.