### PR TITLE
Add support for data-plane LROs

### DIFF
--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,7 +16,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.13\n\n';
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
-  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3';
+  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4';
   if (<boolean>session.model.language.go!.azureARM) {
     text += 'require (\n';
     text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0\n';

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -58,9 +58,10 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   }
   if (needsJSONPopulate) {
     text += 'func populate(m map[string]interface{}, k string, v interface{}) {\n';
+    text += '\tif v == nil {\n\t\treturn\n\t}\n';
     text += '\tif azcore.IsNullValue(v) {\n';
     text += '\t\tm[k] = nil\n';
-    text += '\t} else if !reflect.ValueOf(v).IsNil() {\n';
+    text += '\t} else {\n';
     text += '\t\tm[k] = v\n';
     text += '\t}\n';
     text += '}\n\n';
@@ -399,7 +400,6 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
       generateInternalUnmarshaller(obj, structDef, parentType);
     }
     if (needsM) {
-      imports.add('reflect');
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
       structDef.HasJSONMarshaller = true;
       generateJSONMarshaller(imports, obj, structDef, parentType);

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -61,7 +61,7 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
     text += '\tif v == nil {\n\t\treturn\n\t}\n';
     text += '\tif azcore.IsNullValue(v) {\n';
     text += '\t\tm[k] = nil\n';
-    text += '\t} else {\n';
+    text += '\t} else if !reflect.ValueOf(v).IsNil() {\n';
     text += '\t\tm[k] = v\n';
     text += '\t}\n';
     text += '}\n\n';
@@ -400,6 +400,7 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
       generateInternalUnmarshaller(obj, structDef, parentType);
     }
     if (needsM) {
+      imports.add('reflect');
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
       structDef.HasJSONMarshaller = true;
       generateJSONMarshaller(imports, obj, structDef, parentType);

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -58,8 +58,9 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   }
   if (needsJSONPopulate) {
     text += 'func populate(m map[string]interface{}, k string, v interface{}) {\n';
-    text += '\tif v == nil {\n\t\treturn\n\t}\n';
-    text += '\tif azcore.IsNullValue(v) {\n';
+    text += '\tif v == nil {\n';
+    text += '\t\treturn\n';
+    text += '\t} else if azcore.IsNullValue(v) {\n';
     text += '\t\tm[k] = nil\n';
     text += '\t} else if !reflect.ValueOf(v).IsNil() {\n';
     text += '\t\tm[k] = v\n';

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -1088,7 +1088,7 @@ function generateLROBeginMethod(op: Operation, imports: ImportManager, isARM: bo
   text += '\tif err != nil {\n';
   text += `\t\treturn ${zeroResp}, err\n`;
   text += '\t}\n';
-  text += emitPoller(op, isARM, imports);
+  text += emitPoller(op, imports, isARM);
   text += '\tresult.Poller = poller\n';
   // determine the poller response based on the name and whether is is a pageable operation
   let pollerResponse = '*http.Response';
@@ -1122,7 +1122,7 @@ function generateLROResumeMethod(op: Operation, imports: ImportManager, isARM: b
   text += '\tif err != nil {\n';
   text += `\t\treturn ${zeroResp}, err\n`;
   text += '\t}\n';
-  text += emitPoller(op, isARM, imports);
+  text += emitPoller(op, imports, isARM);
   text += '\tresp, err := poller.Poll(ctx)\n';
   text += '\tif err != nil {\n';
   text += `\t\treturn ${zeroResp}, err\n`;
@@ -1152,7 +1152,7 @@ function generateLROResumeMethod(op: Operation, imports: ImportManager, isARM: b
   return text;
 }
 
-function emitPoller(op: Operation, isARM: boolean, imports: ImportManager): string {
+function emitPoller(op: Operation, imports: ImportManager, isARM: boolean): string {
   let text = `\tpoller := &${internalPollerTypeName(<PollerInfo>op.language.go!.pollerType)}{\n`;
   if (isARM) {
     text += '\t\tpipeline: client.con.Pipeline(),\n';

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -419,8 +419,7 @@ type PetsCreateCatAPTrueOptions struct {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 )
 
 type CatAPTrue struct {
@@ -417,9 +416,12 @@ type PetsCreateCatAPTrueOptions struct {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 )
 
 type CatAPTrue struct {
@@ -421,7 +422,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -1260,8 +1260,7 @@ type StringWrapperResponse struct {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -1258,9 +1257,12 @@ type StringWrapperResponse struct {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -1262,7 +1263,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 )
 
 type Animal struct {
@@ -317,9 +316,12 @@ func (p *PetSadError) unmarshalInternal(rawMsg map[string]*json.RawMessage) erro
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 )
 
 type Animal struct {
@@ -321,7 +322,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -319,8 +319,7 @@ func (p *PetSadError) unmarshalInternal(rawMsg map[string]*json.RawMessage) erro
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -31,7 +31,7 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDelete202Retry200(rt)
+	resp, err = op.ResumeDelete202Retry200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRelativeRetrySucceeded(rt)
+	resp, err = op.ResumeDeleteAsyncRelativeRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(rt)
+	resp, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost202Retry200(rt)
+	resp, err = op.ResumePost202Retry200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRelativeRetrySucceeded(rt)
+	resp, err = op.ResumePostAsyncRelativeRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut201CreatingSucceeded200(rt)
+	resp, err = op.ResumePut201CreatingSucceeded200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRelativeRetrySucceeded(rt)
+	resp, err = op.ResumePutAsyncRelativeRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -45,12 +45,9 @@ func TestLROResumeWrongPoller(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	diffPoller, err := op.ResumePost200WithPayload(rt)
+	_, err = op.ResumePost200WithPayload(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not find receive one")
-	}
-	if diffPoller != nil {
-		t.Fatal("expected a nil poller from the resume operation")
 	}
 }
 
@@ -65,7 +62,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDelete202NoRetry204(rt)
+	resp, err = op.ResumeDelete202NoRetry204(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +86,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDelete202Retry200(rt)
+	resp, err = op.ResumeDelete202Retry200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +130,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncNoHeaderInRetry(rt)
+	resp, err = op.ResumeDeleteAsyncNoHeaderInRetry(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +154,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncNoRetrySucceeded(rt)
+	resp, err = op.ResumeDeleteAsyncNoRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +178,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRetryFailed(rt)
+	resp, err = op.ResumeDeleteAsyncRetryFailed(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +212,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRetrySucceeded(rt)
+	resp, err = op.ResumeDeleteAsyncRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +236,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRetrycanceled(rt)
+	resp, err = op.ResumeDeleteAsyncRetrycanceled(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -273,7 +270,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteNoHeaderInRetry(rt)
+	resp, err = op.ResumeDeleteNoHeaderInRetry(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +294,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(rt)
+	resp, err = op.ResumeDeleteProvisioning202Accepted200Succeeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,11 +318,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteProvisioning202DeletingFailed200(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDeleteProvisioning202DeletingFailed200(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -342,11 +335,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteProvisioning202Deletingcanceled200(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDeleteProvisioning202Deletingcanceled200(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
 	}
@@ -363,7 +352,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost200WithPayload(rt)
+	resp, err = op.ResumePost200WithPayload(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -393,7 +382,7 @@ func TestLROBeginPost202List(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost202List(rt)
+	resp, err = op.ResumePost202List(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +416,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost202NoRetry204(rt)
+	resp, err = op.ResumePost202NoRetry204(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +440,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost202Retry200(rt)
+	resp, err = op.ResumePost202Retry200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +464,7 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncNoRetrySucceeded(rt)
+	resp, err = op.ResumePostAsyncNoRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -510,7 +499,7 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRetryFailed(rt)
+	resp, err = op.ResumePostAsyncRetryFailed(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -544,7 +533,7 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRetrySucceeded(rt)
+	resp, err = op.ResumePostAsyncRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +568,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRetrycanceled(rt)
+	resp, err = op.ResumePostAsyncRetrycanceled(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +602,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostDoubleHeadersFinalAzureHeaderGet(rt)
+	resp, err = op.ResumePostDoubleHeadersFinalAzureHeaderGet(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -644,7 +633,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostDoubleHeadersFinalAzureHeaderGetDefault(rt)
+	resp, err = op.ResumePostDoubleHeadersFinalAzureHeaderGetDefault(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -676,7 +665,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostDoubleHeadersFinalLocationGet(rt)
+	resp, err = op.ResumePostDoubleHeadersFinalLocationGet(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -703,16 +692,9 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut200Acceptedcanceled200(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePut200Acceptedcanceled200(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 	var cloudErr *CloudError
 	if !errors.As(err, &cloudErr) {
@@ -797,7 +779,7 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut200UpdatingSucceeded204(rt)
+	resp, err = op.ResumePut200UpdatingSucceeded204(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -832,16 +814,9 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut201CreatingFailed200(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePut201CreatingFailed200(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 	var cloudErr *CloudError
 	if !errors.As(err, &cloudErr) {
@@ -866,7 +841,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut201CreatingSucceeded200(rt)
+	resp, err = op.ResumePut201CreatingSucceeded200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -901,7 +876,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePut202Retry200(rt)
+	resp, err = op.ResumePut202Retry200(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -933,7 +908,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncNoHeaderInRetry(rt)
+	resp, err = op.ResumePutAsyncNoHeaderInRetry(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -968,7 +943,7 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncNoRetrySucceeded(rt)
+	resp, err = op.ResumePutAsyncNoRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1003,7 +978,7 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncNoRetrycanceled(rt)
+	resp, err = op.ResumePutAsyncNoRetrycanceled(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1037,7 +1012,7 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncNonResource(rt)
+	resp, err = op.ResumePutAsyncNonResource(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1067,7 +1042,7 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRetryFailed(rt)
+	resp, err = op.ResumePutAsyncRetryFailed(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1101,7 +1076,7 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRetrySucceeded(rt)
+	resp, err = op.ResumePutAsyncRetrySucceeded(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1136,7 +1111,7 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncSubResource(rt)
+	resp, err = op.ResumePutAsyncSubResource(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1171,7 +1146,7 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutNoHeaderInRetry(rt)
+	resp, err = op.ResumePutNoHeaderInRetry(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1206,7 +1181,7 @@ func TestLROBeginPutNonResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutNonResource(rt)
+	resp, err = op.ResumePutNonResource(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1237,7 +1212,7 @@ func TestLROBeginPutSubResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutSubResource(rt)
+	resp, err = op.ResumePutSubResource(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"testing"
 	"time"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func newLrosaDsClient() *LROSADsClient {
@@ -30,16 +28,9 @@ func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDelete202NonRetry400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDelete202NonRetry400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -85,16 +76,9 @@ func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRelativeRetry400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDeleteAsyncRelativeRetry400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -117,16 +101,9 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -141,16 +118,9 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumeDeleteAsyncRelativeRetryNoStatus(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumeDeleteAsyncRelativeRetryNoStatus(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -181,16 +151,9 @@ func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePost202NonRetry400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePost202NonRetry400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -213,16 +176,9 @@ func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRelativeRetry400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePostAsyncRelativeRetry400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -245,16 +201,9 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRelativeRetryInvalidJSONPolling(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePostAsyncRelativeRetryInvalidJSONPolling(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -269,16 +218,9 @@ func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePostAsyncRelativeRetryNoPayload(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePostAsyncRelativeRetryNoPayload(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if res != nil {
-		t.Fatal("expected a nil response with the error")
 	}
 }
 
@@ -309,16 +251,9 @@ func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRelativeRetry400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutAsyncRelativeRetry400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -341,16 +276,9 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRelativeRetryInvalidJSONPolling(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutAsyncRelativeRetryInvalidJSONPolling(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -365,16 +293,9 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRelativeRetryNoStatus(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutAsyncRelativeRetryNoStatus(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -389,16 +310,9 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutAsyncRelativeRetryNoStatusPayload(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutAsyncRelativeRetryNoStatusPayload(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -413,16 +327,9 @@ func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutError201NoProvisioningStatePayload(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutError201NoProvisioningStatePayload(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -437,16 +344,9 @@ func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutNonRetry201Creating400(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutNonRetry201Creating400(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 
@@ -461,16 +361,9 @@ func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = op.ResumePutNonRetry201Creating400InvalidJSON(rt)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res, err := resp.PollUntilDone(context.Background(), 1*time.Millisecond)
+	resp, err = op.ResumePutNonRetry201Creating400InvalidJSON(context.Background(), rt)
 	if err == nil {
 		t.Fatal("expected an error but did not receive one")
-	}
-	if r := cmp.Diff(res, ProductResponse{}); r != "" {
-		t.Fatal(r)
 	}
 }
 

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -38,21 +38,21 @@ func TestBeginPost202Retry200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err := op.ResumePost202Retry200(tk)
+	env, err = op.ResumePost202Retry200(ctxWithHTTPHeader(), tk)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var resp *http.Response
 	for {
-		resp, err = poller.Poll(ctxWithHTTPHeader())
+		resp, err = env.Poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if poller.Done() {
+		if env.Poller.Done() {
 			break
 		}
 	}
-	resp, err = poller.FinalResponse(context.Background())
+	resp, err = env.Poller.FinalResponse(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -72,21 +72,21 @@ func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err := op.ResumePostAsyncRetrySucceeded(tk)
+	env, err = op.ResumePostAsyncRetrySucceeded(ctxWithHTTPHeader(), tk)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var resp *http.Response
 	for {
-		resp, err = poller.Poll(ctxWithHTTPHeader())
+		resp, err = env.Poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if poller.Done() {
+		if env.Poller.Done() {
 			break
 		}
 	}
-	resp, err = poller.FinalResponse(context.Background())
+	resp, err = env.Poller.FinalResponse(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -106,20 +106,20 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err := op.ResumePut201CreatingSucceeded200(tk)
+	env, err = op.ResumePut201CreatingSucceeded200(ctxWithHTTPHeader(), tk)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for {
-		_, err = poller.Poll(ctxWithHTTPHeader())
+		_, err = env.Poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if poller.Done() {
+		if env.Poller.Done() {
 			break
 		}
 	}
-	pr, err := poller.FinalResponse(ctxWithHTTPHeader())
+	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,20 +150,20 @@ func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err := op.ResumePutAsyncRetrySucceeded(tk)
+	env, err = op.ResumePutAsyncRetrySucceeded(ctxWithHTTPHeader(), tk)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for {
-		_, err = poller.Poll(ctxWithHTTPHeader())
+		_, err = env.Poller.Poll(ctxWithHTTPHeader())
 		if err != nil {
 			t.Fatal(err)
 		}
-		if poller.Done() {
+		if env.Poller.Done() {
 			break
 		}
 	}
-	pr, err := poller.FinalResponse(ctxWithHTTPHeader())
+	pr, err := env.Poller.FinalResponse(ctxWithHTTPHeader())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -41,8 +41,8 @@ func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, optio
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -53,15 +53,27 @@ func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, optio
 
 // ResumeDelete202Retry200 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LRORetrysClient) ResumeDelete202Retry200(token string) (HTTPPoller, error) {
+func (client *LRORetrysClient) ResumeDelete202Retry200(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.Delete202Retry200", token, client.delete202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 500, then a 202 to the initial request. Polls return this value until the last poll
@@ -117,8 +129,8 @@ func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -129,15 +141,27 @@ func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 
 // ResumeDeleteAsyncRelativeRetrySucceeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LRORetrysClient) ResumeDeleteAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error) {
+func (client *LRORetrysClient) ResumeDeleteAsyncRelativeRetrySucceeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.DeleteAsyncRelativeRetrySucceeded", token, client.deleteAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRelativeRetrySucceeded - Long running delete request, service returns a 500, then a 202 to the initial request. Poll the endpoint indicated
@@ -194,8 +218,8 @@ func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -206,15 +230,27 @@ func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 
 // ResumeDeleteProvisioning202Accepted200Succeeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LRORetrysClient) ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error) {
+func (client *LRORetrysClient) ResumeDeleteProvisioning202Accepted200Succeeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.DeleteProvisioning202Accepted200Succeeded", token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 500, then a 202 to the initial request, with an entity that
@@ -280,8 +316,8 @@ func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -292,15 +328,27 @@ func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options
 
 // ResumePost202Retry200 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LRORetrysClient) ResumePost202Retry200(token string) (HTTPPoller, error) {
+func (client *LRORetrysClient) ResumePost202Retry200(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202Retry200 - Long running post request, service returns a 500, then a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls
@@ -360,8 +408,8 @@ func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -372,15 +420,27 @@ func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 
 // ResumePostAsyncRelativeRetrySucceeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LRORetrysClient) ResumePostAsyncRelativeRetrySucceeded(token string) (HTTPPoller, error) {
+func (client *LRORetrysClient) ResumePostAsyncRelativeRetrySucceeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.PostAsyncRelativeRetrySucceeded", token, client.postAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRelativeRetrySucceeded - Long running post request, service returns a 500, then a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -441,8 +501,8 @@ func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -453,15 +513,27 @@ func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 
 // ResumePut201CreatingSucceeded200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LRORetrysClient) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
+func (client *LRORetrysClient) ResumePut201CreatingSucceeded200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 500, then a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -531,8 +603,8 @@ func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -543,15 +615,27 @@ func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 
 // ResumePutAsyncRelativeRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LRORetrysClient) ResumePutAsyncRelativeRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LRORetrysClient) ResumePutAsyncRelativeRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LRORetrysClient.PutAsyncRelativeRetrySucceeded", token, client.putAsyncRelativeRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetrySucceeded - Long running put request, service returns a 500, then a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -41,8 +41,8 @@ func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options 
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -53,15 +53,27 @@ func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options 
 
 // ResumeDelete202NoRetry204 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumeDelete202NoRetry204(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumeDelete202NoRetry204(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Delete202NoRetry204", token, client.delete202NoRetry204HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete202NoRetry204 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns
@@ -126,8 +138,8 @@ func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *L
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -138,15 +150,27 @@ func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *L
 
 // ResumeDelete202Retry200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumeDelete202Retry200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumeDelete202Retry200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Delete202Retry200", token, client.delete202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete202Retry200 - Long running delete request, service returns a 202 to the initial request. Polls return this value until the last poll returns a
@@ -210,8 +234,8 @@ func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -222,15 +246,27 @@ func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *
 
 // ResumeDelete204Succeeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDelete204Succeeded(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDelete204Succeeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Delete204Succeeded", token, client.delete204SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete204Succeeded - Long running delete succeeds and returns right away
@@ -285,8 +321,8 @@ func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, o
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -297,15 +333,27 @@ func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, o
 
 // ResumeDeleteAsyncNoHeaderInRetry creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteAsyncNoHeaderInRetry(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteAsyncNoHeaderInRetry(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoHeaderInRetry", token, client.deleteAsyncNoHeaderInRetryHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncNoHeaderInRetry - Long running delete request, service returns an Azure-AsyncOperation header in the initial request. Subsequent calls to
@@ -361,8 +409,8 @@ func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -373,15 +421,27 @@ func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, 
 
 // ResumeDeleteAsyncNoRetrySucceeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteAsyncNoRetrySucceeded(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteAsyncNoRetrySucceeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteAsyncNoRetrySucceeded", token, client.deleteAsyncNoRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncNoRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -437,8 +497,8 @@ func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, optio
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -449,15 +509,27 @@ func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, optio
 
 // ResumeDeleteAsyncRetryFailed creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteAsyncRetryFailed(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteAsyncRetryFailed(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetryFailed", token, client.deleteAsyncRetryFailedHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRetryFailed - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -513,8 +585,8 @@ func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, op
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -525,15 +597,27 @@ func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, op
 
 // ResumeDeleteAsyncRetrySucceeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteAsyncRetrySucceeded(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteAsyncRetrySucceeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrySucceeded", token, client.deleteAsyncRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRetrySucceeded - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -589,8 +673,8 @@ func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, opt
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -601,15 +685,27 @@ func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, opt
 
 // ResumeDeleteAsyncRetrycanceled creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteAsyncRetrycanceled(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteAsyncRetrycanceled(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteAsyncRetrycanceled", token, client.deleteAsyncRetrycanceledHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRetrycanceled - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -665,8 +761,8 @@ func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, option
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -677,15 +773,27 @@ func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, option
 
 // ResumeDeleteNoHeaderInRetry creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteNoHeaderInRetry(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumeDeleteNoHeaderInRetry(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteNoHeaderInRetry", token, client.deleteNoHeaderInRetryHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteNoHeaderInRetry - Long running delete request, service returns a location header in the initial request. Subsequent calls to operation status do
@@ -742,8 +850,8 @@ func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -754,15 +862,27 @@ func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 
 // ResumeDeleteProvisioning202Accepted200Succeeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteProvisioning202Accepted200Succeeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumeDeleteProvisioning202Accepted200Succeeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Accepted200Succeeded", token, client.deleteProvisioning202Accepted200SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteProvisioning202Accepted200Succeeded - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Accepted’.
@@ -829,8 +949,8 @@ func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -841,15 +961,27 @@ func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 
 // ResumeDeleteProvisioning202DeletingFailed200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteProvisioning202DeletingFailed200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumeDeleteProvisioning202DeletingFailed200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202DeletingFailed200", token, client.deleteProvisioning202DeletingFailed200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteProvisioning202DeletingFailed200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -916,8 +1048,8 @@ func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -928,15 +1060,27 @@ func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 
 // ResumeDeleteProvisioning202Deletingcanceled200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumeDeleteProvisioning202Deletingcanceled200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumeDeleteProvisioning202Deletingcanceled200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.DeleteProvisioning202Deletingcanceled200", token, client.deleteProvisioning202Deletingcanceled200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteProvisioning202Deletingcanceled200 - Long running delete request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1002,8 +1146,8 @@ func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *
 		return SKUPollerResponse{}, err
 	}
 	poller := &skuPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
@@ -1014,15 +1158,27 @@ func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *
 
 // ResumePost200WithPayload creates a new SKUPoller from the specified resume token.
 // token - The value must come from a previous call to SKUPoller.ResumeToken().
-func (client *LROsClient) ResumePost200WithPayload(token string) (SKUPoller, error) {
+func (client *LROsClient) ResumePost200WithPayload(ctx context.Context, token string) (SKUPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Post200WithPayload", token, client.post200WithPayloadHandleError)
 	if err != nil {
-		return nil, err
+		return SKUPollerResponse{}, err
 	}
-	return &skuPoller{
+	poller := &skuPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SKUPollerResponse{}, err
+	}
+	result := SKUPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post200WithPayload - Long running post request, service returns a 202 to the initial request, with 'Location' header. Poll returns a 200 with a response
@@ -1087,8 +1243,8 @@ func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsBeg
 		return ProductArrayPollerResponse{}, err
 	}
 	poller := &productArrayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error) {
@@ -1099,15 +1255,27 @@ func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsBeg
 
 // ResumePost202List creates a new ProductArrayPoller from the specified resume token.
 // token - The value must come from a previous call to ProductArrayPoller.ResumeToken().
-func (client *LROsClient) ResumePost202List(token string) (ProductArrayPoller, error) {
+func (client *LROsClient) ResumePost202List(ctx context.Context, token string) (ProductArrayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Post202List", token, client.post202ListHandleError)
 	if err != nil {
-		return nil, err
+		return ProductArrayPollerResponse{}, err
 	}
-	return &productArrayPoller{
+	poller := &productArrayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductArrayPollerResponse{}, err
+	}
+	result := ProductArrayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202List - Long running put request, service returns a 202 with empty body to first request, returns a 200 with body [{ 'id': '100', 'name': 'foo'
@@ -1172,8 +1340,8 @@ func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *L
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1184,15 +1352,27 @@ func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *L
 
 // ResumePost202NoRetry204 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePost202NoRetry204(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePost202NoRetry204(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Post202NoRetry204", token, client.post202NoRetry204HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202NoRetry204 - Long running post request, service returns a 202 to the initial request, with 'Location' header, 204 with noresponse body after success
@@ -1259,8 +1439,8 @@ func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LRO
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1271,15 +1451,27 @@ func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LRO
 
 // ResumePost202Retry200 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumePost202Retry200(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumePost202Retry200(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202Retry200 - Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a
@@ -1339,8 +1531,8 @@ func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, op
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1351,15 +1543,27 @@ func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, op
 
 // ResumePostAsyncNoRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePostAsyncNoRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePostAsyncNoRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostAsyncNoRetrySucceeded", token, client.postAsyncNoRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncNoRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1429,8 +1633,8 @@ func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1441,15 +1645,27 @@ func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options
 
 // ResumePostAsyncRetryFailed creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumePostAsyncRetryFailed(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumePostAsyncRetryFailed(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostAsyncRetryFailed", token, client.postAsyncRetryFailedHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRetryFailed - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1510,8 +1726,8 @@ func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, opti
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1522,15 +1738,27 @@ func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, opti
 
 // ResumePostAsyncRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePostAsyncRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePostAsyncRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostAsyncRetrySucceeded", token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRetrySucceeded - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1600,8 +1828,8 @@ func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, optio
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1612,15 +1840,27 @@ func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, optio
 
 // ResumePostAsyncRetrycanceled creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsClient) ResumePostAsyncRetrycanceled(token string) (HTTPPoller, error) {
+func (client *LROsClient) ResumePostAsyncRetrycanceled(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostAsyncRetrycanceled", token, client.postAsyncRetrycanceledHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRetrycanceled - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1680,8 +1920,8 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1692,15 +1932,27 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 
 // ResumePostDoubleHeadersFinalAzureHeaderGet creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePostDoubleHeadersFinalAzureHeaderGet(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePostDoubleHeadersFinalAzureHeaderGet(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGet", token, client.postDoubleHeadersFinalAzureHeaderGetHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header.
@@ -1766,8 +2018,8 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1778,15 +2030,27 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 
 // ResumePostDoubleHeadersFinalAzureHeaderGetDefault creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePostDoubleHeadersFinalAzureHeaderGetDefault(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalAzureHeaderGetDefault", token, client.postDoubleHeadersFinalAzureHeaderGetDefaultHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostDoubleHeadersFinalAzureHeaderGetDefault - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async
@@ -1852,8 +2116,8 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1864,15 +2128,27 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 
 // ResumePostDoubleHeadersFinalLocationGet creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePostDoubleHeadersFinalLocationGet(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePostDoubleHeadersFinalLocationGet(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PostDoubleHeadersFinalLocationGet", token, client.postDoubleHeadersFinalLocationGetHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostDoubleHeadersFinalLocationGet - Long running post request, service returns a 202 to the initial request with both Location and Azure-Async header.
@@ -1938,8 +2214,8 @@ func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, op
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1950,15 +2226,27 @@ func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, op
 
 // ResumePut200Acceptedcanceled200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut200Acceptedcanceled200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut200Acceptedcanceled200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put200Acceptedcanceled200", token, client.put200Acceptedcanceled200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put200Acceptedcanceled200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -2026,8 +2314,8 @@ func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, options *LRO
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2038,15 +2326,27 @@ func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, options *LRO
 
 // ResumePut200Succeeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut200Succeeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut200Succeeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put200Succeeded", token, client.put200SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put200Succeeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -2112,8 +2412,8 @@ func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, optio
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2124,15 +2424,27 @@ func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, optio
 
 // ResumePut200SucceededNoState creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut200SucceededNoState(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut200SucceededNoState(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put200SucceededNoState", token, client.put200SucceededNoStateHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put200SucceededNoState - Long running put request, service returns a 200 to the initial request, with an entity that does not contain ProvisioningState=’Succeeded’.
@@ -2200,8 +2512,8 @@ func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, o
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2212,15 +2524,27 @@ func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, o
 
 // ResumePut200UpdatingSucceeded204 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut200UpdatingSucceeded204(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut200UpdatingSucceeded204(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put200UpdatingSucceeded204", token, client.put200UpdatingSucceeded204HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put200UpdatingSucceeded204 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Updating’.
@@ -2290,8 +2614,8 @@ func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, opti
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2302,15 +2626,27 @@ func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, opti
 
 // ResumePut201CreatingFailed200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut201CreatingFailed200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut201CreatingFailed200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put201CreatingFailed200", token, client.put201CreatingFailed200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put201CreatingFailed200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Created’.
@@ -2380,8 +2716,8 @@ func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, o
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2392,15 +2728,27 @@ func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, o
 
 // ResumePut201CreatingSucceeded200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut201CreatingSucceeded200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put201CreatingSucceeded200 - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -2468,8 +2816,8 @@ func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, options *LRO
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2480,15 +2828,27 @@ func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, options *LRO
 
 // ResumePut201Succeeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut201Succeeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut201Succeeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put201Succeeded", token, client.put201SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put201Succeeded - Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.
@@ -2555,8 +2915,8 @@ func (client *LROsClient) BeginPut202Retry200(ctx context.Context, options *LROs
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2567,15 +2927,27 @@ func (client *LROsClient) BeginPut202Retry200(ctx context.Context, options *LROs
 
 // ResumePut202Retry200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePut202Retry200(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePut202Retry200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.Put202Retry200", token, client.put202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put202Retry200 - Long running put request, service returns a 202 to the initial request, with a location header that points to a polling URL that returns
@@ -2643,8 +3015,8 @@ func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, opti
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2655,15 +3027,27 @@ func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, opti
 
 // ResumePutAsyncNoHeaderInRetry creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncNoHeaderInRetry(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncNoHeaderInRetry(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncNoHeaderInRetry", token, client.putAsyncNoHeaderInRetryHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation header. Subsequent calls to
@@ -2732,8 +3116,8 @@ func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, opt
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2744,15 +3128,27 @@ func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, opt
 
 // ResumePutAsyncNoRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncNoRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncNoRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrySucceeded", token, client.putAsyncNoRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncNoRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -2822,8 +3218,8 @@ func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, opti
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2834,15 +3230,27 @@ func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, opti
 
 // ResumePutAsyncNoRetrycanceled creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncNoRetrycanceled(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncNoRetrycanceled(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncNoRetrycanceled", token, client.putAsyncNoRetrycanceledHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncNoRetrycanceled - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -2910,8 +3318,8 @@ func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, options 
 		return SKUPollerResponse{}, err
 	}
 	poller := &skuPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
@@ -2922,15 +3330,27 @@ func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, options 
 
 // ResumePutAsyncNonResource creates a new SKUPoller from the specified resume token.
 // token - The value must come from a previous call to SKUPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncNonResource(token string) (SKUPoller, error) {
+func (client *LROsClient) ResumePutAsyncNonResource(ctx context.Context, token string) (SKUPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncNonResource", token, client.putAsyncNonResourceHandleError)
 	if err != nil {
-		return nil, err
+		return SKUPollerResponse{}, err
 	}
-	return &skuPoller{
+	poller := &skuPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SKUPollerResponse{}, err
+	}
+	result := SKUPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncNonResource - Long running put request with non resource.
@@ -2998,8 +3418,8 @@ func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, options 
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -3010,15 +3430,27 @@ func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, options 
 
 // ResumePutAsyncRetryFailed creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncRetryFailed(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncRetryFailed(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncRetryFailed", token, client.putAsyncRetryFailedHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRetryFailed - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -3088,8 +3520,8 @@ func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, optio
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -3100,15 +3532,27 @@ func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, optio
 
 // ResumePutAsyncRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncRetrySucceeded", token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRetrySucceeded - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -3176,8 +3620,8 @@ func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, options 
 		return SubProductPollerResponse{}, err
 	}
 	poller := &subProductPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubProductResponse, error) {
@@ -3188,15 +3632,27 @@ func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, options 
 
 // ResumePutAsyncSubResource creates a new SubProductPoller from the specified resume token.
 // token - The value must come from a previous call to SubProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutAsyncSubResource(token string) (SubProductPoller, error) {
+func (client *LROsClient) ResumePutAsyncSubResource(ctx context.Context, token string) (SubProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutAsyncSubResource", token, client.putAsyncSubResourceHandleError)
 	if err != nil {
-		return nil, err
+		return SubProductPollerResponse{}, err
 	}
-	return &subProductPoller{
+	poller := &subProductPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SubProductPollerResponse{}, err
+	}
+	result := SubProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncSubResource - Long running put request with sub resource.
@@ -3263,8 +3719,8 @@ func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, options *
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -3275,15 +3731,27 @@ func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, options *
 
 // ResumePutNoHeaderInRetry creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutNoHeaderInRetry(token string) (ProductPoller, error) {
+func (client *LROsClient) ResumePutNoHeaderInRetry(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutNoHeaderInRetry", token, client.putNoHeaderInRetryHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutNoHeaderInRetry - Long running put request, service returns a 202 to the initial request with location header. Subsequent calls to operation status
@@ -3350,8 +3818,8 @@ func (client *LROsClient) BeginPutNonResource(ctx context.Context, options *LROs
 		return SKUPollerResponse{}, err
 	}
 	poller := &skuPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
@@ -3362,15 +3830,27 @@ func (client *LROsClient) BeginPutNonResource(ctx context.Context, options *LROs
 
 // ResumePutNonResource creates a new SKUPoller from the specified resume token.
 // token - The value must come from a previous call to SKUPoller.ResumeToken().
-func (client *LROsClient) ResumePutNonResource(token string) (SKUPoller, error) {
+func (client *LROsClient) ResumePutNonResource(ctx context.Context, token string) (SKUPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutNonResource", token, client.putNonResourceHandleError)
 	if err != nil {
-		return nil, err
+		return SKUPollerResponse{}, err
 	}
-	return &skuPoller{
+	poller := &skuPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SKUPollerResponse{}, err
+	}
+	result := SKUPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutNonResource - Long running put request with non resource.
@@ -3436,8 +3916,8 @@ func (client *LROsClient) BeginPutSubResource(ctx context.Context, options *LROs
 		return SubProductPollerResponse{}, err
 	}
 	poller := &subProductPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubProductResponse, error) {
@@ -3448,15 +3928,27 @@ func (client *LROsClient) BeginPutSubResource(ctx context.Context, options *LROs
 
 // ResumePutSubResource creates a new SubProductPoller from the specified resume token.
 // token - The value must come from a previous call to SubProductPoller.ResumeToken().
-func (client *LROsClient) ResumePutSubResource(token string) (SubProductPoller, error) {
+func (client *LROsClient) ResumePutSubResource(ctx context.Context, token string) (SubProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsClient.PutSubResource", token, client.putSubResourceHandleError)
 	if err != nil {
-		return nil, err
+		return SubProductPollerResponse{}, err
 	}
-	return &subProductPoller{
+	poller := &subProductPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SubProductPollerResponse{}, err
+	}
+	result := SubProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutSubResource - Long running put request with sub resource.

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -40,8 +40,8 @@ func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, opti
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -52,15 +52,27 @@ func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, opti
 
 // ResumeDelete202NonRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDelete202NonRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDelete202NonRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Delete202NonRetry400", token, client.delete202NonRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete202NonRetry400 - Long running delete request, service returns a 202 with a location header
@@ -115,8 +127,8 @@ func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -127,15 +139,27 @@ func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 
 // ResumeDelete202RetryInvalidHeader creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDelete202RetryInvalidHeader(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDelete202RetryInvalidHeader(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Delete202RetryInvalidHeader", token, client.delete202RetryInvalidHeaderHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete202RetryInvalidHeader - Long running delete request, service returns a 202 to the initial request receing a reponse with an invalid 'Location'
@@ -190,8 +214,8 @@ func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, option
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -202,15 +226,27 @@ func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, option
 
 // ResumeDelete204Succeeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDelete204Succeeded(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDelete204Succeeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Delete204Succeeded", token, client.delete204SucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete204Succeeded - Long running delete request, service returns a 204 to the initial request, indicating success.
@@ -265,8 +301,8 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -277,15 +313,27 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 
 // ResumeDeleteAsyncRelativeRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetry400", token, client.deleteAsyncRelativeRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRelativeRetry400 - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -341,8 +389,8 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -353,15 +401,27 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 
 // ResumeDeleteAsyncRelativeRetryInvalidHeader creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryInvalidHeader(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidHeader", token, client.deleteAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidHeader - Long running delete request, service returns a 202 to the initial request. The endpoint indicated in the Azure-AsyncOperation
@@ -417,8 +477,8 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -429,15 +489,27 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 
 // ResumeDeleteAsyncRelativeRetryInvalidJSONPolling creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryInvalidJSONPolling", token, client.deleteAsyncRelativeRetryInvalidJSONPollingHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRelativeRetryInvalidJSONPolling - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in
@@ -493,8 +565,8 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -505,15 +577,27 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 
 // ResumeDeleteAsyncRelativeRetryNoStatus creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryNoStatus(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDeleteAsyncRelativeRetryNoStatus(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.DeleteAsyncRelativeRetryNoStatus", token, client.deleteAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteAsyncRelativeRetryNoStatus - Long running delete request, service returns a 202 to the initial request. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -568,8 +652,8 @@ func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -580,15 +664,27 @@ func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options
 
 // ResumeDeleteNonRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumeDeleteNonRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumeDeleteNonRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.DeleteNonRetry400", token, client.deleteNonRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteNonRetry400 - Long running delete request, service returns a 400 with an error body
@@ -642,8 +738,8 @@ func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -654,15 +750,27 @@ func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options
 
 // ResumePost202NoLocation creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePost202NoLocation(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePost202NoLocation(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Post202NoLocation", token, client.post202NoLocationHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202NoLocation - Long running post request, service returns a 202 to the initial request, without a location header.
@@ -719,8 +827,8 @@ func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, option
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -731,15 +839,27 @@ func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, option
 
 // ResumePost202NonRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePost202NonRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePost202NonRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Post202NonRetry400", token, client.post202NonRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202NonRetry400 - Long running post request, service returns a 202 with a location header
@@ -796,8 +916,8 @@ func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -808,15 +928,27 @@ func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 
 // ResumePost202RetryInvalidHeader creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePost202RetryInvalidHeader(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePost202RetryInvalidHeader(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Post202RetryInvalidHeader", token, client.post202RetryInvalidHeaderHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202RetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with invalid 'Location' and 'Retry-After' headers.
@@ -874,8 +1006,8 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -886,15 +1018,27 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 
 // ResumePostAsyncRelativeRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePostAsyncRelativeRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePostAsyncRelativeRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetry400", token, client.postAsyncRelativeRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRelativeRetry400 - Long running post request, service returns a 202 to the initial request Poll the endpoint indicated in the Azure-AsyncOperation
@@ -954,8 +1098,8 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -966,15 +1110,27 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 
 // ResumePostAsyncRelativeRetryInvalidHeader creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePostAsyncRelativeRetryInvalidHeader(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePostAsyncRelativeRetryInvalidHeader(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidHeader", token, client.postAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRelativeRetryInvalidHeader - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1035,8 +1191,8 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1047,15 +1203,27 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 
 // ResumePostAsyncRelativeRetryInvalidJSONPolling creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePostAsyncRelativeRetryInvalidJSONPolling(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePostAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryInvalidJSONPolling", token, client.postAsyncRelativeRetryInvalidJSONPollingHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRelativeRetryInvalidJSONPolling - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1116,8 +1284,8 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1128,15 +1296,27 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 
 // ResumePostAsyncRelativeRetryNoPayload creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePostAsyncRelativeRetryNoPayload(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePostAsyncRelativeRetryNoPayload(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PostAsyncRelativeRetryNoPayload", token, client.postAsyncRelativeRetryNoPayloadHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRelativeRetryNoPayload - Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1195,8 +1375,8 @@ func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1207,15 +1387,27 @@ func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *
 
 // ResumePostNonRetry400 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROSADsClient) ResumePostNonRetry400(token string) (HTTPPoller, error) {
+func (client *LROSADsClient) ResumePostNonRetry400(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PostNonRetry400", token, client.postNonRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostNonRetry400 - Long running post request, service returns a 400 with no error body
@@ -1272,8 +1464,8 @@ func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, options
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1284,15 +1476,27 @@ func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, options
 
 // ResumePut200InvalidJSON creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePut200InvalidJSON(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePut200InvalidJSON(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.Put200InvalidJSON", token, client.put200InvalidJSONHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put200InvalidJSON - Long running put request, service returns a 200 to the initial request, with an entity that is not a valid json
@@ -1359,8 +1563,8 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1371,15 +1575,27 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 
 // ResumePutAsyncRelativeRetry400 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutAsyncRelativeRetry400(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutAsyncRelativeRetry400(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetry400", token, client.putAsyncRelativeRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetry400 - Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
@@ -1447,8 +1663,8 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1459,15 +1675,27 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 
 // ResumePutAsyncRelativeRetryInvalidHeader creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutAsyncRelativeRetryInvalidHeader(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutAsyncRelativeRetryInvalidHeader(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidHeader", token, client.putAsyncRelativeRetryInvalidHeaderHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetryInvalidHeader - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1536,8 +1764,8 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1548,15 +1776,27 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 
 // ResumePutAsyncRelativeRetryInvalidJSONPolling creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutAsyncRelativeRetryInvalidJSONPolling(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutAsyncRelativeRetryInvalidJSONPolling(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryInvalidJSONPolling", token, client.putAsyncRelativeRetryInvalidJSONPollingHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetryInvalidJSONPolling - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1626,8 +1866,8 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1638,15 +1878,27 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 
 // ResumePutAsyncRelativeRetryNoStatus creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutAsyncRelativeRetryNoStatus(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutAsyncRelativeRetryNoStatus(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatus", token, client.putAsyncRelativeRetryNoStatusHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetryNoStatus - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1716,8 +1968,8 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1728,15 +1980,27 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 
 // ResumePutAsyncRelativeRetryNoStatusPayload creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutAsyncRelativeRetryNoStatusPayload(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutAsyncRelativeRetryNoStatusPayload(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutAsyncRelativeRetryNoStatusPayload", token, client.putAsyncRelativeRetryNoStatusPayloadHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRelativeRetryNoStatusPayload - Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’.
@@ -1804,8 +2068,8 @@ func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1816,15 +2080,27 @@ func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 
 // ResumePutError201NoProvisioningStatePayload creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutError201NoProvisioningStatePayload(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutError201NoProvisioningStatePayload(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutError201NoProvisioningStatePayload", token, client.putError201NoProvisioningStatePayloadHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutError201NoProvisioningStatePayload - Long running put request, service returns a 201 to the initial request with no payload
@@ -1890,8 +2166,8 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1902,15 +2178,27 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 
 // ResumePutNonRetry201Creating400 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutNonRetry201Creating400(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutNonRetry201Creating400(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400", token, client.putNonRetry201Creating400HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutNonRetry201Creating400 - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
@@ -1977,8 +2265,8 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -1989,15 +2277,27 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 
 // ResumePutNonRetry201Creating400InvalidJSON creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutNonRetry201Creating400InvalidJSON(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutNonRetry201Creating400InvalidJSON(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutNonRetry201Creating400InvalidJSON", token, client.putNonRetry201Creating400InvalidJSONHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutNonRetry201Creating400InvalidJSON - Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and 201 response code
@@ -2063,8 +2363,8 @@ func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, options *L
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -2075,15 +2375,27 @@ func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, options *L
 
 // ResumePutNonRetry400 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROSADsClient) ResumePutNonRetry400(token string) (ProductPoller, error) {
+func (client *LROSADsClient) ResumePutNonRetry400(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROSADsClient.PutNonRetry400", token, client.putNonRetry400HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutNonRetry400 - Long running put request, service returns a 400 to the initial request

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -42,8 +42,8 @@ func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -54,15 +54,27 @@ func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 
 // ResumePost202Retry200 creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsCustomHeaderClient) ResumePost202Retry200(token string) (HTTPPoller, error) {
+func (client *LROsCustomHeaderClient) ResumePost202Retry200(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsCustomHeaderClient.Post202Retry200", token, client.post202Retry200HandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Post202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request,
@@ -123,8 +135,8 @@ func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -135,15 +147,27 @@ func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 
 // ResumePostAsyncRetrySucceeded creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LROsCustomHeaderClient) ResumePostAsyncRetrySucceeded(token string) (HTTPPoller, error) {
+func (client *LROsCustomHeaderClient) ResumePostAsyncRetrySucceeded(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsCustomHeaderClient.PostAsyncRetrySucceeded", token, client.postAsyncRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post
@@ -204,8 +228,8 @@ func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -216,15 +240,27 @@ func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 
 // ResumePut201CreatingSucceeded200 creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsCustomHeaderClient) ResumePut201CreatingSucceeded200(token string) (ProductPoller, error) {
+func (client *LROsCustomHeaderClient) ResumePut201CreatingSucceeded200(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsCustomHeaderClient.Put201CreatingSucceeded200", token, client.put201CreatingSucceeded200HandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Put201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running
@@ -294,8 +330,8 @@ func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 		return ProductPollerResponse{}, err
 	}
 	poller := &productPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
@@ -306,15 +342,27 @@ func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 
 // ResumePutAsyncRetrySucceeded creates a new ProductPoller from the specified resume token.
 // token - The value must come from a previous call to ProductPoller.ResumeToken().
-func (client *LROsCustomHeaderClient) ResumePutAsyncRetrySucceeded(token string) (ProductPoller, error) {
+func (client *LROsCustomHeaderClient) ResumePutAsyncRetrySucceeded(ctx context.Context, token string) (ProductPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LROsCustomHeaderClient.PutAsyncRetrySucceeded", token, client.putAsyncRetrySucceededHandleError)
 	if err != nil {
-		return nil, err
+		return ProductPollerResponse{}, err
 	}
-	return &productPoller{
+	poller := &productPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ProductPollerResponse{}, err
+	}
+	result := ProductPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -45,8 +45,8 @@ func (p *httpPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-	return p.pt.PollUntilDone(ctx, frequency, p.pipeline, nil)
+func (p *httpPoller) pollUntilDone(ctx context.Context, freq time.Duration) (*http.Response, error) {
+	return p.pt.PollUntilDone(ctx, freq, p.pipeline, nil)
 }
 
 // ProductArrayPoller provides polling facilities until the operation reaches a terminal state.
@@ -85,9 +85,9 @@ func (p *productArrayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *productArrayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ProductArrayResponse, error) {
+func (p *productArrayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ProductArrayResponse, error) {
 	respType := ProductArrayResponse{ProductArray: []*Product{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, &respType.ProductArray)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, &respType.ProductArray)
 	if err != nil {
 		return ProductArrayResponse{}, err
 	}
@@ -131,9 +131,9 @@ func (p *productPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *productPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ProductResponse, error) {
+func (p *productPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ProductResponse, error) {
 	respType := ProductResponse{Product: &Product{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Product)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Product)
 	if err != nil {
 		return ProductResponse{}, err
 	}
@@ -177,9 +177,9 @@ func (p *skuPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *skuPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SKUResponse, error) {
+func (p *skuPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SKUResponse, error) {
 	respType := SKUResponse{SKU: &SKU{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.SKU)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.SKU)
 	if err != nil {
 		return SKUResponse{}, err
 	}
@@ -223,9 +223,9 @@ func (p *subProductPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *subProductPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SubProductResponse, error) {
+func (p *subProductPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SubProductResponse, error) {
 	respType := SubProductResponse{SubProduct: &SubProduct{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.SubProduct)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.SubProduct)
 	if err != nil {
 		return SubProductResponse{}, err
 	}

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -163,7 +163,7 @@ func TestGetMultiplePagesLro(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	poller, err = client.ResumeGetMultiplePagesLRO(rt)
+	resp, err = client.ResumeGetMultiplePagesLRO(context.Background(), rt)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/autorest/paginggroup/zz_generated_pollers.go
+++ b/test/autorest/paginggroup/zz_generated_pollers.go
@@ -26,10 +26,10 @@ type ProductResultPagerPoller interface {
 
 type productResultPagerPoller struct {
 	pipeline    azcore.Pipeline
+	pt          armcore.Poller
 	errHandler  productResultHandleError
 	respHandler productResultHandleResponse
 	statusCodes []int
-	pt          armcore.Poller
 }
 
 func (p *productResultPagerPoller) Done() bool {
@@ -53,9 +53,9 @@ func (p *productResultPagerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *productResultPagerPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ProductResultPager, error) {
+func (p *productResultPagerPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ProductResultPager, error) {
 	respType := &productResultPager{}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4
 )

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -2,10 +2,12 @@ github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbt
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -46,8 +46,8 @@ func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, 
 		return ContainerServicePollerResponse{}, err
 	}
 	poller := &containerServicePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ContainerServiceResponse, error) {
@@ -58,15 +58,27 @@ func (client *ContainerServicesClient) BeginCreateOrUpdate(ctx context.Context, 
 
 // ResumeCreateOrUpdate creates a new ContainerServicePoller from the specified resume token.
 // token - The value must come from a previous call to ContainerServicePoller.ResumeToken().
-func (client *ContainerServicesClient) ResumeCreateOrUpdate(token string) (ContainerServicePoller, error) {
+func (client *ContainerServicesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ContainerServicePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ContainerServicesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ContainerServicePollerResponse{}, err
 	}
-	return &containerServicePoller{
+	poller := &containerServicePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ContainerServicePollerResponse{}, err
+	}
+	result := ContainerServicePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ContainerServiceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a container service with the specified configuration of orchestrator, masters, and agents.
@@ -150,8 +162,8 @@ func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -162,15 +174,27 @@ func (client *ContainerServicesClient) BeginDelete(ctx context.Context, resource
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ContainerServicesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ContainerServicesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ContainerServicesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified container service in the specified subscription and resource group. The operation does not delete other resources created

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -46,8 +46,8 @@ func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, res
 		return DedicatedHostPollerResponse{}, err
 	}
 	poller := &dedicatedHostPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DedicatedHostResponse, error) {
@@ -58,15 +58,27 @@ func (client *DedicatedHostsClient) BeginCreateOrUpdate(ctx context.Context, res
 
 // ResumeCreateOrUpdate creates a new DedicatedHostPoller from the specified resume token.
 // token - The value must come from a previous call to DedicatedHostPoller.ResumeToken().
-func (client *DedicatedHostsClient) ResumeCreateOrUpdate(token string) (DedicatedHostPoller, error) {
+func (client *DedicatedHostsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (DedicatedHostPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DedicatedHostsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return DedicatedHostPollerResponse{}, err
 	}
-	return &dedicatedHostPoller{
+	poller := &dedicatedHostPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DedicatedHostPollerResponse{}, err
+	}
+	result := DedicatedHostPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DedicatedHostResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a dedicated host .
@@ -151,8 +163,8 @@ func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -163,15 +175,27 @@ func (client *DedicatedHostsClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DedicatedHostsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *DedicatedHostsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DedicatedHostsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a dedicated host.
@@ -382,8 +406,8 @@ func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGro
 		return DedicatedHostPollerResponse{}, err
 	}
 	poller := &dedicatedHostPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DedicatedHostResponse, error) {
@@ -394,15 +418,27 @@ func (client *DedicatedHostsClient) BeginUpdate(ctx context.Context, resourceGro
 
 // ResumeUpdate creates a new DedicatedHostPoller from the specified resume token.
 // token - The value must come from a previous call to DedicatedHostPoller.ResumeToken().
-func (client *DedicatedHostsClient) ResumeUpdate(token string) (DedicatedHostPoller, error) {
+func (client *DedicatedHostsClient) ResumeUpdate(ctx context.Context, token string) (DedicatedHostPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DedicatedHostsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return DedicatedHostPollerResponse{}, err
 	}
-	return &dedicatedHostPoller{
+	poller := &dedicatedHostPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DedicatedHostPollerResponse{}, err
+	}
+	result := DedicatedHostPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DedicatedHostResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update an dedicated host .

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -44,8 +44,8 @@ func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context,
 		return DiskEncryptionSetPollerResponse{}, err
 	}
 	poller := &diskEncryptionSetPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskEncryptionSetResponse, error) {
@@ -56,15 +56,27 @@ func (client *DiskEncryptionSetsClient) BeginCreateOrUpdate(ctx context.Context,
 
 // ResumeCreateOrUpdate creates a new DiskEncryptionSetPoller from the specified resume token.
 // token - The value must come from a previous call to DiskEncryptionSetPoller.ResumeToken().
-func (client *DiskEncryptionSetsClient) ResumeCreateOrUpdate(token string) (DiskEncryptionSetPoller, error) {
+func (client *DiskEncryptionSetsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (DiskEncryptionSetPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DiskEncryptionSetsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return DiskEncryptionSetPollerResponse{}, err
 	}
-	return &diskEncryptionSetPoller{
+	poller := &diskEncryptionSetPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DiskEncryptionSetPollerResponse{}, err
+	}
+	result := DiskEncryptionSetPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskEncryptionSetResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a disk encryption set
@@ -142,8 +154,8 @@ func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourc
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *DiskEncryptionSetsClient) BeginDelete(ctx context.Context, resourc
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DiskEncryptionSetsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *DiskEncryptionSetsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DiskEncryptionSetsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a disk encryption set.
@@ -402,8 +426,8 @@ func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourc
 		return DiskEncryptionSetPollerResponse{}, err
 	}
 	poller := &diskEncryptionSetPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskEncryptionSetResponse, error) {
@@ -414,15 +438,27 @@ func (client *DiskEncryptionSetsClient) BeginUpdate(ctx context.Context, resourc
 
 // ResumeUpdate creates a new DiskEncryptionSetPoller from the specified resume token.
 // token - The value must come from a previous call to DiskEncryptionSetPoller.ResumeToken().
-func (client *DiskEncryptionSetsClient) ResumeUpdate(token string) (DiskEncryptionSetPoller, error) {
+func (client *DiskEncryptionSetsClient) ResumeUpdate(ctx context.Context, token string) (DiskEncryptionSetPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DiskEncryptionSetsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return DiskEncryptionSetPollerResponse{}, err
 	}
-	return &diskEncryptionSetPoller{
+	poller := &diskEncryptionSetPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DiskEncryptionSetPollerResponse{}, err
+	}
+	result := DiskEncryptionSetPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskEncryptionSetResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Updates (patches) a disk encryption set.

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -46,8 +46,8 @@ func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGrou
 		return DiskPollerResponse{}, err
 	}
 	poller := &diskPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskResponse, error) {
@@ -58,15 +58,27 @@ func (client *DisksClient) BeginCreateOrUpdate(ctx context.Context, resourceGrou
 
 // ResumeCreateOrUpdate creates a new DiskPoller from the specified resume token.
 // token - The value must come from a previous call to DiskPoller.ResumeToken().
-func (client *DisksClient) ResumeCreateOrUpdate(token string) (DiskPoller, error) {
+func (client *DisksClient) ResumeCreateOrUpdate(ctx context.Context, token string) (DiskPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DisksClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return DiskPollerResponse{}, err
 	}
-	return &diskPoller{
+	poller := &diskPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DiskPollerResponse{}, err
+	}
+	result := DiskPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a disk.
@@ -147,8 +159,8 @@ func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName st
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -159,15 +171,27 @@ func (client *DisksClient) BeginDelete(ctx context.Context, resourceGroupName st
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DisksClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *DisksClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DisksClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a disk.
@@ -302,8 +326,8 @@ func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupNa
 		return AccessURIPollerResponse{}, err
 	}
 	poller := &accessURIPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AccessURIResponse, error) {
@@ -314,15 +338,27 @@ func (client *DisksClient) BeginGrantAccess(ctx context.Context, resourceGroupNa
 
 // ResumeGrantAccess creates a new AccessURIPoller from the specified resume token.
 // token - The value must come from a previous call to AccessURIPoller.ResumeToken().
-func (client *DisksClient) ResumeGrantAccess(token string) (AccessURIPoller, error) {
+func (client *DisksClient) ResumeGrantAccess(ctx context.Context, token string) (AccessURIPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DisksClient.GrantAccess", token, client.grantAccessHandleError)
 	if err != nil {
-		return nil, err
+		return AccessURIPollerResponse{}, err
 	}
-	return &accessURIPoller{
+	poller := &accessURIPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AccessURIPollerResponse{}, err
+	}
+	result := AccessURIPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AccessURIResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GrantAccess - Grants access to a disk.
@@ -519,8 +555,8 @@ func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -531,15 +567,27 @@ func (client *DisksClient) BeginRevokeAccess(ctx context.Context, resourceGroupN
 
 // ResumeRevokeAccess creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DisksClient) ResumeRevokeAccess(token string) (HTTPPoller, error) {
+func (client *DisksClient) ResumeRevokeAccess(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DisksClient.RevokeAccess", token, client.revokeAccessHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RevokeAccess - Revokes access to a disk.
@@ -610,8 +658,8 @@ func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName st
 		return DiskPollerResponse{}, err
 	}
 	poller := &diskPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskResponse, error) {
@@ -622,15 +670,27 @@ func (client *DisksClient) BeginUpdate(ctx context.Context, resourceGroupName st
 
 // ResumeUpdate creates a new DiskPoller from the specified resume token.
 // token - The value must come from a previous call to DiskPoller.ResumeToken().
-func (client *DisksClient) ResumeUpdate(token string) (DiskPoller, error) {
+func (client *DisksClient) ResumeUpdate(ctx context.Context, token string) (DiskPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DisksClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return DiskPollerResponse{}, err
 	}
-	return &diskPoller{
+	poller := &diskPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DiskPollerResponse{}, err
+	}
+	result := DiskPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DiskResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Updates (patches) a disk.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -44,8 +44,8 @@ func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resource
 		return GalleryPollerResponse{}, err
 	}
 	poller := &galleryPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryResponse, error) {
@@ -56,15 +56,27 @@ func (client *GalleriesClient) BeginCreateOrUpdate(ctx context.Context, resource
 
 // ResumeCreateOrUpdate creates a new GalleryPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryPoller.ResumeToken().
-func (client *GalleriesClient) ResumeCreateOrUpdate(token string) (GalleryPoller, error) {
+func (client *GalleriesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (GalleryPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleriesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryPollerResponse{}, err
 	}
-	return &galleryPoller{
+	poller := &galleryPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryPollerResponse{}, err
+	}
+	result := GalleryPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a Shared Image Gallery.
@@ -142,8 +154,8 @@ func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupNam
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *GalleriesClient) BeginDelete(ctx context.Context, resourceGroupNam
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *GalleriesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *GalleriesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleriesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a Shared Image Gallery.
@@ -402,8 +426,8 @@ func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupNam
 		return GalleryPollerResponse{}, err
 	}
 	poller := &galleryPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryResponse, error) {
@@ -414,15 +438,27 @@ func (client *GalleriesClient) BeginUpdate(ctx context.Context, resourceGroupNam
 
 // ResumeUpdate creates a new GalleryPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryPoller.ResumeToken().
-func (client *GalleriesClient) ResumeUpdate(token string) (GalleryPoller, error) {
+func (client *GalleriesClient) ResumeUpdate(ctx context.Context, token string) (GalleryPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleriesClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryPollerResponse{}, err
 	}
-	return &galleryPoller{
+	poller := &galleryPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryPollerResponse{}, err
+	}
+	result := GalleryPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a Shared Image Gallery.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -44,8 +44,8 @@ func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context
 		return GalleryApplicationPollerResponse{}, err
 	}
 	poller := &galleryApplicationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationResponse, error) {
@@ -56,15 +56,27 @@ func (client *GalleryApplicationsClient) BeginCreateOrUpdate(ctx context.Context
 
 // ResumeCreateOrUpdate creates a new GalleryApplicationPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryApplicationPoller.ResumeToken().
-func (client *GalleryApplicationsClient) ResumeCreateOrUpdate(token string) (GalleryApplicationPoller, error) {
+func (client *GalleryApplicationsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (GalleryApplicationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryApplicationPollerResponse{}, err
 	}
-	return &galleryApplicationPoller{
+	poller := &galleryApplicationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryApplicationPollerResponse{}, err
+	}
+	result := GalleryApplicationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Application Definition.
@@ -146,8 +158,8 @@ func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resour
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *GalleryApplicationsClient) BeginDelete(ctx context.Context, resour
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *GalleryApplicationsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *GalleryApplicationsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a gallery Application.
@@ -365,8 +389,8 @@ func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resour
 		return GalleryApplicationPollerResponse{}, err
 	}
 	poller := &galleryApplicationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationResponse, error) {
@@ -377,15 +401,27 @@ func (client *GalleryApplicationsClient) BeginUpdate(ctx context.Context, resour
 
 // ResumeUpdate creates a new GalleryApplicationPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryApplicationPoller.ResumeToken().
-func (client *GalleryApplicationsClient) ResumeUpdate(token string) (GalleryApplicationPoller, error) {
+func (client *GalleryApplicationsClient) ResumeUpdate(ctx context.Context, token string) (GalleryApplicationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryApplicationPollerResponse{}, err
 	}
-	return &galleryApplicationPoller{
+	poller := &galleryApplicationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryApplicationPollerResponse{}, err
+	}
+	result := GalleryApplicationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a gallery Application Definition.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -44,8 +44,8 @@ func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.
 		return GalleryApplicationVersionPollerResponse{}, err
 	}
 	poller := &galleryApplicationVersionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationVersionResponse, error) {
@@ -56,15 +56,27 @@ func (client *GalleryApplicationVersionsClient) BeginCreateOrUpdate(ctx context.
 
 // ResumeCreateOrUpdate creates a new GalleryApplicationVersionPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryApplicationVersionPoller.ResumeToken().
-func (client *GalleryApplicationVersionsClient) ResumeCreateOrUpdate(token string) (GalleryApplicationVersionPoller, error) {
+func (client *GalleryApplicationVersionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (GalleryApplicationVersionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationVersionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryApplicationVersionPollerResponse{}, err
 	}
-	return &galleryApplicationVersionPoller{
+	poller := &galleryApplicationVersionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryApplicationVersionPollerResponse{}, err
+	}
+	result := GalleryApplicationVersionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationVersionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Application Version.
@@ -150,8 +162,8 @@ func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context,
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -162,15 +174,27 @@ func (client *GalleryApplicationVersionsClient) BeginDelete(ctx context.Context,
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *GalleryApplicationVersionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *GalleryApplicationVersionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a gallery Application Version.
@@ -384,8 +408,8 @@ func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context,
 		return GalleryApplicationVersionPollerResponse{}, err
 	}
 	poller := &galleryApplicationVersionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationVersionResponse, error) {
@@ -396,15 +420,27 @@ func (client *GalleryApplicationVersionsClient) BeginUpdate(ctx context.Context,
 
 // ResumeUpdate creates a new GalleryApplicationVersionPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryApplicationVersionPoller.ResumeToken().
-func (client *GalleryApplicationVersionsClient) ResumeUpdate(token string) (GalleryApplicationVersionPoller, error) {
+func (client *GalleryApplicationVersionsClient) ResumeUpdate(ctx context.Context, token string) (GalleryApplicationVersionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryApplicationVersionsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryApplicationVersionPollerResponse{}, err
 	}
-	return &galleryApplicationVersionPoller{
+	poller := &galleryApplicationVersionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryApplicationVersionPollerResponse{}, err
+	}
+	result := GalleryApplicationVersionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryApplicationVersionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a gallery Application Version.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -44,8 +44,8 @@ func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, reso
 		return GalleryImagePollerResponse{}, err
 	}
 	poller := &galleryImagePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageResponse, error) {
@@ -56,15 +56,27 @@ func (client *GalleryImagesClient) BeginCreateOrUpdate(ctx context.Context, reso
 
 // ResumeCreateOrUpdate creates a new GalleryImagePoller from the specified resume token.
 // token - The value must come from a previous call to GalleryImagePoller.ResumeToken().
-func (client *GalleryImagesClient) ResumeCreateOrUpdate(token string) (GalleryImagePoller, error) {
+func (client *GalleryImagesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (GalleryImagePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImagesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryImagePollerResponse{}, err
 	}
-	return &galleryImagePoller{
+	poller := &galleryImagePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryImagePollerResponse{}, err
+	}
+	result := GalleryImagePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Image Definition.
@@ -146,8 +158,8 @@ func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGrou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *GalleryImagesClient) BeginDelete(ctx context.Context, resourceGrou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *GalleryImagesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *GalleryImagesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImagesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a gallery image.
@@ -365,8 +389,8 @@ func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGrou
 		return GalleryImagePollerResponse{}, err
 	}
 	poller := &galleryImagePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageResponse, error) {
@@ -377,15 +401,27 @@ func (client *GalleryImagesClient) BeginUpdate(ctx context.Context, resourceGrou
 
 // ResumeUpdate creates a new GalleryImagePoller from the specified resume token.
 // token - The value must come from a previous call to GalleryImagePoller.ResumeToken().
-func (client *GalleryImagesClient) ResumeUpdate(token string) (GalleryImagePoller, error) {
+func (client *GalleryImagesClient) ResumeUpdate(ctx context.Context, token string) (GalleryImagePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImagesClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryImagePollerResponse{}, err
 	}
-	return &galleryImagePoller{
+	poller := &galleryImagePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryImagePollerResponse{}, err
+	}
+	result := GalleryImagePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a gallery Image Definition.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -44,8 +44,8 @@ func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Contex
 		return GalleryImageVersionPollerResponse{}, err
 	}
 	poller := &galleryImageVersionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageVersionResponse, error) {
@@ -56,15 +56,27 @@ func (client *GalleryImageVersionsClient) BeginCreateOrUpdate(ctx context.Contex
 
 // ResumeCreateOrUpdate creates a new GalleryImageVersionPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryImageVersionPoller.ResumeToken().
-func (client *GalleryImageVersionsClient) ResumeCreateOrUpdate(token string) (GalleryImageVersionPoller, error) {
+func (client *GalleryImageVersionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (GalleryImageVersionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImageVersionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryImageVersionPollerResponse{}, err
 	}
-	return &galleryImageVersionPoller{
+	poller := &galleryImageVersionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryImageVersionPollerResponse{}, err
+	}
+	result := GalleryImageVersionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageVersionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a gallery Image Version.
@@ -150,8 +162,8 @@ func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -162,15 +174,27 @@ func (client *GalleryImageVersionsClient) BeginDelete(ctx context.Context, resou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *GalleryImageVersionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *GalleryImageVersionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImageVersionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete a gallery Image Version.
@@ -384,8 +408,8 @@ func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resou
 		return GalleryImageVersionPollerResponse{}, err
 	}
 	poller := &galleryImageVersionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageVersionResponse, error) {
@@ -396,15 +420,27 @@ func (client *GalleryImageVersionsClient) BeginUpdate(ctx context.Context, resou
 
 // ResumeUpdate creates a new GalleryImageVersionPoller from the specified resume token.
 // token - The value must come from a previous call to GalleryImageVersionPoller.ResumeToken().
-func (client *GalleryImageVersionsClient) ResumeUpdate(token string) (GalleryImageVersionPoller, error) {
+func (client *GalleryImageVersionsClient) ResumeUpdate(ctx context.Context, token string) (GalleryImageVersionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("GalleryImageVersionsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return GalleryImageVersionPollerResponse{}, err
 	}
-	return &galleryImageVersionPoller{
+	poller := &galleryImageVersionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GalleryImageVersionPollerResponse{}, err
+	}
+	result := GalleryImageVersionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GalleryImageVersionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a gallery Image Version.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -46,8 +46,8 @@ func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 		return ImagePollerResponse{}, err
 	}
 	poller := &imagePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ImageResponse, error) {
@@ -58,15 +58,27 @@ func (client *ImagesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 
 // ResumeCreateOrUpdate creates a new ImagePoller from the specified resume token.
 // token - The value must come from a previous call to ImagePoller.ResumeToken().
-func (client *ImagesClient) ResumeCreateOrUpdate(token string) (ImagePoller, error) {
+func (client *ImagesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ImagePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ImagesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ImagePollerResponse{}, err
 	}
-	return &imagePoller{
+	poller := &imagePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ImagePollerResponse{}, err
+	}
+	result := ImagePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ImageResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update an image.
@@ -147,8 +159,8 @@ func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName s
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -159,15 +171,27 @@ func (client *ImagesClient) BeginDelete(ctx context.Context, resourceGroupName s
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ImagesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ImagesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ImagesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes an Image.
@@ -422,8 +446,8 @@ func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName s
 		return ImagePollerResponse{}, err
 	}
 	poller := &imagePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ImageResponse, error) {
@@ -434,15 +458,27 @@ func (client *ImagesClient) BeginUpdate(ctx context.Context, resourceGroupName s
 
 // ResumeUpdate creates a new ImagePoller from the specified resume token.
 // token - The value must come from a previous call to ImagePoller.ResumeToken().
-func (client *ImagesClient) ResumeUpdate(token string) (ImagePoller, error) {
+func (client *ImagesClient) ResumeUpdate(ctx context.Context, token string) (ImagePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ImagesClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return ImagePollerResponse{}, err
 	}
-	return &imagePoller{
+	poller := &imagePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ImagePollerResponse{}, err
+	}
+	result := ImagePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ImageResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update an image.

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
@@ -46,8 +46,8 @@ func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.C
 		return LogAnalyticsOperationResultPollerResponse{}, err
 	}
 	poller := &logAnalyticsOperationResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LogAnalyticsOperationResultResponse, error) {
@@ -58,15 +58,27 @@ func (client *LogAnalyticsClient) BeginExportRequestRateByInterval(ctx context.C
 
 // ResumeExportRequestRateByInterval creates a new LogAnalyticsOperationResultPoller from the specified resume token.
 // token - The value must come from a previous call to LogAnalyticsOperationResultPoller.ResumeToken().
-func (client *LogAnalyticsClient) ResumeExportRequestRateByInterval(token string) (LogAnalyticsOperationResultPoller, error) {
+func (client *LogAnalyticsClient) ResumeExportRequestRateByInterval(ctx context.Context, token string) (LogAnalyticsOperationResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LogAnalyticsClient.ExportRequestRateByInterval", token, client.exportRequestRateByIntervalHandleError)
 	if err != nil {
-		return nil, err
+		return LogAnalyticsOperationResultPollerResponse{}, err
 	}
-	return &logAnalyticsOperationResultPoller{
+	poller := &logAnalyticsOperationResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LogAnalyticsOperationResultPollerResponse{}, err
+	}
+	result := LogAnalyticsOperationResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LogAnalyticsOperationResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ExportRequestRateByInterval - Export logs that show Api requests made by this subscription in the given time window to show throttling activities.
@@ -143,8 +155,8 @@ func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Conte
 		return LogAnalyticsOperationResultPollerResponse{}, err
 	}
 	poller := &logAnalyticsOperationResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LogAnalyticsOperationResultResponse, error) {
@@ -155,15 +167,27 @@ func (client *LogAnalyticsClient) BeginExportThrottledRequests(ctx context.Conte
 
 // ResumeExportThrottledRequests creates a new LogAnalyticsOperationResultPoller from the specified resume token.
 // token - The value must come from a previous call to LogAnalyticsOperationResultPoller.ResumeToken().
-func (client *LogAnalyticsClient) ResumeExportThrottledRequests(token string) (LogAnalyticsOperationResultPoller, error) {
+func (client *LogAnalyticsClient) ResumeExportThrottledRequests(ctx context.Context, token string) (LogAnalyticsOperationResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LogAnalyticsClient.ExportThrottledRequests", token, client.exportThrottledRequestsHandleError)
 	if err != nil {
-		return nil, err
+		return LogAnalyticsOperationResultPollerResponse{}, err
 	}
-	return &logAnalyticsOperationResultPoller{
+	poller := &logAnalyticsOperationResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LogAnalyticsOperationResultPollerResponse{}, err
+	}
+	result := LogAnalyticsOperationResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LogAnalyticsOperationResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ExportThrottledRequests - Export logs that show total throttled Api requests for this subscription in the given time window.

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -6924,7 +6925,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -6920,9 +6919,12 @@ type WindowsConfiguration struct {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -6922,8 +6922,7 @@ type WindowsConfiguration struct {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
@@ -51,9 +51,9 @@ func (p *accessURIPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *accessURIPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (AccessURIResponse, error) {
+func (p *accessURIPoller) pollUntilDone(ctx context.Context, freq time.Duration) (AccessURIResponse, error) {
 	respType := AccessURIResponse{AccessURI: &AccessURI{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.AccessURI)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.AccessURI)
 	if err != nil {
 		return AccessURIResponse{}, err
 	}
@@ -97,9 +97,9 @@ func (p *containerServicePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *containerServicePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ContainerServiceResponse, error) {
+func (p *containerServicePoller) pollUntilDone(ctx context.Context, freq time.Duration) (ContainerServiceResponse, error) {
 	respType := ContainerServiceResponse{ContainerService: &ContainerService{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ContainerService)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ContainerService)
 	if err != nil {
 		return ContainerServiceResponse{}, err
 	}
@@ -143,9 +143,9 @@ func (p *dedicatedHostPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *dedicatedHostPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (DedicatedHostResponse, error) {
+func (p *dedicatedHostPoller) pollUntilDone(ctx context.Context, freq time.Duration) (DedicatedHostResponse, error) {
 	respType := DedicatedHostResponse{DedicatedHost: &DedicatedHost{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.DedicatedHost)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.DedicatedHost)
 	if err != nil {
 		return DedicatedHostResponse{}, err
 	}
@@ -189,9 +189,9 @@ func (p *diskEncryptionSetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *diskEncryptionSetPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (DiskEncryptionSetResponse, error) {
+func (p *diskEncryptionSetPoller) pollUntilDone(ctx context.Context, freq time.Duration) (DiskEncryptionSetResponse, error) {
 	respType := DiskEncryptionSetResponse{DiskEncryptionSet: &DiskEncryptionSet{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.DiskEncryptionSet)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.DiskEncryptionSet)
 	if err != nil {
 		return DiskEncryptionSetResponse{}, err
 	}
@@ -235,9 +235,9 @@ func (p *diskPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *diskPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (DiskResponse, error) {
+func (p *diskPoller) pollUntilDone(ctx context.Context, freq time.Duration) (DiskResponse, error) {
 	respType := DiskResponse{Disk: &Disk{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Disk)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Disk)
 	if err != nil {
 		return DiskResponse{}, err
 	}
@@ -281,9 +281,9 @@ func (p *galleryApplicationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *galleryApplicationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GalleryApplicationResponse, error) {
+func (p *galleryApplicationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationResponse, error) {
 	respType := GalleryApplicationResponse{GalleryApplication: &GalleryApplication{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.GalleryApplication)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.GalleryApplication)
 	if err != nil {
 		return GalleryApplicationResponse{}, err
 	}
@@ -327,9 +327,9 @@ func (p *galleryApplicationVersionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *galleryApplicationVersionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GalleryApplicationVersionResponse, error) {
+func (p *galleryApplicationVersionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (GalleryApplicationVersionResponse, error) {
 	respType := GalleryApplicationVersionResponse{GalleryApplicationVersion: &GalleryApplicationVersion{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.GalleryApplicationVersion)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.GalleryApplicationVersion)
 	if err != nil {
 		return GalleryApplicationVersionResponse{}, err
 	}
@@ -373,9 +373,9 @@ func (p *galleryImagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *galleryImagePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GalleryImageResponse, error) {
+func (p *galleryImagePoller) pollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageResponse, error) {
 	respType := GalleryImageResponse{GalleryImage: &GalleryImage{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.GalleryImage)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.GalleryImage)
 	if err != nil {
 		return GalleryImageResponse{}, err
 	}
@@ -419,9 +419,9 @@ func (p *galleryImageVersionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *galleryImageVersionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GalleryImageVersionResponse, error) {
+func (p *galleryImageVersionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (GalleryImageVersionResponse, error) {
 	respType := GalleryImageVersionResponse{GalleryImageVersion: &GalleryImageVersion{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.GalleryImageVersion)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.GalleryImageVersion)
 	if err != nil {
 		return GalleryImageVersionResponse{}, err
 	}
@@ -465,9 +465,9 @@ func (p *galleryPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *galleryPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GalleryResponse, error) {
+func (p *galleryPoller) pollUntilDone(ctx context.Context, freq time.Duration) (GalleryResponse, error) {
 	respType := GalleryResponse{Gallery: &Gallery{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Gallery)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Gallery)
 	if err != nil {
 		return GalleryResponse{}, err
 	}
@@ -505,8 +505,8 @@ func (p *httpPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-	return p.pt.PollUntilDone(ctx, frequency, p.pipeline, nil)
+func (p *httpPoller) pollUntilDone(ctx context.Context, freq time.Duration) (*http.Response, error) {
+	return p.pt.PollUntilDone(ctx, freq, p.pipeline, nil)
 }
 
 // ImagePoller provides polling facilities until the operation reaches a terminal state.
@@ -545,9 +545,9 @@ func (p *imagePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *imagePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ImageResponse, error) {
+func (p *imagePoller) pollUntilDone(ctx context.Context, freq time.Duration) (ImageResponse, error) {
 	respType := ImageResponse{Image: &Image{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Image)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Image)
 	if err != nil {
 		return ImageResponse{}, err
 	}
@@ -591,9 +591,9 @@ func (p *logAnalyticsOperationResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *logAnalyticsOperationResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (LogAnalyticsOperationResultResponse, error) {
+func (p *logAnalyticsOperationResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (LogAnalyticsOperationResultResponse, error) {
 	respType := LogAnalyticsOperationResultResponse{LogAnalyticsOperationResult: &LogAnalyticsOperationResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.LogAnalyticsOperationResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.LogAnalyticsOperationResult)
 	if err != nil {
 		return LogAnalyticsOperationResultResponse{}, err
 	}
@@ -637,9 +637,9 @@ func (p *runCommandResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *runCommandResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (RunCommandResultResponse, error) {
+func (p *runCommandResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (RunCommandResultResponse, error) {
 	respType := RunCommandResultResponse{RunCommandResult: &RunCommandResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.RunCommandResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.RunCommandResult)
 	if err != nil {
 		return RunCommandResultResponse{}, err
 	}
@@ -683,9 +683,9 @@ func (p *snapshotPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *snapshotPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SnapshotResponse, error) {
+func (p *snapshotPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SnapshotResponse, error) {
 	respType := SnapshotResponse{Snapshot: &Snapshot{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Snapshot)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Snapshot)
 	if err != nil {
 		return SnapshotResponse{}, err
 	}
@@ -729,9 +729,9 @@ func (p *virtualMachineCaptureResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachineCaptureResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineCaptureResultResponse, error) {
+func (p *virtualMachineCaptureResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineCaptureResultResponse, error) {
 	respType := VirtualMachineCaptureResultResponse{VirtualMachineCaptureResult: &VirtualMachineCaptureResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachineCaptureResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachineCaptureResult)
 	if err != nil {
 		return VirtualMachineCaptureResultResponse{}, err
 	}
@@ -775,9 +775,9 @@ func (p *virtualMachineExtensionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachineExtensionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
+func (p *virtualMachineExtensionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineExtensionResponse, error) {
 	respType := VirtualMachineExtensionResponse{VirtualMachineExtension: &VirtualMachineExtension{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachineExtension)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachineExtension)
 	if err != nil {
 		return VirtualMachineExtensionResponse{}, err
 	}
@@ -821,9 +821,9 @@ func (p *virtualMachinePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachinePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineResponse, error) {
+func (p *virtualMachinePoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineResponse, error) {
 	respType := VirtualMachineResponse{VirtualMachine: &VirtualMachine{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachine)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachine)
 	if err != nil {
 		return VirtualMachineResponse{}, err
 	}
@@ -867,9 +867,9 @@ func (p *virtualMachineScaleSetExtensionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachineScaleSetExtensionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
+func (p *virtualMachineScaleSetExtensionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
 	respType := VirtualMachineScaleSetExtensionResponse{VirtualMachineScaleSetExtension: &VirtualMachineScaleSetExtension{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachineScaleSetExtension)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachineScaleSetExtension)
 	if err != nil {
 		return VirtualMachineScaleSetExtensionResponse{}, err
 	}
@@ -913,9 +913,9 @@ func (p *virtualMachineScaleSetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachineScaleSetPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetResponse, error) {
+func (p *virtualMachineScaleSetPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetResponse, error) {
 	respType := VirtualMachineScaleSetResponse{VirtualMachineScaleSet: &VirtualMachineScaleSet{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachineScaleSet)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachineScaleSet)
 	if err != nil {
 		return VirtualMachineScaleSetResponse{}, err
 	}
@@ -959,9 +959,9 @@ func (p *virtualMachineScaleSetVMPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualMachineScaleSetVMPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetVMResponse, error) {
+func (p *virtualMachineScaleSetVMPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualMachineScaleSetVMResponse, error) {
 	respType := VirtualMachineScaleSetVMResponse{VirtualMachineScaleSetVM: &VirtualMachineScaleSetVM{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualMachineScaleSetVM)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualMachineScaleSetVM)
 	if err != nil {
 		return VirtualMachineScaleSetVMResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -46,8 +46,8 @@ func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resource
 		return SnapshotPollerResponse{}, err
 	}
 	poller := &snapshotPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SnapshotResponse, error) {
@@ -58,15 +58,27 @@ func (client *SnapshotsClient) BeginCreateOrUpdate(ctx context.Context, resource
 
 // ResumeCreateOrUpdate creates a new SnapshotPoller from the specified resume token.
 // token - The value must come from a previous call to SnapshotPoller.ResumeToken().
-func (client *SnapshotsClient) ResumeCreateOrUpdate(token string) (SnapshotPoller, error) {
+func (client *SnapshotsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (SnapshotPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SnapshotsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return SnapshotPollerResponse{}, err
 	}
-	return &snapshotPoller{
+	poller := &snapshotPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SnapshotPollerResponse{}, err
+	}
+	result := SnapshotPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SnapshotResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a snapshot.
@@ -147,8 +159,8 @@ func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupNam
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -159,15 +171,27 @@ func (client *SnapshotsClient) BeginDelete(ctx context.Context, resourceGroupNam
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SnapshotsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *SnapshotsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SnapshotsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a snapshot.
@@ -302,8 +326,8 @@ func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGro
 		return AccessURIPollerResponse{}, err
 	}
 	poller := &accessURIPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AccessURIResponse, error) {
@@ -314,15 +338,27 @@ func (client *SnapshotsClient) BeginGrantAccess(ctx context.Context, resourceGro
 
 // ResumeGrantAccess creates a new AccessURIPoller from the specified resume token.
 // token - The value must come from a previous call to AccessURIPoller.ResumeToken().
-func (client *SnapshotsClient) ResumeGrantAccess(token string) (AccessURIPoller, error) {
+func (client *SnapshotsClient) ResumeGrantAccess(ctx context.Context, token string) (AccessURIPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SnapshotsClient.GrantAccess", token, client.grantAccessHandleError)
 	if err != nil {
-		return nil, err
+		return AccessURIPollerResponse{}, err
 	}
-	return &accessURIPoller{
+	poller := &accessURIPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AccessURIPollerResponse{}, err
+	}
+	result := AccessURIPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AccessURIResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GrantAccess - Grants access to a snapshot.
@@ -519,8 +555,8 @@ func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -531,15 +567,27 @@ func (client *SnapshotsClient) BeginRevokeAccess(ctx context.Context, resourceGr
 
 // ResumeRevokeAccess creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SnapshotsClient) ResumeRevokeAccess(token string) (HTTPPoller, error) {
+func (client *SnapshotsClient) ResumeRevokeAccess(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SnapshotsClient.RevokeAccess", token, client.revokeAccessHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RevokeAccess - Revokes access to a snapshot.
@@ -610,8 +658,8 @@ func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupNam
 		return SnapshotPollerResponse{}, err
 	}
 	poller := &snapshotPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SnapshotResponse, error) {
@@ -622,15 +670,27 @@ func (client *SnapshotsClient) BeginUpdate(ctx context.Context, resourceGroupNam
 
 // ResumeUpdate creates a new SnapshotPoller from the specified resume token.
 // token - The value must come from a previous call to SnapshotPoller.ResumeToken().
-func (client *SnapshotsClient) ResumeUpdate(token string) (SnapshotPoller, error) {
+func (client *SnapshotsClient) ResumeUpdate(ctx context.Context, token string) (SnapshotPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SnapshotsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return SnapshotPollerResponse{}, err
 	}
-	return &snapshotPoller{
+	poller := &snapshotPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SnapshotPollerResponse{}, err
+	}
+	result := SnapshotPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SnapshotResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Updates (patches) a snapshot.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -46,8 +46,8 @@ func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Co
 		return VirtualMachineExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
@@ -58,15 +58,27 @@ func (client *VirtualMachineExtensionsClient) BeginCreateOrUpdate(ctx context.Co
 
 // ResumeCreateOrUpdate creates a new VirtualMachineExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineExtensionPoller.ResumeToken().
-func (client *VirtualMachineExtensionsClient) ResumeCreateOrUpdate(token string) (VirtualMachineExtensionPoller, error) {
+func (client *VirtualMachineExtensionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualMachineExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineExtensionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineExtensionPollerResponse{}, err
 	}
-	return &virtualMachineExtensionPoller{
+	poller := &virtualMachineExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - The operation to create or update the extension.
@@ -151,8 +163,8 @@ func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -163,15 +175,27 @@ func (client *VirtualMachineExtensionsClient) BeginDelete(ctx context.Context, r
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineExtensionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachineExtensionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - The operation to delete the extension.
@@ -384,8 +408,8 @@ func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, r
 		return VirtualMachineExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
@@ -396,15 +420,27 @@ func (client *VirtualMachineExtensionsClient) BeginUpdate(ctx context.Context, r
 
 // ResumeUpdate creates a new VirtualMachineExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineExtensionPoller.ResumeToken().
-func (client *VirtualMachineExtensionsClient) ResumeUpdate(token string) (VirtualMachineExtensionPoller, error) {
+func (client *VirtualMachineExtensionsClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachineExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineExtensionsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineExtensionPollerResponse{}, err
 	}
-	return &virtualMachineExtensionPoller{
+	poller := &virtualMachineExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - The operation to update the extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -47,8 +47,8 @@ func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceG
 		return VirtualMachineCaptureResultPollerResponse{}, err
 	}
 	poller := &virtualMachineCaptureResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineCaptureResultResponse, error) {
@@ -59,15 +59,27 @@ func (client *VirtualMachinesClient) BeginCapture(ctx context.Context, resourceG
 
 // ResumeCapture creates a new VirtualMachineCaptureResultPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineCaptureResultPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeCapture(token string) (VirtualMachineCaptureResultPoller, error) {
+func (client *VirtualMachinesClient) ResumeCapture(ctx context.Context, token string) (VirtualMachineCaptureResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Capture", token, client.captureHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineCaptureResultPollerResponse{}, err
 	}
-	return &virtualMachineCaptureResultPoller{
+	poller := &virtualMachineCaptureResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineCaptureResultPollerResponse{}, err
+	}
+	result := VirtualMachineCaptureResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineCaptureResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Capture - Captures the VM by copying virtual hard disks of the VM and outputs a template that can be used to create similar VMs.
@@ -152,8 +164,8 @@ func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Cont
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -164,15 +176,27 @@ func (client *VirtualMachinesClient) BeginConvertToManagedDisks(ctx context.Cont
 
 // ResumeConvertToManagedDisks creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeConvertToManagedDisks(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeConvertToManagedDisks(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.ConvertToManagedDisks", token, client.convertToManagedDisksHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ConvertToManagedDisks - Converts virtual machine disks from blob-based to managed disks. Virtual machine must be stop-deallocated before invoking this
@@ -247,8 +271,8 @@ func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, re
 		return VirtualMachinePollerResponse{}, err
 	}
 	poller := &virtualMachinePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineResponse, error) {
@@ -259,15 +283,27 @@ func (client *VirtualMachinesClient) BeginCreateOrUpdate(ctx context.Context, re
 
 // ResumeCreateOrUpdate creates a new VirtualMachinePoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachinePoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeCreateOrUpdate(token string) (VirtualMachinePoller, error) {
+func (client *VirtualMachinesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualMachinePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachinePollerResponse{}, err
 	}
-	return &virtualMachinePoller{
+	poller := &virtualMachinePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachinePollerResponse{}, err
+	}
+	result := VirtualMachinePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - The operation to create or update a virtual machine. Please note some properties can be set only during virtual machine creation.
@@ -349,8 +385,8 @@ func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resour
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -361,15 +397,27 @@ func (client *VirtualMachinesClient) BeginDeallocate(ctx context.Context, resour
 
 // ResumeDeallocate creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeDeallocate(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeDeallocate(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Deallocate", token, client.deallocateHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Deallocate - Shuts down the virtual machine and releases the compute resources. You are not billed for the compute resources that this virtual machine
@@ -441,8 +489,8 @@ func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -453,15 +501,27 @@ func (client *VirtualMachinesClient) BeginDelete(ctx context.Context, resourceGr
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - The operation to delete a virtual machine.
@@ -966,8 +1026,8 @@ func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -978,15 +1038,27 @@ func (client *VirtualMachinesClient) BeginPerformMaintenance(ctx context.Context
 
 // ResumePerformMaintenance creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumePerformMaintenance(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumePerformMaintenance(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.PerformMaintenance", token, client.performMaintenanceHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PerformMaintenance - Shuts down the virtual machine, moves it to an already updated node, and powers it back on during the self-service phase of planned
@@ -1059,8 +1131,8 @@ func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1071,15 +1143,27 @@ func (client *VirtualMachinesClient) BeginPowerOff(ctx context.Context, resource
 
 // ResumePowerOff creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumePowerOff(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumePowerOff(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.PowerOff", token, client.powerOffHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PowerOff - The operation to power off (stop) a virtual machine. The virtual machine can be restarted with the same provisioned resources. You are still
@@ -1154,8 +1238,8 @@ func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1166,15 +1250,27 @@ func (client *VirtualMachinesClient) BeginReapply(ctx context.Context, resourceG
 
 // ResumeReapply creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeReapply(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeReapply(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Reapply", token, client.reapplyHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reapply - The operation to reapply a virtual machine's state.
@@ -1243,8 +1339,8 @@ func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1255,15 +1351,27 @@ func (client *VirtualMachinesClient) BeginRedeploy(ctx context.Context, resource
 
 // ResumeRedeploy creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeRedeploy(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeRedeploy(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Redeploy", token, client.redeployHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Redeploy - Shuts down the virtual machine, moves it to a new node, and powers it back on.
@@ -1334,8 +1442,8 @@ func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1346,15 +1454,27 @@ func (client *VirtualMachinesClient) BeginReimage(ctx context.Context, resourceG
 
 // ResumeReimage creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeReimage(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeReimage(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Reimage", token, client.reimageHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reimage - Reimages the virtual machine which has an ephemeral OS disk back to its initial state.
@@ -1428,8 +1548,8 @@ func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1440,15 +1560,27 @@ func (client *VirtualMachinesClient) BeginRestart(ctx context.Context, resourceG
 
 // ResumeRestart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeRestart(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeRestart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Restart", token, client.restartHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Restart - The operation to restart a virtual machine.
@@ -1519,8 +1651,8 @@ func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resour
 		return RunCommandResultPollerResponse{}, err
 	}
 	poller := &runCommandResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RunCommandResultResponse, error) {
@@ -1531,15 +1663,27 @@ func (client *VirtualMachinesClient) BeginRunCommand(ctx context.Context, resour
 
 // ResumeRunCommand creates a new RunCommandResultPoller from the specified resume token.
 // token - The value must come from a previous call to RunCommandResultPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeRunCommand(token string) (RunCommandResultPoller, error) {
+func (client *VirtualMachinesClient) ResumeRunCommand(ctx context.Context, token string) (RunCommandResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.RunCommand", token, client.runCommandHandleError)
 	if err != nil {
-		return nil, err
+		return RunCommandResultPollerResponse{}, err
 	}
-	return &runCommandResultPoller{
+	poller := &runCommandResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RunCommandResultPollerResponse{}, err
+	}
+	result := RunCommandResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RunCommandResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RunCommand - Run command on the VM.
@@ -1674,8 +1818,8 @@ func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1686,15 +1830,27 @@ func (client *VirtualMachinesClient) BeginStart(ctx context.Context, resourceGro
 
 // ResumeStart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeStart(token string) (HTTPPoller, error) {
+func (client *VirtualMachinesClient) ResumeStart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Start", token, client.startHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Start - The operation to start a virtual machine.
@@ -1765,8 +1921,8 @@ func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGr
 		return VirtualMachinePollerResponse{}, err
 	}
 	poller := &virtualMachinePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineResponse, error) {
@@ -1777,15 +1933,27 @@ func (client *VirtualMachinesClient) BeginUpdate(ctx context.Context, resourceGr
 
 // ResumeUpdate creates a new VirtualMachinePoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachinePoller.ResumeToken().
-func (client *VirtualMachinesClient) ResumeUpdate(token string) (VirtualMachinePoller, error) {
+func (client *VirtualMachinesClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachinePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachinesClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachinePollerResponse{}, err
 	}
-	return &virtualMachinePoller{
+	poller := &virtualMachinePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachinePollerResponse{}, err
+	}
+	result := VirtualMachinePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - The operation to update a virtual machine.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -46,8 +46,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx co
 		return VirtualMachineScaleSetExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineScaleSetExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
@@ -58,15 +58,27 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginCreateOrUpdate(ctx co
 
 // ResumeCreateOrUpdate creates a new VirtualMachineScaleSetExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineScaleSetExtensionPoller.ResumeToken().
-func (client *VirtualMachineScaleSetExtensionsClient) ResumeCreateOrUpdate(token string) (VirtualMachineScaleSetExtensionPoller, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualMachineScaleSetExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineScaleSetExtensionPollerResponse{}, err
 	}
-	return &virtualMachineScaleSetExtensionPoller{
+	poller := &virtualMachineScaleSetExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineScaleSetExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineScaleSetExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - The operation to create or update an extension.
@@ -151,8 +163,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -163,15 +175,27 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginDelete(ctx context.Co
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetExtensionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - The operation to delete the extension.
@@ -381,8 +405,8 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Co
 		return VirtualMachineScaleSetExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineScaleSetExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
@@ -393,15 +417,27 @@ func (client *VirtualMachineScaleSetExtensionsClient) BeginUpdate(ctx context.Co
 
 // ResumeUpdate creates a new VirtualMachineScaleSetExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineScaleSetExtensionPoller.ResumeToken().
-func (client *VirtualMachineScaleSetExtensionsClient) ResumeUpdate(token string) (VirtualMachineScaleSetExtensionPoller, error) {
+func (client *VirtualMachineScaleSetExtensionsClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachineScaleSetExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetExtensionsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineScaleSetExtensionPollerResponse{}, err
 	}
-	return &virtualMachineScaleSetExtensionPoller{
+	poller := &virtualMachineScaleSetExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineScaleSetExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineScaleSetExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - The operation to update an extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
@@ -46,8 +46,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx conte
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -58,15 +58,27 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx conte
 
 // ResumeCancel creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeCancel(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeCancel(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.Cancel", token, client.cancelHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Cancel - Cancels the current virtual machine scale set rolling upgrade.
@@ -203,8 +215,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUp
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -215,15 +227,27 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUp
 
 // ResumeStartExtensionUpgrade creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartExtensionUpgrade(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartExtensionUpgrade(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartExtensionUpgrade", token, client.startExtensionUpgradeHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StartExtensionUpgrade - Starts a rolling upgrade to move all extensions for all virtual machine scale set instances to the latest available extension
@@ -298,8 +322,8 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(c
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -310,15 +334,27 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(c
 
 // ResumeStartOSUpgrade creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartOSUpgrade(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetRollingUpgradesClient) ResumeStartOSUpgrade(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetRollingUpgradesClient.StartOSUpgrade", token, client.startOSUpgradeHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StartOSUpgrade - Starts a rolling upgrade to move all virtual machine scale set instances to the latest available Platform Image OS version. Instances

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -101,8 +101,8 @@ func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Con
 		return VirtualMachineScaleSetPollerResponse{}, err
 	}
 	poller := &virtualMachineScaleSetPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetResponse, error) {
@@ -113,15 +113,27 @@ func (client *VirtualMachineScaleSetsClient) BeginCreateOrUpdate(ctx context.Con
 
 // ResumeCreateOrUpdate creates a new VirtualMachineScaleSetPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineScaleSetPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeCreateOrUpdate(token string) (VirtualMachineScaleSetPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualMachineScaleSetPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineScaleSetPollerResponse{}, err
 	}
-	return &virtualMachineScaleSetPoller{
+	poller := &virtualMachineScaleSetPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineScaleSetPollerResponse{}, err
+	}
+	result := VirtualMachineScaleSetPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a VM scale set.
@@ -204,8 +216,8 @@ func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -216,15 +228,27 @@ func (client *VirtualMachineScaleSetsClient) BeginDeallocate(ctx context.Context
 
 // ResumeDeallocate creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeDeallocate(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeDeallocate(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Deallocate", token, client.deallocateHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Deallocate - Deallocates specific virtual machines in a VM scale set. Shuts down the virtual machines and releases the compute resources. You are not
@@ -300,8 +324,8 @@ func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -312,15 +336,27 @@ func (client *VirtualMachineScaleSetsClient) BeginDelete(ctx context.Context, re
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VM scale set.
@@ -391,8 +427,8 @@ func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -403,15 +439,27 @@ func (client *VirtualMachineScaleSetsClient) BeginDeleteInstances(ctx context.Co
 
 // ResumeDeleteInstances creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeDeleteInstances(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeDeleteInstances(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.DeleteInstances", token, client.deleteInstancesHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteInstances - Deletes virtual machines in a VM scale set.
@@ -924,8 +972,8 @@ func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -936,15 +984,27 @@ func (client *VirtualMachineScaleSetsClient) BeginPerformMaintenance(ctx context
 
 // ResumePerformMaintenance creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumePerformMaintenance(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumePerformMaintenance(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PerformMaintenance", token, client.performMaintenanceHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PerformMaintenance - Perform maintenance on one or more virtual machines in a VM scale set. Operation on instances which are not eligible for perform
@@ -1022,8 +1082,8 @@ func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1034,15 +1094,27 @@ func (client *VirtualMachineScaleSetsClient) BeginPowerOff(ctx context.Context, 
 
 // ResumePowerOff creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumePowerOff(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumePowerOff(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.PowerOff", token, client.powerOffHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PowerOff - Power off (stop) one or more virtual machines in a VM scale set. Note that resources are still attached and you are getting charged for the
@@ -1121,8 +1193,8 @@ func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1133,15 +1205,27 @@ func (client *VirtualMachineScaleSetsClient) BeginRedeploy(ctx context.Context, 
 
 // ResumeRedeploy creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeRedeploy(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeRedeploy(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Redeploy", token, client.redeployHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Redeploy - Shuts down all the virtual machines in the virtual machine scale set, moves them to a new node, and powers them back on.
@@ -1217,8 +1301,8 @@ func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1229,15 +1313,27 @@ func (client *VirtualMachineScaleSetsClient) BeginReimage(ctx context.Context, r
 
 // ResumeReimage creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeReimage(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeReimage(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Reimage", token, client.reimageHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reimage - Reimages (upgrade the operating system) one or more virtual machines in a VM scale set which don't have a ephemeral OS disk, for virtual machines
@@ -1314,8 +1410,8 @@ func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1326,15 +1422,27 @@ func (client *VirtualMachineScaleSetsClient) BeginReimageAll(ctx context.Context
 
 // ResumeReimageAll creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeReimageAll(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeReimageAll(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.ReimageAll", token, client.reimageAllHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ReimageAll - Reimages all the disks ( including data disks ) in the virtual machines in a VM scale set. This operation is only supported for managed
@@ -1409,8 +1517,8 @@ func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1421,15 +1529,27 @@ func (client *VirtualMachineScaleSetsClient) BeginRestart(ctx context.Context, r
 
 // ResumeRestart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeRestart(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeRestart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Restart", token, client.restartHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Restart - Restarts one or more virtual machines in a VM scale set.
@@ -1503,8 +1623,8 @@ func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(c
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1515,15 +1635,27 @@ func (client *VirtualMachineScaleSetsClient) BeginSetOrchestrationServiceState(c
 
 // ResumeSetOrchestrationServiceState creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeSetOrchestrationServiceState(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeSetOrchestrationServiceState(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.SetOrchestrationServiceState", token, client.setOrchestrationServiceStateHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // SetOrchestrationServiceState - Changes ServiceState property for a given service
@@ -1594,8 +1726,8 @@ func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, res
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1606,15 +1738,27 @@ func (client *VirtualMachineScaleSetsClient) BeginStart(ctx context.Context, res
 
 // ResumeStart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeStart(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeStart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Start", token, client.startHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Start - Starts one or more virtual machines in a VM scale set.
@@ -1688,8 +1832,8 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, re
 		return VirtualMachineScaleSetPollerResponse{}, err
 	}
 	poller := &virtualMachineScaleSetPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetResponse, error) {
@@ -1700,15 +1844,27 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdate(ctx context.Context, re
 
 // ResumeUpdate creates a new VirtualMachineScaleSetPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineScaleSetPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeUpdate(token string) (VirtualMachineScaleSetPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachineScaleSetPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineScaleSetPollerResponse{}, err
 	}
-	return &virtualMachineScaleSetPoller{
+	poller := &virtualMachineScaleSetPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineScaleSetPollerResponse{}, err
+	}
+	result := VirtualMachineScaleSetPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Update a VM scale set.
@@ -1789,8 +1945,8 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1801,15 +1957,27 @@ func (client *VirtualMachineScaleSetsClient) BeginUpdateInstances(ctx context.Co
 
 // ResumeUpdateInstances creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetsClient) ResumeUpdateInstances(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetsClient) ResumeUpdateInstances(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetsClient.UpdateInstances", token, client.updateInstancesHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UpdateInstances - Upgrades one or more virtual machines to the latest SKU set in the VM scale set model.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -44,8 +44,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx 
 		return VirtualMachineExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginCreateOrUpdate(ctx 
 
 // ResumeCreateOrUpdate creates a new VirtualMachineExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineExtensionPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeCreateOrUpdate(token string) (VirtualMachineExtensionPoller, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualMachineExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineExtensionPollerResponse{}, err
 	}
-	return &virtualMachineExtensionPoller{
+	poller := &virtualMachineExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - The operation to create or update the VMSS VM extension.
@@ -150,8 +162,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -162,15 +174,27 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginDelete(ctx context.
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - The operation to delete the VMSS VM extension.
@@ -387,8 +411,8 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.
 		return VirtualMachineExtensionPollerResponse{}, err
 	}
 	poller := &virtualMachineExtensionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
@@ -399,15 +423,27 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) BeginUpdate(ctx context.
 
 // ResumeUpdate creates a new VirtualMachineExtensionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineExtensionPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeUpdate(token string) (VirtualMachineExtensionPoller, error) {
+func (client *VirtualMachineScaleSetVMExtensionsClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachineExtensionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMExtensionsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineExtensionPollerResponse{}, err
 	}
-	return &virtualMachineExtensionPoller{
+	poller := &virtualMachineExtensionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineExtensionPollerResponse{}, err
+	}
+	result := VirtualMachineExtensionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineExtensionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - The operation to update the VMSS VM extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -49,8 +49,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDeallocate(ctx context.Conte
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -61,15 +61,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDeallocate(ctx context.Conte
 
 // ResumeDeallocate creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeDeallocate(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeDeallocate(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Deallocate", token, client.deallocateHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Deallocate - Deallocates a specific virtual machine in a VM scale set. Shuts down the virtual machine and releases the compute resources it uses. You
@@ -146,8 +158,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDelete(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginDelete(ctx context.Context, 
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a virtual machine from a VM scale set.
@@ -454,8 +478,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPerformMaintenance(ctx conte
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -466,15 +490,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPerformMaintenance(ctx conte
 
 // ResumePerformMaintenance creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumePerformMaintenance(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumePerformMaintenance(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PerformMaintenance", token, client.performMaintenanceHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PerformMaintenance - Shuts down the virtual machine in a VMScaleSet, moves it to an already updated node, and powers it back on during the self-service
@@ -552,8 +588,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPowerOff(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -564,15 +600,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginPowerOff(ctx context.Context
 
 // ResumePowerOff creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumePowerOff(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumePowerOff(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.PowerOff", token, client.powerOffHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PowerOff - Power off (stop) a virtual machine in a VM scale set. Note that resources are still attached and you are getting charged for the resources.
@@ -652,8 +700,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRedeploy(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -664,15 +712,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRedeploy(ctx context.Context
 
 // ResumeRedeploy creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeRedeploy(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeRedeploy(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Redeploy", token, client.redeployHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Redeploy - Shuts down the virtual machine in the virtual machine scale set, moves it to a new node, and powers it back on.
@@ -747,8 +807,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimage(ctx context.Context,
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -759,15 +819,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimage(ctx context.Context,
 
 // ResumeReimage creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeReimage(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeReimage(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Reimage", token, client.reimageHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reimage - Reimages (upgrade the operating system) a specific virtual machine in a VM scale set.
@@ -846,8 +918,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimageAll(ctx context.Conte
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -858,15 +930,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginReimageAll(ctx context.Conte
 
 // ResumeReimageAll creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeReimageAll(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeReimageAll(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.ReimageAll", token, client.reimageAllHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ReimageAll - Allows you to re-image all the disks ( including data disks ) in the a VM scale set instance. This operation is only supported for managed
@@ -942,8 +1026,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRestart(ctx context.Context,
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -954,15 +1038,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRestart(ctx context.Context,
 
 // ResumeRestart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeRestart(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeRestart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Restart", token, client.restartHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Restart - Restarts a virtual machine in a VM scale set.
@@ -1037,8 +1133,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRunCommand(ctx context.Conte
 		return RunCommandResultPollerResponse{}, err
 	}
 	poller := &runCommandResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RunCommandResultResponse, error) {
@@ -1049,15 +1145,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginRunCommand(ctx context.Conte
 
 // ResumeRunCommand creates a new RunCommandResultPoller from the specified resume token.
 // token - The value must come from a previous call to RunCommandResultPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeRunCommand(token string) (RunCommandResultPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeRunCommand(ctx context.Context, token string) (RunCommandResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.RunCommand", token, client.runCommandHandleError)
 	if err != nil {
-		return nil, err
+		return RunCommandResultPollerResponse{}, err
 	}
-	return &runCommandResultPoller{
+	poller := &runCommandResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RunCommandResultPollerResponse{}, err
+	}
+	result := RunCommandResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RunCommandResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RunCommand - Run command on a virtual machine in a VM scale set.
@@ -1201,8 +1309,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginStart(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1213,15 +1321,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginStart(ctx context.Context, r
 
 // ResumeStart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeStart(token string) (HTTPPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeStart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Start", token, client.startHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Start - Starts a virtual machine in a VM scale set.
@@ -1296,8 +1416,8 @@ func (client *VirtualMachineScaleSetVMsClient) BeginUpdate(ctx context.Context, 
 		return VirtualMachineScaleSetVMPollerResponse{}, err
 	}
 	poller := &virtualMachineScaleSetVMPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetVMResponse, error) {
@@ -1308,15 +1428,27 @@ func (client *VirtualMachineScaleSetVMsClient) BeginUpdate(ctx context.Context, 
 
 // ResumeUpdate creates a new VirtualMachineScaleSetVMPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualMachineScaleSetVMPoller.ResumeToken().
-func (client *VirtualMachineScaleSetVMsClient) ResumeUpdate(token string) (VirtualMachineScaleSetVMPoller, error) {
+func (client *VirtualMachineScaleSetVMsClient) ResumeUpdate(ctx context.Context, token string) (VirtualMachineScaleSetVMPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualMachineScaleSetVMsClient.Update", token, client.updateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualMachineScaleSetVMPollerResponse{}, err
 	}
-	return &virtualMachineScaleSetVMPoller{
+	poller := &virtualMachineScaleSetVMPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualMachineScaleSetVMPollerResponse{}, err
+	}
+	result := VirtualMachineScaleSetVMPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualMachineScaleSetVMResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Update - Updates a virtual machine of a VM scale set.

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4
 	github.com/google/go-cmp v0.5.4
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -2,10 +2,12 @@ github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0 h1:mAQkeMH5c0NUAfkYqhpzdLIX
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.6.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4 h1:3w4gk+uYOwplGhID1fDP305/8bI5Aug3URoC1V493KU=
 github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4/go.mod h1:UL/d4lvWAzSJUuX+19uKdN0ktyjoOyQhgY+HWNgtIYI=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4
 )

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -2,10 +2,12 @@ github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbt
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0 h1:4HBTI/9UDZN7tsXyB5TYP3xCv5xVHIUTbvHHH2HFxQY=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -44,8 +44,8 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 		return ApplicationGatewayBackendHealthPollerResponse{}, err
 	}
 	poller := &applicationGatewayBackendHealthPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthResponse, error) {
@@ -56,15 +56,27 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 
 // ResumeBackendHealth creates a new ApplicationGatewayBackendHealthPoller from the specified resume token.
 // token - The value must come from a previous call to ApplicationGatewayBackendHealthPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeBackendHealth(token string) (ApplicationGatewayBackendHealthPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeBackendHealth(ctx context.Context, token string) (ApplicationGatewayBackendHealthPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealth", token, client.backendHealthHandleError)
 	if err != nil {
-		return nil, err
+		return ApplicationGatewayBackendHealthPollerResponse{}, err
 	}
-	return &applicationGatewayBackendHealthPoller{
+	poller := &applicationGatewayBackendHealthPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ApplicationGatewayBackendHealthPollerResponse{}, err
+	}
+	result := ApplicationGatewayBackendHealthPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // BackendHealth - Gets the backend health of the specified application gateway in a resource group.
@@ -146,8 +158,8 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 		return ApplicationGatewayBackendHealthOnDemandPollerResponse{}, err
 	}
 	poller := &applicationGatewayBackendHealthOnDemandPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
@@ -158,15 +170,27 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 
 // ResumeBackendHealthOnDemand creates a new ApplicationGatewayBackendHealthOnDemandPoller from the specified resume token.
 // token - The value must come from a previous call to ApplicationGatewayBackendHealthOnDemandPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeBackendHealthOnDemand(token string) (ApplicationGatewayBackendHealthOnDemandPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeBackendHealthOnDemand(ctx context.Context, token string) (ApplicationGatewayBackendHealthOnDemandPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.BackendHealthOnDemand", token, client.backendHealthOnDemandHandleError)
 	if err != nil {
-		return nil, err
+		return ApplicationGatewayBackendHealthOnDemandPollerResponse{}, err
 	}
-	return &applicationGatewayBackendHealthOnDemandPoller{
+	poller := &applicationGatewayBackendHealthOnDemandPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ApplicationGatewayBackendHealthOnDemandPollerResponse{}, err
+	}
+	result := ApplicationGatewayBackendHealthOnDemandPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // BackendHealthOnDemand - Gets the backend health for given combination of backend pool and http setting of the specified application gateway in a resource
@@ -248,8 +272,8 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 		return ApplicationGatewayPollerResponse{}, err
 	}
 	poller := &applicationGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayResponse, error) {
@@ -260,15 +284,27 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 
 // ResumeCreateOrUpdate creates a new ApplicationGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to ApplicationGatewayPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeCreateOrUpdate(token string) (ApplicationGatewayPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ApplicationGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ApplicationGatewayPollerResponse{}, err
 	}
-	return &applicationGatewayPoller{
+	poller := &applicationGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ApplicationGatewayPollerResponse{}, err
+	}
+	result := ApplicationGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified application gateway.
@@ -346,8 +382,8 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -358,15 +394,27 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified application gateway.
@@ -981,8 +1029,8 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -993,15 +1041,27 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 
 // ResumeStart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeStart(token string) (HTTPPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeStart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.Start", token, client.startHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Start - Starts the specified application gateway.
@@ -1070,8 +1130,8 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1082,15 +1142,27 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 
 // ResumeStop creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ApplicationGatewaysClient) ResumeStop(token string) (HTTPPoller, error) {
+func (client *ApplicationGatewaysClient) ResumeStop(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationGatewaysClient.Stop", token, client.stopHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Stop - Stops the specified application gateway in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -44,8 +44,8 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 		return ApplicationSecurityGroupPollerResponse{}, err
 	}
 	poller := &applicationSecurityGroupPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationSecurityGroupResponse, error) {
@@ -56,15 +56,27 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 
 // ResumeCreateOrUpdate creates a new ApplicationSecurityGroupPoller from the specified resume token.
 // token - The value must come from a previous call to ApplicationSecurityGroupPoller.ResumeToken().
-func (client *ApplicationSecurityGroupsClient) ResumeCreateOrUpdate(token string) (ApplicationSecurityGroupPoller, error) {
+func (client *ApplicationSecurityGroupsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ApplicationSecurityGroupPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ApplicationSecurityGroupPollerResponse{}, err
 	}
-	return &applicationSecurityGroupPoller{
+	poller := &applicationSecurityGroupPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ApplicationSecurityGroupPollerResponse{}, err
+	}
+	result := ApplicationSecurityGroupPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ApplicationSecurityGroupResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an application security group.
@@ -142,8 +154,8 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ApplicationSecurityGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ApplicationSecurityGroupsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ApplicationSecurityGroupsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified application security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -44,8 +44,8 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 		return AzureFirewallPollerResponse{}, err
 	}
 	poller := &azureFirewallPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureFirewallResponse, error) {
@@ -56,15 +56,27 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 
 // ResumeCreateOrUpdate creates a new AzureFirewallPoller from the specified resume token.
 // token - The value must come from a previous call to AzureFirewallPoller.ResumeToken().
-func (client *AzureFirewallsClient) ResumeCreateOrUpdate(token string) (AzureFirewallPoller, error) {
+func (client *AzureFirewallsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (AzureFirewallPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("AzureFirewallsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return AzureFirewallPollerResponse{}, err
 	}
-	return &azureFirewallPoller{
+	poller := &azureFirewallPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AzureFirewallPollerResponse{}, err
+	}
+	result := AzureFirewallPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureFirewallResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Azure Firewall.
@@ -142,8 +154,8 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *AzureFirewallsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *AzureFirewallsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("AzureFirewallsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Azure Firewall.
@@ -402,8 +426,8 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 		return AzureFirewallPollerResponse{}, err
 	}
 	poller := &azureFirewallPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureFirewallResponse, error) {
@@ -414,15 +438,27 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 
 // ResumeUpdateTags creates a new AzureFirewallPoller from the specified resume token.
 // token - The value must come from a previous call to AzureFirewallPoller.ResumeToken().
-func (client *AzureFirewallsClient) ResumeUpdateTags(token string) (AzureFirewallPoller, error) {
+func (client *AzureFirewallsClient) ResumeUpdateTags(ctx context.Context, token string) (AzureFirewallPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("AzureFirewallsClient.UpdateTags", token, client.updateTagsHandleError)
 	if err != nil {
-		return nil, err
+		return AzureFirewallPollerResponse{}, err
 	}
-	return &azureFirewallPoller{
+	poller := &azureFirewallPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AzureFirewallPollerResponse{}, err
+	}
+	result := AzureFirewallPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureFirewallResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UpdateTags - Updates tags of an Azure Firewall resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -44,8 +44,8 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 		return BastionHostPollerResponse{}, err
 	}
 	poller := &bastionHostPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionHostResponse, error) {
@@ -56,15 +56,27 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 
 // ResumeCreateOrUpdate creates a new BastionHostPoller from the specified resume token.
 // token - The value must come from a previous call to BastionHostPoller.ResumeToken().
-func (client *BastionHostsClient) ResumeCreateOrUpdate(token string) (BastionHostPoller, error) {
+func (client *BastionHostsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (BastionHostPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("BastionHostsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return BastionHostPollerResponse{}, err
 	}
-	return &bastionHostPoller{
+	poller := &bastionHostPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return BastionHostPollerResponse{}, err
+	}
+	result := BastionHostPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionHostResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Bastion Host.
@@ -142,8 +154,8 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *BastionHostsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *BastionHostsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("BastionHostsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Bastion Host.

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -44,8 +44,8 @@ func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context,
 		return ConnectionMonitorResultPollerResponse{}, err
 	}
 	poller := &connectionMonitorResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionMonitorResultResponse, error) {
@@ -56,15 +56,27 @@ func (client *ConnectionMonitorsClient) BeginCreateOrUpdate(ctx context.Context,
 
 // ResumeCreateOrUpdate creates a new ConnectionMonitorResultPoller from the specified resume token.
 // token - The value must come from a previous call to ConnectionMonitorResultPoller.ResumeToken().
-func (client *ConnectionMonitorsClient) ResumeCreateOrUpdate(token string) (ConnectionMonitorResultPoller, error) {
+func (client *ConnectionMonitorsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ConnectionMonitorResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ConnectionMonitorsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ConnectionMonitorResultPollerResponse{}, err
 	}
-	return &connectionMonitorResultPoller{
+	poller := &connectionMonitorResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ConnectionMonitorResultPollerResponse{}, err
+	}
+	result := ConnectionMonitorResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionMonitorResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a connection monitor.
@@ -146,8 +158,8 @@ func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourc
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ConnectionMonitorsClient) BeginDelete(ctx context.Context, resourc
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ConnectionMonitorsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ConnectionMonitorsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ConnectionMonitorsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified connection monitor.
@@ -365,8 +389,8 @@ func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resource
 		return ConnectionMonitorQueryResultPollerResponse{}, err
 	}
 	poller := &connectionMonitorQueryResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionMonitorQueryResultResponse, error) {
@@ -377,15 +401,27 @@ func (client *ConnectionMonitorsClient) BeginQuery(ctx context.Context, resource
 
 // ResumeQuery creates a new ConnectionMonitorQueryResultPoller from the specified resume token.
 // token - The value must come from a previous call to ConnectionMonitorQueryResultPoller.ResumeToken().
-func (client *ConnectionMonitorsClient) ResumeQuery(token string) (ConnectionMonitorQueryResultPoller, error) {
+func (client *ConnectionMonitorsClient) ResumeQuery(ctx context.Context, token string) (ConnectionMonitorQueryResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ConnectionMonitorsClient.Query", token, client.queryHandleError)
 	if err != nil {
-		return nil, err
+		return ConnectionMonitorQueryResultPollerResponse{}, err
 	}
-	return &connectionMonitorQueryResultPoller{
+	poller := &connectionMonitorQueryResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ConnectionMonitorQueryResultPollerResponse{}, err
+	}
+	result := ConnectionMonitorQueryResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionMonitorQueryResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Query - Query a snapshot of the most recent connection states.
@@ -467,8 +503,8 @@ func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -479,15 +515,27 @@ func (client *ConnectionMonitorsClient) BeginStart(ctx context.Context, resource
 
 // ResumeStart creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ConnectionMonitorsClient) ResumeStart(token string) (HTTPPoller, error) {
+func (client *ConnectionMonitorsClient) ResumeStart(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ConnectionMonitorsClient.Start", token, client.startHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Start - Starts the specified connection monitor.
@@ -560,8 +608,8 @@ func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -572,15 +620,27 @@ func (client *ConnectionMonitorsClient) BeginStop(ctx context.Context, resourceG
 
 // ResumeStop creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ConnectionMonitorsClient) ResumeStop(token string) (HTTPPoller, error) {
+func (client *ConnectionMonitorsClient) ResumeStop(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ConnectionMonitorsClient.Stop", token, client.stopHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Stop - Stops the specified connection monitor.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -44,8 +44,8 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 		return DdosCustomPolicyPollerResponse{}, err
 	}
 	poller := &ddosCustomPolicyPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DdosCustomPolicyResponse, error) {
@@ -56,15 +56,27 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 
 // ResumeCreateOrUpdate creates a new DdosCustomPolicyPoller from the specified resume token.
 // token - The value must come from a previous call to DdosCustomPolicyPoller.ResumeToken().
-func (client *DdosCustomPoliciesClient) ResumeCreateOrUpdate(token string) (DdosCustomPolicyPoller, error) {
+func (client *DdosCustomPoliciesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (DdosCustomPolicyPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DdosCustomPoliciesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return DdosCustomPolicyPollerResponse{}, err
 	}
-	return &ddosCustomPolicyPoller{
+	poller := &ddosCustomPolicyPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DdosCustomPolicyPollerResponse{}, err
+	}
+	result := DdosCustomPolicyPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DdosCustomPolicyResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a DDoS custom policy.
@@ -142,8 +154,8 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DdosCustomPoliciesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *DdosCustomPoliciesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DdosCustomPoliciesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified DDoS custom policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -44,8 +44,8 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 		return DdosProtectionPlanPollerResponse{}, err
 	}
 	poller := &ddosProtectionPlanPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DdosProtectionPlanResponse, error) {
@@ -56,15 +56,27 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 
 // ResumeCreateOrUpdate creates a new DdosProtectionPlanPoller from the specified resume token.
 // token - The value must come from a previous call to DdosProtectionPlanPoller.ResumeToken().
-func (client *DdosProtectionPlansClient) ResumeCreateOrUpdate(token string) (DdosProtectionPlanPoller, error) {
+func (client *DdosProtectionPlansClient) ResumeCreateOrUpdate(ctx context.Context, token string) (DdosProtectionPlanPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DdosProtectionPlansClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return DdosProtectionPlanPollerResponse{}, err
 	}
-	return &ddosProtectionPlanPoller{
+	poller := &ddosProtectionPlanPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DdosProtectionPlanPollerResponse{}, err
+	}
+	result := DdosProtectionPlanPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DdosProtectionPlanResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a DDoS protection plan.
@@ -142,8 +154,8 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *DdosProtectionPlansClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *DdosProtectionPlansClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("DdosProtectionPlansClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified DDoS protection plan.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 		return ExpressRouteCircuitAuthorizationPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitAuthorizationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitAuthorizationResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCircuitAuthorizationPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitAuthorizationPoller.ResumeToken().
-func (client *ExpressRouteCircuitAuthorizationsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCircuitAuthorizationPoller, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCircuitAuthorizationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitAuthorizationPollerResponse{}, err
 	}
-	return &expressRouteCircuitAuthorizationPoller{
+	poller := &expressRouteCircuitAuthorizationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitAuthorizationPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitAuthorizationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitAuthorizationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an authorization in the specified express route circuit.
@@ -146,8 +158,8 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteCircuitAuthorizationsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteCircuitAuthorizationsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitAuthorizationsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified authorization from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 		return ExpressRouteCircuitConnectionPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitConnectionResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCircuitConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitConnectionPoller.ResumeToken().
-func (client *ExpressRouteCircuitConnectionsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCircuitConnectionPoller, error) {
+func (client *ExpressRouteCircuitConnectionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCircuitConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitConnectionPollerResponse{}, err
 	}
-	return &expressRouteCircuitConnectionPoller{
+	poller := &expressRouteCircuitConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitConnectionPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a Express Route Circuit Connection in the specified express route circuits.
@@ -150,8 +162,8 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -162,15 +174,27 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteCircuitConnectionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteCircuitConnectionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitConnectionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Express Route Circuit Connection from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 		return ExpressRouteCircuitPeeringPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitPeeringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitPeeringResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCircuitPeeringPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitPeeringPoller.ResumeToken().
-func (client *ExpressRouteCircuitPeeringsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCircuitPeeringPoller, error) {
+func (client *ExpressRouteCircuitPeeringsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCircuitPeeringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitPeeringPollerResponse{}, err
 	}
-	return &expressRouteCircuitPeeringPoller{
+	poller := &expressRouteCircuitPeeringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitPeeringPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitPeeringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitPeeringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified express route circuits.
@@ -146,8 +158,8 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteCircuitPeeringsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteCircuitPeeringsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitPeeringsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified peering from the specified express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 		return ExpressRouteCircuitPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCircuitPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitPoller.ResumeToken().
-func (client *ExpressRouteCircuitsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCircuitPoller, error) {
+func (client *ExpressRouteCircuitsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCircuitPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitPollerResponse{}, err
 	}
-	return &expressRouteCircuitPoller{
+	poller := &expressRouteCircuitPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an express route circuit.
@@ -142,8 +154,8 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteCircuitsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteCircuitsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified express route circuit.
@@ -528,8 +552,8 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitsArpTableListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
@@ -540,15 +564,27 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 
 // ResumeListArpTable creates a new ExpressRouteCircuitsArpTableListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitsArpTableListResultPoller.ResumeToken().
-func (client *ExpressRouteCircuitsClient) ResumeListArpTable(token string) (ExpressRouteCircuitsArpTableListResultPoller, error) {
+func (client *ExpressRouteCircuitsClient) ResumeListArpTable(ctx context.Context, token string) (ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListArpTable", token, client.listArpTableHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
 	}
-	return &expressRouteCircuitsArpTableListResultPoller{
+	poller := &expressRouteCircuitsArpTableListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitsArpTableListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route circuit in a resource group.
@@ -634,8 +670,8 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitsRoutesTableListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
@@ -646,15 +682,27 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 
 // ResumeListRoutesTable creates a new ExpressRouteCircuitsRoutesTableListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitsRoutesTableListResultPoller.ResumeToken().
-func (client *ExpressRouteCircuitsClient) ResumeListRoutesTable(token string) (ExpressRouteCircuitsRoutesTableListResultPoller, error) {
+func (client *ExpressRouteCircuitsClient) ResumeListRoutesTable(ctx context.Context, token string) (ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTable", token, client.listRoutesTableHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
 	}
-	return &expressRouteCircuitsRoutesTableListResultPoller{
+	poller := &expressRouteCircuitsRoutesTableListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitsRoutesTableListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route circuit in a resource group.
@@ -740,8 +788,8 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 		return ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitsRoutesTableSummaryListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
@@ -752,15 +800,27 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 
 // ResumeListRoutesTableSummary creates a new ExpressRouteCircuitsRoutesTableSummaryListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitsRoutesTableSummaryListResultPoller.ResumeToken().
-func (client *ExpressRouteCircuitsClient) ResumeListRoutesTableSummary(token string) (ExpressRouteCircuitsRoutesTableSummaryListResultPoller, error) {
+func (client *ExpressRouteCircuitsClient) ResumeListRoutesTableSummary(ctx context.Context, token string) (ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCircuitsClient.ListRoutesTableSummary", token, client.listRoutesTableSummaryHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse{}, err
 	}
-	return &expressRouteCircuitsRoutesTableSummaryListResultPoller{
+	poller := &expressRouteCircuitsRoutesTableSummaryListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListRoutesTableSummary - Gets the currently advertised routes table summary associated with the express route circuit in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 		return ExpressRouteConnectionPollerResponse{}, err
 	}
 	poller := &expressRouteConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteConnectionResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 
 // ResumeCreateOrUpdate creates a new ExpressRouteConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteConnectionPoller.ResumeToken().
-func (client *ExpressRouteConnectionsClient) ResumeCreateOrUpdate(token string) (ExpressRouteConnectionPoller, error) {
+func (client *ExpressRouteConnectionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteConnectionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteConnectionPollerResponse{}, err
 	}
-	return &expressRouteConnectionPoller{
+	poller := &expressRouteConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteConnectionPollerResponse{}, err
+	}
+	result := ExpressRouteConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a connection between an ExpressRoute gateway and an ExpressRoute circuit.
@@ -146,8 +158,8 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteConnectionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteConnectionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteConnectionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a connection to a ExpressRoute circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 		return ExpressRouteCrossConnectionPeeringPollerResponse{}, err
 	}
 	poller := &expressRouteCrossConnectionPeeringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionPeeringResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCrossConnectionPeeringPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCrossConnectionPeeringPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCrossConnectionPeeringPoller, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCrossConnectionPeeringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCrossConnectionPeeringPollerResponse{}, err
 	}
-	return &expressRouteCrossConnectionPeeringPoller{
+	poller := &expressRouteCrossConnectionPeeringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCrossConnectionPeeringPollerResponse{}, err
+	}
+	result := ExpressRouteCrossConnectionPeeringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionPeeringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified ExpressRouteCrossConnection.
@@ -146,8 +158,8 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteCrossConnectionPeeringsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionPeeringsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified peering from the ExpressRouteCrossConnection.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 		return ExpressRouteCrossConnectionPollerResponse{}, err
 	}
 	poller := &expressRouteCrossConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 
 // ResumeCreateOrUpdate creates a new ExpressRouteCrossConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCrossConnectionPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionsClient) ResumeCreateOrUpdate(token string) (ExpressRouteCrossConnectionPoller, error) {
+func (client *ExpressRouteCrossConnectionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteCrossConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCrossConnectionPollerResponse{}, err
 	}
-	return &expressRouteCrossConnectionPoller{
+	poller := &expressRouteCrossConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCrossConnectionPollerResponse{}, err
+	}
+	result := ExpressRouteCrossConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Update the specified ExpressRouteCrossConnection.
@@ -256,8 +268,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitsArpTableListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
@@ -268,15 +280,27 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 
 // ResumeListArpTable creates a new ExpressRouteCircuitsArpTableListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitsArpTableListResultPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionsClient) ResumeListArpTable(token string) (ExpressRouteCircuitsArpTableListResultPoller, error) {
+func (client *ExpressRouteCrossConnectionsClient) ResumeListArpTable(ctx context.Context, token string) (ExpressRouteCircuitsArpTableListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListArpTable", token, client.listArpTableHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
 	}
-	return &expressRouteCircuitsArpTableListResultPoller{
+	poller := &expressRouteCircuitsArpTableListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitsArpTableListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitsArpTableListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListArpTable - Gets the currently advertised ARP table associated with the express route cross connection in a resource group.
@@ -419,8 +443,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCircuitsRoutesTableListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
@@ -431,15 +455,27 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 
 // ResumeListRoutesTable creates a new ExpressRouteCircuitsRoutesTableListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCircuitsRoutesTableListResultPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTable(token string) (ExpressRouteCircuitsRoutesTableListResultPoller, error) {
+func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTable(ctx context.Context, token string) (ExpressRouteCircuitsRoutesTableListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTable", token, client.listRoutesTableHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
 	}
-	return &expressRouteCircuitsRoutesTableListResultPoller{
+	poller := &expressRouteCircuitsRoutesTableListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCircuitsRoutesTableListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCircuitsRoutesTableListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListRoutesTable - Gets the currently advertised routes table associated with the express route cross connection in a resource group.
@@ -525,8 +561,8 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse{}, err
 	}
 	poller := &expressRouteCrossConnectionsRoutesTableSummaryListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
@@ -537,15 +573,27 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 
 // ResumeListRoutesTableSummary creates a new ExpressRouteCrossConnectionsRoutesTableSummaryListResultPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteCrossConnectionsRoutesTableSummaryListResultPoller.ResumeToken().
-func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTableSummary(token string) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultPoller, error) {
+func (client *ExpressRouteCrossConnectionsClient) ResumeListRoutesTableSummary(ctx context.Context, token string) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteCrossConnectionsClient.ListRoutesTableSummary", token, client.listRoutesTableSummaryHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse{}, err
 	}
-	return &expressRouteCrossConnectionsRoutesTableSummaryListResultPoller{
+	poller := &expressRouteCrossConnectionsRoutesTableSummaryListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse{}, err
+	}
+	result := ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListRoutesTableSummary - Gets the route table summary associated with the express route cross connection in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 		return ExpressRouteGatewayPollerResponse{}, err
 	}
 	poller := &expressRouteGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 
 // ResumeCreateOrUpdate creates a new ExpressRouteGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRouteGatewayPoller.ResumeToken().
-func (client *ExpressRouteGatewaysClient) ResumeCreateOrUpdate(token string) (ExpressRouteGatewayPoller, error) {
+func (client *ExpressRouteGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRouteGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRouteGatewayPollerResponse{}, err
 	}
-	return &expressRouteGatewayPoller{
+	poller := &expressRouteGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRouteGatewayPollerResponse{}, err
+	}
+	result := ExpressRouteGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRouteGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a ExpressRoute gateway in a specified resource group.
@@ -143,8 +155,8 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -155,15 +167,27 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRouteGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRouteGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRouteGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified ExpressRoute gateway in a resource group. An ExpressRoute gateway resource can only be deleted when there are no connection

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -44,8 +44,8 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 		return ExpressRoutePortPollerResponse{}, err
 	}
 	poller := &expressRoutePortPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRoutePortResponse, error) {
@@ -56,15 +56,27 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 
 // ResumeCreateOrUpdate creates a new ExpressRoutePortPoller from the specified resume token.
 // token - The value must come from a previous call to ExpressRoutePortPoller.ResumeToken().
-func (client *ExpressRoutePortsClient) ResumeCreateOrUpdate(token string) (ExpressRoutePortPoller, error) {
+func (client *ExpressRoutePortsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ExpressRoutePortPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRoutePortsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ExpressRoutePortPollerResponse{}, err
 	}
-	return &expressRoutePortPoller{
+	poller := &expressRoutePortPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ExpressRoutePortPollerResponse{}, err
+	}
+	result := ExpressRoutePortPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ExpressRoutePortResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified ExpressRoutePort resource.
@@ -142,8 +154,8 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ExpressRoutePortsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ExpressRoutePortsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ExpressRoutePortsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified ExpressRoutePort resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -44,8 +44,8 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 		return FirewallPolicyPollerResponse{}, err
 	}
 	poller := &firewallPolicyPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FirewallPolicyResponse, error) {
@@ -56,15 +56,27 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 
 // ResumeCreateOrUpdate creates a new FirewallPolicyPoller from the specified resume token.
 // token - The value must come from a previous call to FirewallPolicyPoller.ResumeToken().
-func (client *FirewallPoliciesClient) ResumeCreateOrUpdate(token string) (FirewallPolicyPoller, error) {
+func (client *FirewallPoliciesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (FirewallPolicyPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FirewallPoliciesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return FirewallPolicyPollerResponse{}, err
 	}
-	return &firewallPolicyPoller{
+	poller := &firewallPolicyPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return FirewallPolicyPollerResponse{}, err
+	}
+	result := FirewallPolicyPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FirewallPolicyResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Firewall Policy.
@@ -142,8 +154,8 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *FirewallPoliciesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *FirewallPoliciesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FirewallPoliciesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Firewall Policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -44,8 +44,8 @@ func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Co
 		return FirewallPolicyRuleGroupPollerResponse{}, err
 	}
 	poller := &firewallPolicyRuleGroupPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FirewallPolicyRuleGroupResponse, error) {
@@ -56,15 +56,27 @@ func (client *FirewallPolicyRuleGroupsClient) BeginCreateOrUpdate(ctx context.Co
 
 // ResumeCreateOrUpdate creates a new FirewallPolicyRuleGroupPoller from the specified resume token.
 // token - The value must come from a previous call to FirewallPolicyRuleGroupPoller.ResumeToken().
-func (client *FirewallPolicyRuleGroupsClient) ResumeCreateOrUpdate(token string) (FirewallPolicyRuleGroupPoller, error) {
+func (client *FirewallPolicyRuleGroupsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (FirewallPolicyRuleGroupPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return FirewallPolicyRuleGroupPollerResponse{}, err
 	}
-	return &firewallPolicyRuleGroupPoller{
+	poller := &firewallPolicyRuleGroupPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return FirewallPolicyRuleGroupPollerResponse{}, err
+	}
+	result := FirewallPolicyRuleGroupPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FirewallPolicyRuleGroupResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified FirewallPolicyRuleGroup.
@@ -146,8 +158,8 @@ func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *FirewallPolicyRuleGroupsClient) BeginDelete(ctx context.Context, r
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *FirewallPolicyRuleGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *FirewallPolicyRuleGroupsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FirewallPolicyRuleGroupsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified FirewallPolicyRuleGroup.

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -44,8 +44,8 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		return FlowLogPollerResponse{}, err
 	}
 	poller := &flowLogPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogResponse, error) {
@@ -56,15 +56,27 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 
 // ResumeCreateOrUpdate creates a new FlowLogPoller from the specified resume token.
 // token - The value must come from a previous call to FlowLogPoller.ResumeToken().
-func (client *FlowLogsClient) ResumeCreateOrUpdate(token string) (FlowLogPoller, error) {
+func (client *FlowLogsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (FlowLogPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FlowLogsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return FlowLogPollerResponse{}, err
 	}
-	return &flowLogPoller{
+	poller := &flowLogPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return FlowLogPollerResponse{}, err
+	}
+	result := FlowLogPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or update a flow log for the specified network security group.
@@ -146,8 +158,8 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *FlowLogsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *FlowLogsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("FlowLogsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified flow log resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -44,8 +44,8 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 		return InboundNatRulePollerResponse{}, err
 	}
 	poller := &inboundNatRulePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (InboundNatRuleResponse, error) {
@@ -56,15 +56,27 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 
 // ResumeCreateOrUpdate creates a new InboundNatRulePoller from the specified resume token.
 // token - The value must come from a previous call to InboundNatRulePoller.ResumeToken().
-func (client *InboundNatRulesClient) ResumeCreateOrUpdate(token string) (InboundNatRulePoller, error) {
+func (client *InboundNatRulesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (InboundNatRulePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("InboundNatRulesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return InboundNatRulePollerResponse{}, err
 	}
-	return &inboundNatRulePoller{
+	poller := &inboundNatRulePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return InboundNatRulePollerResponse{}, err
+	}
+	result := InboundNatRulePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (InboundNatRuleResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a load balancer inbound nat rule.
@@ -146,8 +158,8 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *InboundNatRulesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *InboundNatRulesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("InboundNatRulesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified load balancer inbound nat rule.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -44,8 +44,8 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 		return IPAllocationPollerResponse{}, err
 	}
 	poller := &ipAllocationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (IPAllocationResponse, error) {
@@ -56,15 +56,27 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 
 // ResumeCreateOrUpdate creates a new IPAllocationPoller from the specified resume token.
 // token - The value must come from a previous call to IPAllocationPoller.ResumeToken().
-func (client *IPAllocationsClient) ResumeCreateOrUpdate(token string) (IPAllocationPoller, error) {
+func (client *IPAllocationsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (IPAllocationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("IPAllocationsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return IPAllocationPollerResponse{}, err
 	}
-	return &ipAllocationPoller{
+	poller := &ipAllocationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return IPAllocationPollerResponse{}, err
+	}
+	result := IPAllocationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (IPAllocationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an IpAllocation in the specified resource group.
@@ -142,8 +154,8 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *IPAllocationsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *IPAllocationsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("IPAllocationsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified IpAllocation.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -44,8 +44,8 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		return IPGroupPollerResponse{}, err
 	}
 	poller := &ipGroupPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (IPGroupResponse, error) {
@@ -56,15 +56,27 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 
 // ResumeCreateOrUpdate creates a new IPGroupPoller from the specified resume token.
 // token - The value must come from a previous call to IPGroupPoller.ResumeToken().
-func (client *IPGroupsClient) ResumeCreateOrUpdate(token string) (IPGroupPoller, error) {
+func (client *IPGroupsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (IPGroupPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("IPGroupsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return IPGroupPollerResponse{}, err
 	}
-	return &ipGroupPoller{
+	poller := &ipGroupPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return IPGroupPollerResponse{}, err
+	}
+	result := IPGroupPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (IPGroupResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an ipGroups in a specified resource group.
@@ -142,8 +154,8 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *IPGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *IPGroupsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("IPGroupsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified ipGroups.

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -44,8 +44,8 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 		return LocalNetworkGatewayPollerResponse{}, err
 	}
 	poller := &localNetworkGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LocalNetworkGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 
 // ResumeCreateOrUpdate creates a new LocalNetworkGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to LocalNetworkGatewayPoller.ResumeToken().
-func (client *LocalNetworkGatewaysClient) ResumeCreateOrUpdate(token string) (LocalNetworkGatewayPoller, error) {
+func (client *LocalNetworkGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (LocalNetworkGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LocalNetworkGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return LocalNetworkGatewayPollerResponse{}, err
 	}
-	return &localNetworkGatewayPoller{
+	poller := &localNetworkGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LocalNetworkGatewayPollerResponse{}, err
+	}
+	result := LocalNetworkGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LocalNetworkGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a local network gateway in the specified resource group.
@@ -142,8 +154,8 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *LocalNetworkGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *LocalNetworkGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("LocalNetworkGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified local network gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -14814,8 +14814,7 @@ type WebApplicationFirewallPolicyResponse struct {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -14812,9 +14811,12 @@ type WebApplicationFirewallPolicyResponse struct {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -14816,7 +14817,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -44,8 +44,8 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 		return NatGatewayPollerResponse{}, err
 	}
 	poller := &natGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NatGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 
 // ResumeCreateOrUpdate creates a new NatGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to NatGatewayPoller.ResumeToken().
-func (client *NatGatewaysClient) ResumeCreateOrUpdate(token string) (NatGatewayPoller, error) {
+func (client *NatGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (NatGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NatGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return NatGatewayPollerResponse{}, err
 	}
-	return &natGatewayPoller{
+	poller := &natGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NatGatewayPollerResponse{}, err
+	}
+	result := NatGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NatGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a nat gateway.
@@ -142,8 +154,8 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NatGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NatGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NatGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified nat gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
@@ -44,8 +44,8 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 		return NetworkInterfacePollerResponse{}, err
 	}
 	poller := &networkInterfacePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkInterfaceResponse, error) {
@@ -56,15 +56,27 @@ func (client *NetworkInterfacesClient) BeginCreateOrUpdate(ctx context.Context, 
 
 // ResumeCreateOrUpdate creates a new NetworkInterfacePoller from the specified resume token.
 // token - The value must come from a previous call to NetworkInterfacePoller.ResumeToken().
-func (client *NetworkInterfacesClient) ResumeCreateOrUpdate(token string) (NetworkInterfacePoller, error) {
+func (client *NetworkInterfacesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (NetworkInterfacePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfacesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return NetworkInterfacePollerResponse{}, err
 	}
-	return &networkInterfacePoller{
+	poller := &networkInterfacePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NetworkInterfacePollerResponse{}, err
+	}
+	result := NetworkInterfacePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkInterfaceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a network interface.
@@ -142,8 +154,8 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *NetworkInterfacesClient) BeginDelete(ctx context.Context, resource
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkInterfacesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkInterfacesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfacesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified network interface.
@@ -295,8 +319,8 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 		return EffectiveRouteListResultPollerResponse{}, err
 	}
 	poller := &effectiveRouteListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (EffectiveRouteListResultResponse, error) {
@@ -307,15 +331,27 @@ func (client *NetworkInterfacesClient) BeginGetEffectiveRouteTable(ctx context.C
 
 // ResumeGetEffectiveRouteTable creates a new EffectiveRouteListResultPoller from the specified resume token.
 // token - The value must come from a previous call to EffectiveRouteListResultPoller.ResumeToken().
-func (client *NetworkInterfacesClient) ResumeGetEffectiveRouteTable(token string) (EffectiveRouteListResultPoller, error) {
+func (client *NetworkInterfacesClient) ResumeGetEffectiveRouteTable(ctx context.Context, token string) (EffectiveRouteListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfacesClient.GetEffectiveRouteTable", token, client.getEffectiveRouteTableHandleError)
 	if err != nil {
-		return nil, err
+		return EffectiveRouteListResultPollerResponse{}, err
 	}
-	return &effectiveRouteListResultPoller{
+	poller := &effectiveRouteListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return EffectiveRouteListResultPollerResponse{}, err
+	}
+	result := EffectiveRouteListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (EffectiveRouteListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetEffectiveRouteTable - Gets all route tables applied to a network interface.
@@ -651,8 +687,8 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 		return EffectiveNetworkSecurityGroupListResultPollerResponse{}, err
 	}
 	poller := &effectiveNetworkSecurityGroupListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (EffectiveNetworkSecurityGroupListResultResponse, error) {
@@ -663,15 +699,27 @@ func (client *NetworkInterfacesClient) BeginListEffectiveNetworkSecurityGroups(c
 
 // ResumeListEffectiveNetworkSecurityGroups creates a new EffectiveNetworkSecurityGroupListResultPoller from the specified resume token.
 // token - The value must come from a previous call to EffectiveNetworkSecurityGroupListResultPoller.ResumeToken().
-func (client *NetworkInterfacesClient) ResumeListEffectiveNetworkSecurityGroups(token string) (EffectiveNetworkSecurityGroupListResultPoller, error) {
+func (client *NetworkInterfacesClient) ResumeListEffectiveNetworkSecurityGroups(ctx context.Context, token string) (EffectiveNetworkSecurityGroupListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfacesClient.ListEffectiveNetworkSecurityGroups", token, client.listEffectiveNetworkSecurityGroupsHandleError)
 	if err != nil {
-		return nil, err
+		return EffectiveNetworkSecurityGroupListResultPollerResponse{}, err
 	}
-	return &effectiveNetworkSecurityGroupListResultPoller{
+	poller := &effectiveNetworkSecurityGroupListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return EffectiveNetworkSecurityGroupListResultPollerResponse{}, err
+	}
+	result := EffectiveNetworkSecurityGroupListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (EffectiveNetworkSecurityGroupListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListEffectiveNetworkSecurityGroups - Gets all network security groups applied to a network interface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
@@ -44,8 +44,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 		return NetworkInterfaceTapConfigurationPollerResponse{}, err
 	}
 	poller := &networkInterfaceTapConfigurationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkInterfaceTapConfigurationResponse, error) {
@@ -56,15 +56,27 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx c
 
 // ResumeCreateOrUpdate creates a new NetworkInterfaceTapConfigurationPoller from the specified resume token.
 // token - The value must come from a previous call to NetworkInterfaceTapConfigurationPoller.ResumeToken().
-func (client *NetworkInterfaceTapConfigurationsClient) ResumeCreateOrUpdate(token string) (NetworkInterfaceTapConfigurationPoller, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (NetworkInterfaceTapConfigurationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfaceTapConfigurationsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return NetworkInterfaceTapConfigurationPollerResponse{}, err
 	}
-	return &networkInterfaceTapConfigurationPoller{
+	poller := &networkInterfaceTapConfigurationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NetworkInterfaceTapConfigurationPollerResponse{}, err
+	}
+	result := NetworkInterfaceTapConfigurationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkInterfaceTapConfigurationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a Tap configuration in the specified NetworkInterface.
@@ -146,8 +158,8 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *NetworkInterfaceTapConfigurationsClient) BeginDelete(ctx context.C
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkInterfaceTapConfigurationsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkInterfaceTapConfigurationsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkInterfaceTapConfigurationsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified tap configuration from the NetworkInterface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
@@ -102,8 +102,8 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -114,15 +114,27 @@ func (client *NetworkManagementClient) BeginDeleteBastionShareableLink(ctx conte
 
 // ResumeDeleteBastionShareableLink creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkManagementClient) ResumeDeleteBastionShareableLink(token string) (HTTPPoller, error) {
+func (client *NetworkManagementClient) ResumeDeleteBastionShareableLink(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkManagementClient.DeleteBastionShareableLink", token, client.deleteBastionShareableLinkHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteBastionShareableLink - Deletes the Bastion Shareable Links for all the VMs specified in the request.
@@ -253,8 +265,8 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 		return VPNProfileResponsePollerResponse{}, err
 	}
 	poller := &vpnProfileResponsePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNProfileResponseResponse, error) {
@@ -265,15 +277,27 @@ func (client *NetworkManagementClient) BeginGeneratevirtualwanvpnserverconfigura
 
 // ResumeGeneratevirtualwanvpnserverconfigurationvpnprofile creates a new VPNProfileResponsePoller from the specified resume token.
 // token - The value must come from a previous call to VPNProfileResponsePoller.ResumeToken().
-func (client *NetworkManagementClient) ResumeGeneratevirtualwanvpnserverconfigurationvpnprofile(token string) (VPNProfileResponsePoller, error) {
+func (client *NetworkManagementClient) ResumeGeneratevirtualwanvpnserverconfigurationvpnprofile(ctx context.Context, token string) (VPNProfileResponsePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkManagementClient.Generatevirtualwanvpnserverconfigurationvpnprofile", token, client.generatevirtualwanvpnserverconfigurationvpnprofileHandleError)
 	if err != nil {
-		return nil, err
+		return VPNProfileResponsePollerResponse{}, err
 	}
-	return &vpnProfileResponsePoller{
+	poller := &vpnProfileResponsePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNProfileResponsePollerResponse{}, err
+	}
+	result := VPNProfileResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNProfileResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Generatevirtualwanvpnserverconfigurationvpnprofile - Generates a unique VPN profile for P2S clients for VirtualWan and associated VpnServerConfiguration
@@ -352,7 +376,8 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 		return BastionActiveSessionListResultPagerPollerResponse{}, err
 	}
 	poller := &bastionActiveSessionListResultPagerPoller{
-		pt: pt,
+		pipeline: client.con.Pipeline(),
+		pt:       pt,
 		errHandler: func(resp *azcore.Response) error {
 			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
 				return nil
@@ -367,7 +392,6 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 			return BastionActiveSessionListResultResponse{RawResponse: resp.Response, BastionActiveSessionListResult: val}, nil
 		},
 		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
-		pipeline:    client.con.Pipeline(),
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionActiveSessionListResultPager, error) {
@@ -378,15 +402,41 @@ func (client *NetworkManagementClient) BeginGetActiveSessions(ctx context.Contex
 
 // ResumeGetActiveSessions creates a new BastionActiveSessionListResultPagerPoller from the specified resume token.
 // token - The value must come from a previous call to BastionActiveSessionListResultPagerPoller.ResumeToken().
-func (client *NetworkManagementClient) ResumeGetActiveSessions(token string) (BastionActiveSessionListResultPagerPoller, error) {
+func (client *NetworkManagementClient) ResumeGetActiveSessions(ctx context.Context, token string) (BastionActiveSessionListResultPagerPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkManagementClient.GetActiveSessions", token, client.getActiveSessionsHandleError)
 	if err != nil {
-		return nil, err
+		return BastionActiveSessionListResultPagerPollerResponse{}, err
 	}
-	return &bastionActiveSessionListResultPagerPoller{
+	poller := &bastionActiveSessionListResultPagerPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+		errHandler: func(resp *azcore.Response) error {
+			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+				return nil
+			}
+			return client.getActiveSessionsHandleError(resp)
+		},
+		respHandler: func(resp *azcore.Response) (BastionActiveSessionListResultResponse, error) {
+			var val *BastionActiveSessionListResult
+			if err := resp.UnmarshalAsJSON(&val); err != nil {
+				return BastionActiveSessionListResultResponse{}, err
+			}
+			return BastionActiveSessionListResultResponse{RawResponse: resp.Response, BastionActiveSessionListResult: val}, nil
+		},
+		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return BastionActiveSessionListResultPagerPollerResponse{}, err
+	}
+	result := BastionActiveSessionListResultPagerPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionActiveSessionListResultPager, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetActiveSessions - Returns the list of currently active sessions on the Bastion.
@@ -525,7 +575,8 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 		return BastionShareableLinkListResultPagerPollerResponse{}, err
 	}
 	poller := &bastionShareableLinkListResultPagerPoller{
-		pt: pt,
+		pipeline: client.con.Pipeline(),
+		pt:       pt,
 		errHandler: func(resp *azcore.Response) error {
 			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
 				return nil
@@ -540,7 +591,6 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 			return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
 		},
 		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
-		pipeline:    client.con.Pipeline(),
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionShareableLinkListResultPager, error) {
@@ -551,15 +601,41 @@ func (client *NetworkManagementClient) BeginPutBastionShareableLink(ctx context.
 
 // ResumePutBastionShareableLink creates a new BastionShareableLinkListResultPagerPoller from the specified resume token.
 // token - The value must come from a previous call to BastionShareableLinkListResultPagerPoller.ResumeToken().
-func (client *NetworkManagementClient) ResumePutBastionShareableLink(token string) (BastionShareableLinkListResultPagerPoller, error) {
+func (client *NetworkManagementClient) ResumePutBastionShareableLink(ctx context.Context, token string) (BastionShareableLinkListResultPagerPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkManagementClient.PutBastionShareableLink", token, client.putBastionShareableLinkHandleError)
 	if err != nil {
-		return nil, err
+		return BastionShareableLinkListResultPagerPollerResponse{}, err
 	}
-	return &bastionShareableLinkListResultPagerPoller{
+	poller := &bastionShareableLinkListResultPagerPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+		errHandler: func(resp *azcore.Response) error {
+			if resp.HasStatusCode(http.StatusOK, http.StatusAccepted, http.StatusNoContent) {
+				return nil
+			}
+			return client.putBastionShareableLinkHandleError(resp)
+		},
+		respHandler: func(resp *azcore.Response) (BastionShareableLinkListResultResponse, error) {
+			var val *BastionShareableLinkListResult
+			if err := resp.UnmarshalAsJSON(&val); err != nil {
+				return BastionShareableLinkListResultResponse{}, err
+			}
+			return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
+		},
+		statusCodes: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return BastionShareableLinkListResultPagerPollerResponse{}, err
+	}
+	result := BastionShareableLinkListResultPagerPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BastionShareableLinkListResultPager, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
@@ -105,8 +105,8 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -117,15 +117,27 @@ func (client *NetworkProfilesClient) BeginDelete(ctx context.Context, resourceGr
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkProfilesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkProfilesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkProfilesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified network profile.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
@@ -44,8 +44,8 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 		return NetworkSecurityGroupPollerResponse{}, err
 	}
 	poller := &networkSecurityGroupPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkSecurityGroupResponse, error) {
@@ -56,15 +56,27 @@ func (client *NetworkSecurityGroupsClient) BeginCreateOrUpdate(ctx context.Conte
 
 // ResumeCreateOrUpdate creates a new NetworkSecurityGroupPoller from the specified resume token.
 // token - The value must come from a previous call to NetworkSecurityGroupPoller.ResumeToken().
-func (client *NetworkSecurityGroupsClient) ResumeCreateOrUpdate(token string) (NetworkSecurityGroupPoller, error) {
+func (client *NetworkSecurityGroupsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (NetworkSecurityGroupPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkSecurityGroupsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return NetworkSecurityGroupPollerResponse{}, err
 	}
-	return &networkSecurityGroupPoller{
+	poller := &networkSecurityGroupPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NetworkSecurityGroupPollerResponse{}, err
+	}
+	result := NetworkSecurityGroupPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkSecurityGroupResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a network security group in the specified resource group.
@@ -142,8 +154,8 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *NetworkSecurityGroupsClient) BeginDelete(ctx context.Context, reso
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkSecurityGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkSecurityGroupsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkSecurityGroupsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified network security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
@@ -44,8 +44,8 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 		return NetworkVirtualAppliancePollerResponse{}, err
 	}
 	poller := &networkVirtualAppliancePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkVirtualApplianceResponse, error) {
@@ -56,15 +56,27 @@ func (client *NetworkVirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Co
 
 // ResumeCreateOrUpdate creates a new NetworkVirtualAppliancePoller from the specified resume token.
 // token - The value must come from a previous call to NetworkVirtualAppliancePoller.ResumeToken().
-func (client *NetworkVirtualAppliancesClient) ResumeCreateOrUpdate(token string) (NetworkVirtualAppliancePoller, error) {
+func (client *NetworkVirtualAppliancesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (NetworkVirtualAppliancePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkVirtualAppliancesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return NetworkVirtualAppliancePollerResponse{}, err
 	}
-	return &networkVirtualAppliancePoller{
+	poller := &networkVirtualAppliancePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NetworkVirtualAppliancePollerResponse{}, err
+	}
+	result := NetworkVirtualAppliancePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkVirtualApplianceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Network Virtual Appliance.
@@ -142,8 +154,8 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *NetworkVirtualAppliancesClient) BeginDelete(ctx context.Context, r
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkVirtualAppliancesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkVirtualAppliancesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkVirtualAppliancesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Network Virtual Appliance.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
@@ -45,8 +45,8 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 		return ConnectivityInformationPollerResponse{}, err
 	}
 	poller := &connectivityInformationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectivityInformationResponse, error) {
@@ -57,15 +57,27 @@ func (client *NetworkWatchersClient) BeginCheckConnectivity(ctx context.Context,
 
 // ResumeCheckConnectivity creates a new ConnectivityInformationPoller from the specified resume token.
 // token - The value must come from a previous call to ConnectivityInformationPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeCheckConnectivity(token string) (ConnectivityInformationPoller, error) {
+func (client *NetworkWatchersClient) ResumeCheckConnectivity(ctx context.Context, token string) (ConnectivityInformationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.CheckConnectivity", token, client.checkConnectivityHandleError)
 	if err != nil {
-		return nil, err
+		return ConnectivityInformationPollerResponse{}, err
 	}
-	return &connectivityInformationPoller{
+	poller := &connectivityInformationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ConnectivityInformationPollerResponse{}, err
+	}
+	result := ConnectivityInformationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectivityInformationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CheckConnectivity - Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given endpoint including another VM
@@ -205,8 +217,8 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -217,15 +229,27 @@ func (client *NetworkWatchersClient) BeginDelete(ctx context.Context, resourceGr
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *NetworkWatchersClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified network watcher resource.
@@ -356,8 +380,8 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 		return AzureReachabilityReportPollerResponse{}, err
 	}
 	poller := &azureReachabilityReportPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureReachabilityReportResponse, error) {
@@ -368,15 +392,27 @@ func (client *NetworkWatchersClient) BeginGetAzureReachabilityReport(ctx context
 
 // ResumeGetAzureReachabilityReport creates a new AzureReachabilityReportPoller from the specified resume token.
 // token - The value must come from a previous call to AzureReachabilityReportPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetAzureReachabilityReport(token string) (AzureReachabilityReportPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetAzureReachabilityReport(ctx context.Context, token string) (AzureReachabilityReportPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetAzureReachabilityReport", token, client.getAzureReachabilityReportHandleError)
 	if err != nil {
-		return nil, err
+		return AzureReachabilityReportPollerResponse{}, err
 	}
-	return &azureReachabilityReportPoller{
+	poller := &azureReachabilityReportPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AzureReachabilityReportPollerResponse{}, err
+	}
+	result := AzureReachabilityReportPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AzureReachabilityReportResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetAzureReachabilityReport - NOTE: This feature is currently in preview and still being tested for stability. Gets the relative latency score for internet
@@ -455,8 +491,8 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 		return FlowLogInformationPollerResponse{}, err
 	}
 	poller := &flowLogInformationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogInformationResponse, error) {
@@ -467,15 +503,27 @@ func (client *NetworkWatchersClient) BeginGetFlowLogStatus(ctx context.Context, 
 
 // ResumeGetFlowLogStatus creates a new FlowLogInformationPoller from the specified resume token.
 // token - The value must come from a previous call to FlowLogInformationPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetFlowLogStatus(token string) (FlowLogInformationPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetFlowLogStatus(ctx context.Context, token string) (FlowLogInformationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetFlowLogStatus", token, client.getFlowLogStatusHandleError)
 	if err != nil {
-		return nil, err
+		return FlowLogInformationPollerResponse{}, err
 	}
-	return &flowLogInformationPoller{
+	poller := &flowLogInformationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return FlowLogInformationPollerResponse{}, err
+	}
+	result := FlowLogInformationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogInformationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetFlowLogStatus - Queries status of flow log and traffic analytics (optional) on a specified resource.
@@ -557,8 +605,8 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 		return NetworkConfigurationDiagnosticResponsePollerResponse{}, err
 	}
 	poller := &networkConfigurationDiagnosticResponsePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkConfigurationDiagnosticResponseResponse, error) {
@@ -569,15 +617,27 @@ func (client *NetworkWatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx 
 
 // ResumeGetNetworkConfigurationDiagnostic creates a new NetworkConfigurationDiagnosticResponsePoller from the specified resume token.
 // token - The value must come from a previous call to NetworkConfigurationDiagnosticResponsePoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetNetworkConfigurationDiagnostic(token string) (NetworkConfigurationDiagnosticResponsePoller, error) {
+func (client *NetworkWatchersClient) ResumeGetNetworkConfigurationDiagnostic(ctx context.Context, token string) (NetworkConfigurationDiagnosticResponsePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetNetworkConfigurationDiagnostic", token, client.getNetworkConfigurationDiagnosticHandleError)
 	if err != nil {
-		return nil, err
+		return NetworkConfigurationDiagnosticResponsePollerResponse{}, err
 	}
-	return &networkConfigurationDiagnosticResponsePoller{
+	poller := &networkConfigurationDiagnosticResponsePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NetworkConfigurationDiagnosticResponsePollerResponse{}, err
+	}
+	result := NetworkConfigurationDiagnosticResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NetworkConfigurationDiagnosticResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetNetworkConfigurationDiagnostic - Gets Network Configuration Diagnostic data to help customers understand and debug network behavior. It provides detailed
@@ -659,8 +719,8 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 		return NextHopResultPollerResponse{}, err
 	}
 	poller := &nextHopResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NextHopResultResponse, error) {
@@ -671,15 +731,27 @@ func (client *NetworkWatchersClient) BeginGetNextHop(ctx context.Context, resour
 
 // ResumeGetNextHop creates a new NextHopResultPoller from the specified resume token.
 // token - The value must come from a previous call to NextHopResultPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetNextHop(token string) (NextHopResultPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetNextHop(ctx context.Context, token string) (NextHopResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetNextHop", token, client.getNextHopHandleError)
 	if err != nil {
-		return nil, err
+		return NextHopResultPollerResponse{}, err
 	}
-	return &nextHopResultPoller{
+	poller := &nextHopResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NextHopResultPollerResponse{}, err
+	}
+	result := NextHopResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NextHopResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetNextHop - Gets the next hop from the specified VM.
@@ -818,8 +890,8 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 		return TroubleshootingResultPollerResponse{}, err
 	}
 	poller := &troubleshootingResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TroubleshootingResultResponse, error) {
@@ -830,15 +902,27 @@ func (client *NetworkWatchersClient) BeginGetTroubleshooting(ctx context.Context
 
 // ResumeGetTroubleshooting creates a new TroubleshootingResultPoller from the specified resume token.
 // token - The value must come from a previous call to TroubleshootingResultPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetTroubleshooting(token string) (TroubleshootingResultPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetTroubleshooting(ctx context.Context, token string) (TroubleshootingResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetTroubleshooting", token, client.getTroubleshootingHandleError)
 	if err != nil {
-		return nil, err
+		return TroubleshootingResultPollerResponse{}, err
 	}
-	return &troubleshootingResultPoller{
+	poller := &troubleshootingResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return TroubleshootingResultPollerResponse{}, err
+	}
+	result := TroubleshootingResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TroubleshootingResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetTroubleshooting - Initiate troubleshooting on a specified resource.
@@ -916,8 +1000,8 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 		return TroubleshootingResultPollerResponse{}, err
 	}
 	poller := &troubleshootingResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TroubleshootingResultResponse, error) {
@@ -928,15 +1012,27 @@ func (client *NetworkWatchersClient) BeginGetTroubleshootingResult(ctx context.C
 
 // ResumeGetTroubleshootingResult creates a new TroubleshootingResultPoller from the specified resume token.
 // token - The value must come from a previous call to TroubleshootingResultPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetTroubleshootingResult(token string) (TroubleshootingResultPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetTroubleshootingResult(ctx context.Context, token string) (TroubleshootingResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetTroubleshootingResult", token, client.getTroubleshootingResultHandleError)
 	if err != nil {
-		return nil, err
+		return TroubleshootingResultPollerResponse{}, err
 	}
-	return &troubleshootingResultPoller{
+	poller := &troubleshootingResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return TroubleshootingResultPollerResponse{}, err
+	}
+	result := TroubleshootingResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TroubleshootingResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetTroubleshootingResult - Get the last completed troubleshooting result on a specified resource.
@@ -1014,8 +1110,8 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 		return SecurityGroupViewResultPollerResponse{}, err
 	}
 	poller := &securityGroupViewResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityGroupViewResultResponse, error) {
@@ -1026,15 +1122,27 @@ func (client *NetworkWatchersClient) BeginGetVMSecurityRules(ctx context.Context
 
 // ResumeGetVMSecurityRules creates a new SecurityGroupViewResultPoller from the specified resume token.
 // token - The value must come from a previous call to SecurityGroupViewResultPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeGetVMSecurityRules(token string) (SecurityGroupViewResultPoller, error) {
+func (client *NetworkWatchersClient) ResumeGetVMSecurityRules(ctx context.Context, token string) (SecurityGroupViewResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.GetVMSecurityRules", token, client.getVMSecurityRulesHandleError)
 	if err != nil {
-		return nil, err
+		return SecurityGroupViewResultPollerResponse{}, err
 	}
-	return &securityGroupViewResultPoller{
+	poller := &securityGroupViewResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SecurityGroupViewResultPollerResponse{}, err
+	}
+	result := SecurityGroupViewResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityGroupViewResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetVMSecurityRules - Gets the configured and effective security group rules on the specified VM.
@@ -1223,8 +1331,8 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 		return AvailableProvidersListPollerResponse{}, err
 	}
 	poller := &availableProvidersListPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AvailableProvidersListResponse, error) {
@@ -1235,15 +1343,27 @@ func (client *NetworkWatchersClient) BeginListAvailableProviders(ctx context.Con
 
 // ResumeListAvailableProviders creates a new AvailableProvidersListPoller from the specified resume token.
 // token - The value must come from a previous call to AvailableProvidersListPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeListAvailableProviders(token string) (AvailableProvidersListPoller, error) {
+func (client *NetworkWatchersClient) ResumeListAvailableProviders(ctx context.Context, token string) (AvailableProvidersListPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.ListAvailableProviders", token, client.listAvailableProvidersHandleError)
 	if err != nil {
-		return nil, err
+		return AvailableProvidersListPollerResponse{}, err
 	}
-	return &availableProvidersListPoller{
+	poller := &availableProvidersListPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return AvailableProvidersListPollerResponse{}, err
+	}
+	result := AvailableProvidersListPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (AvailableProvidersListResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ListAvailableProviders - NOTE: This feature is currently in preview and still being tested for stability. Lists all available internet service providers
@@ -1322,8 +1442,8 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 		return FlowLogInformationPollerResponse{}, err
 	}
 	poller := &flowLogInformationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogInformationResponse, error) {
@@ -1334,15 +1454,27 @@ func (client *NetworkWatchersClient) BeginSetFlowLogConfiguration(ctx context.Co
 
 // ResumeSetFlowLogConfiguration creates a new FlowLogInformationPoller from the specified resume token.
 // token - The value must come from a previous call to FlowLogInformationPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeSetFlowLogConfiguration(token string) (FlowLogInformationPoller, error) {
+func (client *NetworkWatchersClient) ResumeSetFlowLogConfiguration(ctx context.Context, token string) (FlowLogInformationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.SetFlowLogConfiguration", token, client.setFlowLogConfigurationHandleError)
 	if err != nil {
-		return nil, err
+		return FlowLogInformationPollerResponse{}, err
 	}
-	return &flowLogInformationPoller{
+	poller := &flowLogInformationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return FlowLogInformationPollerResponse{}, err
+	}
+	result := FlowLogInformationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (FlowLogInformationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // SetFlowLogConfiguration - Configures flow log and traffic analytics (optional) on a specified resource.
@@ -1481,8 +1613,8 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 		return VerificationIPFlowResultPollerResponse{}, err
 	}
 	poller := &verificationIPFlowResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VerificationIPFlowResultResponse, error) {
@@ -1493,15 +1625,27 @@ func (client *NetworkWatchersClient) BeginVerifyIPFlow(ctx context.Context, reso
 
 // ResumeVerifyIPFlow creates a new VerificationIPFlowResultPoller from the specified resume token.
 // token - The value must come from a previous call to VerificationIPFlowResultPoller.ResumeToken().
-func (client *NetworkWatchersClient) ResumeVerifyIPFlow(token string) (VerificationIPFlowResultPoller, error) {
+func (client *NetworkWatchersClient) ResumeVerifyIPFlow(ctx context.Context, token string) (VerificationIPFlowResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("NetworkWatchersClient.VerifyIPFlow", token, client.verifyIPFlowHandleError)
 	if err != nil {
-		return nil, err
+		return VerificationIPFlowResultPollerResponse{}, err
 	}
-	return &verificationIPFlowResultPoller{
+	poller := &verificationIPFlowResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VerificationIPFlowResultPollerResponse{}, err
+	}
+	result := VerificationIPFlowResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VerificationIPFlowResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // VerifyIPFlow - Verify IP flow from the specified VM to a location given the currently configured NSG rules.

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -44,8 +44,8 @@ func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 		return P2SVPNGatewayPollerResponse{}, err
 	}
 	poller := &p2SVPNGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 
 // ResumeCreateOrUpdate creates a new P2SVPNGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to P2SVPNGatewayPoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeCreateOrUpdate(token string) (P2SVPNGatewayPoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (P2SVPNGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return P2SVPNGatewayPollerResponse{}, err
 	}
-	return &p2SVPNGatewayPoller{
+	poller := &p2SVPNGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return P2SVPNGatewayPollerResponse{}, err
+	}
+	result := P2SVPNGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a virtual wan p2s vpn gateway if it doesn't exist else updates the existing gateway.
@@ -142,8 +154,8 @@ func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a virtual wan p2s vpn gateway.
@@ -231,8 +255,8 @@ func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -243,15 +267,27 @@ func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context
 
 // ResumeDisconnectP2SVPNConnections creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeDisconnectP2SVPNConnections(token string) (HTTPPoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeDisconnectP2SVPNConnections(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.DisconnectP2SVPNConnections", token, client.disconnectP2SVPNConnectionsHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DisconnectP2SVPNConnections - Disconnect P2S vpn connections of the virtual wan P2SVpnGateway in the specified resource group.
@@ -320,8 +356,8 @@ func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context,
 		return VPNProfileResponsePollerResponse{}, err
 	}
 	poller := &vpnProfileResponsePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNProfileResponseResponse, error) {
@@ -332,15 +368,27 @@ func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context,
 
 // ResumeGenerateVPNProfile creates a new VPNProfileResponsePoller from the specified resume token.
 // token - The value must come from a previous call to VPNProfileResponsePoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeGenerateVPNProfile(token string) (VPNProfileResponsePoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeGenerateVPNProfile(ctx context.Context, token string) (VPNProfileResponsePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.GenerateVPNProfile", token, client.generateVPNProfileHandleError)
 	if err != nil {
-		return nil, err
+		return VPNProfileResponsePollerResponse{}, err
 	}
-	return &vpnProfileResponsePoller{
+	poller := &vpnProfileResponsePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNProfileResponsePollerResponse{}, err
+	}
+	result := VPNProfileResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNProfileResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GenerateVPNProfile - Generates VPN profile for P2S client of the P2SVpnGateway in the specified resource group.
@@ -479,8 +527,8 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.C
 		return P2SVPNGatewayPollerResponse{}, err
 	}
 	poller := &p2SVPNGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNGatewayResponse, error) {
@@ -491,15 +539,27 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.C
 
 // ResumeGetP2SVPNConnectionHealth creates a new P2SVPNGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to P2SVPNGatewayPoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeGetP2SVPNConnectionHealth(token string) (P2SVPNGatewayPoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeGetP2SVPNConnectionHealth(ctx context.Context, token string) (P2SVPNGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealth", token, client.getP2SVPNConnectionHealthHandleError)
 	if err != nil {
-		return nil, err
+		return P2SVPNGatewayPollerResponse{}, err
 	}
-	return &p2SVPNGatewayPoller{
+	poller := &p2SVPNGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return P2SVPNGatewayPollerResponse{}, err
+	}
+	result := P2SVPNGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetP2SVPNConnectionHealth - Gets the connection health of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.
@@ -578,8 +638,8 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx c
 		return P2SVPNConnectionHealthPollerResponse{}, err
 	}
 	poller := &p2SVPNConnectionHealthPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNConnectionHealthResponse, error) {
@@ -590,15 +650,27 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx c
 
 // ResumeGetP2SVPNConnectionHealthDetailed creates a new P2SVPNConnectionHealthPoller from the specified resume token.
 // token - The value must come from a previous call to P2SVPNConnectionHealthPoller.ResumeToken().
-func (client *P2SVPNGatewaysClient) ResumeGetP2SVPNConnectionHealthDetailed(token string) (P2SVPNConnectionHealthPoller, error) {
+func (client *P2SVPNGatewaysClient) ResumeGetP2SVPNConnectionHealthDetailed(ctx context.Context, token string) (P2SVPNConnectionHealthPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("P2SVPNGatewaysClient.GetP2SVPNConnectionHealthDetailed", token, client.getP2SVPNConnectionHealthDetailedHandleError)
 	if err != nil {
-		return nil, err
+		return P2SVPNConnectionHealthPollerResponse{}, err
 	}
-	return &p2SVPNConnectionHealthPoller{
+	poller := &p2SVPNConnectionHealthPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return P2SVPNConnectionHealthPollerResponse{}, err
+	}
+	result := P2SVPNConnectionHealthPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (P2SVPNConnectionHealthResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetP2SVPNConnectionHealthDetailed - Gets the sas url to get the connection health detail of P2S clients of the virtual wan P2SVpnGateway in the specified

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -44,8 +44,8 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 		return PacketCaptureResultPollerResponse{}, err
 	}
 	poller := &packetCaptureResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PacketCaptureResultResponse, error) {
@@ -56,15 +56,27 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 
 // ResumeCreate creates a new PacketCaptureResultPoller from the specified resume token.
 // token - The value must come from a previous call to PacketCaptureResultPoller.ResumeToken().
-func (client *PacketCapturesClient) ResumeCreate(token string) (PacketCaptureResultPoller, error) {
+func (client *PacketCapturesClient) ResumeCreate(ctx context.Context, token string) (PacketCaptureResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PacketCapturesClient.Create", token, client.createHandleError)
 	if err != nil {
-		return nil, err
+		return PacketCaptureResultPollerResponse{}, err
 	}
-	return &packetCaptureResultPoller{
+	poller := &packetCaptureResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PacketCaptureResultPollerResponse{}, err
+	}
+	result := PacketCaptureResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PacketCaptureResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Create - Create and start a packet capture on the specified VM.
@@ -146,8 +158,8 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PacketCapturesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *PacketCapturesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PacketCapturesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified packet capture session.
@@ -304,8 +328,8 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 		return PacketCaptureQueryStatusResultPollerResponse{}, err
 	}
 	poller := &packetCaptureQueryStatusResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PacketCaptureQueryStatusResultResponse, error) {
@@ -316,15 +340,27 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 
 // ResumeGetStatus creates a new PacketCaptureQueryStatusResultPoller from the specified resume token.
 // token - The value must come from a previous call to PacketCaptureQueryStatusResultPoller.ResumeToken().
-func (client *PacketCapturesClient) ResumeGetStatus(token string) (PacketCaptureQueryStatusResultPoller, error) {
+func (client *PacketCapturesClient) ResumeGetStatus(ctx context.Context, token string) (PacketCaptureQueryStatusResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PacketCapturesClient.GetStatus", token, client.getStatusHandleError)
 	if err != nil {
-		return nil, err
+		return PacketCaptureQueryStatusResultPollerResponse{}, err
 	}
-	return &packetCaptureQueryStatusResultPoller{
+	poller := &packetCaptureQueryStatusResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PacketCaptureQueryStatusResultPollerResponse{}, err
+	}
+	result := PacketCaptureQueryStatusResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PacketCaptureQueryStatusResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetStatus - Query the status of a running packet capture session.
@@ -467,8 +503,8 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -479,15 +515,27 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 
 // ResumeStop creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PacketCapturesClient) ResumeStop(token string) (HTTPPoller, error) {
+func (client *PacketCapturesClient) ResumeStop(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PacketCapturesClient.Stop", token, client.stopHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Stop - Stops a specified packet capture session.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -51,9 +51,9 @@ func (p *applicationGatewayBackendHealthOnDemandPoller) ResumeToken() (string, e
 	return p.pt.ResumeToken()
 }
 
-func (p *applicationGatewayBackendHealthOnDemandPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
+func (p *applicationGatewayBackendHealthOnDemandPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
 	respType := ApplicationGatewayBackendHealthOnDemandResponse{ApplicationGatewayBackendHealthOnDemand: &ApplicationGatewayBackendHealthOnDemand{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ApplicationGatewayBackendHealthOnDemand)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ApplicationGatewayBackendHealthOnDemand)
 	if err != nil {
 		return ApplicationGatewayBackendHealthOnDemandResponse{}, err
 	}
@@ -97,9 +97,9 @@ func (p *applicationGatewayBackendHealthPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *applicationGatewayBackendHealthPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ApplicationGatewayBackendHealthResponse, error) {
+func (p *applicationGatewayBackendHealthPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewayBackendHealthResponse, error) {
 	respType := ApplicationGatewayBackendHealthResponse{ApplicationGatewayBackendHealth: &ApplicationGatewayBackendHealth{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ApplicationGatewayBackendHealth)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ApplicationGatewayBackendHealth)
 	if err != nil {
 		return ApplicationGatewayBackendHealthResponse{}, err
 	}
@@ -143,9 +143,9 @@ func (p *applicationGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *applicationGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ApplicationGatewayResponse, error) {
+func (p *applicationGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ApplicationGatewayResponse, error) {
 	respType := ApplicationGatewayResponse{ApplicationGateway: &ApplicationGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ApplicationGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ApplicationGateway)
 	if err != nil {
 		return ApplicationGatewayResponse{}, err
 	}
@@ -189,9 +189,9 @@ func (p *applicationSecurityGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *applicationSecurityGroupPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ApplicationSecurityGroupResponse, error) {
+func (p *applicationSecurityGroupPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ApplicationSecurityGroupResponse, error) {
 	respType := ApplicationSecurityGroupResponse{ApplicationSecurityGroup: &ApplicationSecurityGroup{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ApplicationSecurityGroup)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ApplicationSecurityGroup)
 	if err != nil {
 		return ApplicationSecurityGroupResponse{}, err
 	}
@@ -235,9 +235,9 @@ func (p *availableProvidersListPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *availableProvidersListPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (AvailableProvidersListResponse, error) {
+func (p *availableProvidersListPoller) pollUntilDone(ctx context.Context, freq time.Duration) (AvailableProvidersListResponse, error) {
 	respType := AvailableProvidersListResponse{AvailableProvidersList: &AvailableProvidersList{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.AvailableProvidersList)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.AvailableProvidersList)
 	if err != nil {
 		return AvailableProvidersListResponse{}, err
 	}
@@ -281,9 +281,9 @@ func (p *azureFirewallPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *azureFirewallPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (AzureFirewallResponse, error) {
+func (p *azureFirewallPoller) pollUntilDone(ctx context.Context, freq time.Duration) (AzureFirewallResponse, error) {
 	respType := AzureFirewallResponse{AzureFirewall: &AzureFirewall{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.AzureFirewall)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.AzureFirewall)
 	if err != nil {
 		return AzureFirewallResponse{}, err
 	}
@@ -327,9 +327,9 @@ func (p *azureReachabilityReportPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *azureReachabilityReportPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (AzureReachabilityReportResponse, error) {
+func (p *azureReachabilityReportPoller) pollUntilDone(ctx context.Context, freq time.Duration) (AzureReachabilityReportResponse, error) {
 	respType := AzureReachabilityReportResponse{AzureReachabilityReport: &AzureReachabilityReport{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.AzureReachabilityReport)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.AzureReachabilityReport)
 	if err != nil {
 		return AzureReachabilityReportResponse{}, err
 	}
@@ -348,10 +348,10 @@ type BastionActiveSessionListResultPagerPoller interface {
 
 type bastionActiveSessionListResultPagerPoller struct {
 	pipeline    azcore.Pipeline
+	pt          armcore.Poller
 	errHandler  bastionActiveSessionListResultHandleError
 	respHandler bastionActiveSessionListResultHandleResponse
 	statusCodes []int
-	pt          armcore.Poller
 }
 
 func (p *bastionActiveSessionListResultPagerPoller) Done() bool {
@@ -375,9 +375,9 @@ func (p *bastionActiveSessionListResultPagerPoller) ResumeToken() (string, error
 	return p.pt.ResumeToken()
 }
 
-func (p *bastionActiveSessionListResultPagerPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (BastionActiveSessionListResultPager, error) {
+func (p *bastionActiveSessionListResultPagerPoller) pollUntilDone(ctx context.Context, freq time.Duration) (BastionActiveSessionListResultPager, error) {
 	respType := &bastionActiveSessionListResultPager{}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType)
 	if err != nil {
 		return nil, err
 	}
@@ -433,9 +433,9 @@ func (p *bastionHostPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *bastionHostPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (BastionHostResponse, error) {
+func (p *bastionHostPoller) pollUntilDone(ctx context.Context, freq time.Duration) (BastionHostResponse, error) {
 	respType := BastionHostResponse{BastionHost: &BastionHost{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.BastionHost)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.BastionHost)
 	if err != nil {
 		return BastionHostResponse{}, err
 	}
@@ -454,10 +454,10 @@ type BastionShareableLinkListResultPagerPoller interface {
 
 type bastionShareableLinkListResultPagerPoller struct {
 	pipeline    azcore.Pipeline
+	pt          armcore.Poller
 	errHandler  bastionShareableLinkListResultHandleError
 	respHandler bastionShareableLinkListResultHandleResponse
 	statusCodes []int
-	pt          armcore.Poller
 }
 
 func (p *bastionShareableLinkListResultPagerPoller) Done() bool {
@@ -481,9 +481,9 @@ func (p *bastionShareableLinkListResultPagerPoller) ResumeToken() (string, error
 	return p.pt.ResumeToken()
 }
 
-func (p *bastionShareableLinkListResultPagerPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (BastionShareableLinkListResultPager, error) {
+func (p *bastionShareableLinkListResultPagerPoller) pollUntilDone(ctx context.Context, freq time.Duration) (BastionShareableLinkListResultPager, error) {
 	respType := &bastionShareableLinkListResultPager{}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType)
 	if err != nil {
 		return nil, err
 	}
@@ -539,9 +539,9 @@ func (p *bgpPeerStatusListResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *bgpPeerStatusListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (BgpPeerStatusListResultResponse, error) {
+func (p *bgpPeerStatusListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (BgpPeerStatusListResultResponse, error) {
 	respType := BgpPeerStatusListResultResponse{BgpPeerStatusListResult: &BgpPeerStatusListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.BgpPeerStatusListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.BgpPeerStatusListResult)
 	if err != nil {
 		return BgpPeerStatusListResultResponse{}, err
 	}
@@ -585,9 +585,9 @@ func (p *connectionMonitorQueryResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *connectionMonitorQueryResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ConnectionMonitorQueryResultResponse, error) {
+func (p *connectionMonitorQueryResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorQueryResultResponse, error) {
 	respType := ConnectionMonitorQueryResultResponse{ConnectionMonitorQueryResult: &ConnectionMonitorQueryResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ConnectionMonitorQueryResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ConnectionMonitorQueryResult)
 	if err != nil {
 		return ConnectionMonitorQueryResultResponse{}, err
 	}
@@ -631,9 +631,9 @@ func (p *connectionMonitorResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *connectionMonitorResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ConnectionMonitorResultResponse, error) {
+func (p *connectionMonitorResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ConnectionMonitorResultResponse, error) {
 	respType := ConnectionMonitorResultResponse{ConnectionMonitorResult: &ConnectionMonitorResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ConnectionMonitorResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ConnectionMonitorResult)
 	if err != nil {
 		return ConnectionMonitorResultResponse{}, err
 	}
@@ -677,9 +677,9 @@ func (p *connectionResetSharedKeyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *connectionResetSharedKeyPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ConnectionResetSharedKeyResponse, error) {
+func (p *connectionResetSharedKeyPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ConnectionResetSharedKeyResponse, error) {
 	respType := ConnectionResetSharedKeyResponse{ConnectionResetSharedKey: &ConnectionResetSharedKey{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ConnectionResetSharedKey)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ConnectionResetSharedKey)
 	if err != nil {
 		return ConnectionResetSharedKeyResponse{}, err
 	}
@@ -723,9 +723,9 @@ func (p *connectionSharedKeyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *connectionSharedKeyPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ConnectionSharedKeyResponse, error) {
+func (p *connectionSharedKeyPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ConnectionSharedKeyResponse, error) {
 	respType := ConnectionSharedKeyResponse{ConnectionSharedKey: &ConnectionSharedKey{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ConnectionSharedKey)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ConnectionSharedKey)
 	if err != nil {
 		return ConnectionSharedKeyResponse{}, err
 	}
@@ -769,9 +769,9 @@ func (p *connectivityInformationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *connectivityInformationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ConnectivityInformationResponse, error) {
+func (p *connectivityInformationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ConnectivityInformationResponse, error) {
 	respType := ConnectivityInformationResponse{ConnectivityInformation: &ConnectivityInformation{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ConnectivityInformation)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ConnectivityInformation)
 	if err != nil {
 		return ConnectivityInformationResponse{}, err
 	}
@@ -815,9 +815,9 @@ func (p *ddosCustomPolicyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *ddosCustomPolicyPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (DdosCustomPolicyResponse, error) {
+func (p *ddosCustomPolicyPoller) pollUntilDone(ctx context.Context, freq time.Duration) (DdosCustomPolicyResponse, error) {
 	respType := DdosCustomPolicyResponse{DdosCustomPolicy: &DdosCustomPolicy{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.DdosCustomPolicy)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.DdosCustomPolicy)
 	if err != nil {
 		return DdosCustomPolicyResponse{}, err
 	}
@@ -861,9 +861,9 @@ func (p *ddosProtectionPlanPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *ddosProtectionPlanPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (DdosProtectionPlanResponse, error) {
+func (p *ddosProtectionPlanPoller) pollUntilDone(ctx context.Context, freq time.Duration) (DdosProtectionPlanResponse, error) {
 	respType := DdosProtectionPlanResponse{DdosProtectionPlan: &DdosProtectionPlan{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.DdosProtectionPlan)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.DdosProtectionPlan)
 	if err != nil {
 		return DdosProtectionPlanResponse{}, err
 	}
@@ -907,9 +907,9 @@ func (p *effectiveNetworkSecurityGroupListResultPoller) ResumeToken() (string, e
 	return p.pt.ResumeToken()
 }
 
-func (p *effectiveNetworkSecurityGroupListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (EffectiveNetworkSecurityGroupListResultResponse, error) {
+func (p *effectiveNetworkSecurityGroupListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (EffectiveNetworkSecurityGroupListResultResponse, error) {
 	respType := EffectiveNetworkSecurityGroupListResultResponse{EffectiveNetworkSecurityGroupListResult: &EffectiveNetworkSecurityGroupListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.EffectiveNetworkSecurityGroupListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.EffectiveNetworkSecurityGroupListResult)
 	if err != nil {
 		return EffectiveNetworkSecurityGroupListResultResponse{}, err
 	}
@@ -953,9 +953,9 @@ func (p *effectiveRouteListResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *effectiveRouteListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (EffectiveRouteListResultResponse, error) {
+func (p *effectiveRouteListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (EffectiveRouteListResultResponse, error) {
 	respType := EffectiveRouteListResultResponse{EffectiveRouteListResult: &EffectiveRouteListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.EffectiveRouteListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.EffectiveRouteListResult)
 	if err != nil {
 		return EffectiveRouteListResultResponse{}, err
 	}
@@ -999,9 +999,9 @@ func (p *expressRouteCircuitAuthorizationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitAuthorizationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitAuthorizationResponse, error) {
+func (p *expressRouteCircuitAuthorizationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitAuthorizationResponse, error) {
 	respType := ExpressRouteCircuitAuthorizationResponse{ExpressRouteCircuitAuthorization: &ExpressRouteCircuitAuthorization{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitAuthorization)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitAuthorization)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationResponse{}, err
 	}
@@ -1045,9 +1045,9 @@ func (p *expressRouteCircuitConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitConnectionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitConnectionResponse, error) {
+func (p *expressRouteCircuitConnectionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitConnectionResponse, error) {
 	respType := ExpressRouteCircuitConnectionResponse{ExpressRouteCircuitConnection: &ExpressRouteCircuitConnection{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitConnection)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitConnection)
 	if err != nil {
 		return ExpressRouteCircuitConnectionResponse{}, err
 	}
@@ -1091,9 +1091,9 @@ func (p *expressRouteCircuitPeeringPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitPeeringPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitPeeringResponse, error) {
+func (p *expressRouteCircuitPeeringPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitPeeringResponse, error) {
 	respType := ExpressRouteCircuitPeeringResponse{ExpressRouteCircuitPeering: &ExpressRouteCircuitPeering{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitPeering)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitPeering)
 	if err != nil {
 		return ExpressRouteCircuitPeeringResponse{}, err
 	}
@@ -1137,9 +1137,9 @@ func (p *expressRouteCircuitPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitResponse, error) {
+func (p *expressRouteCircuitPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitResponse, error) {
 	respType := ExpressRouteCircuitResponse{ExpressRouteCircuit: &ExpressRouteCircuit{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuit)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuit)
 	if err != nil {
 		return ExpressRouteCircuitResponse{}, err
 	}
@@ -1183,9 +1183,9 @@ func (p *expressRouteCircuitsArpTableListResultPoller) ResumeToken() (string, er
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitsArpTableListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
+func (p *expressRouteCircuitsArpTableListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsArpTableListResultResponse, error) {
 	respType := ExpressRouteCircuitsArpTableListResultResponse{ExpressRouteCircuitsArpTableListResult: &ExpressRouteCircuitsArpTableListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitsArpTableListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitsArpTableListResult)
 	if err != nil {
 		return ExpressRouteCircuitsArpTableListResultResponse{}, err
 	}
@@ -1229,9 +1229,9 @@ func (p *expressRouteCircuitsRoutesTableListResultPoller) ResumeToken() (string,
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitsRoutesTableListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
+func (p *expressRouteCircuitsRoutesTableListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
 	respType := ExpressRouteCircuitsRoutesTableListResultResponse{ExpressRouteCircuitsRoutesTableListResult: &ExpressRouteCircuitsRoutesTableListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitsRoutesTableListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitsRoutesTableListResult)
 	if err != nil {
 		return ExpressRouteCircuitsRoutesTableListResultResponse{}, err
 	}
@@ -1275,9 +1275,9 @@ func (p *expressRouteCircuitsRoutesTableSummaryListResultPoller) ResumeToken() (
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCircuitsRoutesTableSummaryListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
+func (p *expressRouteCircuitsRoutesTableSummaryListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
 	respType := ExpressRouteCircuitsRoutesTableSummaryListResultResponse{ExpressRouteCircuitsRoutesTableSummaryListResult: &ExpressRouteCircuitsRoutesTableSummaryListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCircuitsRoutesTableSummaryListResult)
 	if err != nil {
 		return ExpressRouteCircuitsRoutesTableSummaryListResultResponse{}, err
 	}
@@ -1321,9 +1321,9 @@ func (p *expressRouteConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteConnectionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteConnectionResponse, error) {
+func (p *expressRouteConnectionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteConnectionResponse, error) {
 	respType := ExpressRouteConnectionResponse{ExpressRouteConnection: &ExpressRouteConnection{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteConnection)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteConnection)
 	if err != nil {
 		return ExpressRouteConnectionResponse{}, err
 	}
@@ -1367,9 +1367,9 @@ func (p *expressRouteCrossConnectionPeeringPoller) ResumeToken() (string, error)
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCrossConnectionPeeringPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionPeeringResponse, error) {
+func (p *expressRouteCrossConnectionPeeringPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionPeeringResponse, error) {
 	respType := ExpressRouteCrossConnectionPeeringResponse{ExpressRouteCrossConnectionPeering: &ExpressRouteCrossConnectionPeering{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCrossConnectionPeering)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCrossConnectionPeering)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringResponse{}, err
 	}
@@ -1413,9 +1413,9 @@ func (p *expressRouteCrossConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCrossConnectionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionResponse, error) {
+func (p *expressRouteCrossConnectionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionResponse, error) {
 	respType := ExpressRouteCrossConnectionResponse{ExpressRouteCrossConnection: &ExpressRouteCrossConnection{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCrossConnection)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCrossConnection)
 	if err != nil {
 		return ExpressRouteCrossConnectionResponse{}, err
 	}
@@ -1459,9 +1459,9 @@ func (p *expressRouteCrossConnectionsRoutesTableSummaryListResultPoller) ResumeT
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteCrossConnectionsRoutesTableSummaryListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
+func (p *expressRouteCrossConnectionsRoutesTableSummaryListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
 	respType := ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{ExpressRouteCrossConnectionsRoutesTableSummaryListResult: &ExpressRouteCrossConnectionsRoutesTableSummaryListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteCrossConnectionsRoutesTableSummaryListResult)
 	if err != nil {
 		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{}, err
 	}
@@ -1505,9 +1505,9 @@ func (p *expressRouteGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRouteGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRouteGatewayResponse, error) {
+func (p *expressRouteGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRouteGatewayResponse, error) {
 	respType := ExpressRouteGatewayResponse{ExpressRouteGateway: &ExpressRouteGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRouteGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRouteGateway)
 	if err != nil {
 		return ExpressRouteGatewayResponse{}, err
 	}
@@ -1551,9 +1551,9 @@ func (p *expressRoutePortPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *expressRoutePortPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ExpressRoutePortResponse, error) {
+func (p *expressRoutePortPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ExpressRoutePortResponse, error) {
 	respType := ExpressRoutePortResponse{ExpressRoutePort: &ExpressRoutePort{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ExpressRoutePort)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ExpressRoutePort)
 	if err != nil {
 		return ExpressRoutePortResponse{}, err
 	}
@@ -1597,9 +1597,9 @@ func (p *firewallPolicyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *firewallPolicyPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (FirewallPolicyResponse, error) {
+func (p *firewallPolicyPoller) pollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyResponse, error) {
 	respType := FirewallPolicyResponse{FirewallPolicy: &FirewallPolicy{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.FirewallPolicy)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.FirewallPolicy)
 	if err != nil {
 		return FirewallPolicyResponse{}, err
 	}
@@ -1643,9 +1643,9 @@ func (p *firewallPolicyRuleGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *firewallPolicyRuleGroupPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (FirewallPolicyRuleGroupResponse, error) {
+func (p *firewallPolicyRuleGroupPoller) pollUntilDone(ctx context.Context, freq time.Duration) (FirewallPolicyRuleGroupResponse, error) {
 	respType := FirewallPolicyRuleGroupResponse{FirewallPolicyRuleGroup: &FirewallPolicyRuleGroup{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.FirewallPolicyRuleGroup)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.FirewallPolicyRuleGroup)
 	if err != nil {
 		return FirewallPolicyRuleGroupResponse{}, err
 	}
@@ -1689,9 +1689,9 @@ func (p *flowLogInformationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *flowLogInformationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (FlowLogInformationResponse, error) {
+func (p *flowLogInformationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (FlowLogInformationResponse, error) {
 	respType := FlowLogInformationResponse{FlowLogInformation: &FlowLogInformation{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.FlowLogInformation)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.FlowLogInformation)
 	if err != nil {
 		return FlowLogInformationResponse{}, err
 	}
@@ -1735,9 +1735,9 @@ func (p *flowLogPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *flowLogPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (FlowLogResponse, error) {
+func (p *flowLogPoller) pollUntilDone(ctx context.Context, freq time.Duration) (FlowLogResponse, error) {
 	respType := FlowLogResponse{FlowLog: &FlowLog{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.FlowLog)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.FlowLog)
 	if err != nil {
 		return FlowLogResponse{}, err
 	}
@@ -1781,9 +1781,9 @@ func (p *gatewayRouteListResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *gatewayRouteListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (GatewayRouteListResultResponse, error) {
+func (p *gatewayRouteListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (GatewayRouteListResultResponse, error) {
 	respType := GatewayRouteListResultResponse{GatewayRouteListResult: &GatewayRouteListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.GatewayRouteListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.GatewayRouteListResult)
 	if err != nil {
 		return GatewayRouteListResultResponse{}, err
 	}
@@ -1821,8 +1821,8 @@ func (p *httpPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *httpPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (*http.Response, error) {
-	return p.pt.PollUntilDone(ctx, frequency, p.pipeline, nil)
+func (p *httpPoller) pollUntilDone(ctx context.Context, freq time.Duration) (*http.Response, error) {
+	return p.pt.PollUntilDone(ctx, freq, p.pipeline, nil)
 }
 
 // IPAllocationPoller provides polling facilities until the operation reaches a terminal state.
@@ -1861,9 +1861,9 @@ func (p *ipAllocationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *ipAllocationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (IPAllocationResponse, error) {
+func (p *ipAllocationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (IPAllocationResponse, error) {
 	respType := IPAllocationResponse{IPAllocation: &IPAllocation{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.IPAllocation)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.IPAllocation)
 	if err != nil {
 		return IPAllocationResponse{}, err
 	}
@@ -1907,9 +1907,9 @@ func (p *ipGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *ipGroupPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (IPGroupResponse, error) {
+func (p *ipGroupPoller) pollUntilDone(ctx context.Context, freq time.Duration) (IPGroupResponse, error) {
 	respType := IPGroupResponse{IPGroup: &IPGroup{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.IPGroup)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.IPGroup)
 	if err != nil {
 		return IPGroupResponse{}, err
 	}
@@ -1953,9 +1953,9 @@ func (p *inboundNatRulePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *inboundNatRulePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (InboundNatRuleResponse, error) {
+func (p *inboundNatRulePoller) pollUntilDone(ctx context.Context, freq time.Duration) (InboundNatRuleResponse, error) {
 	respType := InboundNatRuleResponse{InboundNatRule: &InboundNatRule{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.InboundNatRule)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.InboundNatRule)
 	if err != nil {
 		return InboundNatRuleResponse{}, err
 	}
@@ -1999,9 +1999,9 @@ func (p *loadBalancerPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *loadBalancerPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (LoadBalancerResponse, error) {
+func (p *loadBalancerPoller) pollUntilDone(ctx context.Context, freq time.Duration) (LoadBalancerResponse, error) {
 	respType := LoadBalancerResponse{LoadBalancer: &LoadBalancer{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.LoadBalancer)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.LoadBalancer)
 	if err != nil {
 		return LoadBalancerResponse{}, err
 	}
@@ -2045,9 +2045,9 @@ func (p *localNetworkGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *localNetworkGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (LocalNetworkGatewayResponse, error) {
+func (p *localNetworkGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (LocalNetworkGatewayResponse, error) {
 	respType := LocalNetworkGatewayResponse{LocalNetworkGateway: &LocalNetworkGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.LocalNetworkGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.LocalNetworkGateway)
 	if err != nil {
 		return LocalNetworkGatewayResponse{}, err
 	}
@@ -2091,9 +2091,9 @@ func (p *natGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *natGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NatGatewayResponse, error) {
+func (p *natGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (NatGatewayResponse, error) {
 	respType := NatGatewayResponse{NatGateway: &NatGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NatGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NatGateway)
 	if err != nil {
 		return NatGatewayResponse{}, err
 	}
@@ -2137,9 +2137,9 @@ func (p *networkConfigurationDiagnosticResponsePoller) ResumeToken() (string, er
 	return p.pt.ResumeToken()
 }
 
-func (p *networkConfigurationDiagnosticResponsePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NetworkConfigurationDiagnosticResponseResponse, error) {
+func (p *networkConfigurationDiagnosticResponsePoller) pollUntilDone(ctx context.Context, freq time.Duration) (NetworkConfigurationDiagnosticResponseResponse, error) {
 	respType := NetworkConfigurationDiagnosticResponseResponse{NetworkConfigurationDiagnosticResponse: &NetworkConfigurationDiagnosticResponse{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NetworkConfigurationDiagnosticResponse)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NetworkConfigurationDiagnosticResponse)
 	if err != nil {
 		return NetworkConfigurationDiagnosticResponseResponse{}, err
 	}
@@ -2183,9 +2183,9 @@ func (p *networkInterfacePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *networkInterfacePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NetworkInterfaceResponse, error) {
+func (p *networkInterfacePoller) pollUntilDone(ctx context.Context, freq time.Duration) (NetworkInterfaceResponse, error) {
 	respType := NetworkInterfaceResponse{NetworkInterface: &NetworkInterface{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NetworkInterface)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NetworkInterface)
 	if err != nil {
 		return NetworkInterfaceResponse{}, err
 	}
@@ -2229,9 +2229,9 @@ func (p *networkInterfaceTapConfigurationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *networkInterfaceTapConfigurationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NetworkInterfaceTapConfigurationResponse, error) {
+func (p *networkInterfaceTapConfigurationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (NetworkInterfaceTapConfigurationResponse, error) {
 	respType := NetworkInterfaceTapConfigurationResponse{NetworkInterfaceTapConfiguration: &NetworkInterfaceTapConfiguration{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NetworkInterfaceTapConfiguration)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NetworkInterfaceTapConfiguration)
 	if err != nil {
 		return NetworkInterfaceTapConfigurationResponse{}, err
 	}
@@ -2275,9 +2275,9 @@ func (p *networkSecurityGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *networkSecurityGroupPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NetworkSecurityGroupResponse, error) {
+func (p *networkSecurityGroupPoller) pollUntilDone(ctx context.Context, freq time.Duration) (NetworkSecurityGroupResponse, error) {
 	respType := NetworkSecurityGroupResponse{NetworkSecurityGroup: &NetworkSecurityGroup{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NetworkSecurityGroup)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NetworkSecurityGroup)
 	if err != nil {
 		return NetworkSecurityGroupResponse{}, err
 	}
@@ -2321,9 +2321,9 @@ func (p *networkVirtualAppliancePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *networkVirtualAppliancePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NetworkVirtualApplianceResponse, error) {
+func (p *networkVirtualAppliancePoller) pollUntilDone(ctx context.Context, freq time.Duration) (NetworkVirtualApplianceResponse, error) {
 	respType := NetworkVirtualApplianceResponse{NetworkVirtualAppliance: &NetworkVirtualAppliance{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NetworkVirtualAppliance)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NetworkVirtualAppliance)
 	if err != nil {
 		return NetworkVirtualApplianceResponse{}, err
 	}
@@ -2367,9 +2367,9 @@ func (p *nextHopResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *nextHopResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (NextHopResultResponse, error) {
+func (p *nextHopResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (NextHopResultResponse, error) {
 	respType := NextHopResultResponse{NextHopResult: &NextHopResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.NextHopResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.NextHopResult)
 	if err != nil {
 		return NextHopResultResponse{}, err
 	}
@@ -2413,9 +2413,9 @@ func (p *p2SVPNConnectionHealthPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *p2SVPNConnectionHealthPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (P2SVPNConnectionHealthResponse, error) {
+func (p *p2SVPNConnectionHealthPoller) pollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNConnectionHealthResponse, error) {
 	respType := P2SVPNConnectionHealthResponse{P2SVPNConnectionHealth: &P2SVPNConnectionHealth{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.P2SVPNConnectionHealth)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.P2SVPNConnectionHealth)
 	if err != nil {
 		return P2SVPNConnectionHealthResponse{}, err
 	}
@@ -2459,9 +2459,9 @@ func (p *p2SVPNGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *p2SVPNGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (P2SVPNGatewayResponse, error) {
+func (p *p2SVPNGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (P2SVPNGatewayResponse, error) {
 	respType := P2SVPNGatewayResponse{P2SVPNGateway: &P2SVPNGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.P2SVPNGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.P2SVPNGateway)
 	if err != nil {
 		return P2SVPNGatewayResponse{}, err
 	}
@@ -2505,9 +2505,9 @@ func (p *packetCaptureQueryStatusResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *packetCaptureQueryStatusResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PacketCaptureQueryStatusResultResponse, error) {
+func (p *packetCaptureQueryStatusResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PacketCaptureQueryStatusResultResponse, error) {
 	respType := PacketCaptureQueryStatusResultResponse{PacketCaptureQueryStatusResult: &PacketCaptureQueryStatusResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PacketCaptureQueryStatusResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PacketCaptureQueryStatusResult)
 	if err != nil {
 		return PacketCaptureQueryStatusResultResponse{}, err
 	}
@@ -2551,9 +2551,9 @@ func (p *packetCaptureResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *packetCaptureResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PacketCaptureResultResponse, error) {
+func (p *packetCaptureResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PacketCaptureResultResponse, error) {
 	respType := PacketCaptureResultResponse{PacketCaptureResult: &PacketCaptureResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PacketCaptureResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PacketCaptureResult)
 	if err != nil {
 		return PacketCaptureResultResponse{}, err
 	}
@@ -2597,9 +2597,9 @@ func (p *privateDNSZoneGroupPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *privateDNSZoneGroupPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PrivateDNSZoneGroupResponse, error) {
+func (p *privateDNSZoneGroupPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PrivateDNSZoneGroupResponse, error) {
 	respType := PrivateDNSZoneGroupResponse{PrivateDNSZoneGroup: &PrivateDNSZoneGroup{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PrivateDNSZoneGroup)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PrivateDNSZoneGroup)
 	if err != nil {
 		return PrivateDNSZoneGroupResponse{}, err
 	}
@@ -2643,9 +2643,9 @@ func (p *privateEndpointPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *privateEndpointPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PrivateEndpointResponse, error) {
+func (p *privateEndpointPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PrivateEndpointResponse, error) {
 	respType := PrivateEndpointResponse{PrivateEndpoint: &PrivateEndpoint{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PrivateEndpoint)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PrivateEndpoint)
 	if err != nil {
 		return PrivateEndpointResponse{}, err
 	}
@@ -2689,9 +2689,9 @@ func (p *privateLinkServicePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *privateLinkServicePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PrivateLinkServiceResponse, error) {
+func (p *privateLinkServicePoller) pollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServiceResponse, error) {
 	respType := PrivateLinkServiceResponse{PrivateLinkService: &PrivateLinkService{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PrivateLinkService)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PrivateLinkService)
 	if err != nil {
 		return PrivateLinkServiceResponse{}, err
 	}
@@ -2735,9 +2735,9 @@ func (p *privateLinkServiceVisibilityPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *privateLinkServiceVisibilityPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
+func (p *privateLinkServiceVisibilityPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
 	respType := PrivateLinkServiceVisibilityResponse{PrivateLinkServiceVisibility: &PrivateLinkServiceVisibility{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PrivateLinkServiceVisibility)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PrivateLinkServiceVisibility)
 	if err != nil {
 		return PrivateLinkServiceVisibilityResponse{}, err
 	}
@@ -2781,9 +2781,9 @@ func (p *publicIPAddressPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *publicIPAddressPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PublicIPAddressResponse, error) {
+func (p *publicIPAddressPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PublicIPAddressResponse, error) {
 	respType := PublicIPAddressResponse{PublicIPAddress: &PublicIPAddress{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PublicIPAddress)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PublicIPAddress)
 	if err != nil {
 		return PublicIPAddressResponse{}, err
 	}
@@ -2827,9 +2827,9 @@ func (p *publicIPPrefixPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *publicIPPrefixPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (PublicIPPrefixResponse, error) {
+func (p *publicIPPrefixPoller) pollUntilDone(ctx context.Context, freq time.Duration) (PublicIPPrefixResponse, error) {
 	respType := PublicIPPrefixResponse{PublicIPPrefix: &PublicIPPrefix{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.PublicIPPrefix)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.PublicIPPrefix)
 	if err != nil {
 		return PublicIPPrefixResponse{}, err
 	}
@@ -2873,9 +2873,9 @@ func (p *routeFilterPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *routeFilterPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (RouteFilterResponse, error) {
+func (p *routeFilterPoller) pollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterResponse, error) {
 	respType := RouteFilterResponse{RouteFilter: &RouteFilter{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.RouteFilter)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.RouteFilter)
 	if err != nil {
 		return RouteFilterResponse{}, err
 	}
@@ -2919,9 +2919,9 @@ func (p *routeFilterRulePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *routeFilterRulePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (RouteFilterRuleResponse, error) {
+func (p *routeFilterRulePoller) pollUntilDone(ctx context.Context, freq time.Duration) (RouteFilterRuleResponse, error) {
 	respType := RouteFilterRuleResponse{RouteFilterRule: &RouteFilterRule{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.RouteFilterRule)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.RouteFilterRule)
 	if err != nil {
 		return RouteFilterRuleResponse{}, err
 	}
@@ -2965,9 +2965,9 @@ func (p *routePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *routePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (RouteResponse, error) {
+func (p *routePoller) pollUntilDone(ctx context.Context, freq time.Duration) (RouteResponse, error) {
 	respType := RouteResponse{Route: &Route{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Route)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Route)
 	if err != nil {
 		return RouteResponse{}, err
 	}
@@ -3011,9 +3011,9 @@ func (p *routeTablePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *routeTablePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (RouteTableResponse, error) {
+func (p *routeTablePoller) pollUntilDone(ctx context.Context, freq time.Duration) (RouteTableResponse, error) {
 	respType := RouteTableResponse{RouteTable: &RouteTable{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.RouteTable)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.RouteTable)
 	if err != nil {
 		return RouteTableResponse{}, err
 	}
@@ -3057,9 +3057,9 @@ func (p *securityGroupViewResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *securityGroupViewResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SecurityGroupViewResultResponse, error) {
+func (p *securityGroupViewResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SecurityGroupViewResultResponse, error) {
 	respType := SecurityGroupViewResultResponse{SecurityGroupViewResult: &SecurityGroupViewResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.SecurityGroupViewResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.SecurityGroupViewResult)
 	if err != nil {
 		return SecurityGroupViewResultResponse{}, err
 	}
@@ -3103,9 +3103,9 @@ func (p *securityPartnerProviderPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *securityPartnerProviderPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SecurityPartnerProviderResponse, error) {
+func (p *securityPartnerProviderPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SecurityPartnerProviderResponse, error) {
 	respType := SecurityPartnerProviderResponse{SecurityPartnerProvider: &SecurityPartnerProvider{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.SecurityPartnerProvider)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.SecurityPartnerProvider)
 	if err != nil {
 		return SecurityPartnerProviderResponse{}, err
 	}
@@ -3149,9 +3149,9 @@ func (p *securityRulePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *securityRulePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SecurityRuleResponse, error) {
+func (p *securityRulePoller) pollUntilDone(ctx context.Context, freq time.Duration) (SecurityRuleResponse, error) {
 	respType := SecurityRuleResponse{SecurityRule: &SecurityRule{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.SecurityRule)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.SecurityRule)
 	if err != nil {
 		return SecurityRuleResponse{}, err
 	}
@@ -3195,9 +3195,9 @@ func (p *serviceEndpointPolicyDefinitionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *serviceEndpointPolicyDefinitionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyDefinitionResponse, error) {
+func (p *serviceEndpointPolicyDefinitionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyDefinitionResponse, error) {
 	respType := ServiceEndpointPolicyDefinitionResponse{ServiceEndpointPolicyDefinition: &ServiceEndpointPolicyDefinition{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ServiceEndpointPolicyDefinition)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ServiceEndpointPolicyDefinition)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionResponse{}, err
 	}
@@ -3241,9 +3241,9 @@ func (p *serviceEndpointPolicyPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *serviceEndpointPolicyPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyResponse, error) {
+func (p *serviceEndpointPolicyPoller) pollUntilDone(ctx context.Context, freq time.Duration) (ServiceEndpointPolicyResponse, error) {
 	respType := ServiceEndpointPolicyResponse{ServiceEndpointPolicy: &ServiceEndpointPolicy{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.ServiceEndpointPolicy)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.ServiceEndpointPolicy)
 	if err != nil {
 		return ServiceEndpointPolicyResponse{}, err
 	}
@@ -3287,9 +3287,9 @@ func (p *stringPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *stringPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+func (p *stringPoller) pollUntilDone(ctx context.Context, freq time.Duration) (StringResponse, error) {
 	respType := StringResponse{}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, &respType.Value)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, &respType.Value)
 	if err != nil {
 		return StringResponse{}, err
 	}
@@ -3333,9 +3333,9 @@ func (p *subnetPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *subnetPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (SubnetResponse, error) {
+func (p *subnetPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SubnetResponse, error) {
 	respType := SubnetResponse{Subnet: &Subnet{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.Subnet)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.Subnet)
 	if err != nil {
 		return SubnetResponse{}, err
 	}
@@ -3379,9 +3379,9 @@ func (p *troubleshootingResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *troubleshootingResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (TroubleshootingResultResponse, error) {
+func (p *troubleshootingResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (TroubleshootingResultResponse, error) {
 	respType := TroubleshootingResultResponse{TroubleshootingResult: &TroubleshootingResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.TroubleshootingResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.TroubleshootingResult)
 	if err != nil {
 		return TroubleshootingResultResponse{}, err
 	}
@@ -3425,9 +3425,9 @@ func (p *vpnClientConnectionHealthDetailListResultPoller) ResumeToken() (string,
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnClientConnectionHealthDetailListResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNClientConnectionHealthDetailListResultResponse, error) {
+func (p *vpnClientConnectionHealthDetailListResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNClientConnectionHealthDetailListResultResponse, error) {
 	respType := VPNClientConnectionHealthDetailListResultResponse{VPNClientConnectionHealthDetailListResult: &VPNClientConnectionHealthDetailListResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNClientConnectionHealthDetailListResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNClientConnectionHealthDetailListResult)
 	if err != nil {
 		return VPNClientConnectionHealthDetailListResultResponse{}, err
 	}
@@ -3471,9 +3471,9 @@ func (p *vpnClientIPSecParametersPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnClientIPSecParametersPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNClientIPsecParametersResponse, error) {
+func (p *vpnClientIPSecParametersPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNClientIPsecParametersResponse, error) {
 	respType := VPNClientIPsecParametersResponse{VPNClientIPsecParameters: &VPNClientIPsecParameters{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNClientIPsecParameters)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNClientIPsecParameters)
 	if err != nil {
 		return VPNClientIPsecParametersResponse{}, err
 	}
@@ -3517,9 +3517,9 @@ func (p *vpnConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnConnectionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNConnectionResponse, error) {
+func (p *vpnConnectionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNConnectionResponse, error) {
 	respType := VPNConnectionResponse{VPNConnection: &VPNConnection{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNConnection)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNConnection)
 	if err != nil {
 		return VPNConnectionResponse{}, err
 	}
@@ -3563,9 +3563,9 @@ func (p *vpnGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNGatewayResponse, error) {
+func (p *vpnGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNGatewayResponse, error) {
 	respType := VPNGatewayResponse{VPNGateway: &VPNGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNGateway)
 	if err != nil {
 		return VPNGatewayResponse{}, err
 	}
@@ -3609,9 +3609,9 @@ func (p *vpnProfileResponsePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnProfileResponsePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNProfileResponseResponse, error) {
+func (p *vpnProfileResponsePoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNProfileResponseResponse, error) {
 	respType := VPNProfileResponseResponse{VPNProfileResponse: &VPNProfileResponse{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNProfileResponse)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNProfileResponse)
 	if err != nil {
 		return VPNProfileResponseResponse{}, err
 	}
@@ -3655,9 +3655,9 @@ func (p *vpnServerConfigurationPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnServerConfigurationPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNServerConfigurationResponse, error) {
+func (p *vpnServerConfigurationPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationResponse, error) {
 	respType := VPNServerConfigurationResponse{VPNServerConfiguration: &VPNServerConfiguration{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNServerConfiguration)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNServerConfiguration)
 	if err != nil {
 		return VPNServerConfigurationResponse{}, err
 	}
@@ -3701,9 +3701,9 @@ func (p *vpnServerConfigurationsResponsePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnServerConfigurationsResponsePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNServerConfigurationsResponseResponse, error) {
+func (p *vpnServerConfigurationsResponsePoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNServerConfigurationsResponseResponse, error) {
 	respType := VPNServerConfigurationsResponseResponse{VPNServerConfigurationsResponse: &VPNServerConfigurationsResponse{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNServerConfigurationsResponse)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNServerConfigurationsResponse)
 	if err != nil {
 		return VPNServerConfigurationsResponseResponse{}, err
 	}
@@ -3747,9 +3747,9 @@ func (p *vpnSitePoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *vpnSitePoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VPNSiteResponse, error) {
+func (p *vpnSitePoller) pollUntilDone(ctx context.Context, freq time.Duration) (VPNSiteResponse, error) {
 	respType := VPNSiteResponse{VPNSite: &VPNSite{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VPNSite)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VPNSite)
 	if err != nil {
 		return VPNSiteResponse{}, err
 	}
@@ -3793,9 +3793,9 @@ func (p *verificationIPFlowResultPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *verificationIPFlowResultPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VerificationIPFlowResultResponse, error) {
+func (p *verificationIPFlowResultPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VerificationIPFlowResultResponse, error) {
 	respType := VerificationIPFlowResultResponse{VerificationIPFlowResult: &VerificationIPFlowResult{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VerificationIPFlowResult)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VerificationIPFlowResult)
 	if err != nil {
 		return VerificationIPFlowResultResponse{}, err
 	}
@@ -3839,9 +3839,9 @@ func (p *virtualHubPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualHubPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualHubResponse, error) {
+func (p *virtualHubPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubResponse, error) {
 	respType := VirtualHubResponse{VirtualHub: &VirtualHub{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualHub)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualHub)
 	if err != nil {
 		return VirtualHubResponse{}, err
 	}
@@ -3885,9 +3885,9 @@ func (p *virtualHubRouteTableV2Poller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualHubRouteTableV2Poller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualHubRouteTableV2Response, error) {
+func (p *virtualHubRouteTableV2Poller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualHubRouteTableV2Response, error) {
 	respType := VirtualHubRouteTableV2Response{VirtualHubRouteTableV2: &VirtualHubRouteTableV2{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualHubRouteTableV2)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualHubRouteTableV2)
 	if err != nil {
 		return VirtualHubRouteTableV2Response{}, err
 	}
@@ -3931,9 +3931,9 @@ func (p *virtualNetworkGatewayConnectionPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualNetworkGatewayConnectionPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
+func (p *virtualNetworkGatewayConnectionPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
 	respType := VirtualNetworkGatewayConnectionResponse{VirtualNetworkGatewayConnection: &VirtualNetworkGatewayConnection{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualNetworkGatewayConnection)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualNetworkGatewayConnection)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionResponse{}, err
 	}
@@ -3977,9 +3977,9 @@ func (p *virtualNetworkGatewayPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualNetworkGatewayPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
+func (p *virtualNetworkGatewayPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkGatewayResponse, error) {
 	respType := VirtualNetworkGatewayResponse{VirtualNetworkGateway: &VirtualNetworkGateway{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualNetworkGateway)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualNetworkGateway)
 	if err != nil {
 		return VirtualNetworkGatewayResponse{}, err
 	}
@@ -4023,9 +4023,9 @@ func (p *virtualNetworkPeeringPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualNetworkPeeringPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualNetworkPeeringResponse, error) {
+func (p *virtualNetworkPeeringPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkPeeringResponse, error) {
 	respType := VirtualNetworkPeeringResponse{VirtualNetworkPeering: &VirtualNetworkPeering{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualNetworkPeering)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualNetworkPeering)
 	if err != nil {
 		return VirtualNetworkPeeringResponse{}, err
 	}
@@ -4069,9 +4069,9 @@ func (p *virtualNetworkPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualNetworkPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualNetworkResponse, error) {
+func (p *virtualNetworkPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkResponse, error) {
 	respType := VirtualNetworkResponse{VirtualNetwork: &VirtualNetwork{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualNetwork)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualNetwork)
 	if err != nil {
 		return VirtualNetworkResponse{}, err
 	}
@@ -4115,9 +4115,9 @@ func (p *virtualNetworkTapPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualNetworkTapPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualNetworkTapResponse, error) {
+func (p *virtualNetworkTapPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualNetworkTapResponse, error) {
 	respType := VirtualNetworkTapResponse{VirtualNetworkTap: &VirtualNetworkTap{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualNetworkTap)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualNetworkTap)
 	if err != nil {
 		return VirtualNetworkTapResponse{}, err
 	}
@@ -4161,9 +4161,9 @@ func (p *virtualRouterPeeringPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualRouterPeeringPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualRouterPeeringResponse, error) {
+func (p *virtualRouterPeeringPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterPeeringResponse, error) {
 	respType := VirtualRouterPeeringResponse{VirtualRouterPeering: &VirtualRouterPeering{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualRouterPeering)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualRouterPeering)
 	if err != nil {
 		return VirtualRouterPeeringResponse{}, err
 	}
@@ -4207,9 +4207,9 @@ func (p *virtualRouterPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualRouterPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualRouterResponse, error) {
+func (p *virtualRouterPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualRouterResponse, error) {
 	respType := VirtualRouterResponse{VirtualRouter: &VirtualRouter{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualRouter)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualRouter)
 	if err != nil {
 		return VirtualRouterResponse{}, err
 	}
@@ -4253,9 +4253,9 @@ func (p *virtualWANPoller) ResumeToken() (string, error) {
 	return p.pt.ResumeToken()
 }
 
-func (p *virtualWANPoller) pollUntilDone(ctx context.Context, frequency time.Duration) (VirtualWANResponse, error) {
+func (p *virtualWANPoller) pollUntilDone(ctx context.Context, freq time.Duration) (VirtualWANResponse, error) {
 	respType := VirtualWANResponse{VirtualWAN: &VirtualWAN{}}
-	resp, err := p.pt.PollUntilDone(ctx, frequency, p.pipeline, respType.VirtualWAN)
+	resp, err := p.pt.PollUntilDone(ctx, freq, p.pipeline, respType.VirtualWAN)
 	if err != nil {
 		return VirtualWANResponse{}, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -44,8 +44,8 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 		return PrivateDNSZoneGroupPollerResponse{}, err
 	}
 	poller := &privateDNSZoneGroupPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateDNSZoneGroupResponse, error) {
@@ -56,15 +56,27 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 
 // ResumeCreateOrUpdate creates a new PrivateDNSZoneGroupPoller from the specified resume token.
 // token - The value must come from a previous call to PrivateDNSZoneGroupPoller.ResumeToken().
-func (client *PrivateDNSZoneGroupsClient) ResumeCreateOrUpdate(token string) (PrivateDNSZoneGroupPoller, error) {
+func (client *PrivateDNSZoneGroupsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (PrivateDNSZoneGroupPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return PrivateDNSZoneGroupPollerResponse{}, err
 	}
-	return &privateDNSZoneGroupPoller{
+	poller := &privateDNSZoneGroupPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PrivateDNSZoneGroupPollerResponse{}, err
+	}
+	result := PrivateDNSZoneGroupPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateDNSZoneGroupResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a private dns zone group in the specified private endpoint.
@@ -146,8 +158,8 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PrivateDNSZoneGroupsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *PrivateDNSZoneGroupsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateDNSZoneGroupsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified private dns zone group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -44,8 +44,8 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 		return PrivateEndpointPollerResponse{}, err
 	}
 	poller := &privateEndpointPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateEndpointResponse, error) {
@@ -56,15 +56,27 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 
 // ResumeCreateOrUpdate creates a new PrivateEndpointPoller from the specified resume token.
 // token - The value must come from a previous call to PrivateEndpointPoller.ResumeToken().
-func (client *PrivateEndpointsClient) ResumeCreateOrUpdate(token string) (PrivateEndpointPoller, error) {
+func (client *PrivateEndpointsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (PrivateEndpointPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateEndpointsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return PrivateEndpointPollerResponse{}, err
 	}
-	return &privateEndpointPoller{
+	poller := &privateEndpointPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PrivateEndpointPollerResponse{}, err
+	}
+	result := PrivateEndpointPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateEndpointResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an private endpoint in the specified resource group.
@@ -142,8 +154,8 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PrivateEndpointsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *PrivateEndpointsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateEndpointsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified private endpoint.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -44,8 +44,8 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 		return PrivateLinkServiceVisibilityPollerResponse{}, err
 	}
 	poller := &privateLinkServiceVisibilityPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
@@ -56,15 +56,27 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 
 // ResumeCheckPrivateLinkServiceVisibility creates a new PrivateLinkServiceVisibilityPoller from the specified resume token.
 // token - The value must come from a previous call to PrivateLinkServiceVisibilityPoller.ResumeToken().
-func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibility(token string) (PrivateLinkServiceVisibilityPoller, error) {
+func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibility(ctx context.Context, token string) (PrivateLinkServiceVisibilityPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibility", token, client.checkPrivateLinkServiceVisibilityHandleError)
 	if err != nil {
-		return nil, err
+		return PrivateLinkServiceVisibilityPollerResponse{}, err
 	}
-	return &privateLinkServiceVisibilityPoller{
+	poller := &privateLinkServiceVisibilityPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PrivateLinkServiceVisibilityPollerResponse{}, err
+	}
+	result := PrivateLinkServiceVisibilityPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CheckPrivateLinkServiceVisibility - Checks whether the subscription is visible to private link service.
@@ -139,8 +151,8 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 		return PrivateLinkServiceVisibilityPollerResponse{}, err
 	}
 	poller := &privateLinkServiceVisibilityPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
@@ -151,15 +163,27 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 
 // ResumeCheckPrivateLinkServiceVisibilityByResourceGroup creates a new PrivateLinkServiceVisibilityPoller from the specified resume token.
 // token - The value must come from a previous call to PrivateLinkServiceVisibilityPoller.ResumeToken().
-func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibilityByResourceGroup(token string) (PrivateLinkServiceVisibilityPoller, error) {
+func (client *PrivateLinkServicesClient) ResumeCheckPrivateLinkServiceVisibilityByResourceGroup(ctx context.Context, token string) (PrivateLinkServiceVisibilityPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateLinkServicesClient.CheckPrivateLinkServiceVisibilityByResourceGroup", token, client.checkPrivateLinkServiceVisibilityByResourceGroupHandleError)
 	if err != nil {
-		return nil, err
+		return PrivateLinkServiceVisibilityPollerResponse{}, err
 	}
-	return &privateLinkServiceVisibilityPoller{
+	poller := &privateLinkServiceVisibilityPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PrivateLinkServiceVisibilityPollerResponse{}, err
+	}
+	result := PrivateLinkServiceVisibilityPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceVisibilityResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CheckPrivateLinkServiceVisibilityByResourceGroup - Checks whether the subscription is visible to private link service in the specified resource group.
@@ -237,8 +261,8 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 		return PrivateLinkServicePollerResponse{}, err
 	}
 	poller := &privateLinkServicePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceResponse, error) {
@@ -249,15 +273,27 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 
 // ResumeCreateOrUpdate creates a new PrivateLinkServicePoller from the specified resume token.
 // token - The value must come from a previous call to PrivateLinkServicePoller.ResumeToken().
-func (client *PrivateLinkServicesClient) ResumeCreateOrUpdate(token string) (PrivateLinkServicePoller, error) {
+func (client *PrivateLinkServicesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (PrivateLinkServicePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateLinkServicesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return PrivateLinkServicePollerResponse{}, err
 	}
-	return &privateLinkServicePoller{
+	poller := &privateLinkServicePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PrivateLinkServicePollerResponse{}, err
+	}
+	result := PrivateLinkServicePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PrivateLinkServiceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates an private link service in the specified resource group.
@@ -335,8 +371,8 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -347,15 +383,27 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PrivateLinkServicesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *PrivateLinkServicesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateLinkServicesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified private link service.
@@ -424,8 +472,8 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -436,15 +484,27 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 
 // ResumeDeletePrivateEndpointConnection creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PrivateLinkServicesClient) ResumeDeletePrivateEndpointConnection(token string) (HTTPPoller, error) {
+func (client *PrivateLinkServicesClient) ResumeDeletePrivateEndpointConnection(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PrivateLinkServicesClient.DeletePrivateEndpointConnection", token, client.deletePrivateEndpointConnectionHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeletePrivateEndpointConnection - Delete private end point connection for a private link service in a subscription.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -44,8 +44,8 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 		return PublicIPPrefixPollerResponse{}, err
 	}
 	poller := &publicIPPrefixPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PublicIPPrefixResponse, error) {
@@ -56,15 +56,27 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 
 // ResumeCreateOrUpdate creates a new PublicIPPrefixPoller from the specified resume token.
 // token - The value must come from a previous call to PublicIPPrefixPoller.ResumeToken().
-func (client *PublicIPPrefixesClient) ResumeCreateOrUpdate(token string) (PublicIPPrefixPoller, error) {
+func (client *PublicIPPrefixesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (PublicIPPrefixPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PublicIPPrefixesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return PublicIPPrefixPollerResponse{}, err
 	}
-	return &publicIPPrefixPoller{
+	poller := &publicIPPrefixPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PublicIPPrefixPollerResponse{}, err
+	}
+	result := PublicIPPrefixPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PublicIPPrefixResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a static or dynamic public IP prefix.
@@ -142,8 +154,8 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *PublicIPPrefixesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *PublicIPPrefixesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("PublicIPPrefixesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified public IP prefix.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -44,8 +44,8 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 		return RouteFilterRulePollerResponse{}, err
 	}
 	poller := &routeFilterRulePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteFilterRuleResponse, error) {
@@ -56,15 +56,27 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 
 // ResumeCreateOrUpdate creates a new RouteFilterRulePoller from the specified resume token.
 // token - The value must come from a previous call to RouteFilterRulePoller.ResumeToken().
-func (client *RouteFilterRulesClient) ResumeCreateOrUpdate(token string) (RouteFilterRulePoller, error) {
+func (client *RouteFilterRulesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (RouteFilterRulePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteFilterRulesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return RouteFilterRulePollerResponse{}, err
 	}
-	return &routeFilterRulePoller{
+	poller := &routeFilterRulePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RouteFilterRulePollerResponse{}, err
+	}
+	result := RouteFilterRulePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteFilterRuleResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route filter.
@@ -146,8 +158,8 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *RouteFilterRulesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *RouteFilterRulesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteFilterRulesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified rule from a route filter.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -44,8 +44,8 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 		return RouteFilterPollerResponse{}, err
 	}
 	poller := &routeFilterPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteFilterResponse, error) {
@@ -56,15 +56,27 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 
 // ResumeCreateOrUpdate creates a new RouteFilterPoller from the specified resume token.
 // token - The value must come from a previous call to RouteFilterPoller.ResumeToken().
-func (client *RouteFiltersClient) ResumeCreateOrUpdate(token string) (RouteFilterPoller, error) {
+func (client *RouteFiltersClient) ResumeCreateOrUpdate(ctx context.Context, token string) (RouteFilterPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteFiltersClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return RouteFilterPollerResponse{}, err
 	}
-	return &routeFilterPoller{
+	poller := &routeFilterPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RouteFilterPollerResponse{}, err
+	}
+	result := RouteFilterPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteFilterResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a route filter in a specified resource group.
@@ -142,8 +154,8 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *RouteFiltersClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *RouteFiltersClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteFiltersClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified route filter.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -44,8 +44,8 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 		return RoutePollerResponse{}, err
 	}
 	poller := &routePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteResponse, error) {
@@ -56,15 +56,27 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 
 // ResumeCreateOrUpdate creates a new RoutePoller from the specified resume token.
 // token - The value must come from a previous call to RoutePoller.ResumeToken().
-func (client *RoutesClient) ResumeCreateOrUpdate(token string) (RoutePoller, error) {
+func (client *RoutesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (RoutePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RoutesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return RoutePollerResponse{}, err
 	}
-	return &routePoller{
+	poller := &routePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RoutePollerResponse{}, err
+	}
+	result := RoutePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a route in the specified route table.
@@ -146,8 +158,8 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *RoutesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *RoutesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RoutesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified route from a route table.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -44,8 +44,8 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 		return RouteTablePollerResponse{}, err
 	}
 	poller := &routeTablePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteTableResponse, error) {
@@ -56,15 +56,27 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 
 // ResumeCreateOrUpdate creates a new RouteTablePoller from the specified resume token.
 // token - The value must come from a previous call to RouteTablePoller.ResumeToken().
-func (client *RouteTablesClient) ResumeCreateOrUpdate(token string) (RouteTablePoller, error) {
+func (client *RouteTablesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (RouteTablePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteTablesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return RouteTablePollerResponse{}, err
 	}
-	return &routeTablePoller{
+	poller := &routeTablePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return RouteTablePollerResponse{}, err
+	}
+	result := RouteTablePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (RouteTableResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Create or updates a route table in a specified resource group.
@@ -142,8 +154,8 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *RouteTablesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *RouteTablesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("RouteTablesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified route table.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -44,8 +44,8 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 		return SecurityPartnerProviderPollerResponse{}, err
 	}
 	poller := &securityPartnerProviderPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityPartnerProviderResponse, error) {
@@ -56,15 +56,27 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 
 // ResumeCreateOrUpdate creates a new SecurityPartnerProviderPoller from the specified resume token.
 // token - The value must come from a previous call to SecurityPartnerProviderPoller.ResumeToken().
-func (client *SecurityPartnerProvidersClient) ResumeCreateOrUpdate(token string) (SecurityPartnerProviderPoller, error) {
+func (client *SecurityPartnerProvidersClient) ResumeCreateOrUpdate(ctx context.Context, token string) (SecurityPartnerProviderPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SecurityPartnerProvidersClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return SecurityPartnerProviderPollerResponse{}, err
 	}
-	return &securityPartnerProviderPoller{
+	poller := &securityPartnerProviderPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SecurityPartnerProviderPollerResponse{}, err
+	}
+	result := SecurityPartnerProviderPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityPartnerProviderResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Security Partner Provider.
@@ -142,8 +154,8 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SecurityPartnerProvidersClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *SecurityPartnerProvidersClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SecurityPartnerProvidersClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Security Partner Provider.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -44,8 +44,8 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 		return SecurityRulePollerResponse{}, err
 	}
 	poller := &securityRulePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityRuleResponse, error) {
@@ -56,15 +56,27 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 
 // ResumeCreateOrUpdate creates a new SecurityRulePoller from the specified resume token.
 // token - The value must come from a previous call to SecurityRulePoller.ResumeToken().
-func (client *SecurityRulesClient) ResumeCreateOrUpdate(token string) (SecurityRulePoller, error) {
+func (client *SecurityRulesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (SecurityRulePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SecurityRulesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return SecurityRulePollerResponse{}, err
 	}
-	return &securityRulePoller{
+	poller := &securityRulePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SecurityRulePollerResponse{}, err
+	}
+	result := SecurityRulePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SecurityRuleResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a security rule in the specified network security group.
@@ -146,8 +158,8 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SecurityRulesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *SecurityRulesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SecurityRulesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified network security rule.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -44,8 +44,8 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 		return ServiceEndpointPolicyPollerResponse{}, err
 	}
 	poller := &serviceEndpointPolicyPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyResponse, error) {
@@ -56,15 +56,27 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 
 // ResumeCreateOrUpdate creates a new ServiceEndpointPolicyPoller from the specified resume token.
 // token - The value must come from a previous call to ServiceEndpointPolicyPoller.ResumeToken().
-func (client *ServiceEndpointPoliciesClient) ResumeCreateOrUpdate(token string) (ServiceEndpointPolicyPoller, error) {
+func (client *ServiceEndpointPoliciesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ServiceEndpointPolicyPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ServiceEndpointPolicyPollerResponse{}, err
 	}
-	return &serviceEndpointPolicyPoller{
+	poller := &serviceEndpointPolicyPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ServiceEndpointPolicyPollerResponse{}, err
+	}
+	result := ServiceEndpointPolicyPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a service Endpoint Policies.
@@ -142,8 +154,8 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ServiceEndpointPoliciesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ServiceEndpointPoliciesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ServiceEndpointPoliciesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified service endpoint policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -44,8 +44,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 		return ServiceEndpointPolicyDefinitionPollerResponse{}, err
 	}
 	poller := &serviceEndpointPolicyDefinitionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyDefinitionResponse, error) {
@@ -56,15 +56,27 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 
 // ResumeCreateOrUpdate creates a new ServiceEndpointPolicyDefinitionPoller from the specified resume token.
 // token - The value must come from a previous call to ServiceEndpointPolicyDefinitionPoller.ResumeToken().
-func (client *ServiceEndpointPolicyDefinitionsClient) ResumeCreateOrUpdate(token string) (ServiceEndpointPolicyDefinitionPoller, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (ServiceEndpointPolicyDefinitionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return ServiceEndpointPolicyDefinitionPollerResponse{}, err
 	}
-	return &serviceEndpointPolicyDefinitionPoller{
+	poller := &serviceEndpointPolicyDefinitionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ServiceEndpointPolicyDefinitionPollerResponse{}, err
+	}
+	result := ServiceEndpointPolicyDefinitionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ServiceEndpointPolicyDefinitionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a service endpoint policy definition in the specified service endpoint policy.
@@ -146,8 +158,8 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *ServiceEndpointPolicyDefinitionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *ServiceEndpointPolicyDefinitionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("ServiceEndpointPolicyDefinitionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified ServiceEndpoint policy definitions.

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -44,8 +44,8 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 		return SubnetPollerResponse{}, err
 	}
 	poller := &subnetPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubnetResponse, error) {
@@ -56,15 +56,27 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 
 // ResumeCreateOrUpdate creates a new SubnetPoller from the specified resume token.
 // token - The value must come from a previous call to SubnetPoller.ResumeToken().
-func (client *SubnetsClient) ResumeCreateOrUpdate(token string) (SubnetPoller, error) {
+func (client *SubnetsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (SubnetPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SubnetsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return SubnetPollerResponse{}, err
 	}
-	return &subnetPoller{
+	poller := &subnetPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SubnetPollerResponse{}, err
+	}
+	result := SubnetPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SubnetResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a subnet in the specified virtual network.
@@ -146,8 +158,8 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SubnetsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *SubnetsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SubnetsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified subnet.
@@ -368,8 +392,8 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -380,15 +404,27 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 
 // ResumePrepareNetworkPolicies creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SubnetsClient) ResumePrepareNetworkPolicies(token string) (HTTPPoller, error) {
+func (client *SubnetsClient) ResumePrepareNetworkPolicies(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SubnetsClient.PrepareNetworkPolicies", token, client.prepareNetworkPoliciesHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // PrepareNetworkPolicies - Prepares a subnet by applying network intent policies.
@@ -461,8 +497,8 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -473,15 +509,27 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 
 // ResumeUnprepareNetworkPolicies creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *SubnetsClient) ResumeUnprepareNetworkPolicies(token string) (HTTPPoller, error) {
+func (client *SubnetsClient) ResumeUnprepareNetworkPolicies(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("SubnetsClient.UnprepareNetworkPolicies", token, client.unprepareNetworkPoliciesHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UnprepareNetworkPolicies - Unprepares a subnet by removing network intent policies.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -44,8 +44,8 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 		return VirtualHubRouteTableV2PollerResponse{}, err
 	}
 	poller := &virtualHubRouteTableV2Poller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualHubRouteTableV2Response, error) {
@@ -56,15 +56,27 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 
 // ResumeCreateOrUpdate creates a new VirtualHubRouteTableV2Poller from the specified resume token.
 // token - The value must come from a previous call to VirtualHubRouteTableV2Poller.ResumeToken().
-func (client *VirtualHubRouteTableV2SClient) ResumeCreateOrUpdate(token string) (VirtualHubRouteTableV2Poller, error) {
+func (client *VirtualHubRouteTableV2SClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualHubRouteTableV2PollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualHubRouteTableV2PollerResponse{}, err
 	}
-	return &virtualHubRouteTableV2Poller{
+	poller := &virtualHubRouteTableV2Poller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualHubRouteTableV2PollerResponse{}, err
+	}
+	result := VirtualHubRouteTableV2PollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualHubRouteTableV2Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a VirtualHubRouteTableV2 resource if it doesn't exist else updates the existing VirtualHubRouteTableV2.
@@ -146,8 +158,8 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualHubRouteTableV2SClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualHubRouteTableV2SClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualHubRouteTableV2SClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VirtualHubRouteTableV2.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -44,8 +44,8 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 		return VirtualHubPollerResponse{}, err
 	}
 	poller := &virtualHubPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualHubResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 
 // ResumeCreateOrUpdate creates a new VirtualHubPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualHubPoller.ResumeToken().
-func (client *VirtualHubsClient) ResumeCreateOrUpdate(token string) (VirtualHubPoller, error) {
+func (client *VirtualHubsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualHubPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualHubsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualHubPollerResponse{}, err
 	}
-	return &virtualHubPoller{
+	poller := &virtualHubPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualHubPollerResponse{}, err
+	}
+	result := VirtualHubPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualHubResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a VirtualHub resource if it doesn't exist else updates the existing VirtualHub.
@@ -142,8 +154,8 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualHubsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualHubsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualHubsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VirtualHub.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -44,8 +44,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 		return VirtualNetworkGatewayConnectionPollerResponse{}, err
 	}
 	poller := &virtualNetworkGatewayConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 
 // ResumeCreateOrUpdate creates a new VirtualNetworkGatewayConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkGatewayConnectionPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeCreateOrUpdate(token string) (VirtualNetworkGatewayConnectionPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualNetworkGatewayConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkGatewayConnectionPollerResponse{}, err
 	}
-	return &virtualNetworkGatewayConnectionPoller{
+	poller := &virtualNetworkGatewayConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkGatewayConnectionPollerResponse{}, err
+	}
+	result := VirtualNetworkGatewayConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway connection in the specified resource group.
@@ -142,8 +154,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified virtual network Gateway connection.
@@ -413,8 +437,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 		return ConnectionResetSharedKeyPollerResponse{}, err
 	}
 	poller := &connectionResetSharedKeyPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionResetSharedKeyResponse, error) {
@@ -425,15 +449,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 
 // ResumeResetSharedKey creates a new ConnectionResetSharedKeyPoller from the specified resume token.
 // token - The value must come from a previous call to ConnectionResetSharedKeyPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeResetSharedKey(token string) (ConnectionResetSharedKeyPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeResetSharedKey(ctx context.Context, token string) (ConnectionResetSharedKeyPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.ResetSharedKey", token, client.resetSharedKeyHandleError)
 	if err != nil {
-		return nil, err
+		return ConnectionResetSharedKeyPollerResponse{}, err
 	}
-	return &connectionResetSharedKeyPoller{
+	poller := &connectionResetSharedKeyPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ConnectionResetSharedKeyPollerResponse{}, err
+	}
+	result := ConnectionResetSharedKeyPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionResetSharedKeyResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ResetSharedKey - The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection shared key for passed virtual
@@ -515,8 +551,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 		return ConnectionSharedKeyPollerResponse{}, err
 	}
 	poller := &connectionSharedKeyPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionSharedKeyResponse, error) {
@@ -527,15 +563,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 
 // ResumeSetSharedKey creates a new ConnectionSharedKeyPoller from the specified resume token.
 // token - The value must come from a previous call to ConnectionSharedKeyPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeSetSharedKey(token string) (ConnectionSharedKeyPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeSetSharedKey(ctx context.Context, token string) (ConnectionSharedKeyPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.SetSharedKey", token, client.setSharedKeyHandleError)
 	if err != nil {
-		return nil, err
+		return ConnectionSharedKeyPollerResponse{}, err
 	}
-	return &connectionSharedKeyPoller{
+	poller := &connectionSharedKeyPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return ConnectionSharedKeyPollerResponse{}, err
+	}
+	result := ConnectionSharedKeyPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (ConnectionSharedKeyResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // SetSharedKey - The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared key for passed virtual network
@@ -615,8 +663,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -627,15 +675,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 
 // ResumeStartPacketCapture creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeStartPacketCapture(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeStartPacketCapture(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StartPacketCapture", token, client.startPacketCaptureHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway connection in the specified resource group.
@@ -716,8 +776,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -728,15 +788,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 
 // ResumeStopPacketCapture creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeStopPacketCapture(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeStopPacketCapture(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.StopPacketCapture", token, client.stopPacketCaptureHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway connection in the specified resource group.
@@ -814,8 +886,8 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 		return VirtualNetworkGatewayConnectionPollerResponse{}, err
 	}
 	poller := &virtualNetworkGatewayConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
@@ -826,15 +898,27 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 
 // ResumeUpdateTags creates a new VirtualNetworkGatewayConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkGatewayConnectionPoller.ResumeToken().
-func (client *VirtualNetworkGatewayConnectionsClient) ResumeUpdateTags(token string) (VirtualNetworkGatewayConnectionPoller, error) {
+func (client *VirtualNetworkGatewayConnectionsClient) ResumeUpdateTags(ctx context.Context, token string) (VirtualNetworkGatewayConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewayConnectionsClient.UpdateTags", token, client.updateTagsHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkGatewayConnectionPollerResponse{}, err
 	}
-	return &virtualNetworkGatewayConnectionPoller{
+	poller := &virtualNetworkGatewayConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkGatewayConnectionPollerResponse{}, err
+	}
+	result := VirtualNetworkGatewayConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UpdateTags - Updates a virtual network gateway connection tags.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -44,8 +44,8 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 		return VirtualNetworkGatewayPollerResponse{}, err
 	}
 	poller := &virtualNetworkGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 
 // ResumeCreateOrUpdate creates a new VirtualNetworkGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkGatewayPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeCreateOrUpdate(token string) (VirtualNetworkGatewayPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualNetworkGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkGatewayPollerResponse{}, err
 	}
-	return &virtualNetworkGatewayPoller{
+	poller := &virtualNetworkGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkGatewayPollerResponse{}, err
+	}
+	result := VirtualNetworkGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network gateway in the specified resource group.
@@ -142,8 +154,8 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified virtual network gateway.
@@ -231,8 +255,8 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -243,15 +267,27 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 
 // ResumeDisconnectVirtualNetworkGatewayVPNConnections creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeDisconnectVirtualNetworkGatewayVPNConnections(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeDisconnectVirtualNetworkGatewayVPNConnections(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.DisconnectVirtualNetworkGatewayVPNConnections", token, client.disconnectVirtualNetworkGatewayVPNConnectionsHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DisconnectVirtualNetworkGatewayVPNConnections - Disconnect vpn connections of virtual network gateway in the specified resource group.
@@ -321,8 +357,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -333,15 +369,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.
 
 // ResumeGenerateVPNProfile creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGenerateVPNProfile(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGenerateVPNProfile(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GenerateVPNProfile", token, client.generateVPNProfileHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GenerateVPNProfile - Generates VPN profile for P2S client of the virtual network gateway in the specified resource group. Used for IKEV2 and radius based
@@ -420,8 +468,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -432,15 +480,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 
 // ResumeGeneratevpnclientpackage creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGeneratevpnclientpackage(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGeneratevpnclientpackage(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Generatevpnclientpackage", token, client.generatevpnclientpackageHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Generatevpnclientpackage - Generates VPN client package for P2S client of the virtual network gateway in the specified resource group.
@@ -579,8 +639,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 		return GatewayRouteListResultPollerResponse{}, err
 	}
 	poller := &gatewayRouteListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GatewayRouteListResultResponse, error) {
@@ -591,15 +651,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 
 // ResumeGetAdvertisedRoutes creates a new GatewayRouteListResultPoller from the specified resume token.
 // token - The value must come from a previous call to GatewayRouteListResultPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetAdvertisedRoutes(token string) (GatewayRouteListResultPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetAdvertisedRoutes(ctx context.Context, token string) (GatewayRouteListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetAdvertisedRoutes", token, client.getAdvertisedRoutesHandleError)
 	if err != nil {
-		return nil, err
+		return GatewayRouteListResultPollerResponse{}, err
 	}
-	return &gatewayRouteListResultPoller{
+	poller := &gatewayRouteListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GatewayRouteListResultPollerResponse{}, err
+	}
+	result := GatewayRouteListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GatewayRouteListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetAdvertisedRoutes - This operation retrieves a list of routes the virtual network gateway is advertising to the specified peer.
@@ -678,8 +750,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 		return BgpPeerStatusListResultPollerResponse{}, err
 	}
 	poller := &bgpPeerStatusListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BgpPeerStatusListResultResponse, error) {
@@ -690,15 +762,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 
 // ResumeGetBgpPeerStatus creates a new BgpPeerStatusListResultPoller from the specified resume token.
 // token - The value must come from a previous call to BgpPeerStatusListResultPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetBgpPeerStatus(token string) (BgpPeerStatusListResultPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetBgpPeerStatus(ctx context.Context, token string) (BgpPeerStatusListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetBgpPeerStatus", token, client.getBgpPeerStatusHandleError)
 	if err != nil {
-		return nil, err
+		return BgpPeerStatusListResultPollerResponse{}, err
 	}
-	return &bgpPeerStatusListResultPoller{
+	poller := &bgpPeerStatusListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return BgpPeerStatusListResultPollerResponse{}, err
+	}
+	result := BgpPeerStatusListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (BgpPeerStatusListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetBgpPeerStatus - The GetBgpPeerStatus operation retrieves the status of all BGP peers.
@@ -779,8 +863,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 		return GatewayRouteListResultPollerResponse{}, err
 	}
 	poller := &gatewayRouteListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GatewayRouteListResultResponse, error) {
@@ -791,15 +875,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 
 // ResumeGetLearnedRoutes creates a new GatewayRouteListResultPoller from the specified resume token.
 // token - The value must come from a previous call to GatewayRouteListResultPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetLearnedRoutes(token string) (GatewayRouteListResultPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetLearnedRoutes(ctx context.Context, token string) (GatewayRouteListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetLearnedRoutes", token, client.getLearnedRoutesHandleError)
 	if err != nil {
-		return nil, err
+		return GatewayRouteListResultPollerResponse{}, err
 	}
-	return &gatewayRouteListResultPoller{
+	poller := &gatewayRouteListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return GatewayRouteListResultPollerResponse{}, err
+	}
+	result := GatewayRouteListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (GatewayRouteListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetLearnedRoutes - This operation retrieves a list of routes the virtual network gateway has learned, including routes learned from BGP peers.
@@ -878,8 +974,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx con
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -890,15 +986,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx con
 
 // ResumeGetVPNProfilePackageURL creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetVPNProfilePackageURL(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetVPNProfilePackageURL(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVPNProfilePackageURL", token, client.getVPNProfilePackageURLHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetVPNProfilePackageURL - Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified resource group. The profile needs
@@ -978,8 +1086,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 		return VPNClientConnectionHealthDetailListResultPollerResponse{}, err
 	}
 	poller := &vpnClientConnectionHealthDetailListResultPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientConnectionHealthDetailListResultResponse, error) {
@@ -990,15 +1098,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 
 // ResumeGetVpnclientConnectionHealth creates a new VPNClientConnectionHealthDetailListResultPoller from the specified resume token.
 // token - The value must come from a previous call to VPNClientConnectionHealthDetailListResultPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientConnectionHealth(token string) (VPNClientConnectionHealthDetailListResultPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientConnectionHealth(ctx context.Context, token string) (VPNClientConnectionHealthDetailListResultPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientConnectionHealth", token, client.getVpnclientConnectionHealthHandleError)
 	if err != nil {
-		return nil, err
+		return VPNClientConnectionHealthDetailListResultPollerResponse{}, err
 	}
-	return &vpnClientConnectionHealthDetailListResultPoller{
+	poller := &vpnClientConnectionHealthDetailListResultPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNClientConnectionHealthDetailListResultPollerResponse{}, err
+	}
+	result := VPNClientConnectionHealthDetailListResultPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientConnectionHealthDetailListResultResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetVpnclientConnectionHealth - Get VPN client connection health detail per P2S client connection of the virtual network gateway in the specified resource
@@ -1079,8 +1199,8 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx
 		return VPNClientIPsecParametersPollerResponse{}, err
 	}
 	poller := &vpnClientIPSecParametersPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientIPsecParametersResponse, error) {
@@ -1091,15 +1211,27 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx
 
 // ResumeGetVpnclientIPSecParameters creates a new VPNClientIPsecParametersPoller from the specified resume token.
 // token - The value must come from a previous call to VPNClientIPsecParametersPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientIPSecParameters(token string) (VPNClientIPsecParametersPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeGetVpnclientIPSecParameters(ctx context.Context, token string) (VPNClientIPsecParametersPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.GetVpnclientIPSecParameters", token, client.getVpnclientIPSecParametersHandleError)
 	if err != nil {
-		return nil, err
+		return VPNClientIPsecParametersPollerResponse{}, err
 	}
-	return &vpnClientIPSecParametersPoller{
+	poller := &vpnClientIPSecParametersPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNClientIPsecParametersPollerResponse{}, err
+	}
+	result := VPNClientIPsecParametersPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientIPsecParametersResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // GetVpnclientIPSecParameters - The Get VpnclientIpsecParameters operation retrieves information about the vpnclient ipsec policy for P2S client of virtual
@@ -1297,8 +1429,8 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 		return VirtualNetworkGatewayPollerResponse{}, err
 	}
 	poller := &virtualNetworkGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
@@ -1309,15 +1441,27 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 
 // ResumeReset creates a new VirtualNetworkGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkGatewayPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeReset(token string) (VirtualNetworkGatewayPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeReset(ctx context.Context, token string) (VirtualNetworkGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.Reset", token, client.resetHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkGatewayPollerResponse{}, err
 	}
-	return &virtualNetworkGatewayPoller{
+	poller := &virtualNetworkGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkGatewayPollerResponse{}, err
+	}
+	result := VirtualNetworkGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reset - Resets the primary of the virtual network gateway in the specified resource group.
@@ -1398,8 +1542,8 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx con
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -1410,15 +1554,27 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx con
 
 // ResumeResetVPNClientSharedKey creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeResetVPNClientSharedKey(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeResetVPNClientSharedKey(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.ResetVPNClientSharedKey", token, client.resetVPNClientSharedKeyHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ResetVPNClientSharedKey - Resets the VPN client shared key of the virtual network gateway in the specified resource group.
@@ -1488,8 +1644,8 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx
 		return VPNClientIPsecParametersPollerResponse{}, err
 	}
 	poller := &vpnClientIPSecParametersPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientIPsecParametersResponse, error) {
@@ -1500,15 +1656,27 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx
 
 // ResumeSetVpnclientIPSecParameters creates a new VPNClientIPsecParametersPoller from the specified resume token.
 // token - The value must come from a previous call to VPNClientIPsecParametersPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeSetVpnclientIPSecParameters(token string) (VPNClientIPsecParametersPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeSetVpnclientIPSecParameters(ctx context.Context, token string) (VPNClientIPsecParametersPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.SetVpnclientIPSecParameters", token, client.setVpnclientIPSecParametersHandleError)
 	if err != nil {
-		return nil, err
+		return VPNClientIPsecParametersPollerResponse{}, err
 	}
-	return &vpnClientIPSecParametersPoller{
+	poller := &vpnClientIPSecParametersPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNClientIPsecParametersPollerResponse{}, err
+	}
+	result := VPNClientIPsecParametersPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNClientIPsecParametersResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // SetVpnclientIPSecParameters - The Set VpnclientIpsecParameters operation sets the vpnclient ipsec policy for P2S client of virtual network gateway in
@@ -1587,8 +1755,8 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -1599,15 +1767,27 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 
 // ResumeStartPacketCapture creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeStartPacketCapture(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeStartPacketCapture(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StartPacketCapture", token, client.startPacketCaptureHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StartPacketCapture - Starts packet capture on virtual network gateway in the specified resource group.
@@ -1688,8 +1868,8 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 		return StringPollerResponse{}, err
 	}
 	poller := &stringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
@@ -1700,15 +1880,27 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 
 // ResumeStopPacketCapture creates a new StringPoller from the specified resume token.
 // token - The value must come from a previous call to StringPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeStopPacketCapture(token string) (StringPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeStopPacketCapture(ctx context.Context, token string) (StringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.StopPacketCapture", token, client.stopPacketCaptureHandleError)
 	if err != nil {
-		return nil, err
+		return StringPollerResponse{}, err
 	}
-	return &stringPoller{
+	poller := &stringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return StringPollerResponse{}, err
+	}
+	result := StringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (StringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StopPacketCapture - Stops packet capture on virtual network gateway in the specified resource group.
@@ -1847,8 +2039,8 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 		return VirtualNetworkGatewayPollerResponse{}, err
 	}
 	poller := &virtualNetworkGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
@@ -1859,15 +2051,27 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 
 // ResumeUpdateTags creates a new VirtualNetworkGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkGatewayPoller.ResumeToken().
-func (client *VirtualNetworkGatewaysClient) ResumeUpdateTags(token string) (VirtualNetworkGatewayPoller, error) {
+func (client *VirtualNetworkGatewaysClient) ResumeUpdateTags(ctx context.Context, token string) (VirtualNetworkGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkGatewaysClient.UpdateTags", token, client.updateTagsHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkGatewayPollerResponse{}, err
 	}
-	return &virtualNetworkGatewayPoller{
+	poller := &virtualNetworkGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkGatewayPollerResponse{}, err
+	}
+	result := VirtualNetworkGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UpdateTags - Updates a virtual network gateway tags.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -44,8 +44,8 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 		return VirtualNetworkPeeringPollerResponse{}, err
 	}
 	poller := &virtualNetworkPeeringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkPeeringResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 
 // ResumeCreateOrUpdate creates a new VirtualNetworkPeeringPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkPeeringPoller.ResumeToken().
-func (client *VirtualNetworkPeeringsClient) ResumeCreateOrUpdate(token string) (VirtualNetworkPeeringPoller, error) {
+func (client *VirtualNetworkPeeringsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualNetworkPeeringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkPeeringPollerResponse{}, err
 	}
-	return &virtualNetworkPeeringPoller{
+	poller := &virtualNetworkPeeringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkPeeringPollerResponse{}, err
+	}
+	result := VirtualNetworkPeeringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkPeeringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a peering in the specified virtual network.
@@ -146,8 +158,8 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkPeeringsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkPeeringsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkPeeringsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified virtual network peering.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -106,8 +106,8 @@ func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, re
 		return VirtualNetworkPollerResponse{}, err
 	}
 	poller := &virtualNetworkPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkResponse, error) {
@@ -118,15 +118,27 @@ func (client *VirtualNetworksClient) BeginCreateOrUpdate(ctx context.Context, re
 
 // ResumeCreateOrUpdate creates a new VirtualNetworkPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkPoller.ResumeToken().
-func (client *VirtualNetworksClient) ResumeCreateOrUpdate(token string) (VirtualNetworkPoller, error) {
+func (client *VirtualNetworksClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualNetworkPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworksClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkPollerResponse{}, err
 	}
-	return &virtualNetworkPoller{
+	poller := &virtualNetworkPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkPollerResponse{}, err
+	}
+	result := VirtualNetworkPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a virtual network in the specified resource group.
@@ -204,8 +216,8 @@ func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGr
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -216,15 +228,27 @@ func (client *VirtualNetworksClient) BeginDelete(ctx context.Context, resourceGr
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworksClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualNetworksClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworksClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified virtual network.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -44,8 +44,8 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 		return VirtualNetworkTapPollerResponse{}, err
 	}
 	poller := &virtualNetworkTapPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkTapResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 
 // ResumeCreateOrUpdate creates a new VirtualNetworkTapPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualNetworkTapPoller.ResumeToken().
-func (client *VirtualNetworkTapsClient) ResumeCreateOrUpdate(token string) (VirtualNetworkTapPoller, error) {
+func (client *VirtualNetworkTapsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualNetworkTapPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkTapsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualNetworkTapPollerResponse{}, err
 	}
-	return &virtualNetworkTapPoller{
+	poller := &virtualNetworkTapPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualNetworkTapPollerResponse{}, err
+	}
+	result := VirtualNetworkTapPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualNetworkTapResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates a Virtual Network Tap.
@@ -142,8 +154,8 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualNetworkTapsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualNetworkTapsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualNetworkTapsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified virtual network tap.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -44,8 +44,8 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 		return VirtualRouterPeeringPollerResponse{}, err
 	}
 	poller := &virtualRouterPeeringPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualRouterPeeringResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 
 // ResumeCreateOrUpdate creates a new VirtualRouterPeeringPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualRouterPeeringPoller.ResumeToken().
-func (client *VirtualRouterPeeringsClient) ResumeCreateOrUpdate(token string) (VirtualRouterPeeringPoller, error) {
+func (client *VirtualRouterPeeringsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualRouterPeeringPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualRouterPeeringsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualRouterPeeringPollerResponse{}, err
 	}
-	return &virtualRouterPeeringPoller{
+	poller := &virtualRouterPeeringPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualRouterPeeringPollerResponse{}, err
+	}
+	result := VirtualRouterPeeringPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualRouterPeeringResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router Peering.
@@ -146,8 +158,8 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualRouterPeeringsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualRouterPeeringsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualRouterPeeringsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified peering from a Virtual Router.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -44,8 +44,8 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 		return VirtualRouterPollerResponse{}, err
 	}
 	poller := &virtualRouterPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualRouterResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 
 // ResumeCreateOrUpdate creates a new VirtualRouterPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualRouterPoller.ResumeToken().
-func (client *VirtualRoutersClient) ResumeCreateOrUpdate(token string) (VirtualRouterPoller, error) {
+func (client *VirtualRoutersClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualRouterPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualRoutersClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualRouterPollerResponse{}, err
 	}
-	return &virtualRouterPoller{
+	poller := &virtualRouterPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualRouterPollerResponse{}, err
+	}
+	result := VirtualRouterPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualRouterResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates or updates the specified Virtual Router.
@@ -142,8 +154,8 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualRoutersClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualRoutersClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualRoutersClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes the specified Virtual Router.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -44,8 +44,8 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 		return VirtualWANPollerResponse{}, err
 	}
 	poller := &virtualWANPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualWANResponse, error) {
@@ -56,15 +56,27 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 
 // ResumeCreateOrUpdate creates a new VirtualWANPoller from the specified resume token.
 // token - The value must come from a previous call to VirtualWANPoller.ResumeToken().
-func (client *VirtualWansClient) ResumeCreateOrUpdate(token string) (VirtualWANPoller, error) {
+func (client *VirtualWansClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VirtualWANPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualWansClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VirtualWANPollerResponse{}, err
 	}
-	return &virtualWANPoller{
+	poller := &virtualWANPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VirtualWANPollerResponse{}, err
+	}
+	result := VirtualWANPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VirtualWANResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a VirtualWAN resource if it doesn't exist else updates the existing VirtualWAN.
@@ -142,8 +154,8 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VirtualWansClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VirtualWansClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VirtualWansClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VirtualWAN.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -44,8 +44,8 @@ func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 		return VPNConnectionPollerResponse{}, err
 	}
 	poller := &vpnConnectionPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNConnectionResponse, error) {
@@ -56,15 +56,27 @@ func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 
 // ResumeCreateOrUpdate creates a new VPNConnectionPoller from the specified resume token.
 // token - The value must come from a previous call to VPNConnectionPoller.ResumeToken().
-func (client *VPNConnectionsClient) ResumeCreateOrUpdate(token string) (VPNConnectionPoller, error) {
+func (client *VPNConnectionsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VPNConnectionPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNConnectionsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VPNConnectionPollerResponse{}, err
 	}
-	return &vpnConnectionPoller{
+	poller := &vpnConnectionPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNConnectionPollerResponse{}, err
+	}
+	result := VPNConnectionPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNConnectionResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a vpn connection to a scalable vpn gateway if it doesn't exist else updates the existing connection.
@@ -146,8 +158,8 @@ func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -158,15 +170,27 @@ func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VPNConnectionsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VPNConnectionsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNConnectionsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a vpn connection.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -44,8 +44,8 @@ func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 		return VPNGatewayPollerResponse{}, err
 	}
 	poller := &vpnGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNGatewayResponse, error) {
@@ -56,15 +56,27 @@ func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 
 // ResumeCreateOrUpdate creates a new VPNGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to VPNGatewayPoller.ResumeToken().
-func (client *VPNGatewaysClient) ResumeCreateOrUpdate(token string) (VPNGatewayPoller, error) {
+func (client *VPNGatewaysClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VPNGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNGatewaysClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VPNGatewayPollerResponse{}, err
 	}
-	return &vpnGatewayPoller{
+	poller := &vpnGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNGatewayPollerResponse{}, err
+	}
+	result := VPNGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a virtual wan vpn gateway if it doesn't exist else updates the existing gateway.
@@ -142,8 +154,8 @@ func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VPNGatewaysClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VPNGatewaysClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNGatewaysClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a virtual wan vpn gateway.
@@ -402,8 +426,8 @@ func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 		return VPNGatewayPollerResponse{}, err
 	}
 	poller := &vpnGatewayPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNGatewayResponse, error) {
@@ -414,15 +438,27 @@ func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 
 // ResumeReset creates a new VPNGatewayPoller from the specified resume token.
 // token - The value must come from a previous call to VPNGatewayPoller.ResumeToken().
-func (client *VPNGatewaysClient) ResumeReset(token string) (VPNGatewayPoller, error) {
+func (client *VPNGatewaysClient) ResumeReset(ctx context.Context, token string) (VPNGatewayPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNGatewaysClient.Reset", token, client.resetHandleError)
 	if err != nil {
-		return nil, err
+		return VPNGatewayPollerResponse{}, err
 	}
-	return &vpnGatewayPoller{
+	poller := &vpnGatewayPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNGatewayPollerResponse{}, err
+	}
+	result := VPNGatewayPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNGatewayResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Reset - Resets the primary of the vpn gateway in the specified resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -44,8 +44,8 @@ func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 		return VPNServerConfigurationPollerResponse{}, err
 	}
 	poller := &vpnServerConfigurationPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNServerConfigurationResponse, error) {
@@ -56,15 +56,27 @@ func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 
 // ResumeCreateOrUpdate creates a new VPNServerConfigurationPoller from the specified resume token.
 // token - The value must come from a previous call to VPNServerConfigurationPoller.ResumeToken().
-func (client *VPNServerConfigurationsClient) ResumeCreateOrUpdate(token string) (VPNServerConfigurationPoller, error) {
+func (client *VPNServerConfigurationsClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VPNServerConfigurationPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNServerConfigurationsClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VPNServerConfigurationPollerResponse{}, err
 	}
-	return &vpnServerConfigurationPoller{
+	poller := &vpnServerConfigurationPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNServerConfigurationPollerResponse{}, err
+	}
+	result := VPNServerConfigurationPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNServerConfigurationResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a VpnServerConfiguration resource if it doesn't exist else updates the existing VpnServerConfiguration.
@@ -142,8 +154,8 @@ func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, re
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VPNServerConfigurationsClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VPNServerConfigurationsClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNServerConfigurationsClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VpnServerConfiguration.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -44,8 +44,8 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 		return VPNServerConfigurationsResponsePollerResponse{}, err
 	}
 	poller := &vpnServerConfigurationsResponsePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNServerConfigurationsResponseResponse, error) {
@@ -56,15 +56,27 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 
 // ResumeList creates a new VPNServerConfigurationsResponsePoller from the specified resume token.
 // token - The value must come from a previous call to VPNServerConfigurationsResponsePoller.ResumeToken().
-func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) ResumeList(token string) (VPNServerConfigurationsResponsePoller, error) {
+func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) ResumeList(ctx context.Context, token string) (VPNServerConfigurationsResponsePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNServerConfigurationsAssociatedWithVirtualWanClient.List", token, client.listHandleError)
 	if err != nil {
-		return nil, err
+		return VPNServerConfigurationsResponsePollerResponse{}, err
 	}
-	return &vpnServerConfigurationsResponsePoller{
+	poller := &vpnServerConfigurationsResponsePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNServerConfigurationsResponsePollerResponse{}, err
+	}
+	result := VPNServerConfigurationsResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNServerConfigurationsResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // List - Gives the list of VpnServerConfigurations associated with Virtual Wan in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -44,8 +44,8 @@ func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		return VPNSitePollerResponse{}, err
 	}
 	poller := &vpnSitePoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNSiteResponse, error) {
@@ -56,15 +56,27 @@ func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 
 // ResumeCreateOrUpdate creates a new VPNSitePoller from the specified resume token.
 // token - The value must come from a previous call to VPNSitePoller.ResumeToken().
-func (client *VPNSitesClient) ResumeCreateOrUpdate(token string) (VPNSitePoller, error) {
+func (client *VPNSitesClient) ResumeCreateOrUpdate(ctx context.Context, token string) (VPNSitePollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNSitesClient.CreateOrUpdate", token, client.createOrUpdateHandleError)
 	if err != nil {
-		return nil, err
+		return VPNSitePollerResponse{}, err
 	}
-	return &vpnSitePoller{
+	poller := &vpnSitePoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return VPNSitePollerResponse{}, err
+	}
+	result := VPNSitePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (VPNSiteResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdate - Creates a VpnSite resource if it doesn't exist else updates the existing VpnSite.
@@ -142,8 +154,8 @@ func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -154,15 +166,27 @@ func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VPNSitesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *VPNSitesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNSitesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes a VpnSite.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
@@ -44,8 +44,8 @@ func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, re
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -56,15 +56,27 @@ func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, re
 
 // ResumeDownload creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *VPNSitesConfigurationClient) ResumeDownload(token string) (HTTPPoller, error) {
+func (client *VPNSitesConfigurationClient) ResumeDownload(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("VPNSitesConfigurationClient.Download", token, client.downloadHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Download - Gives the sas-url to download the configurations for vpn-sites in a resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -105,8 +105,8 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 		return HTTPPollerResponse{}, err
 	}
 	poller := &httpPoller{
-		pt:       pt,
 		pipeline: client.con.Pipeline(),
+		pt:       pt,
 	}
 	result.Poller = poller
 	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
@@ -117,15 +117,27 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 
 // ResumeDelete creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *WebApplicationFirewallPoliciesClient) ResumeDelete(token string) (HTTPPoller, error) {
+func (client *WebApplicationFirewallPoliciesClient) ResumeDelete(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := armcore.NewPollerFromResumeToken("WebApplicationFirewallPoliciesClient.Delete", token, client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pipeline: client.con.Pipeline(),
 		pt:       pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Deletes Policy.

--- a/test/storage/2020-06-12/azblob/go.mod
+++ b/test/storage/2020-06-12/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4

--- a/test/storage/2020-06-12/azblob/go.sum
+++ b/test/storage/2020-06-12/azblob/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -2,4 +2,4 @@ module azartifacts
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4

--- a/test/synapse/2019-06-01/azartifacts/go.sum
+++ b/test/synapse/2019-06-01/azartifacts/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -46,14 +46,26 @@ func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, d
 
 // ResumeCreateOrUpdateDataFlow creates a new DataFlowResourcePoller from the specified resume token.
 // token - The value must come from a previous call to DataFlowResourcePoller.ResumeToken().
-func (client *dataFlowClient) ResumeCreateOrUpdateDataFlow(token string) (DataFlowResourcePoller, error) {
+func (client *dataFlowClient) ResumeCreateOrUpdateDataFlow(ctx context.Context, token string) (DataFlowResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.con.Pipeline(), client.createOrUpdateDataFlowHandleError)
 	if err != nil {
-		return nil, err
+		return DataFlowResourcePollerResponse{}, err
 	}
-	return &dataFlowResourcePoller{
+	poller := &dataFlowResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DataFlowResourcePollerResponse{}, err
+	}
+	result := DataFlowResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DataFlowResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateDataFlow - Creates or updates a data flow.
@@ -137,14 +149,26 @@ func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowN
 
 // ResumeDeleteDataFlow creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *dataFlowClient) ResumeDeleteDataFlow(token string) (HTTPPoller, error) {
+func (client *dataFlowClient) ResumeDeleteDataFlow(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.con.Pipeline(), client.deleteDataFlowHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteDataFlow - Deletes a data flow.
@@ -321,14 +345,26 @@ func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowN
 
 // ResumeRenameDataFlow creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *dataFlowClient) ResumeRenameDataFlow(token string) (HTTPPoller, error) {
+func (client *dataFlowClient) ResumeRenameDataFlow(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.con.Pipeline(), client.renameDataFlowHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameDataFlow - Renames a dataflow.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type dataFlowClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateDataFlow - Creates or updates a data flow.
+func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowBeginCreateOrUpdateDataFlowOptions) (DataFlowResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateDataFlow(ctx, dataFlowName, dataFlow, options)
+	if err != nil {
+		return DataFlowResourcePollerResponse{}, err
+	}
+	result := DataFlowResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("dataFlowClient.CreateOrUpdateDataFlow", resp, client.con.Pipeline(), client.createOrUpdateDataFlowHandleError)
+	if err != nil {
+		return DataFlowResourcePollerResponse{}, err
+	}
+	poller := &dataFlowResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DataFlowResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateDataFlow creates a new DataFlowResourcePoller from the specified resume token.
+// token - The value must come from a previous call to DataFlowResourcePoller.ResumeToken().
+func (client *dataFlowClient) ResumeCreateOrUpdateDataFlow(token string) (DataFlowResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.CreateOrUpdateDataFlow", token, client.con.Pipeline(), client.createOrUpdateDataFlowHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &dataFlowResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateDataFlow - Creates or updates a data flow.
@@ -74,6 +110,41 @@ func (client *dataFlowClient) createOrUpdateDataFlowHandleError(resp *azcore.Res
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteDataFlow - Deletes a data flow.
+func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowBeginDeleteDataFlowOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteDataFlow(ctx, dataFlowName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("dataFlowClient.DeleteDataFlow", resp, client.con.Pipeline(), client.deleteDataFlowHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteDataFlow creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *dataFlowClient) ResumeDeleteDataFlow(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.DeleteDataFlow", token, client.con.Pipeline(), client.deleteDataFlowHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteDataFlow - Deletes a data flow.
@@ -223,6 +294,41 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceHandleError(resp *azcore.Re
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameDataFlow - Renames a dataflow.
+func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowBeginRenameDataFlowOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameDataFlow(ctx, dataFlowName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("dataFlowClient.RenameDataFlow", resp, client.con.Pipeline(), client.renameDataFlowHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameDataFlow creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *dataFlowClient) ResumeRenameDataFlow(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowClient.RenameDataFlow", token, client.con.Pipeline(), client.renameDataFlowHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameDataFlow - Renames a dataflow.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"time"
 )
 
 type dataFlowDebugSessionClient struct {
@@ -64,6 +65,41 @@ func (client *dataFlowDebugSessionClient) addDataFlowHandleError(resp *azcore.Re
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginCreateDataFlowDebugSession - Creates a data flow debug session.
+func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionBeginCreateDataFlowDebugSessionOptions) (CreateDataFlowDebugSessionResponsePollerResponse, error) {
+	resp, err := client.createDataFlowDebugSession(ctx, request, options)
+	if err != nil {
+		return CreateDataFlowDebugSessionResponsePollerResponse{}, err
+	}
+	result := CreateDataFlowDebugSessionResponsePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("dataFlowDebugSessionClient.CreateDataFlowDebugSession", resp, client.con.Pipeline(), client.createDataFlowDebugSessionHandleError)
+	if err != nil {
+		return CreateDataFlowDebugSessionResponsePollerResponse{}, err
+	}
+	poller := &createDataFlowDebugSessionResponsePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (CreateDataFlowDebugSessionResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateDataFlowDebugSession creates a new CreateDataFlowDebugSessionResponsePoller from the specified resume token.
+// token - The value must come from a previous call to CreateDataFlowDebugSessionResponsePoller.ResumeToken().
+func (client *dataFlowDebugSessionClient) ResumeCreateDataFlowDebugSession(token string) (CreateDataFlowDebugSessionResponsePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.con.Pipeline(), client.createDataFlowDebugSessionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &createDataFlowDebugSessionResponsePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateDataFlowDebugSession - Creates a data flow debug session.
@@ -153,6 +189,41 @@ func (client *dataFlowDebugSessionClient) deleteDataFlowDebugSessionHandleError(
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginExecuteCommand - Execute a data flow debug command.
+func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionBeginExecuteCommandOptions) (DataFlowDebugCommandResponsePollerResponse, error) {
+	resp, err := client.executeCommand(ctx, request, options)
+	if err != nil {
+		return DataFlowDebugCommandResponsePollerResponse{}, err
+	}
+	result := DataFlowDebugCommandResponsePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("dataFlowDebugSessionClient.ExecuteCommand", resp, client.con.Pipeline(), client.executeCommandHandleError)
+	if err != nil {
+		return DataFlowDebugCommandResponsePollerResponse{}, err
+	}
+	poller := &dataFlowDebugCommandResponsePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DataFlowDebugCommandResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeExecuteCommand creates a new DataFlowDebugCommandResponsePoller from the specified resume token.
+// token - The value must come from a previous call to DataFlowDebugCommandResponsePoller.ResumeToken().
+func (client *dataFlowDebugSessionClient) ResumeExecuteCommand(token string) (DataFlowDebugCommandResponsePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.con.Pipeline(), client.executeCommandHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &dataFlowDebugCommandResponsePoller{
+		pt: pt,
+	}, nil
 }
 
 // ExecuteCommand - Execute a data flow debug command.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -92,14 +92,26 @@ func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx co
 
 // ResumeCreateDataFlowDebugSession creates a new CreateDataFlowDebugSessionResponsePoller from the specified resume token.
 // token - The value must come from a previous call to CreateDataFlowDebugSessionResponsePoller.ResumeToken().
-func (client *dataFlowDebugSessionClient) ResumeCreateDataFlowDebugSession(token string) (CreateDataFlowDebugSessionResponsePoller, error) {
+func (client *dataFlowDebugSessionClient) ResumeCreateDataFlowDebugSession(ctx context.Context, token string) (CreateDataFlowDebugSessionResponsePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowDebugSessionClient.CreateDataFlowDebugSession", token, client.con.Pipeline(), client.createDataFlowDebugSessionHandleError)
 	if err != nil {
-		return nil, err
+		return CreateDataFlowDebugSessionResponsePollerResponse{}, err
 	}
-	return &createDataFlowDebugSessionResponsePoller{
+	poller := &createDataFlowDebugSessionResponsePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return CreateDataFlowDebugSessionResponsePollerResponse{}, err
+	}
+	result := CreateDataFlowDebugSessionResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (CreateDataFlowDebugSessionResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateDataFlowDebugSession - Creates a data flow debug session.
@@ -216,14 +228,26 @@ func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Contex
 
 // ResumeExecuteCommand creates a new DataFlowDebugCommandResponsePoller from the specified resume token.
 // token - The value must come from a previous call to DataFlowDebugCommandResponsePoller.ResumeToken().
-func (client *dataFlowDebugSessionClient) ResumeExecuteCommand(token string) (DataFlowDebugCommandResponsePoller, error) {
+func (client *dataFlowDebugSessionClient) ResumeExecuteCommand(ctx context.Context, token string) (DataFlowDebugCommandResponsePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("dataFlowDebugSessionClient.ExecuteCommand", token, client.con.Pipeline(), client.executeCommandHandleError)
 	if err != nil {
-		return nil, err
+		return DataFlowDebugCommandResponsePollerResponse{}, err
 	}
-	return &dataFlowDebugCommandResponsePoller{
+	poller := &dataFlowDebugCommandResponsePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DataFlowDebugCommandResponsePollerResponse{}, err
+	}
+	result := DataFlowDebugCommandResponsePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DataFlowDebugCommandResponseResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ExecuteCommand - Execute a data flow debug command.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type datasetClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateDataset - Creates or updates a dataset.
+func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetBeginCreateOrUpdateDatasetOptions) (DatasetResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateDataset(ctx, datasetName, dataset, options)
+	if err != nil {
+		return DatasetResourcePollerResponse{}, err
+	}
+	result := DatasetResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("datasetClient.CreateOrUpdateDataset", resp, client.con.Pipeline(), client.createOrUpdateDatasetHandleError)
+	if err != nil {
+		return DatasetResourcePollerResponse{}, err
+	}
+	poller := &datasetResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DatasetResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateDataset creates a new DatasetResourcePoller from the specified resume token.
+// token - The value must come from a previous call to DatasetResourcePoller.ResumeToken().
+func (client *datasetClient) ResumeCreateOrUpdateDataset(token string) (DatasetResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.con.Pipeline(), client.createOrUpdateDatasetHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &datasetResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateDataset - Creates or updates a dataset.
@@ -74,6 +110,41 @@ func (client *datasetClient) createOrUpdateDatasetHandleError(resp *azcore.Respo
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteDataset - Deletes a dataset.
+func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName string, options *DatasetBeginDeleteDatasetOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteDataset(ctx, datasetName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("datasetClient.DeleteDataset", resp, client.con.Pipeline(), client.deleteDatasetHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteDataset creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *datasetClient) ResumeDeleteDataset(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.DeleteDataset", token, client.con.Pipeline(), client.deleteDatasetHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteDataset - Deletes a dataset.
@@ -223,6 +294,41 @@ func (client *datasetClient) getDatasetsByWorkspaceHandleError(resp *azcore.Resp
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameDataset - Renames a dataset.
+func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetBeginRenameDatasetOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameDataset(ctx, datasetName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("datasetClient.RenameDataset", resp, client.con.Pipeline(), client.renameDatasetHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameDataset creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *datasetClient) ResumeRenameDataset(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.RenameDataset", token, client.con.Pipeline(), client.renameDatasetHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameDataset - Renames a dataset.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -46,14 +46,26 @@ func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, dat
 
 // ResumeCreateOrUpdateDataset creates a new DatasetResourcePoller from the specified resume token.
 // token - The value must come from a previous call to DatasetResourcePoller.ResumeToken().
-func (client *datasetClient) ResumeCreateOrUpdateDataset(token string) (DatasetResourcePoller, error) {
+func (client *datasetClient) ResumeCreateOrUpdateDataset(ctx context.Context, token string) (DatasetResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.CreateOrUpdateDataset", token, client.con.Pipeline(), client.createOrUpdateDatasetHandleError)
 	if err != nil {
-		return nil, err
+		return DatasetResourcePollerResponse{}, err
 	}
-	return &datasetResourcePoller{
+	poller := &datasetResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return DatasetResourcePollerResponse{}, err
+	}
+	result := DatasetResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (DatasetResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateDataset - Creates or updates a dataset.
@@ -137,14 +149,26 @@ func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName
 
 // ResumeDeleteDataset creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *datasetClient) ResumeDeleteDataset(token string) (HTTPPoller, error) {
+func (client *datasetClient) ResumeDeleteDataset(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.DeleteDataset", token, client.con.Pipeline(), client.deleteDatasetHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteDataset - Deletes a dataset.
@@ -321,14 +345,26 @@ func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName
 
 // ResumeRenameDataset creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *datasetClient) ResumeRenameDataset(token string) (HTTPPoller, error) {
+func (client *datasetClient) ResumeRenameDataset(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("datasetClient.RenameDataset", token, client.con.Pipeline(), client.renameDatasetHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameDataset - Renames a dataset.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -96,14 +96,26 @@ func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string
 
 // ResumeCreate creates a new LibraryResourceInfoPoller from the specified resume token.
 // token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
-func (client *libraryClient) ResumeCreate(token string) (LibraryResourceInfoPoller, error) {
+func (client *libraryClient) ResumeCreate(ctx context.Context, token string) (LibraryResourceInfoPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Create", token, client.con.Pipeline(), client.createHandleError)
 	if err != nil {
-		return nil, err
+		return LibraryResourceInfoPollerResponse{}, err
 	}
-	return &libraryResourceInfoPoller{
+	poller := &libraryResourceInfoPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Create - Creates a library with the library name.
@@ -184,14 +196,26 @@ func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string
 
 // ResumeDelete creates a new LibraryResourceInfoPoller from the specified resume token.
 // token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
-func (client *libraryClient) ResumeDelete(token string) (LibraryResourceInfoPoller, error) {
+func (client *libraryClient) ResumeDelete(ctx context.Context, token string) (LibraryResourceInfoPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Delete", token, client.con.Pipeline(), client.deleteHandleError)
 	if err != nil {
-		return nil, err
+		return LibraryResourceInfoPollerResponse{}, err
 	}
-	return &libraryResourceInfoPoller{
+	poller := &libraryResourceInfoPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Delete - Delete Library
@@ -272,14 +296,26 @@ func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string,
 
 // ResumeFlush creates a new LibraryResourceInfoPoller from the specified resume token.
 // token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
-func (client *libraryClient) ResumeFlush(token string) (LibraryResourceInfoPoller, error) {
+func (client *libraryClient) ResumeFlush(ctx context.Context, token string) (LibraryResourceInfoPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Flush", token, client.con.Pipeline(), client.flushHandleError)
 	if err != nil {
-		return nil, err
+		return LibraryResourceInfoPollerResponse{}, err
 	}
-	return &libraryResourceInfoPoller{
+	poller := &libraryResourceInfoPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // Flush - Flush Library

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type libraryClient struct {
@@ -68,6 +69,41 @@ func (client *libraryClient) appendHandleError(resp *azcore.Response) error {
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginCreate - Creates a library with the library name.
+func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string, options *LibraryBeginCreateOptions) (LibraryResourceInfoPollerResponse, error) {
+	resp, err := client.create(ctx, libraryName, options)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("libraryClient.Create", resp, client.con.Pipeline(), client.createHandleError)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	poller := &libraryResourceInfoPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreate creates a new LibraryResourceInfoPoller from the specified resume token.
+// token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
+func (client *libraryClient) ResumeCreate(token string) (LibraryResourceInfoPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Create", token, client.con.Pipeline(), client.createHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &libraryResourceInfoPoller{
+		pt: pt,
+	}, nil
 }
 
 // Create - Creates a library with the library name.
@@ -123,6 +159,41 @@ func (client *libraryClient) createHandleError(resp *azcore.Response) error {
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
+// BeginDelete - Delete Library
+func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string, options *LibraryBeginDeleteOptions) (LibraryResourceInfoPollerResponse, error) {
+	resp, err := client.deleteOperation(ctx, libraryName, options)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("libraryClient.Delete", resp, client.con.Pipeline(), client.deleteHandleError)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	poller := &libraryResourceInfoPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDelete creates a new LibraryResourceInfoPoller from the specified resume token.
+// token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
+func (client *libraryClient) ResumeDelete(token string) (LibraryResourceInfoPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Delete", token, client.con.Pipeline(), client.deleteHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &libraryResourceInfoPoller{
+		pt: pt,
+	}, nil
+}
+
 // Delete - Delete Library
 func (client *libraryClient) deleteOperation(ctx context.Context, libraryName string, options *LibraryBeginDeleteOptions) (*azcore.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, libraryName, options)
@@ -174,6 +245,41 @@ func (client *libraryClient) deleteHandleError(resp *azcore.Response) error {
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginFlush - Flush Library
+func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string, options *LibraryBeginFlushOptions) (LibraryResourceInfoPollerResponse, error) {
+	resp, err := client.flush(ctx, libraryName, options)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	result := LibraryResourceInfoPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("libraryClient.Flush", resp, client.con.Pipeline(), client.flushHandleError)
+	if err != nil {
+		return LibraryResourceInfoPollerResponse{}, err
+	}
+	poller := &libraryResourceInfoPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LibraryResourceInfoResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeFlush creates a new LibraryResourceInfoPoller from the specified resume token.
+// token - The value must come from a previous call to LibraryResourceInfoPoller.ResumeToken().
+func (client *libraryClient) ResumeFlush(token string) (LibraryResourceInfoPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("libraryClient.Flush", token, client.con.Pipeline(), client.flushHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &libraryResourceInfoPoller{
+		pt: pt,
+	}, nil
 }
 
 // Flush - Flush Library

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type linkedServiceClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateLinkedService - Creates or updates a linked service.
+func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceBeginCreateOrUpdateLinkedServiceOptions) (LinkedServiceResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateLinkedService(ctx, linkedServiceName, linkedService, options)
+	if err != nil {
+		return LinkedServiceResourcePollerResponse{}, err
+	}
+	result := LinkedServiceResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("linkedServiceClient.CreateOrUpdateLinkedService", resp, client.con.Pipeline(), client.createOrUpdateLinkedServiceHandleError)
+	if err != nil {
+		return LinkedServiceResourcePollerResponse{}, err
+	}
+	poller := &linkedServiceResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LinkedServiceResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateLinkedService creates a new LinkedServiceResourcePoller from the specified resume token.
+// token - The value must come from a previous call to LinkedServiceResourcePoller.ResumeToken().
+func (client *linkedServiceClient) ResumeCreateOrUpdateLinkedService(token string) (LinkedServiceResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.con.Pipeline(), client.createOrUpdateLinkedServiceHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &linkedServiceResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateLinkedService - Creates or updates a linked service.
@@ -74,6 +110,41 @@ func (client *linkedServiceClient) createOrUpdateLinkedServiceHandleError(resp *
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteLinkedService - Deletes a linked service.
+func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceBeginDeleteLinkedServiceOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteLinkedService(ctx, linkedServiceName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("linkedServiceClient.DeleteLinkedService", resp, client.con.Pipeline(), client.deleteLinkedServiceHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteLinkedService creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *linkedServiceClient) ResumeDeleteLinkedService(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.con.Pipeline(), client.deleteLinkedServiceHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteLinkedService - Deletes a linked service.
@@ -223,6 +294,41 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleError(resp 
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameLinkedService - Renames a linked service.
+func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceBeginRenameLinkedServiceOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameLinkedService(ctx, linkedServiceName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("linkedServiceClient.RenameLinkedService", resp, client.con.Pipeline(), client.renameLinkedServiceHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameLinkedService creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *linkedServiceClient) ResumeRenameLinkedService(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.con.Pipeline(), client.renameLinkedServiceHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameLinkedService - Renames a linked service.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -46,14 +46,26 @@ func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.
 
 // ResumeCreateOrUpdateLinkedService creates a new LinkedServiceResourcePoller from the specified resume token.
 // token - The value must come from a previous call to LinkedServiceResourcePoller.ResumeToken().
-func (client *linkedServiceClient) ResumeCreateOrUpdateLinkedService(token string) (LinkedServiceResourcePoller, error) {
+func (client *linkedServiceClient) ResumeCreateOrUpdateLinkedService(ctx context.Context, token string) (LinkedServiceResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.CreateOrUpdateLinkedService", token, client.con.Pipeline(), client.createOrUpdateLinkedServiceHandleError)
 	if err != nil {
-		return nil, err
+		return LinkedServiceResourcePollerResponse{}, err
 	}
-	return &linkedServiceResourcePoller{
+	poller := &linkedServiceResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return LinkedServiceResourcePollerResponse{}, err
+	}
+	result := LinkedServiceResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (LinkedServiceResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateLinkedService - Creates or updates a linked service.
@@ -137,14 +149,26 @@ func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context,
 
 // ResumeDeleteLinkedService creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *linkedServiceClient) ResumeDeleteLinkedService(token string) (HTTPPoller, error) {
+func (client *linkedServiceClient) ResumeDeleteLinkedService(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.DeleteLinkedService", token, client.con.Pipeline(), client.deleteLinkedServiceHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteLinkedService - Deletes a linked service.
@@ -321,14 +345,26 @@ func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context,
 
 // ResumeRenameLinkedService creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *linkedServiceClient) ResumeRenameLinkedService(token string) (HTTPPoller, error) {
+func (client *linkedServiceClient) ResumeRenameLinkedService(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("linkedServiceClient.RenameLinkedService", token, client.con.Pipeline(), client.renameLinkedServiceHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameLinkedService - Renames a linked service.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -29658,9 +29657,12 @@ func (z *ZohoSource) UnmarshalJSON(data []byte) error {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -29662,7 +29663,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -29660,8 +29660,7 @@ func (z *ZohoSource) UnmarshalJSON(data []byte) error {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type notebookClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateNotebook - Creates or updates a Note Book.
+func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookBeginCreateOrUpdateNotebookOptions) (NotebookResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateNotebook(ctx, notebookName, notebook, options)
+	if err != nil {
+		return NotebookResourcePollerResponse{}, err
+	}
+	result := NotebookResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("notebookClient.CreateOrUpdateNotebook", resp, client.con.Pipeline(), client.createOrUpdateNotebookHandleError)
+	if err != nil {
+		return NotebookResourcePollerResponse{}, err
+	}
+	poller := &notebookResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NotebookResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateNotebook creates a new NotebookResourcePoller from the specified resume token.
+// token - The value must come from a previous call to NotebookResourcePoller.ResumeToken().
+func (client *notebookClient) ResumeCreateOrUpdateNotebook(token string) (NotebookResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.con.Pipeline(), client.createOrUpdateNotebookHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &notebookResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateNotebook - Creates or updates a Note Book.
@@ -74,6 +110,41 @@ func (client *notebookClient) createOrUpdateNotebookHandleError(resp *azcore.Res
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteNotebook - Deletes a Note book.
+func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookName string, options *NotebookBeginDeleteNotebookOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteNotebook(ctx, notebookName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("notebookClient.DeleteNotebook", resp, client.con.Pipeline(), client.deleteNotebookHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteNotebook creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *notebookClient) ResumeDeleteNotebook(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.con.Pipeline(), client.deleteNotebookHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteNotebook - Deletes a Note book.
@@ -272,6 +343,41 @@ func (client *notebookClient) getNotebooksByWorkspaceHandleError(resp *azcore.Re
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameNotebook - Renames a notebook.
+func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookBeginRenameNotebookOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameNotebook(ctx, notebookName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("notebookClient.RenameNotebook", resp, client.con.Pipeline(), client.renameNotebookHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameNotebook creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *notebookClient) ResumeRenameNotebook(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.RenameNotebook", token, client.con.Pipeline(), client.renameNotebookHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameNotebook - Renames a notebook.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -46,14 +46,26 @@ func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, n
 
 // ResumeCreateOrUpdateNotebook creates a new NotebookResourcePoller from the specified resume token.
 // token - The value must come from a previous call to NotebookResourcePoller.ResumeToken().
-func (client *notebookClient) ResumeCreateOrUpdateNotebook(token string) (NotebookResourcePoller, error) {
+func (client *notebookClient) ResumeCreateOrUpdateNotebook(ctx context.Context, token string) (NotebookResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.CreateOrUpdateNotebook", token, client.con.Pipeline(), client.createOrUpdateNotebookHandleError)
 	if err != nil {
-		return nil, err
+		return NotebookResourcePollerResponse{}, err
 	}
-	return &notebookResourcePoller{
+	poller := &notebookResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return NotebookResourcePollerResponse{}, err
+	}
+	result := NotebookResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (NotebookResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateNotebook - Creates or updates a Note Book.
@@ -137,14 +149,26 @@ func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookN
 
 // ResumeDeleteNotebook creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *notebookClient) ResumeDeleteNotebook(token string) (HTTPPoller, error) {
+func (client *notebookClient) ResumeDeleteNotebook(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.DeleteNotebook", token, client.con.Pipeline(), client.deleteNotebookHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteNotebook - Deletes a Note book.
@@ -370,14 +394,26 @@ func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookN
 
 // ResumeRenameNotebook creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *notebookClient) ResumeRenameNotebook(token string) (HTTPPoller, error) {
+func (client *notebookClient) ResumeRenameNotebook(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("notebookClient.RenameNotebook", token, client.con.Pipeline(), client.renameNotebookHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameNotebook - Renames a notebook.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -15,10 +15,46 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type pipelineClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdatePipeline - Creates or updates a pipeline.
+func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineBeginCreateOrUpdatePipelineOptions) (PipelineResourcePollerResponse, error) {
+	resp, err := client.createOrUpdatePipeline(ctx, pipelineName, pipeline, options)
+	if err != nil {
+		return PipelineResourcePollerResponse{}, err
+	}
+	result := PipelineResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("pipelineClient.CreateOrUpdatePipeline", resp, client.con.Pipeline(), client.createOrUpdatePipelineHandleError)
+	if err != nil {
+		return PipelineResourcePollerResponse{}, err
+	}
+	poller := &pipelineResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PipelineResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdatePipeline creates a new PipelineResourcePoller from the specified resume token.
+// token - The value must come from a previous call to PipelineResourcePoller.ResumeToken().
+func (client *pipelineClient) ResumeCreateOrUpdatePipeline(token string) (PipelineResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.con.Pipeline(), client.createOrUpdatePipelineHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &pipelineResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdatePipeline - Creates or updates a pipeline.
@@ -140,6 +176,41 @@ func (client *pipelineClient) createPipelineRunHandleError(resp *azcore.Response
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeletePipeline - Deletes a pipeline.
+func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineName string, options *PipelineBeginDeletePipelineOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deletePipeline(ctx, pipelineName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("pipelineClient.DeletePipeline", resp, client.con.Pipeline(), client.deletePipelineHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeletePipeline creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *pipelineClient) ResumeDeletePipeline(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.con.Pipeline(), client.deletePipelineHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeletePipeline - Deletes a pipeline.
@@ -289,6 +360,41 @@ func (client *pipelineClient) getPipelinesByWorkspaceHandleError(resp *azcore.Re
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenamePipeline - Renames a pipeline.
+func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineBeginRenamePipelineOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renamePipeline(ctx, pipelineName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("pipelineClient.RenamePipeline", resp, client.con.Pipeline(), client.renamePipelineHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenamePipeline creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *pipelineClient) ResumeRenamePipeline(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.con.Pipeline(), client.renamePipelineHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenamePipeline - Renames a pipeline.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -47,14 +47,26 @@ func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, p
 
 // ResumeCreateOrUpdatePipeline creates a new PipelineResourcePoller from the specified resume token.
 // token - The value must come from a previous call to PipelineResourcePoller.ResumeToken().
-func (client *pipelineClient) ResumeCreateOrUpdatePipeline(token string) (PipelineResourcePoller, error) {
+func (client *pipelineClient) ResumeCreateOrUpdatePipeline(ctx context.Context, token string) (PipelineResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.CreateOrUpdatePipeline", token, client.con.Pipeline(), client.createOrUpdatePipelineHandleError)
 	if err != nil {
-		return nil, err
+		return PipelineResourcePollerResponse{}, err
 	}
-	return &pipelineResourcePoller{
+	poller := &pipelineResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return PipelineResourcePollerResponse{}, err
+	}
+	result := PipelineResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (PipelineResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdatePipeline - Creates or updates a pipeline.
@@ -203,14 +215,26 @@ func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineN
 
 // ResumeDeletePipeline creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *pipelineClient) ResumeDeletePipeline(token string) (HTTPPoller, error) {
+func (client *pipelineClient) ResumeDeletePipeline(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.DeletePipeline", token, client.con.Pipeline(), client.deletePipelineHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeletePipeline - Deletes a pipeline.
@@ -387,14 +411,26 @@ func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineN
 
 // ResumeRenamePipeline creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *pipelineClient) ResumeRenamePipeline(token string) (HTTPPoller, error) {
+func (client *pipelineClient) ResumeRenamePipeline(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("pipelineClient.RenamePipeline", token, client.con.Pipeline(), client.renamePipelineHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenamePipeline - Renames a pipeline.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"time"
 )
 
 // CreateDataFlowDebugSessionResponsePoller provides polling facilities until the operation reaches a terminal state.
@@ -22,6 +23,42 @@ type CreateDataFlowDebugSessionResponsePoller interface {
 	FinalResponse(ctx context.Context) (CreateDataFlowDebugSessionResponseResponse, error)
 }
 
+type createDataFlowDebugSessionResponsePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *createDataFlowDebugSessionResponsePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *createDataFlowDebugSessionResponsePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *createDataFlowDebugSessionResponsePoller) FinalResponse(ctx context.Context) (CreateDataFlowDebugSessionResponseResponse, error) {
+	respType := CreateDataFlowDebugSessionResponseResponse{CreateDataFlowDebugSessionResponse: &CreateDataFlowDebugSessionResponse{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.CreateDataFlowDebugSessionResponse)
+	if err != nil {
+		return CreateDataFlowDebugSessionResponseResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *createDataFlowDebugSessionResponsePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *createDataFlowDebugSessionResponsePoller) pollUntilDone(ctx context.Context, freq time.Duration) (CreateDataFlowDebugSessionResponseResponse, error) {
+	respType := CreateDataFlowDebugSessionResponseResponse{CreateDataFlowDebugSessionResponse: &CreateDataFlowDebugSessionResponse{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.CreateDataFlowDebugSessionResponse)
+	if err != nil {
+		return CreateDataFlowDebugSessionResponseResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // DataFlowDebugCommandResponsePoller provides polling facilities until the operation reaches a terminal state.
 type DataFlowDebugCommandResponsePoller interface {
 	azcore.Poller
@@ -29,6 +66,42 @@ type DataFlowDebugCommandResponsePoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final DataFlowDebugCommandResponseResponse will be returned.
 	FinalResponse(ctx context.Context) (DataFlowDebugCommandResponseResponse, error)
+}
+
+type dataFlowDebugCommandResponsePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *dataFlowDebugCommandResponsePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *dataFlowDebugCommandResponsePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *dataFlowDebugCommandResponsePoller) FinalResponse(ctx context.Context) (DataFlowDebugCommandResponseResponse, error) {
+	respType := DataFlowDebugCommandResponseResponse{DataFlowDebugCommandResponse: &DataFlowDebugCommandResponse{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.DataFlowDebugCommandResponse)
+	if err != nil {
+		return DataFlowDebugCommandResponseResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *dataFlowDebugCommandResponsePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *dataFlowDebugCommandResponsePoller) pollUntilDone(ctx context.Context, freq time.Duration) (DataFlowDebugCommandResponseResponse, error) {
+	respType := DataFlowDebugCommandResponseResponse{DataFlowDebugCommandResponse: &DataFlowDebugCommandResponse{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.DataFlowDebugCommandResponse)
+	if err != nil {
+		return DataFlowDebugCommandResponseResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // DataFlowResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -40,6 +113,42 @@ type DataFlowResourcePoller interface {
 	FinalResponse(ctx context.Context) (DataFlowResourceResponse, error)
 }
 
+type dataFlowResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *dataFlowResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *dataFlowResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *dataFlowResourcePoller) FinalResponse(ctx context.Context) (DataFlowResourceResponse, error) {
+	respType := DataFlowResourceResponse{DataFlowResource: &DataFlowResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.DataFlowResource)
+	if err != nil {
+		return DataFlowResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *dataFlowResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *dataFlowResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (DataFlowResourceResponse, error) {
+	respType := DataFlowResourceResponse{DataFlowResource: &DataFlowResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.DataFlowResource)
+	if err != nil {
+		return DataFlowResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // DatasetResourcePoller provides polling facilities until the operation reaches a terminal state.
 type DatasetResourcePoller interface {
 	azcore.Poller
@@ -47,6 +156,42 @@ type DatasetResourcePoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final DatasetResourceResponse will be returned.
 	FinalResponse(ctx context.Context) (DatasetResourceResponse, error)
+}
+
+type datasetResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *datasetResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *datasetResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *datasetResourcePoller) FinalResponse(ctx context.Context) (DatasetResourceResponse, error) {
+	respType := DatasetResourceResponse{DatasetResource: &DatasetResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.DatasetResource)
+	if err != nil {
+		return DatasetResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *datasetResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *datasetResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (DatasetResourceResponse, error) {
+	respType := DatasetResourceResponse{DatasetResource: &DatasetResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.DatasetResource)
+	if err != nil {
+		return DatasetResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // HTTPPoller provides polling facilities until the operation reaches a terminal state.
@@ -58,6 +203,30 @@ type HTTPPoller interface {
 	FinalResponse(ctx context.Context) (*http.Response, error)
 }
 
+type httpPoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *httpPoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *httpPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *httpPoller) FinalResponse(ctx context.Context) (*http.Response, error) {
+	return p.pt.FinalResponse(ctx, nil)
+}
+
+func (p *httpPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *httpPoller) pollUntilDone(ctx context.Context, freq time.Duration) (*http.Response, error) {
+	return p.pt.PollUntilDone(ctx, freq, nil)
+}
+
 // LibraryResourceInfoPoller provides polling facilities until the operation reaches a terminal state.
 type LibraryResourceInfoPoller interface {
 	azcore.Poller
@@ -65,6 +234,42 @@ type LibraryResourceInfoPoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final LibraryResourceInfoResponse will be returned.
 	FinalResponse(ctx context.Context) (LibraryResourceInfoResponse, error)
+}
+
+type libraryResourceInfoPoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *libraryResourceInfoPoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *libraryResourceInfoPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *libraryResourceInfoPoller) FinalResponse(ctx context.Context) (LibraryResourceInfoResponse, error) {
+	respType := LibraryResourceInfoResponse{LibraryResourceInfo: &LibraryResourceInfo{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.LibraryResourceInfo)
+	if err != nil {
+		return LibraryResourceInfoResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *libraryResourceInfoPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *libraryResourceInfoPoller) pollUntilDone(ctx context.Context, freq time.Duration) (LibraryResourceInfoResponse, error) {
+	respType := LibraryResourceInfoResponse{LibraryResourceInfo: &LibraryResourceInfo{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.LibraryResourceInfo)
+	if err != nil {
+		return LibraryResourceInfoResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // LinkedServiceResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -76,6 +281,42 @@ type LinkedServiceResourcePoller interface {
 	FinalResponse(ctx context.Context) (LinkedServiceResourceResponse, error)
 }
 
+type linkedServiceResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *linkedServiceResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *linkedServiceResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *linkedServiceResourcePoller) FinalResponse(ctx context.Context) (LinkedServiceResourceResponse, error) {
+	respType := LinkedServiceResourceResponse{LinkedServiceResource: &LinkedServiceResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.LinkedServiceResource)
+	if err != nil {
+		return LinkedServiceResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *linkedServiceResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *linkedServiceResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (LinkedServiceResourceResponse, error) {
+	respType := LinkedServiceResourceResponse{LinkedServiceResource: &LinkedServiceResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.LinkedServiceResource)
+	if err != nil {
+		return LinkedServiceResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // NotebookResourcePoller provides polling facilities until the operation reaches a terminal state.
 type NotebookResourcePoller interface {
 	azcore.Poller
@@ -83,6 +324,42 @@ type NotebookResourcePoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final NotebookResourceResponse will be returned.
 	FinalResponse(ctx context.Context) (NotebookResourceResponse, error)
+}
+
+type notebookResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *notebookResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *notebookResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *notebookResourcePoller) FinalResponse(ctx context.Context) (NotebookResourceResponse, error) {
+	respType := NotebookResourceResponse{NotebookResource: &NotebookResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.NotebookResource)
+	if err != nil {
+		return NotebookResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *notebookResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *notebookResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (NotebookResourceResponse, error) {
+	respType := NotebookResourceResponse{NotebookResource: &NotebookResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.NotebookResource)
+	if err != nil {
+		return NotebookResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // PipelineResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -94,6 +371,42 @@ type PipelineResourcePoller interface {
 	FinalResponse(ctx context.Context) (PipelineResourceResponse, error)
 }
 
+type pipelineResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *pipelineResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *pipelineResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *pipelineResourcePoller) FinalResponse(ctx context.Context) (PipelineResourceResponse, error) {
+	respType := PipelineResourceResponse{PipelineResource: &PipelineResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.PipelineResource)
+	if err != nil {
+		return PipelineResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *pipelineResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *pipelineResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (PipelineResourceResponse, error) {
+	respType := PipelineResourceResponse{PipelineResource: &PipelineResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.PipelineResource)
+	if err != nil {
+		return PipelineResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // SQLScriptResourcePoller provides polling facilities until the operation reaches a terminal state.
 type SQLScriptResourcePoller interface {
 	azcore.Poller
@@ -101,6 +414,42 @@ type SQLScriptResourcePoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final SQLScriptResourceResponse will be returned.
 	FinalResponse(ctx context.Context) (SQLScriptResourceResponse, error)
+}
+
+type sqlScriptResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *sqlScriptResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *sqlScriptResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *sqlScriptResourcePoller) FinalResponse(ctx context.Context) (SQLScriptResourceResponse, error) {
+	respType := SQLScriptResourceResponse{SQLScriptResource: &SQLScriptResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.SQLScriptResource)
+	if err != nil {
+		return SQLScriptResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *sqlScriptResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *sqlScriptResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (SQLScriptResourceResponse, error) {
+	respType := SQLScriptResourceResponse{SQLScriptResource: &SQLScriptResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.SQLScriptResource)
+	if err != nil {
+		return SQLScriptResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // SparkBatchJobPoller provides polling facilities until the operation reaches a terminal state.
@@ -112,6 +461,42 @@ type SparkBatchJobPoller interface {
 	FinalResponse(ctx context.Context) (SparkBatchJobResponse, error)
 }
 
+type sparkBatchJobPoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *sparkBatchJobPoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *sparkBatchJobPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *sparkBatchJobPoller) FinalResponse(ctx context.Context) (SparkBatchJobResponse, error) {
+	respType := SparkBatchJobResponse{SparkBatchJob: &SparkBatchJob{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.SparkBatchJob)
+	if err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *sparkBatchJobPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *sparkBatchJobPoller) pollUntilDone(ctx context.Context, freq time.Duration) (SparkBatchJobResponse, error) {
+	respType := SparkBatchJobResponse{SparkBatchJob: &SparkBatchJob{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.SparkBatchJob)
+	if err != nil {
+		return SparkBatchJobResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // SparkJobDefinitionResourcePoller provides polling facilities until the operation reaches a terminal state.
 type SparkJobDefinitionResourcePoller interface {
 	azcore.Poller
@@ -119,6 +504,42 @@ type SparkJobDefinitionResourcePoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final SparkJobDefinitionResourceResponse will be returned.
 	FinalResponse(ctx context.Context) (SparkJobDefinitionResourceResponse, error)
+}
+
+type sparkJobDefinitionResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *sparkJobDefinitionResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *sparkJobDefinitionResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *sparkJobDefinitionResourcePoller) FinalResponse(ctx context.Context) (SparkJobDefinitionResourceResponse, error) {
+	respType := SparkJobDefinitionResourceResponse{SparkJobDefinitionResource: &SparkJobDefinitionResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.SparkJobDefinitionResource)
+	if err != nil {
+		return SparkJobDefinitionResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *sparkJobDefinitionResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *sparkJobDefinitionResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (SparkJobDefinitionResourceResponse, error) {
+	respType := SparkJobDefinitionResourceResponse{SparkJobDefinitionResource: &SparkJobDefinitionResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.SparkJobDefinitionResource)
+	if err != nil {
+		return SparkJobDefinitionResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }
 
 // TriggerResourcePoller provides polling facilities until the operation reaches a terminal state.
@@ -130,6 +551,42 @@ type TriggerResourcePoller interface {
 	FinalResponse(ctx context.Context) (TriggerResourceResponse, error)
 }
 
+type triggerResourcePoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *triggerResourcePoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *triggerResourcePoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *triggerResourcePoller) FinalResponse(ctx context.Context) (TriggerResourceResponse, error) {
+	respType := TriggerResourceResponse{TriggerResource: &TriggerResource{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.TriggerResource)
+	if err != nil {
+		return TriggerResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *triggerResourcePoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *triggerResourcePoller) pollUntilDone(ctx context.Context, freq time.Duration) (TriggerResourceResponse, error) {
+	respType := TriggerResourceResponse{TriggerResource: &TriggerResource{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.TriggerResource)
+	if err != nil {
+		return TriggerResourceResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
 // TriggerSubscriptionOperationStatusPoller provides polling facilities until the operation reaches a terminal state.
 type TriggerSubscriptionOperationStatusPoller interface {
 	azcore.Poller
@@ -137,4 +594,40 @@ type TriggerSubscriptionOperationStatusPoller interface {
 	// for the polling operation. If there is an error performing the final GET then an error is returned.
 	// If the final GET succeeded then the final TriggerSubscriptionOperationStatusResponse will be returned.
 	FinalResponse(ctx context.Context) (TriggerSubscriptionOperationStatusResponse, error)
+}
+
+type triggerSubscriptionOperationStatusPoller struct {
+	pt *azcore.LROPoller
+}
+
+func (p *triggerSubscriptionOperationStatusPoller) Done() bool {
+	return p.pt.Done()
+}
+
+func (p *triggerSubscriptionOperationStatusPoller) Poll(ctx context.Context) (*http.Response, error) {
+	return p.pt.Poll(ctx)
+}
+
+func (p *triggerSubscriptionOperationStatusPoller) FinalResponse(ctx context.Context) (TriggerSubscriptionOperationStatusResponse, error) {
+	respType := TriggerSubscriptionOperationStatusResponse{TriggerSubscriptionOperationStatus: &TriggerSubscriptionOperationStatus{}}
+	resp, err := p.pt.FinalResponse(ctx, respType.TriggerSubscriptionOperationStatus)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
+}
+
+func (p *triggerSubscriptionOperationStatusPoller) ResumeToken() (string, error) {
+	return p.pt.ResumeToken()
+}
+
+func (p *triggerSubscriptionOperationStatusPoller) pollUntilDone(ctx context.Context, freq time.Duration) (TriggerSubscriptionOperationStatusResponse, error) {
+	respType := TriggerSubscriptionOperationStatusResponse{TriggerSubscriptionOperationStatus: &TriggerSubscriptionOperationStatus{}}
+	resp, err := p.pt.PollUntilDone(ctx, freq, respType.TriggerSubscriptionOperationStatus)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusResponse{}, err
+	}
+	respType.RawResponse = resp
+	return respType, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type sparkJobDefinitionClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
+func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionBeginCreateOrUpdateSparkJobDefinitionOptions) (SparkJobDefinitionResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateSparkJobDefinition(ctx, sparkJobDefinitionName, sparkJobDefinition, options)
+	if err != nil {
+		return SparkJobDefinitionResourcePollerResponse{}, err
+	}
+	result := SparkJobDefinitionResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", resp, client.con.Pipeline(), client.createOrUpdateSparkJobDefinitionHandleError)
+	if err != nil {
+		return SparkJobDefinitionResourcePollerResponse{}, err
+	}
+	poller := &sparkJobDefinitionResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkJobDefinitionResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateSparkJobDefinition creates a new SparkJobDefinitionResourcePoller from the specified resume token.
+// token - The value must come from a previous call to SparkJobDefinitionResourcePoller.ResumeToken().
+func (client *sparkJobDefinitionClient) ResumeCreateOrUpdateSparkJobDefinition(token string) (SparkJobDefinitionResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.con.Pipeline(), client.createOrUpdateSparkJobDefinitionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &sparkJobDefinitionResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
@@ -76,6 +112,41 @@ func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionHandleEr
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
+// BeginDebugSparkJobDefinition - Debug the spark job definition.
+func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionBeginDebugSparkJobDefinitionOptions) (SparkBatchJobPollerResponse, error) {
+	resp, err := client.debugSparkJobDefinition(ctx, sparkJobDefinitionAzureResource, options)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	result := SparkBatchJobPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sparkJobDefinitionClient.DebugSparkJobDefinition", resp, client.con.Pipeline(), client.debugSparkJobDefinitionHandleError)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	poller := &sparkBatchJobPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkBatchJobResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDebugSparkJobDefinition creates a new SparkBatchJobPoller from the specified resume token.
+// token - The value must come from a previous call to SparkBatchJobPoller.ResumeToken().
+func (client *sparkJobDefinitionClient) ResumeDebugSparkJobDefinition(token string) (SparkBatchJobPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.con.Pipeline(), client.debugSparkJobDefinitionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &sparkBatchJobPoller{
+		pt: pt,
+	}, nil
+}
+
 // DebugSparkJobDefinition - Debug the spark job definition.
 func (client *sparkJobDefinitionClient) debugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionBeginDebugSparkJobDefinitionOptions) (*azcore.Response, error) {
 	req, err := client.debugSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionAzureResource, options)
@@ -125,6 +196,41 @@ func (client *sparkJobDefinitionClient) debugSparkJobDefinitionHandleError(resp 
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
+// BeginDeleteSparkJobDefinition - Deletes a Spark Job Definition.
+func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionBeginDeleteSparkJobDefinitionOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteSparkJobDefinition(ctx, sparkJobDefinitionName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sparkJobDefinitionClient.DeleteSparkJobDefinition", resp, client.con.Pipeline(), client.deleteSparkJobDefinitionHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteSparkJobDefinition creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *sparkJobDefinitionClient) ResumeDeleteSparkJobDefinition(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.con.Pipeline(), client.deleteSparkJobDefinitionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
+}
+
 // DeleteSparkJobDefinition - Deletes a Spark Job Definition.
 func (client *sparkJobDefinitionClient) deleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionBeginDeleteSparkJobDefinitionOptions) (*azcore.Response, error) {
 	req, err := client.deleteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
@@ -167,6 +273,41 @@ func (client *sparkJobDefinitionClient) deleteSparkJobDefinitionHandleError(resp
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginExecuteSparkJobDefinition - Executes the spark job definition.
+func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionBeginExecuteSparkJobDefinitionOptions) (SparkBatchJobPollerResponse, error) {
+	resp, err := client.executeSparkJobDefinition(ctx, sparkJobDefinitionName, options)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	result := SparkBatchJobPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sparkJobDefinitionClient.ExecuteSparkJobDefinition", resp, client.con.Pipeline(), client.executeSparkJobDefinitionHandleError)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	poller := &sparkBatchJobPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkBatchJobResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeExecuteSparkJobDefinition creates a new SparkBatchJobPoller from the specified resume token.
+// token - The value must come from a previous call to SparkBatchJobPoller.ResumeToken().
+func (client *sparkJobDefinitionClient) ResumeExecuteSparkJobDefinition(token string) (SparkBatchJobPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.con.Pipeline(), client.executeSparkJobDefinitionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &sparkBatchJobPoller{
+		pt: pt,
+	}, nil
 }
 
 // ExecuteSparkJobDefinition - Executes the spark job definition.
@@ -325,6 +466,41 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleE
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameSparkJobDefinition - Renames a sparkJobDefinition.
+func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionBeginRenameSparkJobDefinitionOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameSparkJobDefinition(ctx, sparkJobDefinitionName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sparkJobDefinitionClient.RenameSparkJobDefinition", resp, client.con.Pipeline(), client.renameSparkJobDefinitionHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameSparkJobDefinition creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *sparkJobDefinitionClient) ResumeRenameSparkJobDefinition(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.con.Pipeline(), client.renameSparkJobDefinitionHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameSparkJobDefinition - Renames a sparkJobDefinition.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -46,14 +46,26 @@ func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ct
 
 // ResumeCreateOrUpdateSparkJobDefinition creates a new SparkJobDefinitionResourcePoller from the specified resume token.
 // token - The value must come from a previous call to SparkJobDefinitionResourcePoller.ResumeToken().
-func (client *sparkJobDefinitionClient) ResumeCreateOrUpdateSparkJobDefinition(token string) (SparkJobDefinitionResourcePoller, error) {
+func (client *sparkJobDefinitionClient) ResumeCreateOrUpdateSparkJobDefinition(ctx context.Context, token string) (SparkJobDefinitionResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.CreateOrUpdateSparkJobDefinition", token, client.con.Pipeline(), client.createOrUpdateSparkJobDefinitionHandleError)
 	if err != nil {
-		return nil, err
+		return SparkJobDefinitionResourcePollerResponse{}, err
 	}
-	return &sparkJobDefinitionResourcePoller{
+	poller := &sparkJobDefinitionResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SparkJobDefinitionResourcePollerResponse{}, err
+	}
+	result := SparkJobDefinitionResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkJobDefinitionResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
@@ -137,14 +149,26 @@ func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context
 
 // ResumeDebugSparkJobDefinition creates a new SparkBatchJobPoller from the specified resume token.
 // token - The value must come from a previous call to SparkBatchJobPoller.ResumeToken().
-func (client *sparkJobDefinitionClient) ResumeDebugSparkJobDefinition(token string) (SparkBatchJobPoller, error) {
+func (client *sparkJobDefinitionClient) ResumeDebugSparkJobDefinition(ctx context.Context, token string) (SparkBatchJobPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.DebugSparkJobDefinition", token, client.con.Pipeline(), client.debugSparkJobDefinitionHandleError)
 	if err != nil {
-		return nil, err
+		return SparkBatchJobPollerResponse{}, err
 	}
-	return &sparkBatchJobPoller{
+	poller := &sparkBatchJobPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	result := SparkBatchJobPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkBatchJobResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DebugSparkJobDefinition - Debug the spark job definition.
@@ -221,14 +245,26 @@ func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx contex
 
 // ResumeDeleteSparkJobDefinition creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *sparkJobDefinitionClient) ResumeDeleteSparkJobDefinition(token string) (HTTPPoller, error) {
+func (client *sparkJobDefinitionClient) ResumeDeleteSparkJobDefinition(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.DeleteSparkJobDefinition", token, client.con.Pipeline(), client.deleteSparkJobDefinitionHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteSparkJobDefinition - Deletes a Spark Job Definition.
@@ -300,14 +336,26 @@ func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx conte
 
 // ResumeExecuteSparkJobDefinition creates a new SparkBatchJobPoller from the specified resume token.
 // token - The value must come from a previous call to SparkBatchJobPoller.ResumeToken().
-func (client *sparkJobDefinitionClient) ResumeExecuteSparkJobDefinition(token string) (SparkBatchJobPoller, error) {
+func (client *sparkJobDefinitionClient) ResumeExecuteSparkJobDefinition(ctx context.Context, token string) (SparkBatchJobPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.ExecuteSparkJobDefinition", token, client.con.Pipeline(), client.executeSparkJobDefinitionHandleError)
 	if err != nil {
-		return nil, err
+		return SparkBatchJobPollerResponse{}, err
 	}
-	return &sparkBatchJobPoller{
+	poller := &sparkBatchJobPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SparkBatchJobPollerResponse{}, err
+	}
+	result := SparkBatchJobPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SparkBatchJobResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // ExecuteSparkJobDefinition - Executes the spark job definition.
@@ -493,14 +541,26 @@ func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx contex
 
 // ResumeRenameSparkJobDefinition creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *sparkJobDefinitionClient) ResumeRenameSparkJobDefinition(token string) (HTTPPoller, error) {
+func (client *sparkJobDefinitionClient) ResumeRenameSparkJobDefinition(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sparkJobDefinitionClient.RenameSparkJobDefinition", token, client.con.Pipeline(), client.renameSparkJobDefinitionHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameSparkJobDefinition - Renames a sparkJobDefinition.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -46,14 +46,26 @@ func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context,
 
 // ResumeCreateOrUpdateSQLScript creates a new SQLScriptResourcePoller from the specified resume token.
 // token - The value must come from a previous call to SQLScriptResourcePoller.ResumeToken().
-func (client *sqlScriptClient) ResumeCreateOrUpdateSQLScript(token string) (SQLScriptResourcePoller, error) {
+func (client *sqlScriptClient) ResumeCreateOrUpdateSQLScript(ctx context.Context, token string) (SQLScriptResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.con.Pipeline(), client.createOrUpdateSQLScriptHandleError)
 	if err != nil {
-		return nil, err
+		return SQLScriptResourcePollerResponse{}, err
 	}
-	return &sqlScriptResourcePoller{
+	poller := &sqlScriptResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return SQLScriptResourcePollerResponse{}, err
+	}
+	result := SQLScriptResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SQLScriptResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateSQLScript - Creates or updates a Sql Script.
@@ -137,14 +149,26 @@ func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScri
 
 // ResumeDeleteSQLScript creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *sqlScriptClient) ResumeDeleteSQLScript(token string) (HTTPPoller, error) {
+func (client *sqlScriptClient) ResumeDeleteSQLScript(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.con.Pipeline(), client.deleteSQLScriptHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteSQLScript - Deletes a Sql Script.
@@ -321,14 +345,26 @@ func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScri
 
 // ResumeRenameSQLScript creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *sqlScriptClient) ResumeRenameSQLScript(token string) (HTTPPoller, error) {
+func (client *sqlScriptClient) ResumeRenameSQLScript(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.con.Pipeline(), client.renameSQLScriptHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // RenameSQLScript - Renames a sqlScript.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type sqlScriptClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateSQLScript - Creates or updates a Sql Script.
+func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptBeginCreateOrUpdateSQLScriptOptions) (SQLScriptResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateSQLScript(ctx, sqlScriptName, sqlScript, options)
+	if err != nil {
+		return SQLScriptResourcePollerResponse{}, err
+	}
+	result := SQLScriptResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sqlScriptClient.CreateOrUpdateSQLScript", resp, client.con.Pipeline(), client.createOrUpdateSQLScriptHandleError)
+	if err != nil {
+		return SQLScriptResourcePollerResponse{}, err
+	}
+	poller := &sqlScriptResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (SQLScriptResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateSQLScript creates a new SQLScriptResourcePoller from the specified resume token.
+// token - The value must come from a previous call to SQLScriptResourcePoller.ResumeToken().
+func (client *sqlScriptClient) ResumeCreateOrUpdateSQLScript(token string) (SQLScriptResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.CreateOrUpdateSQLScript", token, client.con.Pipeline(), client.createOrUpdateSQLScriptHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlScriptResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateSQLScript - Creates or updates a Sql Script.
@@ -74,6 +110,41 @@ func (client *sqlScriptClient) createOrUpdateSQLScriptHandleError(resp *azcore.R
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteSQLScript - Deletes a Sql Script.
+func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptBeginDeleteSQLScriptOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteSQLScript(ctx, sqlScriptName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sqlScriptClient.DeleteSQLScript", resp, client.con.Pipeline(), client.deleteSQLScriptHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteSQLScript creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *sqlScriptClient) ResumeDeleteSQLScript(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.DeleteSQLScript", token, client.con.Pipeline(), client.deleteSQLScriptHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteSQLScript - Deletes a Sql Script.
@@ -223,6 +294,41 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleError(resp *azcore.
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginRenameSQLScript - Renames a sqlScript.
+func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SQLScriptBeginRenameSQLScriptOptions) (HTTPPollerResponse, error) {
+	resp, err := client.renameSQLScript(ctx, sqlScriptName, request, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("sqlScriptClient.RenameSQLScript", resp, client.con.Pipeline(), client.renameSQLScriptHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeRenameSQLScript creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *sqlScriptClient) ResumeRenameSQLScript(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("sqlScriptClient.RenameSQLScript", token, client.con.Pipeline(), client.renameSQLScriptHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // RenameSQLScript - Renames a sqlScript.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -46,14 +46,26 @@ func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, tri
 
 // ResumeCreateOrUpdateTrigger creates a new TriggerResourcePoller from the specified resume token.
 // token - The value must come from a previous call to TriggerResourcePoller.ResumeToken().
-func (client *triggerClient) ResumeCreateOrUpdateTrigger(token string) (TriggerResourcePoller, error) {
+func (client *triggerClient) ResumeCreateOrUpdateTrigger(ctx context.Context, token string) (TriggerResourcePollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.con.Pipeline(), client.createOrUpdateTriggerHandleError)
 	if err != nil {
-		return nil, err
+		return TriggerResourcePollerResponse{}, err
 	}
-	return &triggerResourcePoller{
+	poller := &triggerResourcePoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return TriggerResourcePollerResponse{}, err
+	}
+	result := TriggerResourcePollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // CreateOrUpdateTrigger - Creates or updates a trigger.
@@ -137,14 +149,26 @@ func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName
 
 // ResumeDeleteTrigger creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *triggerClient) ResumeDeleteTrigger(token string) (HTTPPoller, error) {
+func (client *triggerClient) ResumeDeleteTrigger(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.con.Pipeline(), client.deleteTriggerHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // DeleteTrigger - Deletes a trigger.
@@ -374,14 +398,26 @@ func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName 
 
 // ResumeStartTrigger creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *triggerClient) ResumeStartTrigger(token string) (HTTPPoller, error) {
+func (client *triggerClient) ResumeStartTrigger(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.StartTrigger", token, client.con.Pipeline(), client.startTriggerHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StartTrigger - Starts a trigger.
@@ -453,14 +489,26 @@ func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName s
 
 // ResumeStopTrigger creates a new HTTPPoller from the specified resume token.
 // token - The value must come from a previous call to HTTPPoller.ResumeToken().
-func (client *triggerClient) ResumeStopTrigger(token string) (HTTPPoller, error) {
+func (client *triggerClient) ResumeStopTrigger(ctx context.Context, token string) (HTTPPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.StopTrigger", token, client.con.Pipeline(), client.stopTriggerHandleError)
 	if err != nil {
-		return nil, err
+		return HTTPPollerResponse{}, err
 	}
-	return &httpPoller{
+	poller := &httpPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // StopTrigger - Stops a trigger.
@@ -532,14 +580,26 @@ func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, 
 
 // ResumeSubscribeTriggerToEvents creates a new TriggerSubscriptionOperationStatusPoller from the specified resume token.
 // token - The value must come from a previous call to TriggerSubscriptionOperationStatusPoller.ResumeToken().
-func (client *triggerClient) ResumeSubscribeTriggerToEvents(token string) (TriggerSubscriptionOperationStatusPoller, error) {
+func (client *triggerClient) ResumeSubscribeTriggerToEvents(ctx context.Context, token string) (TriggerSubscriptionOperationStatusPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.con.Pipeline(), client.subscribeTriggerToEventsHandleError)
 	if err != nil {
-		return nil, err
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
 	}
-	return &triggerSubscriptionOperationStatusPoller{
+	poller := &triggerSubscriptionOperationStatusPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	result := TriggerSubscriptionOperationStatusPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerSubscriptionOperationStatusResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // SubscribeTriggerToEvents - Subscribe event trigger to events.
@@ -620,14 +680,26 @@ func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Conte
 
 // ResumeUnsubscribeTriggerFromEvents creates a new TriggerSubscriptionOperationStatusPoller from the specified resume token.
 // token - The value must come from a previous call to TriggerSubscriptionOperationStatusPoller.ResumeToken().
-func (client *triggerClient) ResumeUnsubscribeTriggerFromEvents(token string) (TriggerSubscriptionOperationStatusPoller, error) {
+func (client *triggerClient) ResumeUnsubscribeTriggerFromEvents(ctx context.Context, token string) (TriggerSubscriptionOperationStatusPollerResponse, error) {
 	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.con.Pipeline(), client.unsubscribeTriggerFromEventsHandleError)
 	if err != nil {
-		return nil, err
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
 	}
-	return &triggerSubscriptionOperationStatusPoller{
+	poller := &triggerSubscriptionOperationStatusPoller{
 		pt: pt,
-	}, nil
+	}
+	resp, err := poller.Poll(ctx)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	result := TriggerSubscriptionOperationStatusPollerResponse{
+		RawResponse: resp,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerSubscriptionOperationStatusResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
 }
 
 // UnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -14,10 +14,46 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type triggerClient struct {
 	con *connection
+}
+
+// BeginCreateOrUpdateTrigger - Creates or updates a trigger.
+func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerBeginCreateOrUpdateTriggerOptions) (TriggerResourcePollerResponse, error) {
+	resp, err := client.createOrUpdateTrigger(ctx, triggerName, trigger, options)
+	if err != nil {
+		return TriggerResourcePollerResponse{}, err
+	}
+	result := TriggerResourcePollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.CreateOrUpdateTrigger", resp, client.con.Pipeline(), client.createOrUpdateTriggerHandleError)
+	if err != nil {
+		return TriggerResourcePollerResponse{}, err
+	}
+	poller := &triggerResourcePoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerResourceResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeCreateOrUpdateTrigger creates a new TriggerResourcePoller from the specified resume token.
+// token - The value must come from a previous call to TriggerResourcePoller.ResumeToken().
+func (client *triggerClient) ResumeCreateOrUpdateTrigger(token string) (TriggerResourcePoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.CreateOrUpdateTrigger", token, client.con.Pipeline(), client.createOrUpdateTriggerHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &triggerResourcePoller{
+		pt: pt,
+	}, nil
 }
 
 // CreateOrUpdateTrigger - Creates or updates a trigger.
@@ -74,6 +110,41 @@ func (client *triggerClient) createOrUpdateTriggerHandleError(resp *azcore.Respo
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginDeleteTrigger - Deletes a trigger.
+func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName string, options *TriggerBeginDeleteTriggerOptions) (HTTPPollerResponse, error) {
+	resp, err := client.deleteTrigger(ctx, triggerName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.DeleteTrigger", resp, client.con.Pipeline(), client.deleteTriggerHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeDeleteTrigger creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *triggerClient) ResumeDeleteTrigger(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.DeleteTrigger", token, client.con.Pipeline(), client.deleteTriggerHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
 }
 
 // DeleteTrigger - Deletes a trigger.
@@ -278,6 +349,41 @@ func (client *triggerClient) getTriggersByWorkspaceHandleError(resp *azcore.Resp
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
+// BeginStartTrigger - Starts a trigger.
+func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName string, options *TriggerBeginStartTriggerOptions) (HTTPPollerResponse, error) {
+	resp, err := client.startTrigger(ctx, triggerName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.StartTrigger", resp, client.con.Pipeline(), client.startTriggerHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeStartTrigger creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *triggerClient) ResumeStartTrigger(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.StartTrigger", token, client.con.Pipeline(), client.startTriggerHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
+}
+
 // StartTrigger - Starts a trigger.
 func (client *triggerClient) startTrigger(ctx context.Context, triggerName string, options *TriggerBeginStartTriggerOptions) (*azcore.Response, error) {
 	req, err := client.startTriggerCreateRequest(ctx, triggerName, options)
@@ -322,6 +428,41 @@ func (client *triggerClient) startTriggerHandleError(resp *azcore.Response) erro
 	return azcore.NewResponseError(&err, resp.Response)
 }
 
+// BeginStopTrigger - Stops a trigger.
+func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName string, options *TriggerBeginStopTriggerOptions) (HTTPPollerResponse, error) {
+	resp, err := client.stopTrigger(ctx, triggerName, options)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	result := HTTPPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.StopTrigger", resp, client.con.Pipeline(), client.stopTriggerHandleError)
+	if err != nil {
+		return HTTPPollerResponse{}, err
+	}
+	poller := &httpPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (*http.Response, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeStopTrigger creates a new HTTPPoller from the specified resume token.
+// token - The value must come from a previous call to HTTPPoller.ResumeToken().
+func (client *triggerClient) ResumeStopTrigger(token string) (HTTPPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.StopTrigger", token, client.con.Pipeline(), client.stopTriggerHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &httpPoller{
+		pt: pt,
+	}, nil
+}
+
 // StopTrigger - Stops a trigger.
 func (client *triggerClient) stopTrigger(ctx context.Context, triggerName string, options *TriggerBeginStopTriggerOptions) (*azcore.Response, error) {
 	req, err := client.stopTriggerCreateRequest(ctx, triggerName, options)
@@ -364,6 +505,41 @@ func (client *triggerClient) stopTriggerHandleError(resp *azcore.Response) error
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginSubscribeTriggerToEvents - Subscribe event trigger to events.
+func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerBeginSubscribeTriggerToEventsOptions) (TriggerSubscriptionOperationStatusPollerResponse, error) {
+	resp, err := client.subscribeTriggerToEvents(ctx, triggerName, options)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	result := TriggerSubscriptionOperationStatusPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.SubscribeTriggerToEvents", resp, client.con.Pipeline(), client.subscribeTriggerToEventsHandleError)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	poller := &triggerSubscriptionOperationStatusPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerSubscriptionOperationStatusResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeSubscribeTriggerToEvents creates a new TriggerSubscriptionOperationStatusPoller from the specified resume token.
+// token - The value must come from a previous call to TriggerSubscriptionOperationStatusPoller.ResumeToken().
+func (client *triggerClient) ResumeSubscribeTriggerToEvents(token string) (TriggerSubscriptionOperationStatusPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.SubscribeTriggerToEvents", token, client.con.Pipeline(), client.subscribeTriggerToEventsHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &triggerSubscriptionOperationStatusPoller{
+		pt: pt,
+	}, nil
 }
 
 // SubscribeTriggerToEvents - Subscribe event trigger to events.
@@ -417,6 +593,41 @@ func (client *triggerClient) subscribeTriggerToEventsHandleError(resp *azcore.Re
 		return err
 	}
 	return azcore.NewResponseError(&err, resp.Response)
+}
+
+// BeginUnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.
+func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerBeginUnsubscribeTriggerFromEventsOptions) (TriggerSubscriptionOperationStatusPollerResponse, error) {
+	resp, err := client.unsubscribeTriggerFromEvents(ctx, triggerName, options)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	result := TriggerSubscriptionOperationStatusPollerResponse{
+		RawResponse: resp.Response,
+	}
+	pt, err := azcore.NewLROPoller("triggerClient.UnsubscribeTriggerFromEvents", resp, client.con.Pipeline(), client.unsubscribeTriggerFromEventsHandleError)
+	if err != nil {
+		return TriggerSubscriptionOperationStatusPollerResponse{}, err
+	}
+	poller := &triggerSubscriptionOperationStatusPoller{
+		pt: pt,
+	}
+	result.Poller = poller
+	result.PollUntilDone = func(ctx context.Context, frequency time.Duration) (TriggerSubscriptionOperationStatusResponse, error) {
+		return poller.pollUntilDone(ctx, frequency)
+	}
+	return result, nil
+}
+
+// ResumeUnsubscribeTriggerFromEvents creates a new TriggerSubscriptionOperationStatusPoller from the specified resume token.
+// token - The value must come from a previous call to TriggerSubscriptionOperationStatusPoller.ResumeToken().
+func (client *triggerClient) ResumeUnsubscribeTriggerFromEvents(token string) (TriggerSubscriptionOperationStatusPoller, error) {
+	pt, err := azcore.NewLROPollerFromResumeToken("triggerClient.UnsubscribeTriggerFromEvents", token, client.con.Pipeline(), client.unsubscribeTriggerFromEventsHandleError)
+	if err != nil {
+		return nil, err
+	}
+	return &triggerSubscriptionOperationStatusPoller{
+		pt: pt,
+	}, nil
 }
 
 // UnsubscribeTriggerFromEvents - Unsubscribe event trigger from events.

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -2,4 +2,4 @@ module azspark
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4

--- a/test/synapse/2019-06-01/azspark/go.sum
+++ b/test/synapse/2019-06-01/azspark/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
-	"reflect"
 	"time"
 )
 
@@ -674,9 +673,12 @@ type SparkStatementResponse struct {
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else if !reflect.ValueOf(v).IsNil() {
+	} else {
 		m[k] = v
 	}
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -676,8 +676,7 @@ type SparkStatementResponse struct {
 func populate(m map[string]interface{}, k string, v interface{}) {
 	if v == nil {
 		return
-	}
-	if azcore.IsNullValue(v) {
+	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -678,7 +679,7 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 	}
 	if azcore.IsNullValue(v) {
 		m[k] = nil
-	} else {
+	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
 	}
 }

--- a/test/tables/2019-02-02/aztables/go.mod
+++ b/test/tables/2019-02-02/aztables/go.mod
@@ -2,4 +2,4 @@ module aztables
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4

--- a/test/tables/2019-02-02/aztables/go.sum
+++ b/test/tables/2019-02-02/aztables/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3 h1:WgQHTcErc4NV3nuMc+OiR16DtpVy7230CjOpjD+FA84=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.3/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0 h1:HG1ggl8L3ZkV/Ydanf7lKr5kkhhPGCpWdnr1J6v7cO4=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4 h1:WCOYbqX0ZXM/GvcZ8fUDhOLQ46saqP4yMI97YBb53hw=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.4/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
+github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
Refactored codegen for LROs to support ARM and data-plane.
Fixed bug in internal populate() func.
Added more types to schemaTypeToGoType() and fixed default case to throw
and error instead of bad codegen.
Fixed tracking of host params to not use reference-equality (fixes
potential for duplicate params).
Shorted some var names in codegen.
Reordered some poller fields as a side-effect of refactor.