### PR TITLE
Fix missing internal unmarshallers

### DIFF
--- a/src/generator/constants.ts
+++ b/src/generator/constants.ts
@@ -45,7 +45,7 @@ export async function generateConstants(session: Session<CodeModel>): Promise<st
     }
     text += '\t}\n';
     text += '}\n\n';
-    text += `// ToPtr() returns a *${enm.name} pointing to the current value.\n`;
+    text += `// ToPtr returns a *${enm.name} pointing to the current value.\n`;
     text += `func (c ${enm.name}) ToPtr() *${enm.name} {\n`;
     text += '\treturn &c\n';
     text += `}\n\n`;

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -356,7 +356,7 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
         const marshallerType = recursiveWalkObjs(obj, true);
         if (marshallerType === 1) {
           needsM = true;
-        } else if (marshallerType === 2) {
+        } else if (marshallerType > 1) {
           needsM = needsU = true;
         }
       } else if (relationship === 'parent') {
@@ -364,14 +364,14 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
         const cMrshallerType = recursiveWalkObjs(obj, false);
         if (pMarshallerType === 1 || cMrshallerType === 1) {
           needsM = needsIntM = true;
-        } else if (pMarshallerType === 2 || cMrshallerType === 2) {
+        } else if (pMarshallerType > 1 || cMrshallerType > 1) {
           needsM = needsU = needsIntM = needsIntU = true;
         }
       } else {
         const marshallerType = recursiveWalkObjs(obj, false);
         if (marshallerType === 1) {
           needsIntM = true;
-        } else if (marshallerType === 2) {
+        } else if (marshallerType > 1) {
           needsIntM = needsIntU = true;
         }
       }
@@ -415,7 +415,7 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
 
 // returns 0 if no nodes in the hierarchy require custom marshalling/unmarshalling.
 // returns 1 if only custom marshalling is required.
-// returns 2 if custom marshalling and unmarshalling is required.
+// returns greater than 1 if custom marshalling and unmarshalling is required.
 function recursiveWalkObjs(obj: ObjectSchema, parents: boolean): number {
   let result = 0;
   let cs: ComplexSchema[] | undefined;
@@ -433,9 +433,6 @@ function recursiveWalkObjs(obj: ObjectSchema, parents: boolean): number {
     }
     if (c.language.go!.needsDateTimeMarshalling || hasAdditionalProperties(c) || hasPolymorphicField(c) || c.discriminator || c.discriminatorValue) {
       result = 2;
-    }
-    if (result > 0) {
-      break;
     }
     result |= recursiveWalkObjs(c, parents);
   }

--- a/test/autorest/arraygroup/zz_generated_constants.go
+++ b/test/autorest/arraygroup/zz_generated_constants.go
@@ -24,7 +24,7 @@ func PossibleEnum0Values() []Enum0 {
 	}
 }
 
-// ToPtr() returns a *Enum0 pointing to the current value.
+// ToPtr returns a *Enum0 pointing to the current value.
 func (c Enum0) ToPtr() *Enum0 {
 	return &c
 }
@@ -46,7 +46,7 @@ func PossibleEnum1Values() []Enum1 {
 	}
 }
 
-// ToPtr() returns a *Enum1 pointing to the current value.
+// ToPtr returns a *Enum1 pointing to the current value.
 func (c Enum1) ToPtr() *Enum1 {
 	return &c
 }
@@ -68,7 +68,7 @@ func PossibleFooEnumValues() []FooEnum {
 	}
 }
 
-// ToPtr() returns a *FooEnum pointing to the current value.
+// ToPtr returns a *FooEnum pointing to the current value.
 func (c FooEnum) ToPtr() *FooEnum {
 	return &c
 }

--- a/test/autorest/complexgroup/zz_generated_constants.go
+++ b/test/autorest/complexgroup/zz_generated_constants.go
@@ -26,7 +26,7 @@ func PossibleCMYKColorsValues() []CMYKColors {
 	}
 }
 
-// ToPtr() returns a *CMYKColors pointing to the current value.
+// ToPtr returns a *CMYKColors pointing to the current value.
 func (c CMYKColors) ToPtr() *CMYKColors {
 	return &c
 }
@@ -55,7 +55,7 @@ func PossibleGoblinSharkColorValues() []GoblinSharkColor {
 	}
 }
 
-// ToPtr() returns a *GoblinSharkColor pointing to the current value.
+// ToPtr returns a *GoblinSharkColor pointing to the current value.
 func (c GoblinSharkColor) ToPtr() *GoblinSharkColor {
 	return &c
 }
@@ -73,7 +73,7 @@ func PossibleMyKindValues() []MyKind {
 	}
 }
 
-// ToPtr() returns a *MyKind pointing to the current value.
+// ToPtr returns a *MyKind pointing to the current value.
 func (c MyKind) ToPtr() *MyKind {
 	return &c
 }

--- a/test/autorest/extenumsgroup/zz_generated_constants.go
+++ b/test/autorest/extenumsgroup/zz_generated_constants.go
@@ -33,7 +33,7 @@ func PossibleDaysOfWeekExtensibleEnumValues() []DaysOfWeekExtensibleEnum {
 	}
 }
 
-// ToPtr() returns a *DaysOfWeekExtensibleEnum pointing to the current value.
+// ToPtr returns a *DaysOfWeekExtensibleEnum pointing to the current value.
 func (c DaysOfWeekExtensibleEnum) ToPtr() *DaysOfWeekExtensibleEnum {
 	return &c
 }
@@ -58,7 +58,7 @@ func PossibleIntEnumValues() []IntEnum {
 	}
 }
 
-// ToPtr() returns a *IntEnum pointing to the current value.
+// ToPtr returns a *IntEnum pointing to the current value.
 func (c IntEnum) ToPtr() *IntEnum {
 	return &c
 }

--- a/test/autorest/headergroup/zz_generated_constants.go
+++ b/test/autorest/headergroup/zz_generated_constants.go
@@ -24,7 +24,7 @@ func PossibleGreyscaleColorsValues() []GreyscaleColors {
 	}
 }
 
-// ToPtr() returns a *GreyscaleColors pointing to the current value.
+// ToPtr returns a *GreyscaleColors pointing to the current value.
 func (c GreyscaleColors) ToPtr() *GreyscaleColors {
 	return &c
 }

--- a/test/autorest/lrogroup/zz_generated_constants.go
+++ b/test/autorest/lrogroup/zz_generated_constants.go
@@ -41,7 +41,7 @@ func PossibleOperationResultStatusValues() []OperationResultStatus {
 	}
 }
 
-// ToPtr() returns a *OperationResultStatus pointing to the current value.
+// ToPtr returns a *OperationResultStatus pointing to the current value.
 func (c OperationResultStatus) ToPtr() *OperationResultStatus {
 	return &c
 }
@@ -79,7 +79,7 @@ func PossibleProductPropertiesProvisioningStateValuesValues() []ProductPropertie
 	}
 }
 
-// ToPtr() returns a *ProductPropertiesProvisioningStateValues pointing to the current value.
+// ToPtr returns a *ProductPropertiesProvisioningStateValues pointing to the current value.
 func (c ProductPropertiesProvisioningStateValues) ToPtr() *ProductPropertiesProvisioningStateValues {
 	return &c
 }
@@ -117,7 +117,7 @@ func PossibleSubProductPropertiesProvisioningStateValuesValues() []SubProductPro
 	}
 }
 
-// ToPtr() returns a *SubProductPropertiesProvisioningStateValues pointing to the current value.
+// ToPtr returns a *SubProductPropertiesProvisioningStateValues pointing to the current value.
 func (c SubProductPropertiesProvisioningStateValues) ToPtr() *SubProductPropertiesProvisioningStateValues {
 	return &c
 }

--- a/test/autorest/mediatypesgroup/zz_generated_constants.go
+++ b/test/autorest/mediatypesgroup/zz_generated_constants.go
@@ -31,7 +31,7 @@ func PossibleContentTypeValues() []ContentType {
 	}
 }
 
-// ToPtr() returns a *ContentType pointing to the current value.
+// ToPtr returns a *ContentType pointing to the current value.
 func (c ContentType) ToPtr() *ContentType {
 	return &c
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_constants.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_constants.go
@@ -29,7 +29,7 @@ func PossibleFloatEnumValues() []FloatEnum {
 	}
 }
 
-// ToPtr() returns a *FloatEnum pointing to the current value.
+// ToPtr returns a *FloatEnum pointing to the current value.
 func (c FloatEnum) ToPtr() *FloatEnum {
 	return &c
 }
@@ -56,7 +56,7 @@ func PossibleIntEnumValues() []IntEnum {
 	}
 }
 
-// ToPtr() returns a *IntEnum pointing to the current value.
+// ToPtr returns a *IntEnum pointing to the current value.
 func (c IntEnum) ToPtr() *IntEnum {
 	return &c
 }

--- a/test/autorest/paginggroup/zz_generated_constants.go
+++ b/test/autorest/paginggroup/zz_generated_constants.go
@@ -41,7 +41,7 @@ func PossibleOperationResultStatusValues() []OperationResultStatus {
 	}
 }
 
-// ToPtr() returns a *OperationResultStatus pointing to the current value.
+// ToPtr returns a *OperationResultStatus pointing to the current value.
 func (c OperationResultStatus) ToPtr() *OperationResultStatus {
 	return &c
 }

--- a/test/autorest/stringgroup/zz_generated_constants.go
+++ b/test/autorest/stringgroup/zz_generated_constants.go
@@ -25,7 +25,7 @@ func PossibleColorsValues() []Colors {
 	}
 }
 
-// ToPtr() returns a *Colors pointing to the current value.
+// ToPtr returns a *Colors pointing to the current value.
 func (c Colors) ToPtr() *Colors {
 	return &c
 }

--- a/test/autorest/urlgroup/zz_generated_constants.go
+++ b/test/autorest/urlgroup/zz_generated_constants.go
@@ -24,7 +24,7 @@ func PossibleURIColorValues() []URIColor {
 	}
 }
 
-// ToPtr() returns a *URIColor pointing to the current value.
+// ToPtr returns a *URIColor pointing to the current value.
 func (c URIColor) ToPtr() *URIColor {
 	return &c
 }

--- a/test/autorest/xmlgroup/zz_generated_constants.go
+++ b/test/autorest/xmlgroup/zz_generated_constants.go
@@ -38,7 +38,7 @@ func PossibleAccessTierValues() []AccessTier {
 	}
 }
 
-// ToPtr() returns a *AccessTier pointing to the current value.
+// ToPtr returns a *AccessTier pointing to the current value.
 func (c AccessTier) ToPtr() *AccessTier {
 	return &c
 }
@@ -58,7 +58,7 @@ func PossibleArchiveStatusValues() []ArchiveStatus {
 	}
 }
 
-// ToPtr() returns a *ArchiveStatus pointing to the current value.
+// ToPtr returns a *ArchiveStatus pointing to the current value.
 func (c ArchiveStatus) ToPtr() *ArchiveStatus {
 	return &c
 }
@@ -80,7 +80,7 @@ func PossibleBlobTypeValues() []BlobType {
 	}
 }
 
-// ToPtr() returns a *BlobType pointing to the current value.
+// ToPtr returns a *BlobType pointing to the current value.
 func (c BlobType) ToPtr() *BlobType {
 	return &c
 }
@@ -104,7 +104,7 @@ func PossibleCopyStatusTypeValues() []CopyStatusType {
 	}
 }
 
-// ToPtr() returns a *CopyStatusType pointing to the current value.
+// ToPtr returns a *CopyStatusType pointing to the current value.
 func (c CopyStatusType) ToPtr() *CopyStatusType {
 	return &c
 }
@@ -124,7 +124,7 @@ func PossibleLeaseDurationTypeValues() []LeaseDurationType {
 	}
 }
 
-// ToPtr() returns a *LeaseDurationType pointing to the current value.
+// ToPtr returns a *LeaseDurationType pointing to the current value.
 func (c LeaseDurationType) ToPtr() *LeaseDurationType {
 	return &c
 }
@@ -150,7 +150,7 @@ func PossibleLeaseStateTypeValues() []LeaseStateType {
 	}
 }
 
-// ToPtr() returns a *LeaseStateType pointing to the current value.
+// ToPtr returns a *LeaseStateType pointing to the current value.
 func (c LeaseStateType) ToPtr() *LeaseStateType {
 	return &c
 }
@@ -170,7 +170,7 @@ func PossibleLeaseStatusTypeValues() []LeaseStatusType {
 	}
 }
 
-// ToPtr() returns a *LeaseStatusType pointing to the current value.
+// ToPtr returns a *LeaseStatusType pointing to the current value.
 func (c LeaseStatusType) ToPtr() *LeaseStatusType {
 	return &c
 }
@@ -190,7 +190,7 @@ func PossiblePublicAccessTypeValues() []PublicAccessType {
 	}
 }
 
-// ToPtr() returns a *PublicAccessType pointing to the current value.
+// ToPtr returns a *PublicAccessType pointing to the current value.
 func (c PublicAccessType) ToPtr() *PublicAccessType {
 	return &c
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_constants.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_constants.go
@@ -24,7 +24,7 @@ func PossibleAccessLevelValues() []AccessLevel {
 	}
 }
 
-// ToPtr() returns a *AccessLevel pointing to the current value.
+// ToPtr returns a *AccessLevel pointing to the current value.
 func (c AccessLevel) ToPtr() *AccessLevel {
 	return &c
 }
@@ -49,7 +49,7 @@ func PossibleAggregatedReplicationStateValues() []AggregatedReplicationState {
 	}
 }
 
-// ToPtr() returns a *AggregatedReplicationState pointing to the current value.
+// ToPtr returns a *AggregatedReplicationState pointing to the current value.
 func (c AggregatedReplicationState) ToPtr() *AggregatedReplicationState {
 	return &c
 }
@@ -71,7 +71,7 @@ func PossibleAvailabilitySetSKUTypesValues() []AvailabilitySetSKUTypes {
 	}
 }
 
-// ToPtr() returns a *AvailabilitySetSKUTypes pointing to the current value.
+// ToPtr returns a *AvailabilitySetSKUTypes pointing to the current value.
 func (c AvailabilitySetSKUTypes) ToPtr() *AvailabilitySetSKUTypes {
 	return &c
 }
@@ -99,7 +99,7 @@ func PossibleCachingTypesValues() []CachingTypes {
 	}
 }
 
-// ToPtr() returns a *CachingTypes pointing to the current value.
+// ToPtr returns a *CachingTypes pointing to the current value.
 func (c CachingTypes) ToPtr() *CachingTypes {
 	return &c
 }
@@ -124,7 +124,7 @@ func PossibleContainerServiceOrchestratorTypesValues() []ContainerServiceOrchest
 	}
 }
 
-// ToPtr() returns a *ContainerServiceOrchestratorTypes pointing to the current value.
+// ToPtr returns a *ContainerServiceOrchestratorTypes pointing to the current value.
 func (c ContainerServiceOrchestratorTypes) ToPtr() *ContainerServiceOrchestratorTypes {
 	return &c
 }
@@ -235,7 +235,7 @@ func PossibleContainerServiceVMSizeTypesValues() []ContainerServiceVMSizeTypes {
 	}
 }
 
-// ToPtr() returns a *ContainerServiceVMSizeTypes pointing to the current value.
+// ToPtr returns a *ContainerServiceVMSizeTypes pointing to the current value.
 func (c ContainerServiceVMSizeTypes) ToPtr() *ContainerServiceVMSizeTypes {
 	return &c
 }
@@ -263,7 +263,7 @@ func PossibleDedicatedHostLicenseTypesValues() []DedicatedHostLicenseTypes {
 	}
 }
 
-// ToPtr() returns a *DedicatedHostLicenseTypes pointing to the current value.
+// ToPtr returns a *DedicatedHostLicenseTypes pointing to the current value.
 func (c DedicatedHostLicenseTypes) ToPtr() *DedicatedHostLicenseTypes {
 	return &c
 }
@@ -282,7 +282,7 @@ func PossibleDiffDiskOptionsValues() []DiffDiskOptions {
 	}
 }
 
-// ToPtr() returns a *DiffDiskOptions pointing to the current value.
+// ToPtr returns a *DiffDiskOptions pointing to the current value.
 func (c DiffDiskOptions) ToPtr() *DiffDiskOptions {
 	return &c
 }
@@ -307,7 +307,7 @@ func PossibleDiffDiskPlacementValues() []DiffDiskPlacement {
 	}
 }
 
-// ToPtr() returns a *DiffDiskPlacement pointing to the current value.
+// ToPtr returns a *DiffDiskPlacement pointing to the current value.
 func (c DiffDiskPlacement) ToPtr() *DiffDiskPlacement {
 	return &c
 }
@@ -345,7 +345,7 @@ func PossibleDiskCreateOptionValues() []DiskCreateOption {
 	}
 }
 
-// ToPtr() returns a *DiskCreateOption pointing to the current value.
+// ToPtr returns a *DiskCreateOption pointing to the current value.
 func (c DiskCreateOption) ToPtr() *DiskCreateOption {
 	return &c
 }
@@ -373,7 +373,7 @@ func PossibleDiskCreateOptionTypesValues() []DiskCreateOptionTypes {
 	}
 }
 
-// ToPtr() returns a *DiskCreateOptionTypes pointing to the current value.
+// ToPtr returns a *DiskCreateOptionTypes pointing to the current value.
 func (c DiskCreateOptionTypes) ToPtr() *DiskCreateOptionTypes {
 	return &c
 }
@@ -392,7 +392,7 @@ func PossibleDiskEncryptionSetIdentityTypeValues() []DiskEncryptionSetIdentityTy
 	}
 }
 
-// ToPtr() returns a *DiskEncryptionSetIdentityType pointing to the current value.
+// ToPtr returns a *DiskEncryptionSetIdentityType pointing to the current value.
 func (c DiskEncryptionSetIdentityType) ToPtr() *DiskEncryptionSetIdentityType {
 	return &c
 }
@@ -427,7 +427,7 @@ func PossibleDiskStateValues() []DiskState {
 	}
 }
 
-// ToPtr() returns a *DiskState pointing to the current value.
+// ToPtr returns a *DiskState pointing to the current value.
 func (c DiskState) ToPtr() *DiskState {
 	return &c
 }
@@ -457,7 +457,7 @@ func PossibleDiskStorageAccountTypesValues() []DiskStorageAccountTypes {
 	}
 }
 
-// ToPtr() returns a *DiskStorageAccountTypes pointing to the current value.
+// ToPtr returns a *DiskStorageAccountTypes pointing to the current value.
 func (c DiskStorageAccountTypes) ToPtr() *DiskStorageAccountTypes {
 	return &c
 }
@@ -480,7 +480,7 @@ func PossibleEncryptionTypeValues() []EncryptionType {
 	}
 }
 
-// ToPtr() returns a *EncryptionType pointing to the current value.
+// ToPtr returns a *EncryptionType pointing to the current value.
 func (c EncryptionType) ToPtr() *EncryptionType {
 	return &c
 }
@@ -503,7 +503,7 @@ func PossibleEnum31Values() []Enum31 {
 	}
 }
 
-// ToPtr() returns a *Enum31 pointing to the current value.
+// ToPtr returns a *Enum31 pointing to the current value.
 func (c Enum31) ToPtr() *Enum31 {
 	return &c
 }
@@ -532,7 +532,7 @@ func PossibleGalleryApplicationVersionPropertiesProvisioningStateValues() []Gall
 	}
 }
 
-// ToPtr() returns a *GalleryApplicationVersionPropertiesProvisioningState pointing to the current value.
+// ToPtr returns a *GalleryApplicationVersionPropertiesProvisioningState pointing to the current value.
 func (c GalleryApplicationVersionPropertiesProvisioningState) ToPtr() *GalleryApplicationVersionPropertiesProvisioningState {
 	return &c
 }
@@ -561,7 +561,7 @@ func PossibleGalleryImagePropertiesProvisioningStateValues() []GalleryImagePrope
 	}
 }
 
-// ToPtr() returns a *GalleryImagePropertiesProvisioningState pointing to the current value.
+// ToPtr returns a *GalleryImagePropertiesProvisioningState pointing to the current value.
 func (c GalleryImagePropertiesProvisioningState) ToPtr() *GalleryImagePropertiesProvisioningState {
 	return &c
 }
@@ -590,7 +590,7 @@ func PossibleGalleryImageVersionPropertiesProvisioningStateValues() []GalleryIma
 	}
 }
 
-// ToPtr() returns a *GalleryImageVersionPropertiesProvisioningState pointing to the current value.
+// ToPtr returns a *GalleryImageVersionPropertiesProvisioningState pointing to the current value.
 func (c GalleryImageVersionPropertiesProvisioningState) ToPtr() *GalleryImageVersionPropertiesProvisioningState {
 	return &c
 }
@@ -619,7 +619,7 @@ func PossibleGalleryPropertiesProvisioningStateValues() []GalleryPropertiesProvi
 	}
 }
 
-// ToPtr() returns a *GalleryPropertiesProvisioningState pointing to the current value.
+// ToPtr returns a *GalleryPropertiesProvisioningState pointing to the current value.
 func (c GalleryPropertiesProvisioningState) ToPtr() *GalleryPropertiesProvisioningState {
 	return &c
 }
@@ -642,7 +642,7 @@ func PossibleHostCachingValues() []HostCaching {
 	}
 }
 
-// ToPtr() returns a *HostCaching pointing to the current value.
+// ToPtr returns a *HostCaching pointing to the current value.
 func (c HostCaching) ToPtr() *HostCaching {
 	return &c
 }
@@ -663,7 +663,7 @@ func PossibleHyperVGenerationValues() []HyperVGeneration {
 	}
 }
 
-// ToPtr() returns a *HyperVGeneration pointing to the current value.
+// ToPtr returns a *HyperVGeneration pointing to the current value.
 func (c HyperVGeneration) ToPtr() *HyperVGeneration {
 	return &c
 }
@@ -684,7 +684,7 @@ func PossibleHyperVGenerationTypeValues() []HyperVGenerationType {
 	}
 }
 
-// ToPtr() returns a *HyperVGenerationType pointing to the current value.
+// ToPtr returns a *HyperVGenerationType pointing to the current value.
 func (c HyperVGenerationType) ToPtr() *HyperVGenerationType {
 	return &c
 }
@@ -705,7 +705,7 @@ func PossibleHyperVGenerationTypesValues() []HyperVGenerationTypes {
 	}
 }
 
-// ToPtr() returns a *HyperVGenerationTypes pointing to the current value.
+// ToPtr returns a *HyperVGenerationTypes pointing to the current value.
 func (c HyperVGenerationTypes) ToPtr() *HyperVGenerationTypes {
 	return &c
 }
@@ -727,7 +727,7 @@ func PossibleIPVersionValues() []IPVersion {
 	}
 }
 
-// ToPtr() returns a *IPVersion pointing to the current value.
+// ToPtr returns a *IPVersion pointing to the current value.
 func (c IPVersion) ToPtr() *IPVersion {
 	return &c
 }
@@ -752,7 +752,7 @@ func PossibleIntervalInMinsValues() []IntervalInMins {
 	}
 }
 
-// ToPtr() returns a *IntervalInMins pointing to the current value.
+// ToPtr returns a *IntervalInMins pointing to the current value.
 func (c IntervalInMins) ToPtr() *IntervalInMins {
 	return &c
 }
@@ -777,7 +777,7 @@ func PossibleMaintenanceOperationResultCodeTypesValues() []MaintenanceOperationR
 	}
 }
 
-// ToPtr() returns a *MaintenanceOperationResultCodeTypes pointing to the current value.
+// ToPtr returns a *MaintenanceOperationResultCodeTypes pointing to the current value.
 func (c MaintenanceOperationResultCodeTypes) ToPtr() *MaintenanceOperationResultCodeTypes {
 	return &c
 }
@@ -800,7 +800,7 @@ func PossibleOperatingSystemStateTypesValues() []OperatingSystemStateTypes {
 	}
 }
 
-// ToPtr() returns a *OperatingSystemStateTypes pointing to the current value.
+// ToPtr returns a *OperatingSystemStateTypes pointing to the current value.
 func (c OperatingSystemStateTypes) ToPtr() *OperatingSystemStateTypes {
 	return &c
 }
@@ -821,7 +821,7 @@ func PossibleOperatingSystemTypesValues() []OperatingSystemTypes {
 	}
 }
 
-// ToPtr() returns a *OperatingSystemTypes pointing to the current value.
+// ToPtr returns a *OperatingSystemTypes pointing to the current value.
 func (c OperatingSystemTypes) ToPtr() *OperatingSystemTypes {
 	return &c
 }
@@ -840,7 +840,7 @@ func PossibleOrchestrationServiceNamesValues() []OrchestrationServiceNames {
 	}
 }
 
-// ToPtr() returns a *OrchestrationServiceNames pointing to the current value.
+// ToPtr returns a *OrchestrationServiceNames pointing to the current value.
 func (c OrchestrationServiceNames) ToPtr() *OrchestrationServiceNames {
 	return &c
 }
@@ -863,7 +863,7 @@ func PossibleOrchestrationServiceStateValues() []OrchestrationServiceState {
 	}
 }
 
-// ToPtr() returns a *OrchestrationServiceState pointing to the current value.
+// ToPtr returns a *OrchestrationServiceState pointing to the current value.
 func (c OrchestrationServiceState) ToPtr() *OrchestrationServiceState {
 	return &c
 }
@@ -884,7 +884,7 @@ func PossibleOrchestrationServiceStateActionValues() []OrchestrationServiceState
 	}
 }
 
-// ToPtr() returns a *OrchestrationServiceStateAction pointing to the current value.
+// ToPtr returns a *OrchestrationServiceStateAction pointing to the current value.
 func (c OrchestrationServiceStateAction) ToPtr() *OrchestrationServiceStateAction {
 	return &c
 }
@@ -908,7 +908,7 @@ func PossibleProtocolTypesValues() []ProtocolTypes {
 	}
 }
 
-// ToPtr() returns a *ProtocolTypes pointing to the current value.
+// ToPtr returns a *ProtocolTypes pointing to the current value.
 func (c ProtocolTypes) ToPtr() *ProtocolTypes {
 	return &c
 }
@@ -932,7 +932,7 @@ func PossibleProximityPlacementGroupTypeValues() []ProximityPlacementGroupType {
 	}
 }
 
-// ToPtr() returns a *ProximityPlacementGroupType pointing to the current value.
+// ToPtr returns a *ProximityPlacementGroupType pointing to the current value.
 func (c ProximityPlacementGroupType) ToPtr() *ProximityPlacementGroupType {
 	return &c
 }
@@ -957,7 +957,7 @@ func PossibleReplicationStateValues() []ReplicationState {
 	}
 }
 
-// ToPtr() returns a *ReplicationState pointing to the current value.
+// ToPtr returns a *ReplicationState pointing to the current value.
 func (c ReplicationState) ToPtr() *ReplicationState {
 	return &c
 }
@@ -975,7 +975,7 @@ func PossibleReplicationStatusTypesValues() []ReplicationStatusTypes {
 	}
 }
 
-// ToPtr() returns a *ReplicationStatusTypes pointing to the current value.
+// ToPtr returns a *ReplicationStatusTypes pointing to the current value.
 func (c ReplicationStatusTypes) ToPtr() *ReplicationStatusTypes {
 	return &c
 }
@@ -1002,7 +1002,7 @@ func PossibleResourceIdentityTypeValues() []ResourceIdentityType {
 	}
 }
 
-// ToPtr() returns a *ResourceIdentityType pointing to the current value.
+// ToPtr returns a *ResourceIdentityType pointing to the current value.
 func (c ResourceIdentityType) ToPtr() *ResourceIdentityType {
 	return &c
 }
@@ -1025,7 +1025,7 @@ func PossibleResourceSKUCapacityScaleTypeValues() []ResourceSKUCapacityScaleType
 	}
 }
 
-// ToPtr() returns a *ResourceSKUCapacityScaleType pointing to the current value.
+// ToPtr returns a *ResourceSKUCapacityScaleType pointing to the current value.
 func (c ResourceSKUCapacityScaleType) ToPtr() *ResourceSKUCapacityScaleType {
 	return &c
 }
@@ -1046,7 +1046,7 @@ func PossibleResourceSKURestrictionsReasonCodeValues() []ResourceSKURestrictions
 	}
 }
 
-// ToPtr() returns a *ResourceSKURestrictionsReasonCode pointing to the current value.
+// ToPtr returns a *ResourceSKURestrictionsReasonCode pointing to the current value.
 func (c ResourceSKURestrictionsReasonCode) ToPtr() *ResourceSKURestrictionsReasonCode {
 	return &c
 }
@@ -1067,7 +1067,7 @@ func PossibleResourceSKURestrictionsTypeValues() []ResourceSKURestrictionsType {
 	}
 }
 
-// ToPtr() returns a *ResourceSKURestrictionsType pointing to the current value.
+// ToPtr returns a *ResourceSKURestrictionsType pointing to the current value.
 func (c ResourceSKURestrictionsType) ToPtr() *ResourceSKURestrictionsType {
 	return &c
 }
@@ -1088,7 +1088,7 @@ func PossibleRollingUpgradeActionTypeValues() []RollingUpgradeActionType {
 	}
 }
 
-// ToPtr() returns a *RollingUpgradeActionType pointing to the current value.
+// ToPtr returns a *RollingUpgradeActionType pointing to the current value.
 func (c RollingUpgradeActionType) ToPtr() *RollingUpgradeActionType {
 	return &c
 }
@@ -1113,7 +1113,7 @@ func PossibleRollingUpgradeStatusCodeValues() []RollingUpgradeStatusCode {
 	}
 }
 
-// ToPtr() returns a *RollingUpgradeStatusCode pointing to the current value.
+// ToPtr returns a *RollingUpgradeStatusCode pointing to the current value.
 func (c RollingUpgradeStatusCode) ToPtr() *RollingUpgradeStatusCode {
 	return &c
 }
@@ -1134,7 +1134,7 @@ func PossibleSettingNamesValues() []SettingNames {
 	}
 }
 
-// ToPtr() returns a *SettingNames pointing to the current value.
+// ToPtr returns a *SettingNames pointing to the current value.
 func (c SettingNames) ToPtr() *SettingNames {
 	return &c
 }
@@ -1160,7 +1160,7 @@ func PossibleSnapshotStorageAccountTypesValues() []SnapshotStorageAccountTypes {
 	}
 }
 
-// ToPtr() returns a *SnapshotStorageAccountTypes pointing to the current value.
+// ToPtr returns a *SnapshotStorageAccountTypes pointing to the current value.
 func (c SnapshotStorageAccountTypes) ToPtr() *SnapshotStorageAccountTypes {
 	return &c
 }
@@ -1183,7 +1183,7 @@ func PossibleStatusLevelTypesValues() []StatusLevelTypes {
 	}
 }
 
-// ToPtr() returns a *StatusLevelTypes pointing to the current value.
+// ToPtr returns a *StatusLevelTypes pointing to the current value.
 func (c StatusLevelTypes) ToPtr() *StatusLevelTypes {
 	return &c
 }
@@ -1206,7 +1206,7 @@ func PossibleStorageAccountTypeValues() []StorageAccountType {
 	}
 }
 
-// ToPtr() returns a *StorageAccountType pointing to the current value.
+// ToPtr returns a *StorageAccountType pointing to the current value.
 func (c StorageAccountType) ToPtr() *StorageAccountType {
 	return &c
 }
@@ -1237,7 +1237,7 @@ func PossibleStorageAccountTypesValues() []StorageAccountTypes {
 	}
 }
 
-// ToPtr() returns a *StorageAccountTypes pointing to the current value.
+// ToPtr returns a *StorageAccountTypes pointing to the current value.
 func (c StorageAccountTypes) ToPtr() *StorageAccountTypes {
 	return &c
 }
@@ -1263,7 +1263,7 @@ func PossibleUpgradeModeValues() []UpgradeMode {
 	}
 }
 
-// ToPtr() returns a *UpgradeMode pointing to the current value.
+// ToPtr returns a *UpgradeMode pointing to the current value.
 func (c UpgradeMode) ToPtr() *UpgradeMode {
 	return &c
 }
@@ -1286,7 +1286,7 @@ func PossibleUpgradeOperationInvokerValues() []UpgradeOperationInvoker {
 	}
 }
 
-// ToPtr() returns a *UpgradeOperationInvoker pointing to the current value.
+// ToPtr returns a *UpgradeOperationInvoker pointing to the current value.
 func (c UpgradeOperationInvoker) ToPtr() *UpgradeOperationInvoker {
 	return &c
 }
@@ -1311,7 +1311,7 @@ func PossibleUpgradeStateValues() []UpgradeState {
 	}
 }
 
-// ToPtr() returns a *UpgradeState pointing to the current value.
+// ToPtr returns a *UpgradeState pointing to the current value.
 func (c UpgradeState) ToPtr() *UpgradeState {
 	return &c
 }
@@ -1332,7 +1332,7 @@ func PossibleVirtualMachineEvictionPolicyTypesValues() []VirtualMachineEvictionP
 	}
 }
 
-// ToPtr() returns a *VirtualMachineEvictionPolicyTypes pointing to the current value.
+// ToPtr returns a *VirtualMachineEvictionPolicyTypes pointing to the current value.
 func (c VirtualMachineEvictionPolicyTypes) ToPtr() *VirtualMachineEvictionPolicyTypes {
 	return &c
 }
@@ -1356,7 +1356,7 @@ func PossibleVirtualMachinePriorityTypesValues() []VirtualMachinePriorityTypes {
 	}
 }
 
-// ToPtr() returns a *VirtualMachinePriorityTypes pointing to the current value.
+// ToPtr returns a *VirtualMachinePriorityTypes pointing to the current value.
 func (c VirtualMachinePriorityTypes) ToPtr() *VirtualMachinePriorityTypes {
 	return &c
 }
@@ -1377,7 +1377,7 @@ func PossibleVirtualMachineScaleSetSKUScaleTypeValues() []VirtualMachineScaleSet
 	}
 }
 
-// ToPtr() returns a *VirtualMachineScaleSetSKUScaleType pointing to the current value.
+// ToPtr returns a *VirtualMachineScaleSetSKUScaleType pointing to the current value.
 func (c VirtualMachineScaleSetSKUScaleType) ToPtr() *VirtualMachineScaleSetSKUScaleType {
 	return &c
 }
@@ -1399,7 +1399,7 @@ func PossibleVirtualMachineScaleSetScaleInRulesValues() []VirtualMachineScaleSet
 	}
 }
 
-// ToPtr() returns a *VirtualMachineScaleSetScaleInRules pointing to the current value.
+// ToPtr returns a *VirtualMachineScaleSetScaleInRules pointing to the current value.
 func (c VirtualMachineScaleSetScaleInRules) ToPtr() *VirtualMachineScaleSetScaleInRules {
 	return &c
 }
@@ -1753,7 +1753,7 @@ func PossibleVirtualMachineSizeTypesValues() []VirtualMachineSizeTypes {
 	}
 }
 
-// ToPtr() returns a *VirtualMachineSizeTypes pointing to the current value.
+// ToPtr returns a *VirtualMachineSizeTypes pointing to the current value.
 func (c VirtualMachineSizeTypes) ToPtr() *VirtualMachineSizeTypes {
 	return &c
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_constants.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_constants.go
@@ -23,7 +23,7 @@ func PossibleAccessValues() []Access {
 	}
 }
 
-// ToPtr() returns a *Access pointing to the current value.
+// ToPtr returns a *Access pointing to the current value.
 func (c Access) ToPtr() *Access {
 	return &c
 }
@@ -50,7 +50,7 @@ func PossibleApplicationGatewayBackendHealthServerHealthValues() []ApplicationGa
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayBackendHealthServerHealth pointing to the current value.
+// ToPtr returns a *ApplicationGatewayBackendHealthServerHealth pointing to the current value.
 func (c ApplicationGatewayBackendHealthServerHealth) ToPtr() *ApplicationGatewayBackendHealthServerHealth {
 	return &c
 }
@@ -71,7 +71,7 @@ func PossibleApplicationGatewayCookieBasedAffinityValues() []ApplicationGatewayC
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayCookieBasedAffinity pointing to the current value.
+// ToPtr returns a *ApplicationGatewayCookieBasedAffinity pointing to the current value.
 func (c ApplicationGatewayCookieBasedAffinity) ToPtr() *ApplicationGatewayCookieBasedAffinity {
 	return &c
 }
@@ -92,7 +92,7 @@ func PossibleApplicationGatewayCustomErrorStatusCodeValues() []ApplicationGatewa
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayCustomErrorStatusCode pointing to the current value.
+// ToPtr returns a *ApplicationGatewayCustomErrorStatusCode pointing to the current value.
 func (c ApplicationGatewayCustomErrorStatusCode) ToPtr() *ApplicationGatewayCustomErrorStatusCode {
 	return &c
 }
@@ -113,7 +113,7 @@ func PossibleApplicationGatewayFirewallModeValues() []ApplicationGatewayFirewall
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayFirewallMode pointing to the current value.
+// ToPtr returns a *ApplicationGatewayFirewallMode pointing to the current value.
 func (c ApplicationGatewayFirewallMode) ToPtr() *ApplicationGatewayFirewallMode {
 	return &c
 }
@@ -138,7 +138,7 @@ func PossibleApplicationGatewayOperationalStateValues() []ApplicationGatewayOper
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayOperationalState pointing to the current value.
+// ToPtr returns a *ApplicationGatewayOperationalState pointing to the current value.
 func (c ApplicationGatewayOperationalState) ToPtr() *ApplicationGatewayOperationalState {
 	return &c
 }
@@ -159,7 +159,7 @@ func PossibleApplicationGatewayProtocolValues() []ApplicationGatewayProtocol {
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayProtocol pointing to the current value.
+// ToPtr returns a *ApplicationGatewayProtocol pointing to the current value.
 func (c ApplicationGatewayProtocol) ToPtr() *ApplicationGatewayProtocol {
 	return &c
 }
@@ -184,7 +184,7 @@ func PossibleApplicationGatewayRedirectTypeValues() []ApplicationGatewayRedirect
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayRedirectType pointing to the current value.
+// ToPtr returns a *ApplicationGatewayRedirectType pointing to the current value.
 func (c ApplicationGatewayRedirectType) ToPtr() *ApplicationGatewayRedirectType {
 	return &c
 }
@@ -205,7 +205,7 @@ func PossibleApplicationGatewayRequestRoutingRuleTypeValues() []ApplicationGatew
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayRequestRoutingRuleType pointing to the current value.
+// ToPtr returns a *ApplicationGatewayRequestRoutingRuleType pointing to the current value.
 func (c ApplicationGatewayRequestRoutingRuleType) ToPtr() *ApplicationGatewayRequestRoutingRuleType {
 	return &c
 }
@@ -236,7 +236,7 @@ func PossibleApplicationGatewaySKUNameValues() []ApplicationGatewaySKUName {
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewaySKUName pointing to the current value.
+// ToPtr returns a *ApplicationGatewaySKUName pointing to the current value.
 func (c ApplicationGatewaySKUName) ToPtr() *ApplicationGatewaySKUName {
 	return &c
 }
@@ -309,7 +309,7 @@ func PossibleApplicationGatewaySSLCipherSuiteValues() []ApplicationGatewaySSLCip
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewaySSLCipherSuite pointing to the current value.
+// ToPtr returns a *ApplicationGatewaySSLCipherSuite pointing to the current value.
 func (c ApplicationGatewaySSLCipherSuite) ToPtr() *ApplicationGatewaySSLCipherSuite {
 	return &c
 }
@@ -332,7 +332,7 @@ func PossibleApplicationGatewaySSLPolicyNameValues() []ApplicationGatewaySSLPoli
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewaySSLPolicyName pointing to the current value.
+// ToPtr returns a *ApplicationGatewaySSLPolicyName pointing to the current value.
 func (c ApplicationGatewaySSLPolicyName) ToPtr() *ApplicationGatewaySSLPolicyName {
 	return &c
 }
@@ -353,7 +353,7 @@ func PossibleApplicationGatewaySSLPolicyTypeValues() []ApplicationGatewaySSLPoli
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewaySSLPolicyType pointing to the current value.
+// ToPtr returns a *ApplicationGatewaySSLPolicyType pointing to the current value.
 func (c ApplicationGatewaySSLPolicyType) ToPtr() *ApplicationGatewaySSLPolicyType {
 	return &c
 }
@@ -376,7 +376,7 @@ func PossibleApplicationGatewaySSLProtocolValues() []ApplicationGatewaySSLProtoc
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewaySSLProtocol pointing to the current value.
+// ToPtr returns a *ApplicationGatewaySSLProtocol pointing to the current value.
 func (c ApplicationGatewaySSLProtocol) ToPtr() *ApplicationGatewaySSLProtocol {
 	return &c
 }
@@ -401,7 +401,7 @@ func PossibleApplicationGatewayTierValues() []ApplicationGatewayTier {
 	}
 }
 
-// ToPtr() returns a *ApplicationGatewayTier pointing to the current value.
+// ToPtr returns a *ApplicationGatewayTier pointing to the current value.
 func (c ApplicationGatewayTier) ToPtr() *ApplicationGatewayTier {
 	return &c
 }
@@ -422,7 +422,7 @@ func PossibleAssociationTypeValues() []AssociationType {
 	}
 }
 
-// ToPtr() returns a *AssociationType pointing to the current value.
+// ToPtr returns a *AssociationType pointing to the current value.
 func (c AssociationType) ToPtr() *AssociationType {
 	return &c
 }
@@ -443,7 +443,7 @@ func PossibleAuthenticationMethodValues() []AuthenticationMethod {
 	}
 }
 
-// ToPtr() returns a *AuthenticationMethod pointing to the current value.
+// ToPtr returns a *AuthenticationMethod pointing to the current value.
 func (c AuthenticationMethod) ToPtr() *AuthenticationMethod {
 	return &c
 }
@@ -464,7 +464,7 @@ func PossibleAuthorizationUseStatusValues() []AuthorizationUseStatus {
 	}
 }
 
-// ToPtr() returns a *AuthorizationUseStatus pointing to the current value.
+// ToPtr returns a *AuthorizationUseStatus pointing to the current value.
 func (c AuthorizationUseStatus) ToPtr() *AuthorizationUseStatus {
 	return &c
 }
@@ -487,7 +487,7 @@ func PossibleAzureFirewallApplicationRuleProtocolTypeValues() []AzureFirewallApp
 	}
 }
 
-// ToPtr() returns a *AzureFirewallApplicationRuleProtocolType pointing to the current value.
+// ToPtr returns a *AzureFirewallApplicationRuleProtocolType pointing to the current value.
 func (c AzureFirewallApplicationRuleProtocolType) ToPtr() *AzureFirewallApplicationRuleProtocolType {
 	return &c
 }
@@ -508,7 +508,7 @@ func PossibleAzureFirewallNatRCActionTypeValues() []AzureFirewallNatRCActionType
 	}
 }
 
-// ToPtr() returns a *AzureFirewallNatRCActionType pointing to the current value.
+// ToPtr returns a *AzureFirewallNatRCActionType pointing to the current value.
 func (c AzureFirewallNatRCActionType) ToPtr() *AzureFirewallNatRCActionType {
 	return &c
 }
@@ -533,7 +533,7 @@ func PossibleAzureFirewallNetworkRuleProtocolValues() []AzureFirewallNetworkRule
 	}
 }
 
-// ToPtr() returns a *AzureFirewallNetworkRuleProtocol pointing to the current value.
+// ToPtr returns a *AzureFirewallNetworkRuleProtocol pointing to the current value.
 func (c AzureFirewallNetworkRuleProtocol) ToPtr() *AzureFirewallNetworkRuleProtocol {
 	return &c
 }
@@ -554,7 +554,7 @@ func PossibleAzureFirewallRCActionTypeValues() []AzureFirewallRCActionType {
 	}
 }
 
-// ToPtr() returns a *AzureFirewallRCActionType pointing to the current value.
+// ToPtr returns a *AzureFirewallRCActionType pointing to the current value.
 func (c AzureFirewallRCActionType) ToPtr() *AzureFirewallRCActionType {
 	return &c
 }
@@ -575,7 +575,7 @@ func PossibleAzureFirewallSKUNameValues() []AzureFirewallSKUName {
 	}
 }
 
-// ToPtr() returns a *AzureFirewallSKUName pointing to the current value.
+// ToPtr returns a *AzureFirewallSKUName pointing to the current value.
 func (c AzureFirewallSKUName) ToPtr() *AzureFirewallSKUName {
 	return &c
 }
@@ -594,7 +594,7 @@ func PossibleAzureFirewallSKUTierValues() []AzureFirewallSKUTier {
 	}
 }
 
-// ToPtr() returns a *AzureFirewallSKUTier pointing to the current value.
+// ToPtr returns a *AzureFirewallSKUTier pointing to the current value.
 func (c AzureFirewallSKUTier) ToPtr() *AzureFirewallSKUTier {
 	return &c
 }
@@ -617,7 +617,7 @@ func PossibleAzureFirewallThreatIntelModeValues() []AzureFirewallThreatIntelMode
 	}
 }
 
-// ToPtr() returns a *AzureFirewallThreatIntelMode pointing to the current value.
+// ToPtr returns a *AzureFirewallThreatIntelMode pointing to the current value.
 func (c AzureFirewallThreatIntelMode) ToPtr() *AzureFirewallThreatIntelMode {
 	return &c
 }
@@ -638,7 +638,7 @@ func PossibleBastionConnectProtocolValues() []BastionConnectProtocol {
 	}
 }
 
-// ToPtr() returns a *BastionConnectProtocol pointing to the current value.
+// ToPtr returns a *BastionConnectProtocol pointing to the current value.
 func (c BastionConnectProtocol) ToPtr() *BastionConnectProtocol {
 	return &c
 }
@@ -665,7 +665,7 @@ func PossibleBgpPeerStateValues() []BgpPeerState {
 	}
 }
 
-// ToPtr() returns a *BgpPeerState pointing to the current value.
+// ToPtr returns a *BgpPeerState pointing to the current value.
 func (c BgpPeerState) ToPtr() *BgpPeerState {
 	return &c
 }
@@ -688,7 +688,7 @@ func PossibleCircuitConnectionStatusValues() []CircuitConnectionStatus {
 	}
 }
 
-// ToPtr() returns a *CircuitConnectionStatus pointing to the current value.
+// ToPtr returns a *CircuitConnectionStatus pointing to the current value.
 func (c CircuitConnectionStatus) ToPtr() *CircuitConnectionStatus {
 	return &c
 }
@@ -707,7 +707,7 @@ func PossibleConnectionMonitorEndpointFilterItemTypeValues() []ConnectionMonitor
 	}
 }
 
-// ToPtr() returns a *ConnectionMonitorEndpointFilterItemType pointing to the current value.
+// ToPtr returns a *ConnectionMonitorEndpointFilterItemType pointing to the current value.
 func (c ConnectionMonitorEndpointFilterItemType) ToPtr() *ConnectionMonitorEndpointFilterItemType {
 	return &c
 }
@@ -726,7 +726,7 @@ func PossibleConnectionMonitorEndpointFilterTypeValues() []ConnectionMonitorEndp
 	}
 }
 
-// ToPtr() returns a *ConnectionMonitorEndpointFilterType pointing to the current value.
+// ToPtr returns a *ConnectionMonitorEndpointFilterType pointing to the current value.
 func (c ConnectionMonitorEndpointFilterType) ToPtr() *ConnectionMonitorEndpointFilterType {
 	return &c
 }
@@ -749,7 +749,7 @@ func PossibleConnectionMonitorSourceStatusValues() []ConnectionMonitorSourceStat
 	}
 }
 
-// ToPtr() returns a *ConnectionMonitorSourceStatus pointing to the current value.
+// ToPtr returns a *ConnectionMonitorSourceStatus pointing to the current value.
 func (c ConnectionMonitorSourceStatus) ToPtr() *ConnectionMonitorSourceStatus {
 	return &c
 }
@@ -772,7 +772,7 @@ func PossibleConnectionMonitorTestConfigurationProtocolValues() []ConnectionMoni
 	}
 }
 
-// ToPtr() returns a *ConnectionMonitorTestConfigurationProtocol pointing to the current value.
+// ToPtr returns a *ConnectionMonitorTestConfigurationProtocol pointing to the current value.
 func (c ConnectionMonitorTestConfigurationProtocol) ToPtr() *ConnectionMonitorTestConfigurationProtocol {
 	return &c
 }
@@ -793,7 +793,7 @@ func PossibleConnectionMonitorTypeValues() []ConnectionMonitorType {
 	}
 }
 
-// ToPtr() returns a *ConnectionMonitorType pointing to the current value.
+// ToPtr returns a *ConnectionMonitorType pointing to the current value.
 func (c ConnectionMonitorType) ToPtr() *ConnectionMonitorType {
 	return &c
 }
@@ -816,7 +816,7 @@ func PossibleConnectionStateValues() []ConnectionState {
 	}
 }
 
-// ToPtr() returns a *ConnectionState pointing to the current value.
+// ToPtr returns a *ConnectionState pointing to the current value.
 func (c ConnectionState) ToPtr() *ConnectionState {
 	return &c
 }
@@ -841,7 +841,7 @@ func PossibleConnectionStatusValues() []ConnectionStatus {
 	}
 }
 
-// ToPtr() returns a *ConnectionStatus pointing to the current value.
+// ToPtr returns a *ConnectionStatus pointing to the current value.
 func (c ConnectionStatus) ToPtr() *ConnectionStatus {
 	return &c
 }
@@ -864,7 +864,7 @@ func PossibleDdosCustomPolicyProtocolValues() []DdosCustomPolicyProtocol {
 	}
 }
 
-// ToPtr() returns a *DdosCustomPolicyProtocol pointing to the current value.
+// ToPtr returns a *DdosCustomPolicyProtocol pointing to the current value.
 func (c DdosCustomPolicyProtocol) ToPtr() *DdosCustomPolicyProtocol {
 	return &c
 }
@@ -891,7 +891,7 @@ func PossibleDdosCustomPolicyTriggerSensitivityOverrideValues() []DdosCustomPoli
 	}
 }
 
-// ToPtr() returns a *DdosCustomPolicyTriggerSensitivityOverride pointing to the current value.
+// ToPtr returns a *DdosCustomPolicyTriggerSensitivityOverride pointing to the current value.
 func (c DdosCustomPolicyTriggerSensitivityOverride) ToPtr() *DdosCustomPolicyTriggerSensitivityOverride {
 	return &c
 }
@@ -912,7 +912,7 @@ func PossibleDdosSettingsProtectionCoverageValues() []DdosSettingsProtectionCove
 	}
 }
 
-// ToPtr() returns a *DdosSettingsProtectionCoverage pointing to the current value.
+// ToPtr returns a *DdosSettingsProtectionCoverage pointing to the current value.
 func (c DdosSettingsProtectionCoverage) ToPtr() *DdosSettingsProtectionCoverage {
 	return &c
 }
@@ -945,7 +945,7 @@ func PossibleDhGroupValues() []DhGroup {
 	}
 }
 
-// ToPtr() returns a *DhGroup pointing to the current value.
+// ToPtr returns a *DhGroup pointing to the current value.
 func (c DhGroup) ToPtr() *DhGroup {
 	return &c
 }
@@ -966,7 +966,7 @@ func PossibleDirectionValues() []Direction {
 	}
 }
 
-// ToPtr() returns a *Direction pointing to the current value.
+// ToPtr returns a *Direction pointing to the current value.
 func (c Direction) ToPtr() *Direction {
 	return &c
 }
@@ -991,7 +991,7 @@ func PossibleEffectiveRouteSourceValues() []EffectiveRouteSource {
 	}
 }
 
-// ToPtr() returns a *EffectiveRouteSource pointing to the current value.
+// ToPtr returns a *EffectiveRouteSource pointing to the current value.
 func (c EffectiveRouteSource) ToPtr() *EffectiveRouteSource {
 	return &c
 }
@@ -1012,7 +1012,7 @@ func PossibleEffectiveRouteStateValues() []EffectiveRouteState {
 	}
 }
 
-// ToPtr() returns a *EffectiveRouteState pointing to the current value.
+// ToPtr returns a *EffectiveRouteState pointing to the current value.
 func (c EffectiveRouteState) ToPtr() *EffectiveRouteState {
 	return &c
 }
@@ -1035,7 +1035,7 @@ func PossibleEffectiveSecurityRuleProtocolValues() []EffectiveSecurityRuleProtoc
 	}
 }
 
-// ToPtr() returns a *EffectiveSecurityRuleProtocol pointing to the current value.
+// ToPtr returns a *EffectiveSecurityRuleProtocol pointing to the current value.
 func (c EffectiveSecurityRuleProtocol) ToPtr() *EffectiveSecurityRuleProtocol {
 	return &c
 }
@@ -1058,7 +1058,7 @@ func PossibleEvaluationStateValues() []EvaluationState {
 	}
 }
 
-// ToPtr() returns a *EvaluationState pointing to the current value.
+// ToPtr returns a *EvaluationState pointing to the current value.
 func (c EvaluationState) ToPtr() *EvaluationState {
 	return &c
 }
@@ -1083,7 +1083,7 @@ func PossibleExpressRouteCircuitPeeringAdvertisedPublicPrefixStateValues() []Exp
 	}
 }
 
-// ToPtr() returns a *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState pointing to the current value.
+// ToPtr returns a *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState pointing to the current value.
 func (c ExpressRouteCircuitPeeringAdvertisedPublicPrefixState) ToPtr() *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState {
 	return &c
 }
@@ -1104,7 +1104,7 @@ func PossibleExpressRouteCircuitPeeringStateValues() []ExpressRouteCircuitPeerin
 	}
 }
 
-// ToPtr() returns a *ExpressRouteCircuitPeeringState pointing to the current value.
+// ToPtr returns a *ExpressRouteCircuitPeeringState pointing to the current value.
 func (c ExpressRouteCircuitPeeringState) ToPtr() *ExpressRouteCircuitPeeringState {
 	return &c
 }
@@ -1125,7 +1125,7 @@ func PossibleExpressRouteCircuitSKUFamilyValues() []ExpressRouteCircuitSKUFamily
 	}
 }
 
-// ToPtr() returns a *ExpressRouteCircuitSKUFamily pointing to the current value.
+// ToPtr returns a *ExpressRouteCircuitSKUFamily pointing to the current value.
 func (c ExpressRouteCircuitSKUFamily) ToPtr() *ExpressRouteCircuitSKUFamily {
 	return &c
 }
@@ -1150,7 +1150,7 @@ func PossibleExpressRouteCircuitSKUTierValues() []ExpressRouteCircuitSKUTier {
 	}
 }
 
-// ToPtr() returns a *ExpressRouteCircuitSKUTier pointing to the current value.
+// ToPtr returns a *ExpressRouteCircuitSKUTier pointing to the current value.
 func (c ExpressRouteCircuitSKUTier) ToPtr() *ExpressRouteCircuitSKUTier {
 	return &c
 }
@@ -1171,7 +1171,7 @@ func PossibleExpressRouteLinkAdminStateValues() []ExpressRouteLinkAdminState {
 	}
 }
 
-// ToPtr() returns a *ExpressRouteLinkAdminState pointing to the current value.
+// ToPtr returns a *ExpressRouteLinkAdminState pointing to the current value.
 func (c ExpressRouteLinkAdminState) ToPtr() *ExpressRouteLinkAdminState {
 	return &c
 }
@@ -1192,7 +1192,7 @@ func PossibleExpressRouteLinkConnectorTypeValues() []ExpressRouteLinkConnectorTy
 	}
 }
 
-// ToPtr() returns a *ExpressRouteLinkConnectorType pointing to the current value.
+// ToPtr returns a *ExpressRouteLinkConnectorType pointing to the current value.
 func (c ExpressRouteLinkConnectorType) ToPtr() *ExpressRouteLinkConnectorType {
 	return &c
 }
@@ -1213,7 +1213,7 @@ func PossibleExpressRouteLinkMacSecCipherValues() []ExpressRouteLinkMacSecCipher
 	}
 }
 
-// ToPtr() returns a *ExpressRouteLinkMacSecCipher pointing to the current value.
+// ToPtr returns a *ExpressRouteLinkMacSecCipher pointing to the current value.
 func (c ExpressRouteLinkMacSecCipher) ToPtr() *ExpressRouteLinkMacSecCipher {
 	return &c
 }
@@ -1234,7 +1234,7 @@ func PossibleExpressRoutePeeringStateValues() []ExpressRoutePeeringState {
 	}
 }
 
-// ToPtr() returns a *ExpressRoutePeeringState pointing to the current value.
+// ToPtr returns a *ExpressRoutePeeringState pointing to the current value.
 func (c ExpressRoutePeeringState) ToPtr() *ExpressRoutePeeringState {
 	return &c
 }
@@ -1257,7 +1257,7 @@ func PossibleExpressRoutePeeringTypeValues() []ExpressRoutePeeringType {
 	}
 }
 
-// ToPtr() returns a *ExpressRoutePeeringType pointing to the current value.
+// ToPtr returns a *ExpressRoutePeeringType pointing to the current value.
 func (c ExpressRoutePeeringType) ToPtr() *ExpressRoutePeeringType {
 	return &c
 }
@@ -1278,7 +1278,7 @@ func PossibleExpressRoutePortsEncapsulationValues() []ExpressRoutePortsEncapsula
 	}
 }
 
-// ToPtr() returns a *ExpressRoutePortsEncapsulation pointing to the current value.
+// ToPtr returns a *ExpressRoutePortsEncapsulation pointing to the current value.
 func (c ExpressRoutePortsEncapsulation) ToPtr() *ExpressRoutePortsEncapsulation {
 	return &c
 }
@@ -1299,7 +1299,7 @@ func PossibleFirewallPolicyFilterRuleActionTypeValues() []FirewallPolicyFilterRu
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyFilterRuleActionType pointing to the current value.
+// ToPtr returns a *FirewallPolicyFilterRuleActionType pointing to the current value.
 func (c FirewallPolicyFilterRuleActionType) ToPtr() *FirewallPolicyFilterRuleActionType {
 	return &c
 }
@@ -1318,7 +1318,7 @@ func PossibleFirewallPolicyNatRuleActionTypeValues() []FirewallPolicyNatRuleActi
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyNatRuleActionType pointing to the current value.
+// ToPtr returns a *FirewallPolicyNatRuleActionType pointing to the current value.
 func (c FirewallPolicyNatRuleActionType) ToPtr() *FirewallPolicyNatRuleActionType {
 	return &c
 }
@@ -1339,7 +1339,7 @@ func PossibleFirewallPolicyRuleConditionApplicationProtocolTypeValues() []Firewa
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyRuleConditionApplicationProtocolType pointing to the current value.
+// ToPtr returns a *FirewallPolicyRuleConditionApplicationProtocolType pointing to the current value.
 func (c FirewallPolicyRuleConditionApplicationProtocolType) ToPtr() *FirewallPolicyRuleConditionApplicationProtocolType {
 	return &c
 }
@@ -1364,7 +1364,7 @@ func PossibleFirewallPolicyRuleConditionNetworkProtocolValues() []FirewallPolicy
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyRuleConditionNetworkProtocol pointing to the current value.
+// ToPtr returns a *FirewallPolicyRuleConditionNetworkProtocol pointing to the current value.
 func (c FirewallPolicyRuleConditionNetworkProtocol) ToPtr() *FirewallPolicyRuleConditionNetworkProtocol {
 	return &c
 }
@@ -1387,7 +1387,7 @@ func PossibleFirewallPolicyRuleConditionTypeValues() []FirewallPolicyRuleConditi
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyRuleConditionType pointing to the current value.
+// ToPtr returns a *FirewallPolicyRuleConditionType pointing to the current value.
 func (c FirewallPolicyRuleConditionType) ToPtr() *FirewallPolicyRuleConditionType {
 	return &c
 }
@@ -1408,7 +1408,7 @@ func PossibleFirewallPolicyRuleTypeValues() []FirewallPolicyRuleType {
 	}
 }
 
-// ToPtr() returns a *FirewallPolicyRuleType pointing to the current value.
+// ToPtr returns a *FirewallPolicyRuleType pointing to the current value.
 func (c FirewallPolicyRuleType) ToPtr() *FirewallPolicyRuleType {
 	return &c
 }
@@ -1427,7 +1427,7 @@ func PossibleFlowLogFormatTypeValues() []FlowLogFormatType {
 	}
 }
 
-// ToPtr() returns a *FlowLogFormatType pointing to the current value.
+// ToPtr returns a *FlowLogFormatType pointing to the current value.
 func (c FlowLogFormatType) ToPtr() *FlowLogFormatType {
 	return &c
 }
@@ -1448,7 +1448,7 @@ func PossibleHTTPConfigurationMethodValues() []HTTPConfigurationMethod {
 	}
 }
 
-// ToPtr() returns a *HTTPConfigurationMethod pointing to the current value.
+// ToPtr returns a *HTTPConfigurationMethod pointing to the current value.
 func (c HTTPConfigurationMethod) ToPtr() *HTTPConfigurationMethod {
 	return &c
 }
@@ -1467,7 +1467,7 @@ func PossibleHTTPMethodValues() []HTTPMethod {
 	}
 }
 
-// ToPtr() returns a *HTTPMethod pointing to the current value.
+// ToPtr returns a *HTTPMethod pointing to the current value.
 func (c HTTPMethod) ToPtr() *HTTPMethod {
 	return &c
 }
@@ -1492,7 +1492,7 @@ func PossibleHubVirtualNetworkConnectionStatusValues() []HubVirtualNetworkConnec
 	}
 }
 
-// ToPtr() returns a *HubVirtualNetworkConnectionStatus pointing to the current value.
+// ToPtr returns a *HubVirtualNetworkConnectionStatus pointing to the current value.
 func (c HubVirtualNetworkConnectionStatus) ToPtr() *HubVirtualNetworkConnectionStatus {
 	return &c
 }
@@ -1513,7 +1513,7 @@ func PossibleIPAllocationMethodValues() []IPAllocationMethod {
 	}
 }
 
-// ToPtr() returns a *IPAllocationMethod pointing to the current value.
+// ToPtr returns a *IPAllocationMethod pointing to the current value.
 func (c IPAllocationMethod) ToPtr() *IPAllocationMethod {
 	return &c
 }
@@ -1534,7 +1534,7 @@ func PossibleIPAllocationTypeValues() []IPAllocationType {
 	}
 }
 
-// ToPtr() returns a *IPAllocationType pointing to the current value.
+// ToPtr returns a *IPAllocationType pointing to the current value.
 func (c IPAllocationType) ToPtr() *IPAllocationType {
 	return &c
 }
@@ -1555,7 +1555,7 @@ func PossibleIPFlowProtocolValues() []IPFlowProtocol {
 	}
 }
 
-// ToPtr() returns a *IPFlowProtocol pointing to the current value.
+// ToPtr returns a *IPFlowProtocol pointing to the current value.
 func (c IPFlowProtocol) ToPtr() *IPFlowProtocol {
 	return &c
 }
@@ -1590,7 +1590,7 @@ func PossibleIPSecEncryptionValues() []IPSecEncryption {
 	}
 }
 
-// ToPtr() returns a *IPSecEncryption pointing to the current value.
+// ToPtr returns a *IPSecEncryption pointing to the current value.
 func (c IPSecEncryption) ToPtr() *IPSecEncryption {
 	return &c
 }
@@ -1619,7 +1619,7 @@ func PossibleIPSecIntegrityValues() []IPSecIntegrity {
 	}
 }
 
-// ToPtr() returns a *IPSecIntegrity pointing to the current value.
+// ToPtr returns a *IPSecIntegrity pointing to the current value.
 func (c IPSecIntegrity) ToPtr() *IPSecIntegrity {
 	return &c
 }
@@ -1640,7 +1640,7 @@ func PossibleIPVersionValues() []IPVersion {
 	}
 }
 
-// ToPtr() returns a *IPVersion pointing to the current value.
+// ToPtr returns a *IPVersion pointing to the current value.
 func (c IPVersion) ToPtr() *IPVersion {
 	return &c
 }
@@ -1671,7 +1671,7 @@ func PossibleIkeEncryptionValues() []IkeEncryption {
 	}
 }
 
-// ToPtr() returns a *IkeEncryption pointing to the current value.
+// ToPtr returns a *IkeEncryption pointing to the current value.
 func (c IkeEncryption) ToPtr() *IkeEncryption {
 	return &c
 }
@@ -1700,7 +1700,7 @@ func PossibleIkeIntegrityValues() []IkeIntegrity {
 	}
 }
 
-// ToPtr() returns a *IkeIntegrity pointing to the current value.
+// ToPtr returns a *IkeIntegrity pointing to the current value.
 func (c IkeIntegrity) ToPtr() *IkeIntegrity {
 	return &c
 }
@@ -1735,7 +1735,7 @@ func PossibleIssueTypeValues() []IssueType {
 	}
 }
 
-// ToPtr() returns a *IssueType pointing to the current value.
+// ToPtr returns a *IssueType pointing to the current value.
 func (c IssueType) ToPtr() *IssueType {
 	return &c
 }
@@ -1758,7 +1758,7 @@ func PossibleLoadBalancerOutboundRuleProtocolValues() []LoadBalancerOutboundRule
 	}
 }
 
-// ToPtr() returns a *LoadBalancerOutboundRuleProtocol pointing to the current value.
+// ToPtr returns a *LoadBalancerOutboundRuleProtocol pointing to the current value.
 func (c LoadBalancerOutboundRuleProtocol) ToPtr() *LoadBalancerOutboundRuleProtocol {
 	return &c
 }
@@ -1779,7 +1779,7 @@ func PossibleLoadBalancerSKUNameValues() []LoadBalancerSKUName {
 	}
 }
 
-// ToPtr() returns a *LoadBalancerSKUName pointing to the current value.
+// ToPtr returns a *LoadBalancerSKUName pointing to the current value.
 func (c LoadBalancerSKUName) ToPtr() *LoadBalancerSKUName {
 	return &c
 }
@@ -1802,7 +1802,7 @@ func PossibleLoadDistributionValues() []LoadDistribution {
 	}
 }
 
-// ToPtr() returns a *LoadDistribution pointing to the current value.
+// ToPtr returns a *LoadDistribution pointing to the current value.
 func (c LoadDistribution) ToPtr() *LoadDistribution {
 	return &c
 }
@@ -1821,7 +1821,7 @@ func PossibleManagedRuleEnabledStateValues() []ManagedRuleEnabledState {
 	}
 }
 
-// ToPtr() returns a *ManagedRuleEnabledState pointing to the current value.
+// ToPtr returns a *ManagedRuleEnabledState pointing to the current value.
 func (c ManagedRuleEnabledState) ToPtr() *ManagedRuleEnabledState {
 	return &c
 }
@@ -1840,7 +1840,7 @@ func PossibleNatGatewaySKUNameValues() []NatGatewaySKUName {
 	}
 }
 
-// ToPtr() returns a *NatGatewaySKUName pointing to the current value.
+// ToPtr returns a *NatGatewaySKUName pointing to the current value.
 func (c NatGatewaySKUName) ToPtr() *NatGatewaySKUName {
 	return &c
 }
@@ -1863,7 +1863,7 @@ func PossibleNetworkOperationStatusValues() []NetworkOperationStatus {
 	}
 }
 
-// ToPtr() returns a *NetworkOperationStatus pointing to the current value.
+// ToPtr returns a *NetworkOperationStatus pointing to the current value.
 func (c NetworkOperationStatus) ToPtr() *NetworkOperationStatus {
 	return &c
 }
@@ -1892,7 +1892,7 @@ func PossibleNextHopTypeValues() []NextHopType {
 	}
 }
 
-// ToPtr() returns a *NextHopType pointing to the current value.
+// ToPtr returns a *NextHopType pointing to the current value.
 func (c NextHopType) ToPtr() *NextHopType {
 	return &c
 }
@@ -1917,7 +1917,7 @@ func PossibleOfficeTrafficCategoryValues() []OfficeTrafficCategory {
 	}
 }
 
-// ToPtr() returns a *OfficeTrafficCategory pointing to the current value.
+// ToPtr returns a *OfficeTrafficCategory pointing to the current value.
 func (c OfficeTrafficCategory) ToPtr() *OfficeTrafficCategory {
 	return &c
 }
@@ -1940,7 +1940,7 @@ func PossibleOriginValues() []Origin {
 	}
 }
 
-// ToPtr() returns a *Origin pointing to the current value.
+// ToPtr returns a *Origin pointing to the current value.
 func (c Origin) ToPtr() *Origin {
 	return &c
 }
@@ -1959,7 +1959,7 @@ func PossibleOutputTypeValues() []OutputType {
 	}
 }
 
-// ToPtr() returns a *OutputType pointing to the current value.
+// ToPtr returns a *OutputType pointing to the current value.
 func (c OutputType) ToPtr() *OutputType {
 	return &c
 }
@@ -1982,7 +1982,7 @@ func PossibleOwaspCrsExclusionEntryMatchVariableValues() []OwaspCrsExclusionEntr
 	}
 }
 
-// ToPtr() returns a *OwaspCrsExclusionEntryMatchVariable pointing to the current value.
+// ToPtr returns a *OwaspCrsExclusionEntryMatchVariable pointing to the current value.
 func (c OwaspCrsExclusionEntryMatchVariable) ToPtr() *OwaspCrsExclusionEntryMatchVariable {
 	return &c
 }
@@ -2010,7 +2010,7 @@ func PossibleOwaspCrsExclusionEntrySelectorMatchOperatorValues() []OwaspCrsExclu
 	}
 }
 
-// ToPtr() returns a *OwaspCrsExclusionEntrySelectorMatchOperator pointing to the current value.
+// ToPtr returns a *OwaspCrsExclusionEntrySelectorMatchOperator pointing to the current value.
 func (c OwaspCrsExclusionEntrySelectorMatchOperator) ToPtr() *OwaspCrsExclusionEntrySelectorMatchOperator {
 	return &c
 }
@@ -2036,7 +2036,7 @@ func PossiblePcErrorValues() []PcError {
 	}
 }
 
-// ToPtr() returns a *PcError pointing to the current value.
+// ToPtr returns a *PcError pointing to the current value.
 func (c PcError) ToPtr() *PcError {
 	return &c
 }
@@ -2059,7 +2059,7 @@ func PossiblePcProtocolValues() []PcProtocol {
 	}
 }
 
-// ToPtr() returns a *PcProtocol pointing to the current value.
+// ToPtr returns a *PcProtocol pointing to the current value.
 func (c PcProtocol) ToPtr() *PcProtocol {
 	return &c
 }
@@ -2086,7 +2086,7 @@ func PossiblePcStatusValues() []PcStatus {
 	}
 }
 
-// ToPtr() returns a *PcStatus pointing to the current value.
+// ToPtr returns a *PcStatus pointing to the current value.
 func (c PcStatus) ToPtr() *PcStatus {
 	return &c
 }
@@ -2121,7 +2121,7 @@ func PossiblePfsGroupValues() []PfsGroup {
 	}
 }
 
-// ToPtr() returns a *PfsGroup pointing to the current value.
+// ToPtr returns a *PfsGroup pointing to the current value.
 func (c PfsGroup) ToPtr() *PfsGroup {
 	return &c
 }
@@ -2143,7 +2143,7 @@ func PossiblePreferredIPVersionValues() []PreferredIPVersion {
 	}
 }
 
-// ToPtr() returns a *PreferredIPVersion pointing to the current value.
+// ToPtr returns a *PreferredIPVersion pointing to the current value.
 func (c PreferredIPVersion) ToPtr() *PreferredIPVersion {
 	return &c
 }
@@ -2168,7 +2168,7 @@ func PossibleProbeProtocolValues() []ProbeProtocol {
 	}
 }
 
-// ToPtr() returns a *ProbeProtocol pointing to the current value.
+// ToPtr returns a *ProbeProtocol pointing to the current value.
 func (c ProbeProtocol) ToPtr() *ProbeProtocol {
 	return &c
 }
@@ -2189,7 +2189,7 @@ func PossibleProcessorArchitectureValues() []ProcessorArchitecture {
 	}
 }
 
-// ToPtr() returns a *ProcessorArchitecture pointing to the current value.
+// ToPtr returns a *ProcessorArchitecture pointing to the current value.
 func (c ProcessorArchitecture) ToPtr() *ProcessorArchitecture {
 	return &c
 }
@@ -2214,7 +2214,7 @@ func PossibleProtocolValues() []Protocol {
 	}
 }
 
-// ToPtr() returns a *Protocol pointing to the current value.
+// ToPtr returns a *Protocol pointing to the current value.
 func (c Protocol) ToPtr() *Protocol {
 	return &c
 }
@@ -2239,7 +2239,7 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 	}
 }
 
-// ToPtr() returns a *ProvisioningState pointing to the current value.
+// ToPtr returns a *ProvisioningState pointing to the current value.
 func (c ProvisioningState) ToPtr() *ProvisioningState {
 	return &c
 }
@@ -2260,7 +2260,7 @@ func PossiblePublicIPAddressSKUNameValues() []PublicIPAddressSKUName {
 	}
 }
 
-// ToPtr() returns a *PublicIPAddressSKUName pointing to the current value.
+// ToPtr returns a *PublicIPAddressSKUName pointing to the current value.
 func (c PublicIPAddressSKUName) ToPtr() *PublicIPAddressSKUName {
 	return &c
 }
@@ -2279,7 +2279,7 @@ func PossiblePublicIPPrefixSKUNameValues() []PublicIPPrefixSKUName {
 	}
 }
 
-// ToPtr() returns a *PublicIPPrefixSKUName pointing to the current value.
+// ToPtr returns a *PublicIPPrefixSKUName pointing to the current value.
 func (c PublicIPPrefixSKUName) ToPtr() *PublicIPPrefixSKUName {
 	return &c
 }
@@ -2306,7 +2306,7 @@ func PossibleResourceIdentityTypeValues() []ResourceIdentityType {
 	}
 }
 
-// ToPtr() returns a *ResourceIdentityType pointing to the current value.
+// ToPtr returns a *ResourceIdentityType pointing to the current value.
 func (c ResourceIdentityType) ToPtr() *ResourceIdentityType {
 	return &c
 }
@@ -2325,7 +2325,7 @@ func PossibleRouteFilterRuleTypeValues() []RouteFilterRuleType {
 	}
 }
 
-// ToPtr() returns a *RouteFilterRuleType pointing to the current value.
+// ToPtr returns a *RouteFilterRuleType pointing to the current value.
 func (c RouteFilterRuleType) ToPtr() *RouteFilterRuleType {
 	return &c
 }
@@ -2352,7 +2352,7 @@ func PossibleRouteNextHopTypeValues() []RouteNextHopType {
 	}
 }
 
-// ToPtr() returns a *RouteNextHopType pointing to the current value.
+// ToPtr returns a *RouteNextHopType pointing to the current value.
 func (c RouteNextHopType) ToPtr() *RouteNextHopType {
 	return &c
 }
@@ -2377,7 +2377,7 @@ func PossibleSecurityPartnerProviderConnectionStatusValues() []SecurityPartnerPr
 	}
 }
 
-// ToPtr() returns a *SecurityPartnerProviderConnectionStatus pointing to the current value.
+// ToPtr returns a *SecurityPartnerProviderConnectionStatus pointing to the current value.
 func (c SecurityPartnerProviderConnectionStatus) ToPtr() *SecurityPartnerProviderConnectionStatus {
 	return &c
 }
@@ -2400,7 +2400,7 @@ func PossibleSecurityProviderNameValues() []SecurityProviderName {
 	}
 }
 
-// ToPtr() returns a *SecurityProviderName pointing to the current value.
+// ToPtr returns a *SecurityProviderName pointing to the current value.
 func (c SecurityProviderName) ToPtr() *SecurityProviderName {
 	return &c
 }
@@ -2421,7 +2421,7 @@ func PossibleSecurityRuleAccessValues() []SecurityRuleAccess {
 	}
 }
 
-// ToPtr() returns a *SecurityRuleAccess pointing to the current value.
+// ToPtr returns a *SecurityRuleAccess pointing to the current value.
 func (c SecurityRuleAccess) ToPtr() *SecurityRuleAccess {
 	return &c
 }
@@ -2442,7 +2442,7 @@ func PossibleSecurityRuleDirectionValues() []SecurityRuleDirection {
 	}
 }
 
-// ToPtr() returns a *SecurityRuleDirection pointing to the current value.
+// ToPtr returns a *SecurityRuleDirection pointing to the current value.
 func (c SecurityRuleDirection) ToPtr() *SecurityRuleDirection {
 	return &c
 }
@@ -2471,7 +2471,7 @@ func PossibleSecurityRuleProtocolValues() []SecurityRuleProtocol {
 	}
 }
 
-// ToPtr() returns a *SecurityRuleProtocol pointing to the current value.
+// ToPtr returns a *SecurityRuleProtocol pointing to the current value.
 func (c SecurityRuleProtocol) ToPtr() *SecurityRuleProtocol {
 	return &c
 }
@@ -2496,7 +2496,7 @@ func PossibleServiceProviderProvisioningStateValues() []ServiceProviderProvision
 	}
 }
 
-// ToPtr() returns a *ServiceProviderProvisioningState pointing to the current value.
+// ToPtr returns a *ServiceProviderProvisioningState pointing to the current value.
 func (c ServiceProviderProvisioningState) ToPtr() *ServiceProviderProvisioningState {
 	return &c
 }
@@ -2517,7 +2517,7 @@ func PossibleSeverityValues() []Severity {
 	}
 }
 
-// ToPtr() returns a *Severity pointing to the current value.
+// ToPtr returns a *Severity pointing to the current value.
 func (c Severity) ToPtr() *Severity {
 	return &c
 }
@@ -2540,7 +2540,7 @@ func PossibleTransportProtocolValues() []TransportProtocol {
 	}
 }
 
-// ToPtr() returns a *TransportProtocol pointing to the current value.
+// ToPtr returns a *TransportProtocol pointing to the current value.
 func (c TransportProtocol) ToPtr() *TransportProtocol {
 	return &c
 }
@@ -2565,7 +2565,7 @@ func PossibleTunnelConnectionStatusValues() []TunnelConnectionStatus {
 	}
 }
 
-// ToPtr() returns a *TunnelConnectionStatus pointing to the current value.
+// ToPtr returns a *TunnelConnectionStatus pointing to the current value.
 func (c TunnelConnectionStatus) ToPtr() *TunnelConnectionStatus {
 	return &c
 }
@@ -2584,7 +2584,7 @@ func PossibleUsageUnitValues() []UsageUnit {
 	}
 }
 
-// ToPtr() returns a *UsageUnit pointing to the current value.
+// ToPtr returns a *UsageUnit pointing to the current value.
 func (c UsageUnit) ToPtr() *UsageUnit {
 	return &c
 }
@@ -2607,7 +2607,7 @@ func PossibleVPNAuthenticationTypeValues() []VPNAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *VPNAuthenticationType pointing to the current value.
+// ToPtr returns a *VPNAuthenticationType pointing to the current value.
 func (c VPNAuthenticationType) ToPtr() *VPNAuthenticationType {
 	return &c
 }
@@ -2630,7 +2630,7 @@ func PossibleVPNClientProtocolValues() []VPNClientProtocol {
 	}
 }
 
-// ToPtr() returns a *VPNClientProtocol pointing to the current value.
+// ToPtr returns a *VPNClientProtocol pointing to the current value.
 func (c VPNClientProtocol) ToPtr() *VPNClientProtocol {
 	return &c
 }
@@ -2655,7 +2655,7 @@ func PossibleVPNConnectionStatusValues() []VPNConnectionStatus {
 	}
 }
 
-// ToPtr() returns a *VPNConnectionStatus pointing to the current value.
+// ToPtr returns a *VPNConnectionStatus pointing to the current value.
 func (c VPNConnectionStatus) ToPtr() *VPNConnectionStatus {
 	return &c
 }
@@ -2678,7 +2678,7 @@ func PossibleVPNGatewayGenerationValues() []VPNGatewayGeneration {
 	}
 }
 
-// ToPtr() returns a *VPNGatewayGeneration pointing to the current value.
+// ToPtr returns a *VPNGatewayGeneration pointing to the current value.
 func (c VPNGatewayGeneration) ToPtr() *VPNGatewayGeneration {
 	return &c
 }
@@ -2699,7 +2699,7 @@ func PossibleVPNGatewayTunnelingProtocolValues() []VPNGatewayTunnelingProtocol {
 	}
 }
 
-// ToPtr() returns a *VPNGatewayTunnelingProtocol pointing to the current value.
+// ToPtr returns a *VPNGatewayTunnelingProtocol pointing to the current value.
 func (c VPNGatewayTunnelingProtocol) ToPtr() *VPNGatewayTunnelingProtocol {
 	return &c
 }
@@ -2720,7 +2720,7 @@ func PossibleVPNTypeValues() []VPNType {
 	}
 }
 
-// ToPtr() returns a *VPNType pointing to the current value.
+// ToPtr returns a *VPNType pointing to the current value.
 func (c VPNType) ToPtr() *VPNType {
 	return &c
 }
@@ -2743,7 +2743,7 @@ func PossibleVerbosityLevelValues() []VerbosityLevel {
 	}
 }
 
-// ToPtr() returns a *VerbosityLevel pointing to the current value.
+// ToPtr returns a *VerbosityLevel pointing to the current value.
 func (c VerbosityLevel) ToPtr() *VerbosityLevel {
 	return &c
 }
@@ -2764,7 +2764,7 @@ func PossibleVirtualNetworkGatewayConnectionProtocolValues() []VirtualNetworkGat
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewayConnectionProtocol pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewayConnectionProtocol pointing to the current value.
 func (c VirtualNetworkGatewayConnectionProtocol) ToPtr() *VirtualNetworkGatewayConnectionProtocol {
 	return &c
 }
@@ -2789,7 +2789,7 @@ func PossibleVirtualNetworkGatewayConnectionStatusValues() []VirtualNetworkGatew
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewayConnectionStatus pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewayConnectionStatus pointing to the current value.
 func (c VirtualNetworkGatewayConnectionStatus) ToPtr() *VirtualNetworkGatewayConnectionStatus {
 	return &c
 }
@@ -2814,7 +2814,7 @@ func PossibleVirtualNetworkGatewayConnectionTypeValues() []VirtualNetworkGateway
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewayConnectionType pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewayConnectionType pointing to the current value.
 func (c VirtualNetworkGatewayConnectionType) ToPtr() *VirtualNetworkGatewayConnectionType {
 	return &c
 }
@@ -2865,7 +2865,7 @@ func PossibleVirtualNetworkGatewaySKUNameValues() []VirtualNetworkGatewaySKUName
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewaySKUName pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewaySKUName pointing to the current value.
 func (c VirtualNetworkGatewaySKUName) ToPtr() *VirtualNetworkGatewaySKUName {
 	return &c
 }
@@ -2916,7 +2916,7 @@ func PossibleVirtualNetworkGatewaySKUTierValues() []VirtualNetworkGatewaySKUTier
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewaySKUTier pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewaySKUTier pointing to the current value.
 func (c VirtualNetworkGatewaySKUTier) ToPtr() *VirtualNetworkGatewaySKUTier {
 	return &c
 }
@@ -2937,7 +2937,7 @@ func PossibleVirtualNetworkGatewayTypeValues() []VirtualNetworkGatewayType {
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkGatewayType pointing to the current value.
+// ToPtr returns a *VirtualNetworkGatewayType pointing to the current value.
 func (c VirtualNetworkGatewayType) ToPtr() *VirtualNetworkGatewayType {
 	return &c
 }
@@ -2960,7 +2960,7 @@ func PossibleVirtualNetworkPeeringStateValues() []VirtualNetworkPeeringState {
 	}
 }
 
-// ToPtr() returns a *VirtualNetworkPeeringState pointing to the current value.
+// ToPtr returns a *VirtualNetworkPeeringState pointing to the current value.
 func (c VirtualNetworkPeeringState) ToPtr() *VirtualNetworkPeeringState {
 	return &c
 }
@@ -2981,7 +2981,7 @@ func PossibleVirtualWanSecurityProviderTypeValues() []VirtualWanSecurityProvider
 	}
 }
 
-// ToPtr() returns a *VirtualWanSecurityProviderType pointing to the current value.
+// ToPtr returns a *VirtualWanSecurityProviderType pointing to the current value.
 func (c VirtualWanSecurityProviderType) ToPtr() *VirtualWanSecurityProviderType {
 	return &c
 }
@@ -3004,7 +3004,7 @@ func PossibleWebApplicationFirewallActionValues() []WebApplicationFirewallAction
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallAction pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallAction pointing to the current value.
 func (c WebApplicationFirewallAction) ToPtr() *WebApplicationFirewallAction {
 	return &c
 }
@@ -3025,7 +3025,7 @@ func PossibleWebApplicationFirewallEnabledStateValues() []WebApplicationFirewall
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallEnabledState pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallEnabledState pointing to the current value.
 func (c WebApplicationFirewallEnabledState) ToPtr() *WebApplicationFirewallEnabledState {
 	return &c
 }
@@ -3058,7 +3058,7 @@ func PossibleWebApplicationFirewallMatchVariableValues() []WebApplicationFirewal
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallMatchVariable pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallMatchVariable pointing to the current value.
 func (c WebApplicationFirewallMatchVariable) ToPtr() *WebApplicationFirewallMatchVariable {
 	return &c
 }
@@ -3079,7 +3079,7 @@ func PossibleWebApplicationFirewallModeValues() []WebApplicationFirewallMode {
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallMode pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallMode pointing to the current value.
 func (c WebApplicationFirewallMode) ToPtr() *WebApplicationFirewallMode {
 	return &c
 }
@@ -3118,7 +3118,7 @@ func PossibleWebApplicationFirewallOperatorValues() []WebApplicationFirewallOper
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallOperator pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallOperator pointing to the current value.
 func (c WebApplicationFirewallOperator) ToPtr() *WebApplicationFirewallOperator {
 	return &c
 }
@@ -3147,7 +3147,7 @@ func PossibleWebApplicationFirewallPolicyResourceStateValues() []WebApplicationF
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallPolicyResourceState pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallPolicyResourceState pointing to the current value.
 func (c WebApplicationFirewallPolicyResourceState) ToPtr() *WebApplicationFirewallPolicyResourceState {
 	return &c
 }
@@ -3168,7 +3168,7 @@ func PossibleWebApplicationFirewallRuleTypeValues() []WebApplicationFirewallRule
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallRuleType pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallRuleType pointing to the current value.
 func (c WebApplicationFirewallRuleType) ToPtr() *WebApplicationFirewallRuleType {
 	return &c
 }
@@ -3197,7 +3197,7 @@ func PossibleWebApplicationFirewallTransformValues() []WebApplicationFirewallTra
 	}
 }
 
-// ToPtr() returns a *WebApplicationFirewallTransform pointing to the current value.
+// ToPtr returns a *WebApplicationFirewallTransform pointing to the current value.
 func (c WebApplicationFirewallTransform) ToPtr() *WebApplicationFirewallTransform {
 	return &c
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_constants.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_constants.go
@@ -46,7 +46,7 @@ func PossibleAccessTierValues() []AccessTier {
 	}
 }
 
-// ToPtr() returns a *AccessTier pointing to the current value.
+// ToPtr returns a *AccessTier pointing to the current value.
 func (c AccessTier) ToPtr() *AccessTier {
 	return &c
 }
@@ -72,7 +72,7 @@ func PossibleAccountKindValues() []AccountKind {
 	}
 }
 
-// ToPtr() returns a *AccountKind pointing to the current value.
+// ToPtr returns a *AccountKind pointing to the current value.
 func (c AccountKind) ToPtr() *AccountKind {
 	return &c
 }
@@ -92,7 +92,7 @@ func PossibleArchiveStatusValues() []ArchiveStatus {
 	}
 }
 
-// ToPtr() returns a *ArchiveStatus pointing to the current value.
+// ToPtr returns a *ArchiveStatus pointing to the current value.
 func (c ArchiveStatus) ToPtr() *ArchiveStatus {
 	return &c
 }
@@ -116,7 +116,7 @@ func PossibleBlobExpiryOptionsValues() []BlobExpiryOptions {
 	}
 }
 
-// ToPtr() returns a *BlobExpiryOptions pointing to the current value.
+// ToPtr returns a *BlobExpiryOptions pointing to the current value.
 func (c BlobExpiryOptions) ToPtr() *BlobExpiryOptions {
 	return &c
 }
@@ -138,7 +138,7 @@ func PossibleBlobImmutabilityPolicyModeValues() []BlobImmutabilityPolicyMode {
 	}
 }
 
-// ToPtr() returns a *BlobImmutabilityPolicyMode pointing to the current value.
+// ToPtr returns a *BlobImmutabilityPolicyMode pointing to the current value.
 func (c BlobImmutabilityPolicyMode) ToPtr() *BlobImmutabilityPolicyMode {
 	return &c
 }
@@ -160,7 +160,7 @@ func PossibleBlobTypeValues() []BlobType {
 	}
 }
 
-// ToPtr() returns a *BlobType pointing to the current value.
+// ToPtr returns a *BlobType pointing to the current value.
 func (c BlobType) ToPtr() *BlobType {
 	return &c
 }
@@ -182,7 +182,7 @@ func PossibleBlockListTypeValues() []BlockListType {
 	}
 }
 
-// ToPtr() returns a *BlockListType pointing to the current value.
+// ToPtr returns a *BlockListType pointing to the current value.
 func (c BlockListType) ToPtr() *BlockListType {
 	return &c
 }
@@ -206,7 +206,7 @@ func PossibleCopyStatusTypeValues() []CopyStatusType {
 	}
 }
 
-// ToPtr() returns a *CopyStatusType pointing to the current value.
+// ToPtr returns a *CopyStatusType pointing to the current value.
 func (c CopyStatusType) ToPtr() *CopyStatusType {
 	return &c
 }
@@ -226,7 +226,7 @@ func PossibleDeleteSnapshotsOptionTypeValues() []DeleteSnapshotsOptionType {
 	}
 }
 
-// ToPtr() returns a *DeleteSnapshotsOptionType pointing to the current value.
+// ToPtr returns a *DeleteSnapshotsOptionType pointing to the current value.
 func (c DeleteSnapshotsOptionType) ToPtr() *DeleteSnapshotsOptionType {
 	return &c
 }
@@ -249,7 +249,7 @@ func PossibleGeoReplicationStatusTypeValues() []GeoReplicationStatusType {
 	}
 }
 
-// ToPtr() returns a *GeoReplicationStatusType pointing to the current value.
+// ToPtr returns a *GeoReplicationStatusType pointing to the current value.
 func (c GeoReplicationStatusType) ToPtr() *GeoReplicationStatusType {
 	return &c
 }
@@ -269,7 +269,7 @@ func PossibleLeaseDurationTypeValues() []LeaseDurationType {
 	}
 }
 
-// ToPtr() returns a *LeaseDurationType pointing to the current value.
+// ToPtr returns a *LeaseDurationType pointing to the current value.
 func (c LeaseDurationType) ToPtr() *LeaseDurationType {
 	return &c
 }
@@ -295,7 +295,7 @@ func PossibleLeaseStateTypeValues() []LeaseStateType {
 	}
 }
 
-// ToPtr() returns a *LeaseStateType pointing to the current value.
+// ToPtr returns a *LeaseStateType pointing to the current value.
 func (c LeaseStateType) ToPtr() *LeaseStateType {
 	return &c
 }
@@ -315,7 +315,7 @@ func PossibleLeaseStatusTypeValues() []LeaseStatusType {
 	}
 }
 
-// ToPtr() returns a *LeaseStatusType pointing to the current value.
+// ToPtr returns a *LeaseStatusType pointing to the current value.
 func (c LeaseStatusType) ToPtr() *LeaseStatusType {
 	return &c
 }
@@ -349,7 +349,7 @@ func PossibleListBlobsIncludeItemValues() []ListBlobsIncludeItem {
 	}
 }
 
-// ToPtr() returns a *ListBlobsIncludeItem pointing to the current value.
+// ToPtr returns a *ListBlobsIncludeItem pointing to the current value.
 func (c ListBlobsIncludeItem) ToPtr() *ListBlobsIncludeItem {
 	return &c
 }
@@ -369,7 +369,7 @@ func PossibleListContainersIncludeTypeValues() []ListContainersIncludeType {
 	}
 }
 
-// ToPtr() returns a *ListContainersIncludeType pointing to the current value.
+// ToPtr returns a *ListContainersIncludeType pointing to the current value.
 func (c ListContainersIncludeType) ToPtr() *ListContainersIncludeType {
 	return &c
 }
@@ -389,7 +389,7 @@ func PossiblePathRenameModeValues() []PathRenameMode {
 	}
 }
 
-// ToPtr() returns a *PathRenameMode pointing to the current value.
+// ToPtr returns a *PathRenameMode pointing to the current value.
 func (c PathRenameMode) ToPtr() *PathRenameMode {
 	return &c
 }
@@ -427,7 +427,7 @@ func PossiblePremiumPageBlobAccessTierValues() []PremiumPageBlobAccessTier {
 	}
 }
 
-// ToPtr() returns a *PremiumPageBlobAccessTier pointing to the current value.
+// ToPtr returns a *PremiumPageBlobAccessTier pointing to the current value.
 func (c PremiumPageBlobAccessTier) ToPtr() *PremiumPageBlobAccessTier {
 	return &c
 }
@@ -447,7 +447,7 @@ func PossiblePublicAccessTypeValues() []PublicAccessType {
 	}
 }
 
-// ToPtr() returns a *PublicAccessType pointing to the current value.
+// ToPtr returns a *PublicAccessType pointing to the current value.
 func (c PublicAccessType) ToPtr() *PublicAccessType {
 	return &c
 }
@@ -470,7 +470,7 @@ func PossibleQueryFormatTypeValues() []QueryFormatType {
 	}
 }
 
-// ToPtr() returns a *QueryFormatType pointing to the current value.
+// ToPtr returns a *QueryFormatType pointing to the current value.
 func (c QueryFormatType) ToPtr() *QueryFormatType {
 	return &c
 }
@@ -491,7 +491,7 @@ func PossibleRehydratePriorityValues() []RehydratePriority {
 	}
 }
 
-// ToPtr() returns a *RehydratePriority pointing to the current value.
+// ToPtr returns a *RehydratePriority pointing to the current value.
 func (c RehydratePriority) ToPtr() *RehydratePriority {
 	return &c
 }
@@ -517,7 +517,7 @@ func PossibleSKUNameValues() []SKUName {
 	}
 }
 
-// ToPtr() returns a *SKUName pointing to the current value.
+// ToPtr returns a *SKUName pointing to the current value.
 func (c SKUName) ToPtr() *SKUName {
 	return &c
 }
@@ -539,7 +539,7 @@ func PossibleSequenceNumberActionTypeValues() []SequenceNumberActionType {
 	}
 }
 
-// ToPtr() returns a *SequenceNumberActionType pointing to the current value.
+// ToPtr returns a *SequenceNumberActionType pointing to the current value.
 func (c SequenceNumberActionType) ToPtr() *SequenceNumberActionType {
 	return &c
 }
@@ -782,7 +782,7 @@ func PossibleStorageErrorCodeValues() []StorageErrorCode {
 	}
 }
 
-// ToPtr() returns a *StorageErrorCode pointing to the current value.
+// ToPtr returns a *StorageErrorCode pointing to the current value.
 func (c StorageErrorCode) ToPtr() *StorageErrorCode {
 	return &c
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
@@ -28,7 +28,7 @@ func PossibleAvroCompressionCodecValues() []AvroCompressionCodec {
 	}
 }
 
-// ToPtr() returns a *AvroCompressionCodec pointing to the current value.
+// ToPtr returns a *AvroCompressionCodec pointing to the current value.
 func (c AvroCompressionCodec) ToPtr() *AvroCompressionCodec {
 	return &c
 }
@@ -59,7 +59,7 @@ func PossibleAzureFunctionActivityMethodValues() []AzureFunctionActivityMethod {
 	}
 }
 
-// ToPtr() returns a *AzureFunctionActivityMethod pointing to the current value.
+// ToPtr returns a *AzureFunctionActivityMethod pointing to the current value.
 func (c AzureFunctionActivityMethod) ToPtr() *AzureFunctionActivityMethod {
 	return &c
 }
@@ -80,7 +80,7 @@ func PossibleAzureSearchIndexWriteBehaviorTypeValues() []AzureSearchIndexWriteBe
 	}
 }
 
-// ToPtr() returns a *AzureSearchIndexWriteBehaviorType pointing to the current value.
+// ToPtr returns a *AzureSearchIndexWriteBehaviorType pointing to the current value.
 func (c AzureSearchIndexWriteBehaviorType) ToPtr() *AzureSearchIndexWriteBehaviorType {
 	return &c
 }
@@ -99,7 +99,7 @@ func PossibleBigDataPoolReferenceTypeValues() []BigDataPoolReferenceType {
 	}
 }
 
-// ToPtr() returns a *BigDataPoolReferenceType pointing to the current value.
+// ToPtr returns a *BigDataPoolReferenceType pointing to the current value.
 func (c BigDataPoolReferenceType) ToPtr() *BigDataPoolReferenceType {
 	return &c
 }
@@ -119,7 +119,7 @@ func PossibleBlobEventTypeValues() []BlobEventType {
 	}
 }
 
-// ToPtr() returns a *BlobEventType pointing to the current value.
+// ToPtr returns a *BlobEventType pointing to the current value.
 func (c BlobEventType) ToPtr() *BlobEventType {
 	return &c
 }
@@ -158,7 +158,7 @@ func PossibleCassandraSourceReadConsistencyLevelsValues() []CassandraSourceReadC
 	}
 }
 
-// ToPtr() returns a *CassandraSourceReadConsistencyLevels pointing to the current value.
+// ToPtr returns a *CassandraSourceReadConsistencyLevels pointing to the current value.
 func (c CassandraSourceReadConsistencyLevels) ToPtr() *CassandraSourceReadConsistencyLevels {
 	return &c
 }
@@ -183,7 +183,7 @@ func PossibleCellOutputTypeValues() []CellOutputType {
 	}
 }
 
-// ToPtr() returns a *CellOutputType pointing to the current value.
+// ToPtr returns a *CellOutputType pointing to the current value.
 func (c CellOutputType) ToPtr() *CellOutputType {
 	return &c
 }
@@ -206,7 +206,7 @@ func PossibleCopyBehaviorTypeValues() []CopyBehaviorType {
 	}
 }
 
-// ToPtr() returns a *CopyBehaviorType pointing to the current value.
+// ToPtr returns a *CopyBehaviorType pointing to the current value.
 func (c CopyBehaviorType) ToPtr() *CopyBehaviorType {
 	return &c
 }
@@ -229,7 +229,7 @@ func PossibleDataFlowComputeTypeValues() []DataFlowComputeType {
 	}
 }
 
-// ToPtr() returns a *DataFlowComputeType pointing to the current value.
+// ToPtr returns a *DataFlowComputeType pointing to the current value.
 func (c DataFlowComputeType) ToPtr() *DataFlowComputeType {
 	return &c
 }
@@ -248,7 +248,7 @@ func PossibleDataFlowReferenceTypeValues() []DataFlowReferenceType {
 	}
 }
 
-// ToPtr() returns a *DataFlowReferenceType pointing to the current value.
+// ToPtr returns a *DataFlowReferenceType pointing to the current value.
 func (c DataFlowReferenceType) ToPtr() *DataFlowReferenceType {
 	return &c
 }
@@ -269,7 +269,7 @@ func PossibleDatasetCompressionLevelValues() []DatasetCompressionLevel {
 	}
 }
 
-// ToPtr() returns a *DatasetCompressionLevel pointing to the current value.
+// ToPtr returns a *DatasetCompressionLevel pointing to the current value.
 func (c DatasetCompressionLevel) ToPtr() *DatasetCompressionLevel {
 	return &c
 }
@@ -288,7 +288,7 @@ func PossibleDatasetReferenceTypeValues() []DatasetReferenceType {
 	}
 }
 
-// ToPtr() returns a *DatasetReferenceType pointing to the current value.
+// ToPtr returns a *DatasetReferenceType pointing to the current value.
 func (c DatasetReferenceType) ToPtr() *DatasetReferenceType {
 	return &c
 }
@@ -318,7 +318,7 @@ func PossibleDayOfWeekValues() []DayOfWeek {
 	}
 }
 
-// ToPtr() returns a *DayOfWeek pointing to the current value.
+// ToPtr returns a *DayOfWeek pointing to the current value.
 func (c DayOfWeek) ToPtr() *DayOfWeek {
 	return &c
 }
@@ -337,7 +337,7 @@ func PossibleDb2AuthenticationTypeValues() []Db2AuthenticationType {
 	}
 }
 
-// ToPtr() returns a *Db2AuthenticationType pointing to the current value.
+// ToPtr returns a *Db2AuthenticationType pointing to the current value.
 func (c Db2AuthenticationType) ToPtr() *Db2AuthenticationType {
 	return &c
 }
@@ -365,7 +365,7 @@ func PossibleDelimitedTextCompressionCodecValues() []DelimitedTextCompressionCod
 	}
 }
 
-// ToPtr() returns a *DelimitedTextCompressionCodec pointing to the current value.
+// ToPtr returns a *DelimitedTextCompressionCodec pointing to the current value.
 func (c DelimitedTextCompressionCodec) ToPtr() *DelimitedTextCompressionCodec {
 	return &c
 }
@@ -389,7 +389,7 @@ func PossibleDependencyConditionValues() []DependencyCondition {
 	}
 }
 
-// ToPtr() returns a *DependencyCondition pointing to the current value.
+// ToPtr returns a *DependencyCondition pointing to the current value.
 func (c DependencyCondition) ToPtr() *DependencyCondition {
 	return &c
 }
@@ -414,7 +414,7 @@ func PossibleDynamicsAuthenticationTypeValues() []DynamicsAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *DynamicsAuthenticationType pointing to the current value.
+// ToPtr returns a *DynamicsAuthenticationType pointing to the current value.
 func (c DynamicsAuthenticationType) ToPtr() *DynamicsAuthenticationType {
 	return &c
 }
@@ -436,7 +436,7 @@ func PossibleDynamicsDeploymentTypeValues() []DynamicsDeploymentType {
 	}
 }
 
-// ToPtr() returns a *DynamicsDeploymentType pointing to the current value.
+// ToPtr returns a *DynamicsDeploymentType pointing to the current value.
 func (c DynamicsDeploymentType) ToPtr() *DynamicsDeploymentType {
 	return &c
 }
@@ -459,7 +459,7 @@ func PossibleDynamicsServicePrincipalCredentialTypeValues() []DynamicsServicePri
 	}
 }
 
-// ToPtr() returns a *DynamicsServicePrincipalCredentialType pointing to the current value.
+// ToPtr returns a *DynamicsServicePrincipalCredentialType pointing to the current value.
 func (c DynamicsServicePrincipalCredentialType) ToPtr() *DynamicsServicePrincipalCredentialType {
 	return &c
 }
@@ -478,7 +478,7 @@ func PossibleDynamicsSinkWriteBehaviorValues() []DynamicsSinkWriteBehavior {
 	}
 }
 
-// ToPtr() returns a *DynamicsSinkWriteBehavior pointing to the current value.
+// ToPtr returns a *DynamicsSinkWriteBehavior pointing to the current value.
 func (c DynamicsSinkWriteBehavior) ToPtr() *DynamicsSinkWriteBehavior {
 	return &c
 }
@@ -505,7 +505,7 @@ func PossibleEventSubscriptionStatusValues() []EventSubscriptionStatus {
 	}
 }
 
-// ToPtr() returns a *EventSubscriptionStatus pointing to the current value.
+// ToPtr returns a *EventSubscriptionStatus pointing to the current value.
 func (c EventSubscriptionStatus) ToPtr() *EventSubscriptionStatus {
 	return &c
 }
@@ -524,7 +524,7 @@ func PossibleExpressionTypeValues() []ExpressionType {
 	}
 }
 
-// ToPtr() returns a *ExpressionType pointing to the current value.
+// ToPtr returns a *ExpressionType pointing to the current value.
 func (c ExpressionType) ToPtr() *ExpressionType {
 	return &c
 }
@@ -545,7 +545,7 @@ func PossibleFtpAuthenticationTypeValues() []FtpAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *FtpAuthenticationType pointing to the current value.
+// ToPtr returns a *FtpAuthenticationType pointing to the current value.
 func (c FtpAuthenticationType) ToPtr() *FtpAuthenticationType {
 	return &c
 }
@@ -567,7 +567,7 @@ func PossibleGoogleAdWordsAuthenticationTypeValues() []GoogleAdWordsAuthenticati
 	}
 }
 
-// ToPtr() returns a *GoogleAdWordsAuthenticationType pointing to the current value.
+// ToPtr returns a *GoogleAdWordsAuthenticationType pointing to the current value.
 func (c GoogleAdWordsAuthenticationType) ToPtr() *GoogleAdWordsAuthenticationType {
 	return &c
 }
@@ -589,7 +589,7 @@ func PossibleGoogleBigQueryAuthenticationTypeValues() []GoogleBigQueryAuthentica
 	}
 }
 
-// ToPtr() returns a *GoogleBigQueryAuthenticationType pointing to the current value.
+// ToPtr returns a *GoogleBigQueryAuthenticationType pointing to the current value.
 func (c GoogleBigQueryAuthenticationType) ToPtr() *GoogleBigQueryAuthenticationType {
 	return &c
 }
@@ -610,7 +610,7 @@ func PossibleHBaseAuthenticationTypeValues() []HBaseAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *HBaseAuthenticationType pointing to the current value.
+// ToPtr returns a *HBaseAuthenticationType pointing to the current value.
 func (c HBaseAuthenticationType) ToPtr() *HBaseAuthenticationType {
 	return &c
 }
@@ -633,7 +633,7 @@ func PossibleHDInsightActivityDebugInfoOptionValues() []HDInsightActivityDebugIn
 	}
 }
 
-// ToPtr() returns a *HDInsightActivityDebugInfoOption pointing to the current value.
+// ToPtr returns a *HDInsightActivityDebugInfoOption pointing to the current value.
 func (c HDInsightActivityDebugInfoOption) ToPtr() *HDInsightActivityDebugInfoOption {
 	return &c
 }
@@ -660,7 +660,7 @@ func PossibleHTTPAuthenticationTypeValues() []HTTPAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *HTTPAuthenticationType pointing to the current value.
+// ToPtr returns a *HTTPAuthenticationType pointing to the current value.
 func (c HTTPAuthenticationType) ToPtr() *HTTPAuthenticationType {
 	return &c
 }
@@ -683,7 +683,7 @@ func PossibleHdiNodeTypesValues() []HdiNodeTypes {
 	}
 }
 
-// ToPtr() returns a *HdiNodeTypes pointing to the current value.
+// ToPtr returns a *HdiNodeTypes pointing to the current value.
 func (c HdiNodeTypes) ToPtr() *HdiNodeTypes {
 	return &c
 }
@@ -708,7 +708,7 @@ func PossibleHiveAuthenticationTypeValues() []HiveAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *HiveAuthenticationType pointing to the current value.
+// ToPtr returns a *HiveAuthenticationType pointing to the current value.
 func (c HiveAuthenticationType) ToPtr() *HiveAuthenticationType {
 	return &c
 }
@@ -731,7 +731,7 @@ func PossibleHiveServerTypeValues() []HiveServerType {
 	}
 }
 
-// ToPtr() returns a *HiveServerType pointing to the current value.
+// ToPtr returns a *HiveServerType pointing to the current value.
 func (c HiveServerType) ToPtr() *HiveServerType {
 	return &c
 }
@@ -754,7 +754,7 @@ func PossibleHiveThriftTransportProtocolValues() []HiveThriftTransportProtocol {
 	}
 }
 
-// ToPtr() returns a *HiveThriftTransportProtocol pointing to the current value.
+// ToPtr returns a *HiveThriftTransportProtocol pointing to the current value.
 func (c HiveThriftTransportProtocol) ToPtr() *HiveThriftTransportProtocol {
 	return &c
 }
@@ -777,7 +777,7 @@ func PossibleImpalaAuthenticationTypeValues() []ImpalaAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *ImpalaAuthenticationType pointing to the current value.
+// ToPtr returns a *ImpalaAuthenticationType pointing to the current value.
 func (c ImpalaAuthenticationType) ToPtr() *ImpalaAuthenticationType {
 	return &c
 }
@@ -798,7 +798,7 @@ func PossibleIntegrationRuntimeEditionValues() []IntegrationRuntimeEdition {
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeEdition pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeEdition pointing to the current value.
 func (c IntegrationRuntimeEdition) ToPtr() *IntegrationRuntimeEdition {
 	return &c
 }
@@ -819,7 +819,7 @@ func PossibleIntegrationRuntimeEntityReferenceTypeValues() []IntegrationRuntimeE
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeEntityReferenceType pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeEntityReferenceType pointing to the current value.
 func (c IntegrationRuntimeEntityReferenceType) ToPtr() *IntegrationRuntimeEntityReferenceType {
 	return &c
 }
@@ -840,7 +840,7 @@ func PossibleIntegrationRuntimeLicenseTypeValues() []IntegrationRuntimeLicenseTy
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeLicenseType pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeLicenseType pointing to the current value.
 func (c IntegrationRuntimeLicenseType) ToPtr() *IntegrationRuntimeLicenseType {
 	return &c
 }
@@ -859,7 +859,7 @@ func PossibleIntegrationRuntimeReferenceTypeValues() []IntegrationRuntimeReferen
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeReferenceType pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeReferenceType pointing to the current value.
 func (c IntegrationRuntimeReferenceType) ToPtr() *IntegrationRuntimeReferenceType {
 	return &c
 }
@@ -884,7 +884,7 @@ func PossibleIntegrationRuntimeSsisCatalogPricingTierValues() []IntegrationRunti
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeSsisCatalogPricingTier pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeSsisCatalogPricingTier pointing to the current value.
 func (c IntegrationRuntimeSsisCatalogPricingTier) ToPtr() *IntegrationRuntimeSsisCatalogPricingTier {
 	return &c
 }
@@ -921,7 +921,7 @@ func PossibleIntegrationRuntimeStateValues() []IntegrationRuntimeState {
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeState pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeState pointing to the current value.
 func (c IntegrationRuntimeState) ToPtr() *IntegrationRuntimeState {
 	return &c
 }
@@ -942,7 +942,7 @@ func PossibleIntegrationRuntimeTypeValues() []IntegrationRuntimeType {
 	}
 }
 
-// ToPtr() returns a *IntegrationRuntimeType pointing to the current value.
+// ToPtr returns a *IntegrationRuntimeType pointing to the current value.
 func (c IntegrationRuntimeType) ToPtr() *IntegrationRuntimeType {
 	return &c
 }
@@ -963,7 +963,7 @@ func PossibleJSONFormatFilePatternValues() []JSONFormatFilePattern {
 	}
 }
 
-// ToPtr() returns a *JSONFormatFilePattern pointing to the current value.
+// ToPtr returns a *JSONFormatFilePattern pointing to the current value.
 func (c JSONFormatFilePattern) ToPtr() *JSONFormatFilePattern {
 	return &c
 }
@@ -985,7 +985,7 @@ func PossibleJSONWriteFilePatternValues() []JSONWriteFilePattern {
 	}
 }
 
-// ToPtr() returns a *JSONWriteFilePattern pointing to the current value.
+// ToPtr returns a *JSONWriteFilePattern pointing to the current value.
 func (c JSONWriteFilePattern) ToPtr() *JSONWriteFilePattern {
 	return &c
 }
@@ -1006,7 +1006,7 @@ func PossibleMongoDbAuthenticationTypeValues() []MongoDbAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *MongoDbAuthenticationType pointing to the current value.
+// ToPtr returns a *MongoDbAuthenticationType pointing to the current value.
 func (c MongoDbAuthenticationType) ToPtr() *MongoDbAuthenticationType {
 	return &c
 }
@@ -1029,7 +1029,7 @@ func PossibleNetezzaPartitionOptionValues() []NetezzaPartitionOption {
 	}
 }
 
-// ToPtr() returns a *NetezzaPartitionOption pointing to the current value.
+// ToPtr returns a *NetezzaPartitionOption pointing to the current value.
 func (c NetezzaPartitionOption) ToPtr() *NetezzaPartitionOption {
 	return &c
 }
@@ -1060,7 +1060,7 @@ func PossibleNodeSizeValues() []NodeSize {
 	}
 }
 
-// ToPtr() returns a *NodeSize pointing to the current value.
+// ToPtr returns a *NodeSize pointing to the current value.
 func (c NodeSize) ToPtr() *NodeSize {
 	return &c
 }
@@ -1081,7 +1081,7 @@ func PossibleNodeSizeFamilyValues() []NodeSizeFamily {
 	}
 }
 
-// ToPtr() returns a *NodeSizeFamily pointing to the current value.
+// ToPtr returns a *NodeSizeFamily pointing to the current value.
 func (c NodeSizeFamily) ToPtr() *NodeSizeFamily {
 	return &c
 }
@@ -1100,7 +1100,7 @@ func PossibleNotebookReferenceTypeValues() []NotebookReferenceType {
 	}
 }
 
-// ToPtr() returns a *NotebookReferenceType pointing to the current value.
+// ToPtr returns a *NotebookReferenceType pointing to the current value.
 func (c NotebookReferenceType) ToPtr() *NotebookReferenceType {
 	return &c
 }
@@ -1121,7 +1121,7 @@ func PossibleODataAADServicePrincipalCredentialTypeValues() []ODataAADServicePri
 	}
 }
 
-// ToPtr() returns a *ODataAADServicePrincipalCredentialType pointing to the current value.
+// ToPtr returns a *ODataAADServicePrincipalCredentialType pointing to the current value.
 func (c ODataAADServicePrincipalCredentialType) ToPtr() *ODataAADServicePrincipalCredentialType {
 	return &c
 }
@@ -1148,7 +1148,7 @@ func PossibleODataAuthenticationTypeValues() []ODataAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *ODataAuthenticationType pointing to the current value.
+// ToPtr returns a *ODataAuthenticationType pointing to the current value.
 func (c ODataAuthenticationType) ToPtr() *ODataAuthenticationType {
 	return &c
 }
@@ -1171,7 +1171,7 @@ func PossibleOraclePartitionOptionValues() []OraclePartitionOption {
 	}
 }
 
-// ToPtr() returns a *OraclePartitionOption pointing to the current value.
+// ToPtr returns a *OraclePartitionOption pointing to the current value.
 func (c OraclePartitionOption) ToPtr() *OraclePartitionOption {
 	return &c
 }
@@ -1193,7 +1193,7 @@ func PossibleOrcCompressionCodecValues() []OrcCompressionCodec {
 	}
 }
 
-// ToPtr() returns a *OrcCompressionCodec pointing to the current value.
+// ToPtr returns a *OrcCompressionCodec pointing to the current value.
 func (c OrcCompressionCodec) ToPtr() *OrcCompressionCodec {
 	return &c
 }
@@ -1224,7 +1224,7 @@ func PossibleParameterTypeValues() []ParameterType {
 	}
 }
 
-// ToPtr() returns a *ParameterType pointing to the current value.
+// ToPtr returns a *ParameterType pointing to the current value.
 func (c ParameterType) ToPtr() *ParameterType {
 	return &c
 }
@@ -1248,7 +1248,7 @@ func PossibleParquetCompressionCodecValues() []ParquetCompressionCodec {
 	}
 }
 
-// ToPtr() returns a *ParquetCompressionCodec pointing to the current value.
+// ToPtr returns a *ParquetCompressionCodec pointing to the current value.
 func (c ParquetCompressionCodec) ToPtr() *ParquetCompressionCodec {
 	return &c
 }
@@ -1271,7 +1271,7 @@ func PossiblePhoenixAuthenticationTypeValues() []PhoenixAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *PhoenixAuthenticationType pointing to the current value.
+// ToPtr returns a *PhoenixAuthenticationType pointing to the current value.
 func (c PhoenixAuthenticationType) ToPtr() *PhoenixAuthenticationType {
 	return &c
 }
@@ -1290,7 +1290,7 @@ func PossiblePipelineReferenceTypeValues() []PipelineReferenceType {
 	}
 }
 
-// ToPtr() returns a *PipelineReferenceType pointing to the current value.
+// ToPtr returns a *PipelineReferenceType pointing to the current value.
 func (c PipelineReferenceType) ToPtr() *PipelineReferenceType {
 	return &c
 }
@@ -1320,7 +1320,7 @@ func PossiblePluginCurrentStateValues() []PluginCurrentState {
 	}
 }
 
-// ToPtr() returns a *PluginCurrentState pointing to the current value.
+// ToPtr returns a *PluginCurrentState pointing to the current value.
 func (c PluginCurrentState) ToPtr() *PluginCurrentState {
 	return &c
 }
@@ -1341,7 +1341,7 @@ func PossiblePolybaseSettingsRejectTypeValues() []PolybaseSettingsRejectType {
 	}
 }
 
-// ToPtr() returns a *PolybaseSettingsRejectType pointing to the current value.
+// ToPtr returns a *PolybaseSettingsRejectType pointing to the current value.
 func (c PolybaseSettingsRejectType) ToPtr() *PolybaseSettingsRejectType {
 	return &c
 }
@@ -1362,7 +1362,7 @@ func PossiblePrestoAuthenticationTypeValues() []PrestoAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *PrestoAuthenticationType pointing to the current value.
+// ToPtr returns a *PrestoAuthenticationType pointing to the current value.
 func (c PrestoAuthenticationType) ToPtr() *PrestoAuthenticationType {
 	return &c
 }
@@ -1393,7 +1393,7 @@ func PossibleRecurrenceFrequencyValues() []RecurrenceFrequency {
 	}
 }
 
-// ToPtr() returns a *RecurrenceFrequency pointing to the current value.
+// ToPtr returns a *RecurrenceFrequency pointing to the current value.
 func (c RecurrenceFrequency) ToPtr() *RecurrenceFrequency {
 	return &c
 }
@@ -1414,7 +1414,7 @@ func PossibleResourceIdentityTypeValues() []ResourceIdentityType {
 	}
 }
 
-// ToPtr() returns a *ResourceIdentityType pointing to the current value.
+// ToPtr returns a *ResourceIdentityType pointing to the current value.
 func (c ResourceIdentityType) ToPtr() *ResourceIdentityType {
 	return &c
 }
@@ -1439,7 +1439,7 @@ func PossibleRestServiceAuthenticationTypeValues() []RestServiceAuthenticationTy
 	}
 }
 
-// ToPtr() returns a *RestServiceAuthenticationType pointing to the current value.
+// ToPtr returns a *RestServiceAuthenticationType pointing to the current value.
 func (c RestServiceAuthenticationType) ToPtr() *RestServiceAuthenticationType {
 	return &c
 }
@@ -1482,7 +1482,7 @@ func PossibleRunQueryFilterOperandValues() []RunQueryFilterOperand {
 	}
 }
 
-// ToPtr() returns a *RunQueryFilterOperand pointing to the current value.
+// ToPtr returns a *RunQueryFilterOperand pointing to the current value.
 func (c RunQueryFilterOperand) ToPtr() *RunQueryFilterOperand {
 	return &c
 }
@@ -1507,7 +1507,7 @@ func PossibleRunQueryFilterOperatorValues() []RunQueryFilterOperator {
 	}
 }
 
-// ToPtr() returns a *RunQueryFilterOperator pointing to the current value.
+// ToPtr returns a *RunQueryFilterOperator pointing to the current value.
 func (c RunQueryFilterOperator) ToPtr() *RunQueryFilterOperator {
 	return &c
 }
@@ -1528,7 +1528,7 @@ func PossibleRunQueryOrderValues() []RunQueryOrder {
 	}
 }
 
-// ToPtr() returns a *RunQueryOrder pointing to the current value.
+// ToPtr returns a *RunQueryOrder pointing to the current value.
 func (c RunQueryOrder) ToPtr() *RunQueryOrder {
 	return &c
 }
@@ -1565,7 +1565,7 @@ func PossibleRunQueryOrderByFieldValues() []RunQueryOrderByField {
 	}
 }
 
-// ToPtr() returns a *RunQueryOrderByField pointing to the current value.
+// ToPtr returns a *RunQueryOrderByField pointing to the current value.
 func (c RunQueryOrderByField) ToPtr() *RunQueryOrderByField {
 	return &c
 }
@@ -1586,7 +1586,7 @@ func PossibleSQLConnectionTypeValues() []SQLConnectionType {
 	}
 }
 
-// ToPtr() returns a *SQLConnectionType pointing to the current value.
+// ToPtr returns a *SQLConnectionType pointing to the current value.
 func (c SQLConnectionType) ToPtr() *SQLConnectionType {
 	return &c
 }
@@ -1605,7 +1605,7 @@ func PossibleSQLPoolReferenceTypeValues() []SQLPoolReferenceType {
 	}
 }
 
-// ToPtr() returns a *SQLPoolReferenceType pointing to the current value.
+// ToPtr returns a *SQLPoolReferenceType pointing to the current value.
 func (c SQLPoolReferenceType) ToPtr() *SQLPoolReferenceType {
 	return &c
 }
@@ -1624,7 +1624,7 @@ func PossibleSQLScriptTypeValues() []SQLScriptType {
 	}
 }
 
-// ToPtr() returns a *SQLScriptType pointing to the current value.
+// ToPtr returns a *SQLScriptType pointing to the current value.
 func (c SQLScriptType) ToPtr() *SQLScriptType {
 	return &c
 }
@@ -1645,7 +1645,7 @@ func PossibleSalesforceSinkWriteBehaviorValues() []SalesforceSinkWriteBehavior {
 	}
 }
 
-// ToPtr() returns a *SalesforceSinkWriteBehavior pointing to the current value.
+// ToPtr returns a *SalesforceSinkWriteBehavior pointing to the current value.
 func (c SalesforceSinkWriteBehavior) ToPtr() *SalesforceSinkWriteBehavior {
 	return &c
 }
@@ -1666,7 +1666,7 @@ func PossibleSalesforceSourceReadBehaviorValues() []SalesforceSourceReadBehavior
 	}
 }
 
-// ToPtr() returns a *SalesforceSourceReadBehavior pointing to the current value.
+// ToPtr returns a *SalesforceSourceReadBehavior pointing to the current value.
 func (c SalesforceSourceReadBehavior) ToPtr() *SalesforceSourceReadBehavior {
 	return &c
 }
@@ -1687,7 +1687,7 @@ func PossibleSapCloudForCustomerSinkWriteBehaviorValues() []SapCloudForCustomerS
 	}
 }
 
-// ToPtr() returns a *SapCloudForCustomerSinkWriteBehavior pointing to the current value.
+// ToPtr returns a *SapCloudForCustomerSinkWriteBehavior pointing to the current value.
 func (c SapCloudForCustomerSinkWriteBehavior) ToPtr() *SapCloudForCustomerSinkWriteBehavior {
 	return &c
 }
@@ -1708,7 +1708,7 @@ func PossibleSapHanaAuthenticationTypeValues() []SapHanaAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *SapHanaAuthenticationType pointing to the current value.
+// ToPtr returns a *SapHanaAuthenticationType pointing to the current value.
 func (c SapHanaAuthenticationType) ToPtr() *SapHanaAuthenticationType {
 	return &c
 }
@@ -1731,7 +1731,7 @@ func PossibleSapHanaPartitionOptionValues() []SapHanaPartitionOption {
 	}
 }
 
-// ToPtr() returns a *SapHanaPartitionOption pointing to the current value.
+// ToPtr returns a *SapHanaPartitionOption pointing to the current value.
 func (c SapHanaPartitionOption) ToPtr() *SapHanaPartitionOption {
 	return &c
 }
@@ -1760,7 +1760,7 @@ func PossibleSapTablePartitionOptionValues() []SapTablePartitionOption {
 	}
 }
 
-// ToPtr() returns a *SapTablePartitionOption pointing to the current value.
+// ToPtr returns a *SapTablePartitionOption pointing to the current value.
 func (c SapTablePartitionOption) ToPtr() *SapTablePartitionOption {
 	return &c
 }
@@ -1782,7 +1782,7 @@ func PossibleSchedulerCurrentStateValues() []SchedulerCurrentState {
 	}
 }
 
-// ToPtr() returns a *SchedulerCurrentState pointing to the current value.
+// ToPtr returns a *SchedulerCurrentState pointing to the current value.
 func (c SchedulerCurrentState) ToPtr() *SchedulerCurrentState {
 	return &c
 }
@@ -1803,7 +1803,7 @@ func PossibleServiceNowAuthenticationTypeValues() []ServiceNowAuthenticationType
 	}
 }
 
-// ToPtr() returns a *ServiceNowAuthenticationType pointing to the current value.
+// ToPtr returns a *ServiceNowAuthenticationType pointing to the current value.
 func (c ServiceNowAuthenticationType) ToPtr() *ServiceNowAuthenticationType {
 	return &c
 }
@@ -1824,7 +1824,7 @@ func PossibleSftpAuthenticationTypeValues() []SftpAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *SftpAuthenticationType pointing to the current value.
+// ToPtr returns a *SftpAuthenticationType pointing to the current value.
 func (c SftpAuthenticationType) ToPtr() *SftpAuthenticationType {
 	return &c
 }
@@ -1849,7 +1849,7 @@ func PossibleSparkAuthenticationTypeValues() []SparkAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *SparkAuthenticationType pointing to the current value.
+// ToPtr returns a *SparkAuthenticationType pointing to the current value.
 func (c SparkAuthenticationType) ToPtr() *SparkAuthenticationType {
 	return &c
 }
@@ -1874,7 +1874,7 @@ func PossibleSparkBatchJobResultTypeValues() []SparkBatchJobResultType {
 	}
 }
 
-// ToPtr() returns a *SparkBatchJobResultType pointing to the current value.
+// ToPtr returns a *SparkBatchJobResultType pointing to the current value.
 func (c SparkBatchJobResultType) ToPtr() *SparkBatchJobResultType {
 	return &c
 }
@@ -1898,7 +1898,7 @@ func PossibleSparkErrorSourceValues() []SparkErrorSource {
 	}
 }
 
-// ToPtr() returns a *SparkErrorSource pointing to the current value.
+// ToPtr returns a *SparkErrorSource pointing to the current value.
 func (c SparkErrorSource) ToPtr() *SparkErrorSource {
 	return &c
 }
@@ -1917,7 +1917,7 @@ func PossibleSparkJobReferenceTypeValues() []SparkJobReferenceType {
 	}
 }
 
-// ToPtr() returns a *SparkJobReferenceType pointing to the current value.
+// ToPtr returns a *SparkJobReferenceType pointing to the current value.
 func (c SparkJobReferenceType) ToPtr() *SparkJobReferenceType {
 	return &c
 }
@@ -1938,7 +1938,7 @@ func PossibleSparkJobTypeValues() []SparkJobType {
 	}
 }
 
-// ToPtr() returns a *SparkJobType pointing to the current value.
+// ToPtr returns a *SparkJobType pointing to the current value.
 func (c SparkJobType) ToPtr() *SparkJobType {
 	return &c
 }
@@ -1961,7 +1961,7 @@ func PossibleSparkServerTypeValues() []SparkServerType {
 	}
 }
 
-// ToPtr() returns a *SparkServerType pointing to the current value.
+// ToPtr returns a *SparkServerType pointing to the current value.
 func (c SparkServerType) ToPtr() *SparkServerType {
 	return &c
 }
@@ -1984,7 +1984,7 @@ func PossibleSparkThriftTransportProtocolValues() []SparkThriftTransportProtocol
 	}
 }
 
-// ToPtr() returns a *SparkThriftTransportProtocol pointing to the current value.
+// ToPtr returns a *SparkThriftTransportProtocol pointing to the current value.
 func (c SparkThriftTransportProtocol) ToPtr() *SparkThriftTransportProtocol {
 	return &c
 }
@@ -2003,7 +2003,7 @@ func PossibleSsisLogLocationTypeValues() []SsisLogLocationType {
 	}
 }
 
-// ToPtr() returns a *SsisLogLocationType pointing to the current value.
+// ToPtr returns a *SsisLogLocationType pointing to the current value.
 func (c SsisLogLocationType) ToPtr() *SsisLogLocationType {
 	return &c
 }
@@ -2026,7 +2026,7 @@ func PossibleSsisPackageLocationTypeValues() []SsisPackageLocationType {
 	}
 }
 
-// ToPtr() returns a *SsisPackageLocationType pointing to the current value.
+// ToPtr returns a *SsisPackageLocationType pointing to the current value.
 func (c SsisPackageLocationType) ToPtr() *SsisPackageLocationType {
 	return &c
 }
@@ -2057,7 +2057,7 @@ func PossibleStoredProcedureParameterTypeValues() []StoredProcedureParameterType
 	}
 }
 
-// ToPtr() returns a *StoredProcedureParameterType pointing to the current value.
+// ToPtr returns a *StoredProcedureParameterType pointing to the current value.
 func (c StoredProcedureParameterType) ToPtr() *StoredProcedureParameterType {
 	return &c
 }
@@ -2078,7 +2078,7 @@ func PossibleSybaseAuthenticationTypeValues() []SybaseAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *SybaseAuthenticationType pointing to the current value.
+// ToPtr returns a *SybaseAuthenticationType pointing to the current value.
 func (c SybaseAuthenticationType) ToPtr() *SybaseAuthenticationType {
 	return &c
 }
@@ -2099,7 +2099,7 @@ func PossibleTeradataAuthenticationTypeValues() []TeradataAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *TeradataAuthenticationType pointing to the current value.
+// ToPtr returns a *TeradataAuthenticationType pointing to the current value.
 func (c TeradataAuthenticationType) ToPtr() *TeradataAuthenticationType {
 	return &c
 }
@@ -2122,7 +2122,7 @@ func PossibleTeradataPartitionOptionValues() []TeradataPartitionOption {
 	}
 }
 
-// ToPtr() returns a *TeradataPartitionOption pointing to the current value.
+// ToPtr returns a *TeradataPartitionOption pointing to the current value.
 func (c TeradataPartitionOption) ToPtr() *TeradataPartitionOption {
 	return &c
 }
@@ -2141,7 +2141,7 @@ func PossibleTriggerReferenceTypeValues() []TriggerReferenceType {
 	}
 }
 
-// ToPtr() returns a *TriggerReferenceType pointing to the current value.
+// ToPtr returns a *TriggerReferenceType pointing to the current value.
 func (c TriggerReferenceType) ToPtr() *TriggerReferenceType {
 	return &c
 }
@@ -2164,7 +2164,7 @@ func PossibleTriggerRunStatusValues() []TriggerRunStatus {
 	}
 }
 
-// ToPtr() returns a *TriggerRunStatus pointing to the current value.
+// ToPtr returns a *TriggerRunStatus pointing to the current value.
 func (c TriggerRunStatus) ToPtr() *TriggerRunStatus {
 	return &c
 }
@@ -2187,7 +2187,7 @@ func PossibleTriggerRuntimeStateValues() []TriggerRuntimeState {
 	}
 }
 
-// ToPtr() returns a *TriggerRuntimeState pointing to the current value.
+// ToPtr returns a *TriggerRuntimeState pointing to the current value.
 func (c TriggerRuntimeState) ToPtr() *TriggerRuntimeState {
 	return &c
 }
@@ -2208,7 +2208,7 @@ func PossibleTumblingWindowFrequencyValues() []TumblingWindowFrequency {
 	}
 }
 
-// ToPtr() returns a *TumblingWindowFrequency pointing to the current value.
+// ToPtr returns a *TumblingWindowFrequency pointing to the current value.
 func (c TumblingWindowFrequency) ToPtr() *TumblingWindowFrequency {
 	return &c
 }
@@ -2227,7 +2227,7 @@ func PossibleTypeValues() []Type {
 	}
 }
 
-// ToPtr() returns a *Type pointing to the current value.
+// ToPtr returns a *Type pointing to the current value.
 func (c Type) ToPtr() *Type {
 	return &c
 }
@@ -2252,7 +2252,7 @@ func PossibleVariableTypeValues() []VariableType {
 	}
 }
 
-// ToPtr() returns a *VariableType pointing to the current value.
+// ToPtr returns a *VariableType pointing to the current value.
 func (c VariableType) ToPtr() *VariableType {
 	return &c
 }
@@ -2277,7 +2277,7 @@ func PossibleWebActivityMethodValues() []WebActivityMethod {
 	}
 }
 
-// ToPtr() returns a *WebActivityMethod pointing to the current value.
+// ToPtr returns a *WebActivityMethod pointing to the current value.
 func (c WebActivityMethod) ToPtr() *WebActivityMethod {
 	return &c
 }
@@ -2300,7 +2300,7 @@ func PossibleWebAuthenticationTypeValues() []WebAuthenticationType {
 	}
 }
 
-// ToPtr() returns a *WebAuthenticationType pointing to the current value.
+// ToPtr returns a *WebAuthenticationType pointing to the current value.
 func (c WebAuthenticationType) ToPtr() *WebAuthenticationType {
 	return &c
 }
@@ -2319,7 +2319,7 @@ func PossibleWebHookActivityMethodValues() []WebHookActivityMethod {
 	}
 }
 
-// ToPtr() returns a *WebHookActivityMethod pointing to the current value.
+// ToPtr returns a *WebHookActivityMethod pointing to the current value.
 func (c WebHookActivityMethod) ToPtr() *WebHookActivityMethod {
 	return &c
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_constants.go
@@ -32,7 +32,7 @@ func PossiblePluginCurrentStateValues() []PluginCurrentState {
 	}
 }
 
-// ToPtr() returns a *PluginCurrentState pointing to the current value.
+// ToPtr returns a *PluginCurrentState pointing to the current value.
 func (c PluginCurrentState) ToPtr() *PluginCurrentState {
 	return &c
 }
@@ -54,7 +54,7 @@ func PossibleSchedulerCurrentStateValues() []SchedulerCurrentState {
 	}
 }
 
-// ToPtr() returns a *SchedulerCurrentState pointing to the current value.
+// ToPtr returns a *SchedulerCurrentState pointing to the current value.
 func (c SchedulerCurrentState) ToPtr() *SchedulerCurrentState {
 	return &c
 }
@@ -79,7 +79,7 @@ func PossibleSparkBatchJobResultTypeValues() []SparkBatchJobResultType {
 	}
 }
 
-// ToPtr() returns a *SparkBatchJobResultType pointing to the current value.
+// ToPtr returns a *SparkBatchJobResultType pointing to the current value.
 func (c SparkBatchJobResultType) ToPtr() *SparkBatchJobResultType {
 	return &c
 }
@@ -103,7 +103,7 @@ func PossibleSparkErrorSourceValues() []SparkErrorSource {
 	}
 }
 
-// ToPtr() returns a *SparkErrorSource pointing to the current value.
+// ToPtr returns a *SparkErrorSource pointing to the current value.
 func (c SparkErrorSource) ToPtr() *SparkErrorSource {
 	return &c
 }
@@ -124,7 +124,7 @@ func PossibleSparkJobTypeValues() []SparkJobType {
 	}
 }
 
-// ToPtr() returns a *SparkJobType pointing to the current value.
+// ToPtr returns a *SparkJobType pointing to the current value.
 func (c SparkJobType) ToPtr() *SparkJobType {
 	return &c
 }
@@ -148,7 +148,7 @@ func PossibleSparkSessionResultTypeValues() []SparkSessionResultType {
 	}
 }
 
-// ToPtr() returns a *SparkSessionResultType pointing to the current value.
+// ToPtr returns a *SparkSessionResultType pointing to the current value.
 func (c SparkSessionResultType) ToPtr() *SparkSessionResultType {
 	return &c
 }
@@ -172,7 +172,7 @@ func PossibleSparkStatementLanguageTypeValues() []SparkStatementLanguageType {
 	}
 }
 
-// ToPtr() returns a *SparkStatementLanguageType pointing to the current value.
+// ToPtr returns a *SparkStatementLanguageType pointing to the current value.
 func (c SparkStatementLanguageType) ToPtr() *SparkStatementLanguageType {
 	return &c
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_constants.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_constants.go
@@ -25,7 +25,7 @@ func PossibleGeoReplicationStatusTypeValues() []GeoReplicationStatusType {
 	}
 }
 
-// ToPtr() returns a *GeoReplicationStatusType pointing to the current value.
+// ToPtr returns a *GeoReplicationStatusType pointing to the current value.
 func (c GeoReplicationStatusType) ToPtr() *GeoReplicationStatusType {
 	return &c
 }
@@ -47,7 +47,7 @@ func PossibleOdataMetadataFormatValues() []OdataMetadataFormat {
 	}
 }
 
-// ToPtr() returns a *OdataMetadataFormat pointing to the current value.
+// ToPtr returns a *OdataMetadataFormat pointing to the current value.
 func (c OdataMetadataFormat) ToPtr() *OdataMetadataFormat {
 	return &c
 }
@@ -67,7 +67,7 @@ func PossibleResponseFormatValues() []ResponseFormat {
 	}
 }
 
-// ToPtr() returns a *ResponseFormat pointing to the current value.
+// ToPtr returns a *ResponseFormat pointing to the current value.
 func (c ResponseFormat) ToPtr() *ResponseFormat {
 	return &c
 }


### PR DESCRIPTION
Always walk the complete object hierarchy when determining what internal
marshallers and unmarshallers to add.