### PR TITLE
Fix unmarshalling for additionalProperties

### DIFF
--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -793,6 +793,9 @@ function generateAliasType(structDef: StructDef, receiver: string, forMarshal: b
     if (prop.schema.type === SchemaType.DateTime) {
       text += `\t\t${prop.language.go!.name} *${prop.schema.language.go!.internalTimeType} \`${structDef.Language.marshallingFormat}:"${sn}"\`\n`;
     } else if (prop.language.go!.isAdditionalProperties || prop.language.go!.needsXMLDictionaryUnmarshalling) {
+      if (prop.language.go!.isAdditionalProperties && prop.language.go!.needsXMLDictionaryUnmarshalling) {
+        sn = ',any'
+      }
       text += `\t\t${prop.language.go!.name} *additionalProperties \`${structDef.Language.marshallingFormat}:"${sn}"\`\n`;
     }
   }

--- a/src/generator/xmlAdditionalProps.ts
+++ b/src/generator/xmlAdditionalProps.ts
@@ -26,22 +26,31 @@ type additionalProperties map[string]*string
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tokName := ""
+	tokVal := ""
+	inserted := false
 	for t, err := d.Token(); err == nil; t, err = d.Token() {
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = strings.ToLower(tt.Name.Local)
-			break
 		case xml.CharData:
-			if tokName == "" {
-				continue
+			temp := string(tt)
+			if tokName != "" {
+				if *ap == nil {
+					*ap = additionalProperties{}
+				}
+				(*ap)[tokName] = &temp
+				tokName = ""
+				inserted = true
 			}
-			if *ap == nil {
-				*ap = additionalProperties{}
+			tokVal = temp
+		case xml.EndElement:
+			if !inserted && tokName == "" && tt.Name.Local != "" {
+				if *ap == nil {
+					*ap = additionalProperties{}
+				}
+				(*ap)[tt.Name.Local] = &tokVal
+				inserted = false
 			}
-			s := string(tt)
-			(*ap)[tokName] = &s
-			tokName = ""
-			break
 		}
 	}
 	return nil

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -119,6 +119,10 @@ async function process(session: Session<CodeModel>) {
       // add an 'AdditionalProperties' field to the type
       const addProps = newProperty('AdditionalProperties', 'Contains additional key/value pairs not defined in the schema.', addPropsSchema);
       addProps.language.go!.isAdditionalProperties = true;
+      if (obj.language.go!.marshallingFormat === 'xml') {
+        addProps.language.go!.needsXMLDictionaryUnmarshalling = true;
+        session.model.language.go!.needsXMLDictionaryUnmarshalling = true;
+      }
       obj.properties?.push(addProps);
     }
   }

--- a/test/storage/2019-07-07/azblob/zz_generated_models.go
+++ b/test/storage/2019-07-07/azblob/zz_generated_models.go
@@ -890,6 +890,22 @@ type BlobMetadata struct {
 	Encrypted            *string `xml:"Encrypted,attr"`
 }
 
+// UnmarshalXML implements the xml.Unmarshaller interface for type BlobMetadata.
+func (b *BlobMetadata) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type alias BlobMetadata
+	aux := &struct {
+		*alias
+		AdditionalProperties *additionalProperties `xml:",any"`
+	}{
+		alias: (*alias)(b),
+	}
+	if err := d.DecodeElement(aux, &start); err != nil {
+		return err
+	}
+	b.AdditionalProperties = (*map[string]*string)(aux.AdditionalProperties)
+	return nil
+}
+
 type BlobPrefix struct {
 	Name *string `xml:"Name"`
 }


### PR DESCRIPTION
Unmarshalling for BlobMetadata additional properties was being skipped during unmarshalling because no custom unmarshaller was being generated for the BlobMetadata struct. 

Make sure key and value pairs are both included in the map. 
 
Fix this case for all additional properties. 