### PR TITLE
Pass maps and slices by value

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -110,33 +110,6 @@ export function hasPolymorphicField(obj: ObjectSchema): boolean {
   return false;
 }
 
-// returns the object's position in an inheritence hierarchy
-export function getRelationship(obj: ObjectSchema): 'none' | 'root' | 'parent' | 'leaf' {
-  let hasParent = false;
-  for (const parent of values(obj.parents?.immediate)) {
-    if (isObjectSchema(parent)) {
-      hasParent = true;
-      break;
-    }
-  }
-  let hasChild = false;
-  for (const child of values(obj.children?.immediate)) {
-    if (isObjectSchema(child)) {
-      hasChild = true;
-      break;
-    }
-  }
-  if (!hasParent && !hasChild) {
-    return 'none';
-  } else if (!hasChild) {
-    return 'leaf';
-  } else if (!hasParent) {
-    return 'root';
-  } else {
-    return 'parent';
-  }
-}
-
 // returns the schema response for this operation.
 // calling this on multi-response operations will result in an error.
 export function getResponse(op: Operation): SchemaResponse | undefined {

--- a/src/generator/polymorphics.ts
+++ b/src/generator/polymorphics.ts
@@ -72,7 +72,7 @@ export async function generatePolymorphicHelpers(session: Session<CodeModel>): P
     text += '}\n\n';
 
     // array unmarshaller
-    text += `func unmarshal${discName}Array(rawMsg json.RawMessage) (*[]${discName}, error) {\n`;
+    text += `func unmarshal${discName}Array(rawMsg json.RawMessage) ([]${discName}, error) {\n`;
     text += '\tif rawMsg == nil {\n';
     text += '\t\treturn nil, nil\n';
     text += '\t}\n';
@@ -88,7 +88,7 @@ export async function generatePolymorphicHelpers(session: Session<CodeModel>): P
     text += '\t\t}\n';
     text += '\t\tfArray[index] = f\n';
     text += '\t}\n';
-    text += '\treturn &fArray, nil\n';
+    text += '\treturn fArray, nil\n';
     text += '}\n\n';
   }
   return text;

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -22,7 +22,7 @@ func TestCreateAPInProperties(t *testing.T) {
 	result, err := client.CreateAPInProperties(context.Background(), PetAPInProperties{
 		ID:   to.Int32Ptr(4),
 		Name: to.StringPtr("Bunny"),
-		AdditionalProperties: &map[string]*float32{
+		AdditionalProperties: map[string]*float32{
 			"height":   to.Float32Ptr(5.61),
 			"weight":   to.Float32Ptr(599),
 			"footsize": to.Float32Ptr(11.5),
@@ -35,7 +35,7 @@ func TestCreateAPInProperties(t *testing.T) {
 		ID:     to.Int32Ptr(4),
 		Name:   to.StringPtr("Bunny"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]*float32{
+		AdditionalProperties: map[string]*float32{
 			"height":   to.Float32Ptr(5.61),
 			"weight":   to.Float32Ptr(599),
 			"footsize": to.Float32Ptr(11.5),
@@ -52,12 +52,12 @@ func TestCreateAPInPropertiesWithAPString(t *testing.T) {
 		ID:            to.Int32Ptr(5),
 		Name:          to.StringPtr("Funny"),
 		OdataLocation: to.StringPtr("westus"),
-		AdditionalProperties: &map[string]*string{
+		AdditionalProperties: map[string]*string{
 			"color": to.StringPtr("red"),
 			"city":  to.StringPtr("Seattle"),
 			"food":  to.StringPtr("tikka masala"),
 		},
-		AdditionalProperties1: &map[string]*float32{
+		AdditionalProperties1: map[string]*float32{
 			"height":   to.Float32Ptr(5.61),
 			"weight":   to.Float32Ptr(599),
 			"footsize": to.Float32Ptr(11.5),
@@ -71,12 +71,12 @@ func TestCreateAPInPropertiesWithAPString(t *testing.T) {
 		Name:          to.StringPtr("Funny"),
 		OdataLocation: to.StringPtr("westus"),
 		Status:        to.BoolPtr(true),
-		AdditionalProperties: &map[string]*string{
+		AdditionalProperties: map[string]*string{
 			"color": to.StringPtr("red"),
 			"city":  to.StringPtr("Seattle"),
 			"food":  to.StringPtr("tikka masala"),
 		},
-		AdditionalProperties1: &map[string]*float32{
+		AdditionalProperties1: map[string]*float32{
 			"height":   to.Float32Ptr(5.61),
 			"weight":   to.Float32Ptr(599),
 			"footsize": to.Float32Ptr(11.5),
@@ -92,7 +92,7 @@ func TestCreateAPObject(t *testing.T) {
 	result, err := client.CreateAPObject(context.Background(), PetAPObject{
 		ID:   to.Int32Ptr(2),
 		Name: to.StringPtr("Hira"),
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"siblings": []interface{}{
 				map[string]interface{}{
 					"id":        float64(1),
@@ -113,7 +113,7 @@ func TestCreateAPObject(t *testing.T) {
 		ID:     to.Int32Ptr(2),
 		Name:   to.StringPtr("Hira"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"siblings": []interface{}{
 				map[string]interface{}{
 					"id":        float64(1),
@@ -137,7 +137,7 @@ func TestCreateAPString(t *testing.T) {
 	result, err := client.CreateAPString(context.Background(), PetAPString{
 		ID:   to.Int32Ptr(3),
 		Name: to.StringPtr("Tommy"),
-		AdditionalProperties: &map[string]*string{
+		AdditionalProperties: map[string]*string{
 			"color":  to.StringPtr("red"),
 			"weight": to.StringPtr("10 kg"),
 			"city":   to.StringPtr("Bombay"),
@@ -150,7 +150,7 @@ func TestCreateAPString(t *testing.T) {
 		ID:     to.Int32Ptr(3),
 		Name:   to.StringPtr("Tommy"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]*string{
+		AdditionalProperties: map[string]*string{
 			"color":  to.StringPtr("red"),
 			"weight": to.StringPtr("10 kg"),
 			"city":   to.StringPtr("Bombay"),
@@ -166,7 +166,7 @@ func TestCreateAPTrue(t *testing.T) {
 	result, err := client.CreateAPTrue(context.Background(), PetAPTrue{
 		ID:   to.Int32Ptr(1),
 		Name: to.StringPtr("Puppy"),
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"birthdate": "2017-12-13T02:29:51Z",
 			"complexProperty": map[string]interface{}{
 				"color": "Red",
@@ -180,7 +180,7 @@ func TestCreateAPTrue(t *testing.T) {
 		ID:     to.Int32Ptr(1),
 		Name:   to.StringPtr("Puppy"),
 		Status: to.BoolPtr(true),
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"birthdate": "2017-12-13T02:29:51Z",
 			"complexProperty": map[string]interface{}{
 				"color": "Red",
@@ -198,7 +198,7 @@ func TestCreateCatAPTrue(t *testing.T) {
 		PetAPTrue: PetAPTrue{
 			ID:   to.Int32Ptr(1),
 			Name: to.StringPtr("Lisa"),
-			AdditionalProperties: &map[string]interface{}{
+			AdditionalProperties: map[string]interface{}{
 				"birthdate": "2017-12-13T02:29:51Z",
 				"complexProperty": map[string]interface{}{
 					"color": "Red",
@@ -215,7 +215,7 @@ func TestCreateCatAPTrue(t *testing.T) {
 			ID:     to.Int32Ptr(1),
 			Name:   to.StringPtr("Lisa"),
 			Status: to.BoolPtr(true),
-			AdditionalProperties: &map[string]interface{}{
+			AdditionalProperties: map[string]interface{}{
 				"birthdate": "2017-12-13T02:29:51Z",
 				"complexProperty": map[string]interface{}{
 					"color": "Red",

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -69,12 +69,22 @@ func (e Error) Error() string {
 
 type PetAPInProperties struct {
 	// Dictionary of
-	AdditionalProperties *map[string]*float32 `json:"additionalProperties,omitempty"`
-	ID                   *int32               `json:"id,omitempty"`
-	Name                 *string              `json:"name,omitempty"`
+	AdditionalProperties map[string]*float32 `json:"additionalProperties,omitempty"`
+	ID                   *int32              `json:"id,omitempty"`
+	Name                 *string             `json:"name,omitempty"`
 
 	// Status - READ-ONLY
 	Status *bool `json:"status,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PetAPInProperties.
+func (p PetAPInProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalProperties", p.AdditionalProperties)
+	populate(objectMap, "id", p.ID)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "status", p.Status)
+	return json.Marshal(objectMap)
 }
 
 // PetAPInPropertiesResponse is the response envelope for operations that return a PetAPInProperties type.
@@ -87,13 +97,13 @@ type PetAPInPropertiesResponse struct {
 
 type PetAPInPropertiesWithAPString struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]*string
+	AdditionalProperties map[string]*string
 
 	// Dictionary of
-	AdditionalProperties1 *map[string]*float32 `json:"additionalProperties,omitempty"`
-	ID                    *int32               `json:"id,omitempty"`
-	Name                  *string              `json:"name,omitempty"`
-	OdataLocation         *string              `json:"@odata.location,omitempty"`
+	AdditionalProperties1 map[string]*float32 `json:"additionalProperties,omitempty"`
+	ID                    *int32              `json:"id,omitempty"`
+	Name                  *string             `json:"name,omitempty"`
+	OdataLocation         *string             `json:"@odata.location,omitempty"`
 
 	// Status - READ-ONLY
 	Status *bool `json:"status,omitempty" azure:"ro"`
@@ -108,7 +118,7 @@ func (p PetAPInPropertiesWithAPString) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "@odata.location", p.OdataLocation)
 	populate(objectMap, "status", p.Status)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -141,12 +151,12 @@ func (p *PetAPInPropertiesWithAPString) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]*string{}
+				p.AdditionalProperties = map[string]*string{}
 			}
 			if val != nil {
 				var aux string
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = &aux
+				p.AdditionalProperties[key] = &aux
 			}
 			delete(rawMsg, key)
 		}
@@ -167,7 +177,7 @@ type PetAPInPropertiesWithAPStringResponse struct {
 
 type PetAPObject struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 	ID                   *int32  `json:"id,omitempty"`
 	Name                 *string `json:"name,omitempty"`
 
@@ -182,7 +192,7 @@ func (p PetAPObject) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "name", p.Name)
 	populate(objectMap, "status", p.Status)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -209,12 +219,12 @@ func (p *PetAPObject) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]interface{}{}
+				p.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				p.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -235,7 +245,7 @@ type PetAPObjectResponse struct {
 
 type PetAPString struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]*string
+	AdditionalProperties map[string]*string
 	ID                   *int32  `json:"id,omitempty"`
 	Name                 *string `json:"name,omitempty"`
 
@@ -250,7 +260,7 @@ func (p PetAPString) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "name", p.Name)
 	populate(objectMap, "status", p.Status)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -277,12 +287,12 @@ func (p *PetAPString) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]*string{}
+				p.AdditionalProperties = map[string]*string{}
 			}
 			if val != nil {
 				var aux string
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = &aux
+				p.AdditionalProperties[key] = &aux
 			}
 			delete(rawMsg, key)
 		}
@@ -303,7 +313,7 @@ type PetAPStringResponse struct {
 
 type PetAPTrue struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 	ID                   *int32  `json:"id,omitempty"`
 	Name                 *string `json:"name,omitempty"`
 
@@ -332,7 +342,7 @@ func (p PetAPTrue) marshalInternal() map[string]interface{} {
 	populate(objectMap, "name", p.Name)
 	populate(objectMap, "status", p.Status)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -354,12 +364,12 @@ func (p *PetAPTrue) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]interface{}{}
+				p.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				p.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -23,7 +23,7 @@ func TestArrayGetEmpty(t *testing.T) {
 		t.Fatalf("GetEmpty: %v", err)
 	}
 	if r := cmp.Diff(result.ArrayWrapper, &ArrayWrapper{
-		Array: &[]*string{},
+		Array: []*string{},
 	}); r != "" {
 		t.Fatal(r)
 	}
@@ -47,7 +47,7 @@ func TestArrayGetValid(t *testing.T) {
 		t.Fatalf("GetValid: %v", err)
 	}
 	if r := cmp.Diff(result.ArrayWrapper, &ArrayWrapper{
-		Array: &[]*string{
+		Array: []*string{
 			to.StringPtr("1, 2, 3, 4"),
 			to.StringPtr(""),
 			nil,
@@ -61,7 +61,7 @@ func TestArrayGetValid(t *testing.T) {
 
 func TestArrayPutEmpty(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: &[]*string{}}, nil)
+	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: []*string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestArrayPutEmpty(t *testing.T) {
 
 func TestArrayPutValid(t *testing.T) {
 	client := newArrayClient()
-	result, err := client.PutValid(context.Background(), ArrayWrapper{Array: &[]*string{
+	result, err := client.PutValid(context.Background(), ArrayWrapper{Array: []*string{
 		to.StringPtr("1, 2, 3, 4"),
 		to.StringPtr(""),
 		nil,

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -21,7 +21,7 @@ func TestDictionaryGetEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetEmpty: %v", err)
 	}
-	if r := cmp.Diff(result.DictionaryWrapper, &DictionaryWrapper{DefaultProgram: &map[string]*string{}}); r != "" {
+	if r := cmp.Diff(result.DictionaryWrapper, &DictionaryWrapper{DefaultProgram: map[string]*string{}}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -55,7 +55,7 @@ func TestDictionaryGetValid(t *testing.T) {
 		t.Fatalf("GetValid: %v", err)
 	}
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
-	val := DictionaryWrapper{DefaultProgram: &map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}
+	val := DictionaryWrapper{DefaultProgram: map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}
 	if r := cmp.Diff(result.DictionaryWrapper, &val); r != "" {
 		t.Fatal(r)
 	}
@@ -63,7 +63,7 @@ func TestDictionaryGetValid(t *testing.T) {
 
 func TestDictionaryPutEmpty(t *testing.T) {
 	client := newDictionaryClient()
-	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]*string{}}, nil)
+	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: map[string]*string{}}, nil)
 	if err != nil {
 		t.Fatalf("PutEmpty: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestDictionaryPutEmpty(t *testing.T) {
 func TestDictionaryPutValid(t *testing.T) {
 	client := newDictionaryClient()
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
-	result, err := client.PutValid(context.Background(), DictionaryWrapper{DefaultProgram: &map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}, nil)
+	result, err := client.PutValid(context.Background(), DictionaryWrapper{DefaultProgram: map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}, nil)
 	if err != nil {
 		t.Fatalf("PutValid: %v", err)
 	}

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -29,7 +29,7 @@ func TestInheritanceGetValid(t *testing.T) {
 				Name: to.StringPtr("Siameeee"),
 			},
 			Color: to.StringPtr("green"),
-			Hates: &[]*Dog{
+			Hates: []*Dog{
 				{
 					Pet: Pet{
 						ID:   to.Int32Ptr(1),
@@ -61,7 +61,7 @@ func TestInheritancePutValid(t *testing.T) {
 				Name: to.StringPtr("Siameeee"),
 			},
 			Color: to.StringPtr("green"),
-			Hates: &[]*Dog{
+			Hates: []*Dog{
 				{
 					Pet: Pet{
 						ID:   to.Int32Ptr(1),

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -30,17 +30,17 @@ func TestGetValid(t *testing.T) {
 		Fish: Fish{
 			Fishtype: to.StringPtr("salmon"),
 			Length:   to.Float32Ptr(1),
-			Siblings: &[]FishClassification{
+			Siblings: []FishClassification{
 				&Shark{
 					Fish: Fish{
 						Fishtype: to.StringPtr("shark"),
 						Length:   to.Float32Ptr(20),
-						Siblings: &[]FishClassification{
+						Siblings: []FishClassification{
 							&Salmon{
 								Fish: Fish{
 									Fishtype: to.StringPtr("salmon"),
 									Length:   to.Float32Ptr(2),
-									Siblings: &[]FishClassification{
+									Siblings: []FishClassification{
 										&Shark{
 											Fish: Fish{
 												Fishtype: to.StringPtr("shark"),
@@ -60,7 +60,7 @@ func TestGetValid(t *testing.T) {
 												Age:      to.Int32Ptr(105),
 												Birthday: &sawBday,
 											},
-											Picture: &[]byte{255, 255, 255, 255, 254},
+											Picture: []byte{255, 255, 255, 255, 254},
 										},
 									},
 									Species: to.StringPtr("coho"),
@@ -73,13 +73,13 @@ func TestGetValid(t *testing.T) {
 									Fish: Fish{
 										Fishtype: to.StringPtr("sawshark"),
 										Length:   to.Float32Ptr(10),
-										Siblings: &[]FishClassification{},
+										Siblings: []FishClassification{},
 										Species:  to.StringPtr("dangerous"),
 									},
 									Age:      to.Int32Ptr(105),
 									Birthday: &sawBday,
 								},
-								Picture: &[]byte{255, 255, 255, 255, 254},
+								Picture: []byte{255, 255, 255, 255, 254},
 							},
 						},
 						Species: to.StringPtr("predator"),
@@ -92,13 +92,13 @@ func TestGetValid(t *testing.T) {
 						Fish: Fish{
 							Fishtype: to.StringPtr("sawshark"),
 							Length:   to.Float32Ptr(10),
-							Siblings: &[]FishClassification{},
+							Siblings: []FishClassification{},
 							Species:  to.StringPtr("dangerous"),
 						},
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
 					},
-					Picture: &[]byte{255, 255, 255, 255, 254},
+					Picture: []byte{255, 255, 255, 255, 254},
 				},
 			},
 			Species: to.StringPtr("king"),
@@ -119,17 +119,17 @@ func TestPutValid(t *testing.T) {
 		Fish: Fish{
 			Fishtype: to.StringPtr("salmon"),
 			Length:   to.Float32Ptr(1),
-			Siblings: &[]FishClassification{
+			Siblings: []FishClassification{
 				&Shark{
 					Fish: Fish{
 						Fishtype: to.StringPtr("shark"),
 						Length:   to.Float32Ptr(20),
-						Siblings: &[]FishClassification{
+						Siblings: []FishClassification{
 							&Salmon{
 								Fish: Fish{
 									Fishtype: to.StringPtr("salmon"),
 									Length:   to.Float32Ptr(2),
-									Siblings: &[]FishClassification{
+									Siblings: []FishClassification{
 										&Shark{
 											Fish: Fish{
 												Fishtype: to.StringPtr("shark"),
@@ -149,7 +149,7 @@ func TestPutValid(t *testing.T) {
 												Age:      to.Int32Ptr(105),
 												Birthday: &sawBday,
 											},
-											Picture: &[]byte{255, 255, 255, 255, 254},
+											Picture: []byte{255, 255, 255, 255, 254},
 										},
 									},
 									Species: to.StringPtr("coho"),
@@ -162,13 +162,13 @@ func TestPutValid(t *testing.T) {
 									Fish: Fish{
 										Fishtype: to.StringPtr("sawshark"),
 										Length:   to.Float32Ptr(10),
-										Siblings: &[]FishClassification{},
+										Siblings: []FishClassification{},
 										Species:  to.StringPtr("dangerous"),
 									},
 									Age:      to.Int32Ptr(105),
 									Birthday: &sawBday,
 								},
-								Picture: &[]byte{255, 255, 255, 255, 254},
+								Picture: []byte{255, 255, 255, 255, 254},
 							},
 						},
 						Species: to.StringPtr("predator"),
@@ -181,13 +181,13 @@ func TestPutValid(t *testing.T) {
 						Fish: Fish{
 							Fishtype: to.StringPtr("sawshark"),
 							Length:   to.Float32Ptr(10),
-							Siblings: &[]FishClassification{},
+							Siblings: []FishClassification{},
 							Species:  to.StringPtr("dangerous"),
 						},
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
 					},
-					Picture: &[]byte{255, 255, 255, 255, 254},
+					Picture: []byte{255, 255, 255, 255, 254},
 				},
 			},
 			Species: to.StringPtr("king"),

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -34,7 +34,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 	expectedFish := Fish{
 		Fishtype: to.StringPtr("smart_salmon"),
 		Length:   to.Float32Ptr(1),
-		Siblings: &[]FishClassification{
+		Siblings: []FishClassification{
 			&Shark{
 				Fish: Fish{
 					Fishtype: to.StringPtr("shark"),
@@ -53,7 +53,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 					Age:      to.Int32Ptr(105),
 					Birthday: &sawBday,
 				},
-				Picture: &[]byte{255, 255, 255, 255, 254},
+				Picture: []byte{255, 255, 255, 255, 254},
 			},
 			&Goblinshark{
 				Shark: Shark{
@@ -78,7 +78,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 	}
 	if r := cmp.Diff(salmon, &SmartSalmon{
 		Salmon: expectedSalmon,
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"additionalProperty1": float64(1),
 			"additionalProperty2": false,
 			"additionalProperty3": "hello",
@@ -109,7 +109,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 		t.Fatal(err)
 	}
 	if r := cmp.Diff(result.DotFishMarket, &DotFishMarket{
-		Fishes: &[]DotFishClassification{
+		Fishes: []DotFishClassification{
 			&DotSalmon{
 				DotFish: DotFish{
 					FishType: to.StringPtr("DotSalmon"),
@@ -127,7 +127,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 				Iswild:   to.BoolPtr(true),
 			},
 		},
-		Salmons: &[]*DotSalmon{
+		Salmons: []*DotSalmon{
 			{
 				DotFish: DotFish{
 					FishType: to.StringPtr("DotSalmon"),
@@ -174,7 +174,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 		t.Fatal(err)
 	}
 	if r := cmp.Diff(result.DotFishMarket, &DotFishMarket{
-		Fishes: &[]DotFishClassification{
+		Fishes: []DotFishClassification{
 			&DotFish{
 				Species: to.StringPtr("king"),
 			},
@@ -182,7 +182,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 				Species: to.StringPtr("king"),
 			},
 		},
-		Salmons: &[]*DotSalmon{
+		Salmons: []*DotSalmon{
 			{
 				DotFish: DotFish{
 					Species: to.StringPtr("king"),
@@ -250,7 +250,7 @@ func TestPolymorphismGetValid(t *testing.T) {
 		Fish: Fish{
 			Fishtype: to.StringPtr("salmon"),
 			Length:   to.Float32Ptr(1),
-			Siblings: &[]FishClassification{
+			Siblings: []FishClassification{
 				&Shark{
 					Fish: Fish{
 						Fishtype: to.StringPtr("shark"),
@@ -270,7 +270,7 @@ func TestPolymorphismGetValid(t *testing.T) {
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
 					},
-					Picture: &[]byte{255, 255, 255, 255, 254},
+					Picture: []byte{255, 255, 255, 255, 254},
 				},
 				&Goblinshark{
 					Shark: Shark{
@@ -306,7 +306,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 			Fish: Fish{
 				Fishtype: to.StringPtr("smart_salmon"),
 				Length:   to.Float32Ptr(1),
-				Siblings: &[]FishClassification{
+				Siblings: []FishClassification{
 					&Shark{
 						Fish: Fish{
 							Fishtype: to.StringPtr("shark"),
@@ -325,7 +325,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 							Age:      to.Int32Ptr(105),
 							Birthday: &sawBday,
 						},
-						Picture: &[]byte{255, 255, 255, 255, 254},
+						Picture: []byte{255, 255, 255, 255, 254},
 					},
 					&Goblinshark{
 						Shark: Shark{
@@ -346,7 +346,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 			Iswild:   to.BoolPtr(true),
 			Location: to.StringPtr("alaska"),
 		},
-		AdditionalProperties: &map[string]interface{}{
+		AdditionalProperties: map[string]interface{}{
 			"additionalProperty1": float64(1),
 			"additionalProperty2": false,
 			"additionalProperty3": "hello",
@@ -376,7 +376,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 	result, err := client.PutMissingDiscriminator(context.Background(), &Salmon{
 		Fish: Fish{
 			Length: to.Float32Ptr(1),
-			Siblings: &[]FishClassification{
+			Siblings: []FishClassification{
 				&Shark{
 					Fish: Fish{
 						Length:  to.Float32Ptr(20),
@@ -394,7 +394,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
 					},
-					Picture: &[]byte{255, 255, 255, 255, 254},
+					Picture: []byte{255, 255, 255, 255, 254},
 				},
 				&Goblinshark{
 					Shark: Shark{
@@ -431,7 +431,7 @@ func TestPolymorphismPutValid(t *testing.T) {
 	resp, err := client.PutValid(context.Background(), &Salmon{
 		Fish: Fish{
 			Length: to.Float32Ptr(1),
-			Siblings: &[]FishClassification{
+			Siblings: []FishClassification{
 				&Shark{
 					Fish: Fish{
 						Length:  to.Float32Ptr(20),
@@ -449,7 +449,7 @@ func TestPolymorphismPutValid(t *testing.T) {
 						Age:      to.Int32Ptr(105),
 						Birthday: &sawBday,
 					},
-					Picture: &[]byte{255, 255, 255, 255, 254},
+					Picture: []byte{255, 255, 255, 255, 254},
 				},
 				&Goblinshark{
 					Shark: Shark{

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -138,7 +138,7 @@ func TestPrimitiveGetByte(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByte: %v", err)
 	}
-	if r := cmp.Diff(result.ByteWrapper, &ByteWrapper{Field: &[]byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}}); r != "" {
+	if r := cmp.Diff(result.ByteWrapper, &ByteWrapper{Field: []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}}); r != "" {
 		t.Fatal(r)
 	}
 }
@@ -157,8 +157,7 @@ func TestPrimitivePutBool(t *testing.T) {
 
 func TestPrimitivePutByte(t *testing.T) {
 	client := newPrimitiveClient()
-	val := []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}
-	result, err := client.PutByte(context.Background(), ByteWrapper{Field: &val}, nil)
+	result, err := client.PutByte(context.Background(), ByteWrapper{Field: []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}}, nil)
 	if err != nil {
 		t.Fatalf("PutByte: %v", err)
 	}

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -41,7 +41,14 @@ type ArrayPutValidOptions struct {
 }
 
 type ArrayWrapper struct {
-	Array *[]*string `json:"array,omitempty"`
+	Array []*string `json:"array,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ArrayWrapper.
+func (a ArrayWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "array", a.Array)
+	return json.Marshal(objectMap)
 }
 
 // ArrayWrapperResponse is the response envelope for operations that return a ArrayWrapper type.
@@ -114,7 +121,14 @@ type BooleanWrapperResponse struct {
 }
 
 type ByteWrapper struct {
-	Field *[]byte `json:"field,omitempty"`
+	Field []byte `json:"field,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ByteWrapper.
+func (b ByteWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "field", b.Field)
+	return json.Marshal(objectMap)
 }
 
 // ByteWrapperResponse is the response envelope for operations that return a ByteWrapper type.
@@ -128,7 +142,20 @@ type ByteWrapperResponse struct {
 type Cat struct {
 	Pet
 	Color *string `json:"color,omitempty"`
-	Hates *[]*Dog `json:"hates,omitempty"`
+	Hates []*Dog  `json:"hates,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Cat.
+func (c Cat) MarshalJSON() ([]byte, error) {
+	objectMap := c.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (c Cat) marshalInternal() map[string]interface{} {
+	objectMap := c.Pet.marshalInternal()
+	populate(objectMap, "color", c.Color)
+	populate(objectMap, "hates", c.Hates)
+	return objectMap
 }
 
 type Cookiecuttershark struct {
@@ -317,7 +344,14 @@ type DictionaryPutValidOptions struct {
 
 type DictionaryWrapper struct {
 	// Dictionary of
-	DefaultProgram *map[string]*string `json:"defaultProgram,omitempty"`
+	DefaultProgram map[string]*string `json:"defaultProgram,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DictionaryWrapper.
+func (d DictionaryWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "defaultProgram", d.DefaultProgram)
+	return json.Marshal(objectMap)
 }
 
 // DictionaryWrapperResponse is the response envelope for operations that return a DictionaryWrapper type.
@@ -331,6 +365,13 @@ type DictionaryWrapperResponse struct {
 type Dog struct {
 	Pet
 	Food *string `json:"food,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Dog.
+func (d Dog) MarshalJSON() ([]byte, error) {
+	objectMap := d.Pet.marshalInternal()
+	populate(objectMap, "food", d.Food)
+	return json.Marshal(objectMap)
 }
 
 // DotFishClassification provides polymorphic access to related types.
@@ -386,10 +427,20 @@ func (d *DotFish) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 }
 
 type DotFishMarket struct {
-	Fishes       *[]DotFishClassification `json:"fishes,omitempty"`
-	Salmons      *[]*DotSalmon            `json:"salmons,omitempty"`
-	SampleFish   DotFishClassification    `json:"sampleFish,omitempty"`
-	SampleSalmon *DotSalmon               `json:"sampleSalmon,omitempty"`
+	Fishes       []DotFishClassification `json:"fishes,omitempty"`
+	Salmons      []*DotSalmon            `json:"salmons,omitempty"`
+	SampleFish   DotFishClassification   `json:"sampleFish,omitempty"`
+	SampleSalmon *DotSalmon              `json:"sampleSalmon,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DotFishMarket.
+func (d DotFishMarket) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fishes", d.Fishes)
+	populate(objectMap, "salmons", d.Salmons)
+	populate(objectMap, "sampleFish", d.SampleFish)
+	populate(objectMap, "sampleSalmon", d.SampleSalmon)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type DotFishMarket.
@@ -532,10 +583,10 @@ type FishClassification interface {
 }
 
 type Fish struct {
-	Fishtype *string               `json:"fishtype,omitempty"`
-	Length   *float32              `json:"length,omitempty"`
-	Siblings *[]FishClassification `json:"siblings,omitempty"`
-	Species  *string               `json:"species,omitempty"`
+	Fishtype *string              `json:"fishtype,omitempty"`
+	Length   *float32             `json:"length,omitempty"`
+	Siblings []FishClassification `json:"siblings,omitempty"`
+	Species  *string              `json:"species,omitempty"`
 }
 
 // GetFish implements the FishClassification interface for type Fish.
@@ -810,6 +861,19 @@ type Pet struct {
 	Name *string `json:"name,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Pet.
+func (p Pet) MarshalJSON() ([]byte, error) {
+	objectMap := p.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (p Pet) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", p.ID)
+	populate(objectMap, "name", p.Name)
+	return objectMap
+}
+
 // PolymorphicrecursiveGetValidOptions contains the optional parameters for the Polymorphicrecursive.GetValid method.
 type PolymorphicrecursiveGetValidOptions struct {
 	// placeholder for future optional parameters
@@ -1076,7 +1140,7 @@ func (s *SalmonResponse) UnmarshalJSON(data []byte) error {
 
 type Sawshark struct {
 	Shark
-	Picture *[]byte `json:"picture,omitempty"`
+	Picture []byte `json:"picture,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type Sawshark.
@@ -1172,6 +1236,13 @@ type Siamese struct {
 	Breed *string `json:"breed,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Siamese.
+func (s Siamese) MarshalJSON() ([]byte, error) {
+	objectMap := s.Cat.marshalInternal()
+	populate(objectMap, "breed", s.Breed)
+	return json.Marshal(objectMap)
+}
+
 // SiameseResponse is the response envelope for operations that return a Siamese type.
 type SiameseResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -1182,7 +1253,7 @@ type SiameseResponse struct {
 type SmartSalmon struct {
 	Salmon
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 	CollegeDegree        *string `json:"college_degree,omitempty"`
 }
 
@@ -1191,7 +1262,7 @@ func (s SmartSalmon) MarshalJSON() ([]byte, error) {
 	objectMap := s.Salmon.marshalInternal("smart_salmon")
 	populate(objectMap, "college_degree", s.CollegeDegree)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -1221,12 +1292,12 @@ func (s *SmartSalmon) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		if s.AdditionalProperties == nil {
-			s.AdditionalProperties = &map[string]interface{}{}
+			s.AdditionalProperties = map[string]interface{}{}
 		}
 		if val != nil {
 			var aux interface{}
 			err = json.Unmarshal(val, &aux)
-			(*s.AdditionalProperties)[key] = aux
+			s.AdditionalProperties[key] = aux
 		}
 		delete(rawMsg, key)
 		if err != nil {

--- a/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
@@ -27,7 +27,7 @@ func unmarshalDotFishClassification(rawMsg json.RawMessage) (DotFishClassificati
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDotFishClassificationArray(rawMsg json.RawMessage) (*[]DotFishClassification, error) {
+func unmarshalDotFishClassificationArray(rawMsg json.RawMessage) ([]DotFishClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -43,7 +43,7 @@ func unmarshalDotFishClassificationArray(rawMsg json.RawMessage) (*[]DotFishClas
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalFishClassification(rawMsg json.RawMessage) (FishClassification, error) {
@@ -74,7 +74,7 @@ func unmarshalFishClassification(rawMsg json.RawMessage) (FishClassification, er
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalFishClassificationArray(rawMsg json.RawMessage) (*[]FishClassification, error) {
+func unmarshalFishClassificationArray(rawMsg json.RawMessage) ([]FishClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -90,7 +90,7 @@ func unmarshalFishClassificationArray(rawMsg json.RawMessage) (*[]FishClassifica
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalMyBaseTypeClassification(rawMsg json.RawMessage) (MyBaseTypeClassification, error) {
@@ -111,7 +111,7 @@ func unmarshalMyBaseTypeClassification(rawMsg json.RawMessage) (MyBaseTypeClassi
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalMyBaseTypeClassificationArray(rawMsg json.RawMessage) (*[]MyBaseTypeClassification, error) {
+func unmarshalMyBaseTypeClassificationArray(rawMsg json.RawMessage) ([]MyBaseTypeClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -127,7 +127,7 @@ func unmarshalMyBaseTypeClassificationArray(rawMsg json.RawMessage) (*[]MyBaseTy
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalSalmonClassification(rawMsg json.RawMessage) (SalmonClassification, error) {
@@ -148,7 +148,7 @@ func unmarshalSalmonClassification(rawMsg json.RawMessage) (SalmonClassification
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalSalmonClassificationArray(rawMsg json.RawMessage) (*[]SalmonClassification, error) {
+func unmarshalSalmonClassificationArray(rawMsg json.RawMessage) ([]SalmonClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -164,7 +164,7 @@ func unmarshalSalmonClassificationArray(rawMsg json.RawMessage) (*[]SalmonClassi
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalSharkClassification(rawMsg json.RawMessage) (SharkClassification, error) {
@@ -189,7 +189,7 @@ func unmarshalSharkClassification(rawMsg json.RawMessage) (SharkClassification, 
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalSharkClassificationArray(rawMsg json.RawMessage) (*[]SharkClassification, error) {
+func unmarshalSharkClassificationArray(rawMsg json.RawMessage) ([]SharkClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -205,5 +205,5 @@ func unmarshalSharkClassificationArray(rawMsg json.RawMessage) (*[]SharkClassifi
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }

--- a/test/autorest/complexmodelgroup/zz_generated_models.go
+++ b/test/autorest/complexmodelgroup/zz_generated_models.go
@@ -7,16 +7,35 @@
 
 package complexmodelgroup
 
-import "net/http"
+import (
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
+	"reflect"
+)
 
 type CatalogArray struct {
 	// Array of products
-	ProductArray *[]*Product `json:"productArray,omitempty"`
+	ProductArray []*Product `json:"productArray,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CatalogArray.
+func (c CatalogArray) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "productArray", c.ProductArray)
+	return json.Marshal(objectMap)
 }
 
 type CatalogArrayOfDictionary struct {
 	// Array of dictionary of products
-	ProductArrayOfDictionary *[]map[string]*Product `json:"productArrayOfDictionary,omitempty"`
+	ProductArrayOfDictionary []map[string]*Product `json:"productArrayOfDictionary,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CatalogArrayOfDictionary.
+func (c CatalogArrayOfDictionary) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "productArrayOfDictionary", c.ProductArrayOfDictionary)
+	return json.Marshal(objectMap)
 }
 
 // CatalogArrayResponse is the response envelope for operations that return a CatalogArray type.
@@ -29,12 +48,26 @@ type CatalogArrayResponse struct {
 
 type CatalogDictionary struct {
 	// Dictionary of products
-	ProductDictionary *map[string]*Product `json:"productDictionary,omitempty"`
+	ProductDictionary map[string]*Product `json:"productDictionary,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CatalogDictionary.
+func (c CatalogDictionary) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "productDictionary", c.ProductDictionary)
+	return json.Marshal(objectMap)
 }
 
 type CatalogDictionaryOfArray struct {
 	// Dictionary of Array of product
-	ProductDictionaryOfArray *map[string][]*Product `json:"productDictionaryOfArray,omitempty"`
+	ProductDictionaryOfArray map[string][]*Product `json:"productDictionaryOfArray,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CatalogDictionaryOfArray.
+func (c CatalogDictionaryOfArray) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "productDictionaryOfArray", c.ProductDictionaryOfArray)
+	return json.Marshal(objectMap)
 }
 
 // CatalogDictionaryResponse is the response envelope for operations that return a CatalogDictionary type.
@@ -90,4 +123,14 @@ type Product struct {
 	// Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id
 	// than uberX in Los Angeles.
 	ProductID *string `json:"product_id,omitempty"`
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
 }

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -48,6 +48,15 @@ type BaseError struct {
 	SomeBaseProp *string `json:"someBaseProp,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaller interface for type BaseError.
+func (b *BaseError) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	return b.unmarshalInternal(rawMsg)
+}
+
 func (b *BaseError) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 	for key, val := range rawMsg {
 		var err error

--- a/test/autorest/errorsgroup/zz_generated_polymorphic_helpers.go
+++ b/test/autorest/errorsgroup/zz_generated_polymorphic_helpers.go
@@ -38,7 +38,7 @@ func unmarshalNotFoundErrorBaseClassification(rawMsg json.RawMessage) (NotFoundE
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalNotFoundErrorBaseClassificationArray(rawMsg json.RawMessage) (*[]NotFoundErrorBaseClassification, error) {
+func unmarshalNotFoundErrorBaseClassificationArray(rawMsg json.RawMessage) ([]NotFoundErrorBaseClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -54,7 +54,7 @@ func unmarshalNotFoundErrorBaseClassificationArray(rawMsg json.RawMessage) (*[]N
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 type petActionError struct {
@@ -86,7 +86,7 @@ func unmarshalPetActionErrorClassification(rawMsg json.RawMessage) (PetActionErr
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalPetActionErrorClassificationArray(rawMsg json.RawMessage) (*[]PetActionErrorClassification, error) {
+func unmarshalPetActionErrorClassificationArray(rawMsg json.RawMessage) ([]PetActionErrorClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -102,7 +102,7 @@ func unmarshalPetActionErrorClassificationArray(rawMsg json.RawMessage) (*[]PetA
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalPetSadErrorClassification(rawMsg json.RawMessage) (PetSadErrorClassification, error) {
@@ -123,7 +123,7 @@ func unmarshalPetSadErrorClassification(rawMsg json.RawMessage) (PetSadErrorClas
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalPetSadErrorClassificationArray(rawMsg json.RawMessage) (*[]PetSadErrorClassification, error) {
+func unmarshalPetSadErrorClassificationArray(rawMsg json.RawMessage) ([]PetSadErrorClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -139,5 +139,5 @@ func unmarshalPetSadErrorClassificationArray(rawMsg json.RawMessage) (*[]PetSadE
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }

--- a/test/autorest/formdatagroup/zz_generated_models.go
+++ b/test/autorest/formdatagroup/zz_generated_models.go
@@ -7,7 +7,11 @@
 
 package formdatagroup
 
-import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+import (
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"reflect"
+)
 
 // Implements the error and azcore.HTTPResponse interfaces.
 type Error struct {
@@ -47,5 +51,22 @@ type Paths1MqqetpFormdataStreamUploadfilePostRequestbodyContentMultipartFormData
 
 type Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema struct {
 	// Files to upload.
-	FileContent *[]azcore.ReadSeekCloser `json:"fileContent,omitempty"`
+	FileContent []azcore.ReadSeekCloser `json:"fileContent,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema.
+func (p Paths1P3Stk3FormdataStreamUploadfilesPostRequestbodyContentMultipartFormDataSchema) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fileContent", p.FileContent)
+	return json.Marshal(objectMap)
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
 }

--- a/test/autorest/optionalgroup/zz_generated_models.go
+++ b/test/autorest/optionalgroup/zz_generated_models.go
@@ -7,12 +7,32 @@
 
 package optionalgroup
 
+import (
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"reflect"
+)
+
 type ArrayOptionalWrapper struct {
-	Value *[]*string `json:"value,omitempty"`
+	Value []*string `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ArrayOptionalWrapper.
+func (a ArrayOptionalWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 type ArrayWrapper struct {
-	Value *[]*string `json:"value,omitempty"`
+	Value []*string `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ArrayWrapper.
+func (a ArrayWrapper) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 type ClassOptionalWrapper struct {
@@ -199,4 +219,14 @@ type StringOptionalWrapper struct {
 
 type StringWrapper struct {
 	Value *string `json:"value,omitempty"`
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
 }

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -40,7 +40,7 @@ func TestGetMultiplePages(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -63,7 +63,7 @@ func TestGetMultiplePagesFailure(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -86,7 +86,7 @@ func TestGetMultiplePagesFailureURI(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -109,7 +109,7 @@ func TestGetMultiplePagesFragmentNextLink(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.OdataProductResult.Values) == 0 {
+		if len(resp.OdataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -135,7 +135,7 @@ func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.OdataProductResult.Values) == 0 {
+		if len(resp.OdataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -174,7 +174,7 @@ func TestGetMultiplePagesLro(t *testing.T) {
 	count := 0
 	for pager.NextPage(context.Background()) {
 		resp := pager.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -195,7 +195,7 @@ func TestGetMultiplePagesRetryFirst(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -218,7 +218,7 @@ func TestGetMultiplePagesRetrySecond(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -241,7 +241,7 @@ func TestGetMultiplePagesWithOffset(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -264,7 +264,7 @@ func TestGetNoItemNamePages(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResultValue.Value) == 0 {
+		if len(resp.ProductResultValue.Value) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -287,7 +287,7 @@ func TestGetNullNextLinkNamePages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(*resp.ProductResult.Values) == 0 {
+	if len(resp.ProductResult.Values) == 0 {
 		t.Fatal("missing payload")
 	}
 }
@@ -299,7 +299,7 @@ func TestGetOdataMultiplePages(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.OdataProductResult.Values) == 0 {
+		if len(resp.OdataProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -322,7 +322,7 @@ func TestGetPagingModelWithItemNameWithXMSClientName(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResultValueWithXMSClientName.Indexes) == 0 {
+		if len(resp.ProductResultValueWithXMSClientName.Indexes) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -345,7 +345,7 @@ func TestGetSinglePages(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -368,7 +368,7 @@ func TestGetSinglePagesFailure(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++
@@ -391,7 +391,7 @@ func TestGetWithQueryParams(t *testing.T) {
 	count := 0
 	for page.NextPage(context.Background()) {
 		resp := page.PageResponse()
-		if len(*resp.ProductResult.Values) == 0 {
+		if len(resp.ProductResult.Values) == 0 {
 			t.Fatal("missing payload")
 		}
 		count++

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -9,7 +9,10 @@ package paginggroup
 
 import (
 	"context"
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"net/http"
+	"reflect"
 	"time"
 )
 
@@ -22,8 +25,16 @@ type CustomParameterGroup struct {
 }
 
 type OdataProductResult struct {
-	OdataNextLink *string     `json:"odata.nextLink,omitempty"`
-	Values        *[]*Product `json:"values,omitempty"`
+	OdataNextLink *string    `json:"odata.nextLink,omitempty"`
+	Values        []*Product `json:"values,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OdataProductResult.
+func (o OdataProductResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "odata.nextLink", o.OdataNextLink)
+	populate(objectMap, "values", o.Values)
+	return json.Marshal(objectMap)
 }
 
 // OdataProductResultResponse is the response envelope for operations that return a OdataProductResult type.
@@ -149,8 +160,16 @@ type ProductProperties struct {
 }
 
 type ProductResult struct {
-	NextLink *string     `json:"nextLink,omitempty"`
-	Values   *[]*Product `json:"values,omitempty"`
+	NextLink *string    `json:"nextLink,omitempty"`
+	Values   []*Product `json:"values,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProductResult.
+func (p ProductResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "values", p.Values)
+	return json.Marshal(objectMap)
 }
 
 // ProductResultPagerPollerResponse is the response envelope for operations that asynchronously return a ProductResultPager type.
@@ -174,8 +193,16 @@ type ProductResultResponse struct {
 }
 
 type ProductResultValue struct {
-	NextLink *string     `json:"nextLink,omitempty"`
-	Value    *[]*Product `json:"value,omitempty"`
+	NextLink *string    `json:"nextLink,omitempty"`
+	Value    []*Product `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProductResultValue.
+func (p ProductResultValue) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // ProductResultValueResponse is the response envelope for operations that return a ProductResultValue type.
@@ -187,8 +214,16 @@ type ProductResultValueResponse struct {
 }
 
 type ProductResultValueWithXMSClientName struct {
-	Indexes  *[]*Product `json:"values,omitempty"`
-	NextLink *string     `json:"nextLink,omitempty"`
+	Indexes  []*Product `json:"values,omitempty"`
+	NextLink *string    `json:"nextLink,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProductResultValueWithXMSClientName.
+func (p ProductResultValueWithXMSClientName) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "values", p.Indexes)
+	populate(objectMap, "nextLink", p.NextLink)
+	return json.Marshal(objectMap)
 }
 
 // ProductResultValueWithXMSClientNameResponse is the response envelope for operations that return a ProductResultValueWithXMSClientName type.
@@ -197,4 +232,14 @@ type ProductResultValueWithXMSClientNameResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
 }

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -49,7 +49,7 @@ func TestValidationValidationOfBody(t *testing.T) {
 	client := newAutoRestValidationTestClient()
 	result, err := client.ValidationOfBody(context.Background(), "123", 150, &AutoRestValidationTestValidationOfBodyOptions{
 		Body: &Product{
-			DisplayNames: &[]*string{
+			DisplayNames: []*string{
 				to.StringPtr("displayname1"),
 				to.StringPtr("displayname2"),
 				to.StringPtr("displayname3"),

--- a/test/autorest/validationgroup/zz_generated_models.go
+++ b/test/autorest/validationgroup/zz_generated_models.go
@@ -7,7 +7,12 @@
 
 package validationgroup
 
-import "net/http"
+import (
+	"encoding/json"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"net/http"
+	"reflect"
+)
 
 // AutoRestValidationTestGetWithConstantInPathOptions contains the optional parameters for the AutoRestValidationTest.GetWithConstantInPath method.
 type AutoRestValidationTestGetWithConstantInPathOptions struct {
@@ -83,10 +88,24 @@ type Product struct {
 	ConstStringAsEnum *string `json:"constStringAsEnum,omitempty"`
 
 	// Non required array of unique items from 0 to 6 elements.
-	DisplayNames *[]*string `json:"display_names,omitempty"`
+	DisplayNames []*string `json:"display_names,omitempty"`
 
 	// Image URL representing the product.
 	Image *string `json:"image,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Product.
+func (p Product) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "capacity", p.Capacity)
+	populate(objectMap, "child", p.Child)
+	populate(objectMap, "constChild", p.ConstChild)
+	populate(objectMap, "constInt", p.ConstInt)
+	populate(objectMap, "constString", p.ConstString)
+	populate(objectMap, "constStringAsEnum", p.ConstStringAsEnum)
+	populate(objectMap, "display_names", p.DisplayNames)
+	populate(objectMap, "image", p.Image)
+	return json.Marshal(objectMap)
 }
 
 // ProductResponse is the response envelope for operations that return a Product type.
@@ -96,4 +115,14 @@ type ProductResponse struct {
 
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
 }

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -264,13 +264,13 @@ func TestGetSimple(t *testing.T) {
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
 		Title:  to.StringPtr("Sample Slide Show"),
-		Slides: &[]*Slide{
+		Slides: []*Slide{
 			{
 				Title: to.StringPtr("Wake up to WonderWidgets!"),
 				Type:  to.StringPtr("all"),
 			},
 			{
-				Items: stringPtrArrayPtr(to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets")),
+				Items: to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets"),
 				Title: to.StringPtr("Overview"),
 				Type:  to.StringPtr("all"),
 			},
@@ -291,8 +291,8 @@ func TestGetWrappedLists(t *testing.T) {
 		t.Fatalf("unexpected status code %d", s)
 	}
 	expected := &AppleBarrel{
-		BadApples:  stringPtrArrayPtr(to.StringPtrArray("Red Delicious")),
-		GoodApples: stringPtrArrayPtr(to.StringPtrArray("Fuji", "Gala")),
+		BadApples:  to.StringPtrArray("Red Delicious"),
+		GoodApples: to.StringPtrArray("Fuji", "Gala"),
 	}
 	if r := cmp.Diff(result.AppleBarrel, expected); r != "" {
 		t.Fatal(r)
@@ -342,9 +342,9 @@ func TestListBlobs(t *testing.T) {
 	}
 	expected := ListBlobsResponse{
 		Blobs: &Blobs{
-			Blob: &[]*Blob{
+			Blob: []*Blob{
 				{
-					Metadata: &map[string]*string{
+					Metadata: map[string]*string{
 						"color":            to.StringPtr("blue"),
 						"blobnumber":       to.StringPtr("01"),
 						"somemetadataname": to.StringPtr("SomeMetadataValue"),
@@ -364,7 +364,7 @@ func TestListBlobs(t *testing.T) {
 					},
 				},
 				{
-					Metadata: &map[string]*string{
+					Metadata: map[string]*string{
 						"color":             to.StringPtr("green"),
 						"blobnumber":        to.StringPtr("02"),
 						"somemetadataname":  to.StringPtr("SomeMetadataValue"),
@@ -385,7 +385,7 @@ func TestListBlobs(t *testing.T) {
 					Snapshot: to.StringPtr("2009-09-09T09:20:03.0427659Z"),
 				},
 				{
-					Metadata: &map[string]*string{
+					Metadata: map[string]*string{
 						"color":            to.StringPtr("green"),
 						"blobnumber":       to.StringPtr("02"),
 						"somemetadataname": to.StringPtr("SomeMetadataValue"),
@@ -405,7 +405,7 @@ func TestListBlobs(t *testing.T) {
 					Snapshot: to.StringPtr("2009-09-09T09:20:03.1587543Z"),
 				},
 				{
-					Metadata: &map[string]*string{
+					Metadata: map[string]*string{
 						"color":            to.StringPtr("green"),
 						"blobnumber":       to.StringPtr("02"),
 						"somemetadataname": to.StringPtr("SomeMetadataValue"),
@@ -425,7 +425,7 @@ func TestListBlobs(t *testing.T) {
 					},
 				},
 				{
-					Metadata: &map[string]*string{
+					Metadata: map[string]*string{
 						"color":            to.StringPtr("yellow"),
 						"blobnumber":       to.StringPtr("03"),
 						"somemetadataname": to.StringPtr("SomeMetadataValue"),
@@ -468,7 +468,7 @@ func TestListContainers(t *testing.T) {
 		ServiceEndpoint: to.StringPtr("https://myaccount.blob.core.windows.net/"),
 		MaxResults:      to.Int32Ptr(3),
 		NextMarker:      to.StringPtr("video"),
-		Containers: &[]*Container{
+		Containers: []*Container{
 			{
 				Name: to.StringPtr("audio"),
 				Properties: &ContainerProperties{
@@ -568,7 +568,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 func TestPutEmptyList(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutEmptyList(context.Background(), Slideshow{
-		Slides: &[]*Slide{},
+		Slides: []*Slide{},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -592,8 +592,8 @@ func TestPutEmptyRootList(t *testing.T) {
 func TestPutEmptyWrappedLists(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutEmptyWrappedLists(context.Background(), AppleBarrel{
-		BadApples:  &[]*string{},
-		GoodApples: &[]*string{},
+		BadApples:  []*string{},
+		GoodApples: []*string{},
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -688,13 +688,13 @@ func TestPutSimple(t *testing.T) {
 		Author: to.StringPtr("Yours Truly"),
 		Date:   to.StringPtr("Date of publication"),
 		Title:  to.StringPtr("Sample Slide Show"),
-		Slides: &[]*Slide{
+		Slides: []*Slide{
 			{
 				Title: to.StringPtr("Wake up to WonderWidgets!"),
 				Type:  to.StringPtr("all"),
 			},
 			{
-				Items: stringPtrArrayPtr(to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets")),
+				Items: to.StringPtrArray("Why WonderWidgets are great", "", "Who buys WonderWidgets"),
 				Title: to.StringPtr("Overview"),
 				Type:  to.StringPtr("all"),
 			},
@@ -711,8 +711,8 @@ func TestPutSimple(t *testing.T) {
 func TestPutWrappedLists(t *testing.T) {
 	client := newXMLClient()
 	result, err := client.PutWrappedLists(context.Background(), AppleBarrel{
-		BadApples:  stringPtrArrayPtr(to.StringPtrArray("Red Delicious")),
-		GoodApples: stringPtrArrayPtr(to.StringPtrArray("Fuji", "Gala")),
+		BadApples:  to.StringPtrArray("Red Delicious"),
+		GoodApples: to.StringPtrArray("Fuji", "Gala"),
 	}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -720,8 +720,4 @@ func TestPutWrappedLists(t *testing.T) {
 	if s := result.StatusCode; s != http.StatusCreated {
 		t.Fatalf("unexpected status code %d", s)
 	}
-}
-
-func stringPtrArrayPtr(s []*string) *[]*string {
-	return &s
 }

--- a/test/autorest/xmlgroup/zz_generated_models.go
+++ b/test/autorest/xmlgroup/zz_generated_models.go
@@ -60,8 +60,27 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 
 // AppleBarrel - A barrel of apples.
 type AppleBarrel struct {
-	BadApples  *[]*string `xml:"BadApples>Apple"`
-	GoodApples *[]*string `xml:"GoodApples>Apple"`
+	BadApples  []*string `xml:"BadApples>Apple"`
+	GoodApples []*string `xml:"GoodApples>Apple"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type AppleBarrel.
+func (a AppleBarrel) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias AppleBarrel
+	aux := &struct {
+		*alias
+		BadApples  *[]*string `xml:"BadApples>Apple"`
+		GoodApples *[]*string `xml:"GoodApples>Apple"`
+	}{
+		alias: (*alias)(&a),
+	}
+	if a.BadApples != nil {
+		aux.BadApples = &a.BadApples
+	}
+	if a.GoodApples != nil {
+		aux.GoodApples = &a.GoodApples
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // AppleBarrelResponse is the response envelope for operations that return a AppleBarrel type.
@@ -134,8 +153,8 @@ type Blob struct {
 	Deleted *bool `xml:"Deleted"`
 
 	// Dictionary of
-	Metadata *map[string]*string `xml:"Metadata"`
-	Name     *string             `xml:"Name"`
+	Metadata map[string]*string `xml:"Metadata"`
+	Name     *string            `xml:"Name"`
 
 	// Properties of a blob
 	Properties *BlobProperties `xml:"Properties"`
@@ -147,14 +166,14 @@ func (b *Blob) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	type alias Blob
 	aux := &struct {
 		*alias
-		Metadata *additionalProperties `xml:"Metadata"`
+		Metadata additionalProperties `xml:"Metadata"`
 	}{
 		alias: (*alias)(b),
 	}
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	b.Metadata = (*map[string]*string)(aux.Metadata)
+	b.Metadata = (map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -234,8 +253,27 @@ func (b *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 }
 
 type Blobs struct {
-	Blob       *[]*Blob       `xml:"Blob"`
-	BlobPrefix *[]*BlobPrefix `xml:"BlobPrefix"`
+	Blob       []*Blob       `xml:"Blob"`
+	BlobPrefix []*BlobPrefix `xml:"BlobPrefix"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type Blobs.
+func (b Blobs) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias Blobs
+	aux := &struct {
+		*alias
+		Blob       *[]*Blob       `xml:"Blob"`
+		BlobPrefix *[]*BlobPrefix `xml:"BlobPrefix"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.Blob != nil {
+		aux.Blob = &b.Blob
+	}
+	if b.BlobPrefix != nil {
+		aux.BlobPrefix = &b.BlobPrefix
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // ComplexTypeNoMeta - I am a complex type with no XML node
@@ -253,8 +291,8 @@ type ComplexTypeWithMeta struct {
 // Container - An Azure Storage container
 type Container struct {
 	// Dictionary of
-	Metadata *map[string]*string `xml:"Metadata"`
-	Name     *string             `xml:"Name"`
+	Metadata map[string]*string `xml:"Metadata"`
+	Name     *string            `xml:"Name"`
 
 	// Properties of a container
 	Properties *ContainerProperties `xml:"Properties"`
@@ -265,14 +303,14 @@ func (c *Container) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	type alias Container
 	aux := &struct {
 		*alias
-		Metadata *additionalProperties `xml:"Metadata"`
+		Metadata additionalProperties `xml:"Metadata"`
 	}{
 		alias: (*alias)(c),
 	}
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.Metadata = (*map[string]*string)(aux.Metadata)
+	c.Metadata = (map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -391,12 +429,27 @@ type ListBlobsResponseResponse struct {
 
 // ListContainersResponse - An enumeration of containers
 type ListContainersResponse struct {
-	Containers      *[]*Container `xml:"Containers>Container"`
-	Marker          *string       `xml:"Marker"`
-	MaxResults      *int32        `xml:"MaxResults"`
-	NextMarker      *string       `xml:"NextMarker"`
-	Prefix          *string       `xml:"Prefix"`
-	ServiceEndpoint *string       `xml:"ServiceEndpoint,attr"`
+	Containers      []*Container `xml:"Containers>Container"`
+	Marker          *string      `xml:"Marker"`
+	MaxResults      *int32       `xml:"MaxResults"`
+	NextMarker      *string      `xml:"NextMarker"`
+	Prefix          *string      `xml:"Prefix"`
+	ServiceEndpoint *string      `xml:"ServiceEndpoint,attr"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type ListContainersResponse.
+func (l ListContainersResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias ListContainersResponse
+	aux := &struct {
+		*alias
+		Containers *[]*Container `xml:"Containers>Container"`
+	}{
+		alias: (*alias)(&l),
+	}
+	if l.Containers != nil {
+		aux.Containers = &l.Containers
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // ListContainersResponseResponse is the response envelope for operations that return a ListContainersResponse type.
@@ -523,17 +576,32 @@ type SignedIdentifierArrayResponse struct {
 
 // Slide - A slide in a slideshow
 type Slide struct {
-	Items *[]*string `xml:"item"`
-	Title *string    `xml:"title"`
-	Type  *string    `xml:"type,attr"`
+	Items []*string `xml:"item"`
+	Title *string   `xml:"title"`
+	Type  *string   `xml:"type,attr"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type Slide.
+func (s Slide) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias Slide
+	aux := &struct {
+		*alias
+		Items *[]*string `xml:"item"`
+	}{
+		alias: (*alias)(&s),
+	}
+	if s.Items != nil {
+		aux.Items = &s.Items
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // Slideshow - Data about a slideshow
 type Slideshow struct {
-	Author *string   `xml:"author,attr"`
-	Date   *string   `xml:"date,attr"`
-	Slides *[]*Slide `xml:"slide"`
-	Title  *string   `xml:"title,attr"`
+	Author *string  `xml:"author,attr"`
+	Date   *string  `xml:"date,attr"`
+	Slides []*Slide `xml:"slide"`
+	Title  *string  `xml:"title,attr"`
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Slideshow.
@@ -542,8 +610,12 @@ func (s Slideshow) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	type alias Slideshow
 	aux := &struct {
 		*alias
+		Slides *[]*Slide `xml:"slide"`
 	}{
 		alias: (*alias)(&s),
+	}
+	if s.Slides != nil {
+		aux.Slides = &s.Slides
 	}
 	return e.EncodeElement(aux, start)
 }
@@ -560,7 +632,7 @@ type SlideshowResponse struct {
 // StorageServiceProperties - Storage Service Properties.
 type StorageServiceProperties struct {
 	// The set of CORS rules.
-	Cors *[]*CorsRule `xml:"Cors>CorsRule"`
+	Cors []*CorsRule `xml:"Cors>CorsRule"`
 
 	// The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27
 	// and all more recent versions
@@ -577,6 +649,21 @@ type StorageServiceProperties struct {
 
 	// a summary of request statistics grouped by API in minute aggregates for blobs
 	MinuteMetrics *Metrics `xml:"MinuteMetrics"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type StorageServiceProperties.
+func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias StorageServiceProperties
+	aux := &struct {
+		*alias
+		Cors *[]*CorsRule `xml:"Cors>CorsRule"`
+	}{
+		alias: (*alias)(&s),
+	}
+	if s.Cors != nil {
+		aux.Cors = &s.Cors
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // StorageServicePropertiesResponse is the response envelope for operations that return a StorageServiceProperties type.

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -28,7 +28,7 @@ type APIError struct {
 	Code *string `json:"code,omitempty"`
 
 	// The Api error details
-	Details *[]*APIErrorBase `json:"details,omitempty"`
+	Details []*APIErrorBase `json:"details,omitempty"`
 
 	// The Api inner error
 	Innererror *InnerError `json:"innererror,omitempty"`
@@ -38,6 +38,17 @@ type APIError struct {
 
 	// The target of the particular error.
 	Target *string `json:"target,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type APIError.
+func (a APIError) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "code", a.Code)
+	populate(objectMap, "details", a.Details)
+	populate(objectMap, "innererror", a.Innererror)
+	populate(objectMap, "message", a.Message)
+	populate(objectMap, "target", a.Target)
+	return json.Marshal(objectMap)
 }
 
 // APIErrorBase - Api error base.
@@ -156,13 +167,29 @@ type AvailabilitySet struct {
 	SKU *SKU `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AvailabilitySet.
+func (a AvailabilitySet) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "sku", a.SKU)
+	return json.Marshal(objectMap)
+}
+
 // AvailabilitySetListResult - The List Availability Set operation response.
 type AvailabilitySetListResult struct {
 	// The URI to fetch the next page of AvailabilitySets. Call ListNext() with this URI to fetch the next page of AvailabilitySets.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of availability sets
-	Value *[]*AvailabilitySet `json:"value,omitempty"`
+	Value []*AvailabilitySet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailabilitySetListResult.
+func (a AvailabilitySetListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AvailabilitySetListResultResponse is the response envelope for operations that return a AvailabilitySetListResult type.
@@ -187,10 +214,21 @@ type AvailabilitySetProperties struct {
 	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
 
 	// READ-ONLY; The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty" azure:"ro"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty" azure:"ro"`
 
 	// A list of references to all virtual machines in the availability set.
-	VirtualMachines *[]*SubResource `json:"virtualMachines,omitempty"`
+	VirtualMachines []*SubResource `json:"virtualMachines,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailabilitySetProperties.
+func (a AvailabilitySetProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "platformFaultDomainCount", a.PlatformFaultDomainCount)
+	populate(objectMap, "platformUpdateDomainCount", a.PlatformUpdateDomainCount)
+	populate(objectMap, "proximityPlacementGroup", a.ProximityPlacementGroup)
+	populate(objectMap, "statuses", a.Statuses)
+	populate(objectMap, "virtualMachines", a.VirtualMachines)
+	return json.Marshal(objectMap)
 }
 
 // AvailabilitySetResponse is the response envelope for operations that return a AvailabilitySet type.
@@ -318,7 +356,14 @@ func (e CloudError) Error() string {
 // ComputeOperationListResult - The List Compute Operation operation response.
 type ComputeOperationListResult struct {
 	// READ-ONLY; The list of compute operations
-	Value *[]*ComputeOperationValue `json:"value,omitempty" azure:"ro"`
+	Value []*ComputeOperationValue `json:"value,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ComputeOperationListResult.
+func (c ComputeOperationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", c.Value)
+	return json.Marshal(objectMap)
 }
 
 // ComputeOperationListResultResponse is the response envelope for operations that return a ComputeOperationListResult type.
@@ -362,6 +407,13 @@ type ContainerService struct {
 	Resource
 	// Properties of the container service.
 	Properties *ContainerServiceProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerService.
+func (c ContainerService) MarshalJSON() ([]byte, error) {
+	objectMap := c.Resource.marshalInternal()
+	populate(objectMap, "properties", c.Properties)
+	return json.Marshal(objectMap)
 }
 
 // ContainerServiceAgentPoolProfile - Profile for the container service agent pool.
@@ -408,7 +460,15 @@ type ContainerServiceListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// the list of container services.
-	Value *[]*ContainerService `json:"value,omitempty"`
+	Value []*ContainerService `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerServiceListResult.
+func (c ContainerServiceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", c.NextLink)
+	populate(objectMap, "value", c.Value)
+	return json.Marshal(objectMap)
 }
 
 // ContainerServiceListResultResponse is the response envelope for operations that return a ContainerServiceListResult type.
@@ -462,7 +522,7 @@ type ContainerServicePrincipalProfile struct {
 // ContainerServiceProperties - Properties of the container service.
 type ContainerServiceProperties struct {
 	// Properties of the agent pool.
-	AgentPoolProfiles *[]*ContainerServiceAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles []*ContainerServiceAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
 
 	// Properties for custom clusters.
 	CustomProfile *ContainerServiceCustomProfile `json:"customProfile,omitempty"`
@@ -489,6 +549,21 @@ type ContainerServiceProperties struct {
 	WindowsProfile *ContainerServiceWindowsProfile `json:"windowsProfile,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ContainerServiceProperties.
+func (c ContainerServiceProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "agentPoolProfiles", c.AgentPoolProfiles)
+	populate(objectMap, "customProfile", c.CustomProfile)
+	populate(objectMap, "diagnosticsProfile", c.DiagnosticsProfile)
+	populate(objectMap, "linuxProfile", c.LinuxProfile)
+	populate(objectMap, "masterProfile", c.MasterProfile)
+	populate(objectMap, "orchestratorProfile", c.OrchestratorProfile)
+	populate(objectMap, "provisioningState", c.ProvisioningState)
+	populate(objectMap, "servicePrincipalProfile", c.ServicePrincipalProfile)
+	populate(objectMap, "windowsProfile", c.WindowsProfile)
+	return json.Marshal(objectMap)
+}
+
 // ContainerServiceResponse is the response envelope for operations that return a ContainerService type.
 type ContainerServiceResponse struct {
 	// Container service.
@@ -501,7 +576,14 @@ type ContainerServiceResponse struct {
 // ContainerServiceSSHConfiguration - SSH configuration for Linux-based VMs running on Azure.
 type ContainerServiceSSHConfiguration struct {
 	// the list of SSH public keys used to authenticate with Linux-based VMs.
-	PublicKeys *[]*ContainerServiceSSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys []*ContainerServiceSSHPublicKey `json:"publicKeys,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerServiceSSHConfiguration.
+func (c ContainerServiceSSHConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "publicKeys", c.PublicKeys)
+	return json.Marshal(objectMap)
 }
 
 // ContainerServiceSSHPublicKey - Contains information about SSH certificate public key data.
@@ -667,6 +749,14 @@ type DedicatedHost struct {
 	SKU *SKU `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHost.
+func (d DedicatedHost) MarshalJSON() ([]byte, error) {
+	objectMap := d.Resource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "sku", d.SKU)
+	return json.Marshal(objectMap)
+}
+
 // DedicatedHostAllocatableVM - Represents the dedicated host unutilized capacity in terms of a specific VM size.
 type DedicatedHostAllocatableVM struct {
 	// Maximum number of VMs of size vmSize that can fit in the dedicated host's remaining capacity.
@@ -679,7 +769,14 @@ type DedicatedHostAllocatableVM struct {
 // DedicatedHostAvailableCapacity - Dedicated host unutilized capacity.
 type DedicatedHostAvailableCapacity struct {
 	// The unutilized capacity of the dedicated host represented in terms of each VM size that is allowed to be deployed to the dedicated host.
-	AllocatableVMs *[]*DedicatedHostAllocatableVM `json:"allocatableVMs,omitempty"`
+	AllocatableVMs []*DedicatedHostAllocatableVM `json:"allocatableVMs,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostAvailableCapacity.
+func (d DedicatedHostAvailableCapacity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allocatableVMs", d.AllocatableVMs)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostGroup - Specifies information about the dedicated host group that the dedicated hosts should be assigned to.
@@ -693,7 +790,15 @@ type DedicatedHostGroup struct {
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group
 	// supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostGroup.
+func (d DedicatedHostGroup) MarshalJSON() ([]byte, error) {
+	objectMap := d.Resource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "zones", d.Zones)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostGroupListResult - The List Dedicated Host Group with resource group response.
@@ -702,7 +807,15 @@ type DedicatedHostGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of dedicated host groups
-	Value *[]*DedicatedHostGroup `json:"value,omitempty"`
+	Value []*DedicatedHostGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostGroupListResult.
+func (d DedicatedHostGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostGroupListResultResponse is the response envelope for operations that return a DedicatedHostGroupListResult type.
@@ -717,10 +830,18 @@ type DedicatedHostGroupListResultResponse struct {
 // DedicatedHostGroupProperties - Dedicated Host Group Properties.
 type DedicatedHostGroupProperties struct {
 	// READ-ONLY; A list of references to all dedicated hosts in the dedicated host group.
-	Hosts *[]*SubResourceReadOnly `json:"hosts,omitempty" azure:"ro"`
+	Hosts []*SubResourceReadOnly `json:"hosts,omitempty" azure:"ro"`
 
 	// Number of fault domains that the host group can span.
 	PlatformFaultDomainCount *int32 `json:"platformFaultDomainCount,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostGroupProperties.
+func (d DedicatedHostGroupProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "hosts", d.Hosts)
+	populate(objectMap, "platformFaultDomainCount", d.PlatformFaultDomainCount)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostGroupResponse is the response envelope for operations that return a DedicatedHostGroup type.
@@ -742,7 +863,7 @@ type DedicatedHostGroupUpdate struct {
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group
 	// supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DedicatedHostGroupUpdate.
@@ -792,7 +913,16 @@ type DedicatedHostInstanceView struct {
 	AvailableCapacity *DedicatedHostAvailableCapacity `json:"availableCapacity,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostInstanceView.
+func (d DedicatedHostInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "assetId", d.AssetID)
+	populate(objectMap, "availableCapacity", d.AvailableCapacity)
+	populate(objectMap, "statuses", d.Statuses)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostListResult - The list dedicated host operation response.
@@ -801,7 +931,15 @@ type DedicatedHostListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of dedicated hosts
-	Value *[]*DedicatedHost `json:"value,omitempty"`
+	Value []*DedicatedHost `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DedicatedHostListResult.
+func (d DedicatedHostListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DedicatedHostListResultResponse is the response envelope for operations that return a DedicatedHostListResult type.
@@ -855,7 +993,7 @@ type DedicatedHostProperties struct {
 	ProvisioningTime *time.Time `json:"provisioningTime,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of references to all virtual machines in the Dedicated Host.
-	VirtualMachines *[]*SubResourceReadOnly `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines []*SubResourceReadOnly `json:"virtualMachines,omitempty" azure:"ro"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DedicatedHostProperties.
@@ -992,7 +1130,14 @@ type DiffDiskSettings struct {
 // Disallowed - Describes the disallowed disk types.
 type Disallowed struct {
 	// A list of disk types.
-	DiskTypes *[]*string `json:"diskTypes,omitempty"`
+	DiskTypes []*string `json:"diskTypes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Disallowed.
+func (d Disallowed) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "diskTypes", d.DiskTypes)
+	return json.Marshal(objectMap)
 }
 
 // Disk resource.
@@ -1003,7 +1148,7 @@ type Disk struct {
 
 	// READ-ONLY; List of relative URIs containing the IDs of the VMs that have the disk attached. maxShares should be set to a value greater than one for disks
 	// to allow attaching them to multiple VMs.
-	ManagedByExtended *[]*string `json:"managedByExtended,omitempty" azure:"ro"`
+	ManagedByExtended []*string `json:"managedByExtended,omitempty" azure:"ro"`
 
 	// Disk resource properties.
 	Properties *DiskProperties `json:"properties,omitempty"`
@@ -1012,7 +1157,18 @@ type Disk struct {
 	SKU *DiskSKU `json:"sku,omitempty"`
 
 	// The Logical zone list for Disk.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Disk.
+func (d Disk) MarshalJSON() ([]byte, error) {
+	objectMap := d.Resource.marshalInternal()
+	populate(objectMap, "managedBy", d.ManagedBy)
+	populate(objectMap, "managedByExtended", d.ManagedByExtended)
+	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "sku", d.SKU)
+	populate(objectMap, "zones", d.Zones)
+	return json.Marshal(objectMap)
 }
 
 // DiskEncryptionSet - disk encryption set resource.
@@ -1023,13 +1179,29 @@ type DiskEncryptionSet struct {
 	Properties *EncryptionSetProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DiskEncryptionSet.
+func (d DiskEncryptionSet) MarshalJSON() ([]byte, error) {
+	objectMap := d.Resource.marshalInternal()
+	populate(objectMap, "identity", d.Identity)
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
 // DiskEncryptionSetList - The List disk encryption set operation response.
 type DiskEncryptionSetList struct {
 	// The uri to fetch the next page of disk encryption sets. Call ListNext() with this to fetch the next page of disk encryption sets.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of disk encryption sets.
-	Value *[]*DiskEncryptionSet `json:"value,omitempty"`
+	Value []*DiskEncryptionSet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DiskEncryptionSetList.
+func (d DiskEncryptionSetList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DiskEncryptionSetListResponse is the response envelope for operations that return a DiskEncryptionSetList type.
@@ -1074,7 +1246,7 @@ type DiskEncryptionSetUpdate struct {
 	Properties *DiskEncryptionSetUpdateProperties `json:"properties,omitempty"`
 
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DiskEncryptionSetUpdate.
@@ -1143,13 +1315,22 @@ type DiskImageEncryption struct {
 type DiskInstanceView struct {
 	// Specifies the encryption settings for the OS Disk.
 	// Minimum api-version: 2015-06-15
-	EncryptionSettings *[]*DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	EncryptionSettings []*DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
 
 	// The disk name.
 	Name *string `json:"name,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DiskInstanceView.
+func (d DiskInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptionSettings", d.EncryptionSettings)
+	populate(objectMap, "name", d.Name)
+	populate(objectMap, "statuses", d.Statuses)
+	return json.Marshal(objectMap)
 }
 
 // DiskList - The List Disks operation response.
@@ -1158,7 +1339,15 @@ type DiskList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of disks.
-	Value *[]*Disk `json:"value,omitempty"`
+	Value []*Disk `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DiskList.
+func (d DiskList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DiskListResponse is the response envelope for operations that return a DiskList type.
@@ -1233,7 +1422,7 @@ type DiskProperties struct {
 
 	// READ-ONLY; Details of the list of all VMs that have the disk attached. maxShares should be set to a value greater than one for disks to allow attaching
 	// them to multiple VMs.
-	ShareInfo *[]*ShareInfoElement `json:"shareInfo,omitempty" azure:"ro"`
+	ShareInfo []*ShareInfoElement `json:"shareInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The time when the disk was created.
 	TimeCreated *time.Time `json:"timeCreated,omitempty" azure:"ro"`
@@ -1362,7 +1551,7 @@ type DiskUpdate struct {
 	SKU *DiskSKU `json:"sku,omitempty"`
 
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type DiskUpdate.
@@ -1461,10 +1650,18 @@ type Encryption struct {
 // EncryptionImages - Optional. Allows users to provide customer managed keys for encrypting the OS and data disks in the gallery artifact.
 type EncryptionImages struct {
 	// A list of encryption specifications for data disk images.
-	DataDiskImages *[]*DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
+	DataDiskImages []*DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
 
 	// Contains encryption settings for an OS disk image.
 	OSDiskImage *OSDiskImageEncryption `json:"osDiskImage,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EncryptionImages.
+func (e EncryptionImages) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDiskImages", e.DataDiskImages)
+	populate(objectMap, "osDiskImage", e.OSDiskImage)
+	return json.Marshal(objectMap)
 }
 
 // EncryptionSetIdentity - The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt
@@ -1489,10 +1686,19 @@ type EncryptionSetProperties struct {
 
 	// READ-ONLY; A readonly collection of key vault keys previously used by this disk encryption set while a key rotation is in progress. It will be empty
 	// if there is no ongoing key rotation.
-	PreviousKeys *[]*KeyVaultAndKeyReference `json:"previousKeys,omitempty" azure:"ro"`
+	PreviousKeys []*KeyVaultAndKeyReference `json:"previousKeys,omitempty" azure:"ro"`
 
 	// READ-ONLY; The disk encryption set provisioning state.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EncryptionSetProperties.
+func (e EncryptionSetProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activeKey", e.ActiveKey)
+	populate(objectMap, "previousKeys", e.PreviousKeys)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // EncryptionSettingsCollection - Encryption settings for disk or snapshot
@@ -1503,12 +1709,21 @@ type EncryptionSettingsCollection struct {
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// A collection of encryption settings, one for each disk volume.
-	EncryptionSettings *[]*EncryptionSettingsElement `json:"encryptionSettings,omitempty"`
+	EncryptionSettings []*EncryptionSettingsElement `json:"encryptionSettings,omitempty"`
 
 	// Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds to Azure Disk Encryption
 	// with AAD app.'1.1' corresponds to Azure Disk
 	// Encryption.
 	EncryptionSettingsVersion *string `json:"encryptionSettingsVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EncryptionSettingsCollection.
+func (e EncryptionSettingsCollection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "enabled", e.Enabled)
+	populate(objectMap, "encryptionSettings", e.EncryptionSettings)
+	populate(objectMap, "encryptionSettingsVersion", e.EncryptionSettingsVersion)
+	return json.Marshal(objectMap)
 }
 
 // EncryptionSettingsElement - Encryption settings for one disk volume.
@@ -1557,11 +1772,25 @@ type Gallery struct {
 	Properties *GalleryProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Gallery.
+func (g Gallery) MarshalJSON() ([]byte, error) {
+	objectMap := g.Resource.marshalInternal()
+	populate(objectMap, "properties", g.Properties)
+	return json.Marshal(objectMap)
+}
+
 // GalleryApplication - Specifies information about the gallery Application Definition that you want to create or update.
 type GalleryApplication struct {
 	Resource
 	// Describes the properties of a gallery Application Definition.
 	Properties *GalleryApplicationProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryApplication.
+func (g GalleryApplication) MarshalJSON() ([]byte, error) {
+	objectMap := g.Resource.marshalInternal()
+	populate(objectMap, "properties", g.Properties)
+	return json.Marshal(objectMap)
 }
 
 // GalleryApplicationList - The List Gallery Applications operation response.
@@ -1571,7 +1800,15 @@ type GalleryApplicationList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Gallery Applications.
-	Value *[]*GalleryApplication `json:"value,omitempty"`
+	Value []*GalleryApplication `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryApplicationList.
+func (g GalleryApplicationList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", g.NextLink)
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GalleryApplicationListResponse is the response envelope for operations that return a GalleryApplicationList type.
@@ -1698,13 +1935,28 @@ type GalleryApplicationVersion struct {
 	Properties *GalleryApplicationVersionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type GalleryApplicationVersion.
+func (g GalleryApplicationVersion) MarshalJSON() ([]byte, error) {
+	objectMap := g.Resource.marshalInternal()
+	populate(objectMap, "properties", g.Properties)
+	return json.Marshal(objectMap)
+}
+
 // GalleryApplicationVersionList - The List Gallery Application version operation response.
 type GalleryApplicationVersionList struct {
 	// The uri to fetch the next page of gallery Application Versions. Call ListNext() with this to fetch the next page of gallery Application Versions.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of gallery Application Versions.
-	Value *[]*GalleryApplicationVersion `json:"value,omitempty"`
+	Value []*GalleryApplicationVersion `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryApplicationVersionList.
+func (g GalleryApplicationVersionList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", g.NextLink)
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GalleryApplicationVersionListResponse is the response envelope for operations that return a GalleryApplicationVersionList type.
@@ -1880,7 +2132,7 @@ type GalleryArtifactPublishingProfileBase struct {
 	StorageAccountType *StorageAccountType `json:"storageAccountType,omitempty"`
 
 	// The target regions where the Image Version is going to be replicated to. This property is updatable.
-	TargetRegions *[]*TargetRegion `json:"targetRegions,omitempty"`
+	TargetRegions []*TargetRegion `json:"targetRegions,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type GalleryArtifactPublishingProfileBase.
@@ -1989,6 +2241,13 @@ type GalleryImage struct {
 	Properties *GalleryImageProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type GalleryImage.
+func (g GalleryImage) MarshalJSON() ([]byte, error) {
+	objectMap := g.Resource.marshalInternal()
+	populate(objectMap, "properties", g.Properties)
+	return json.Marshal(objectMap)
+}
+
 // GalleryImageIdentifier - This is the gallery Image Definition identifier.
 type GalleryImageIdentifier struct {
 	// The name of the gallery Image Definition offer.
@@ -2007,7 +2266,15 @@ type GalleryImageList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Shared Image Gallery images.
-	Value *[]*GalleryImage `json:"value,omitempty"`
+	Value []*GalleryImage `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryImageList.
+func (g GalleryImageList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", g.NextLink)
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GalleryImageListResponse is the response envelope for operations that return a GalleryImageList type.
@@ -2183,13 +2450,28 @@ type GalleryImageVersion struct {
 	Properties *GalleryImageVersionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type GalleryImageVersion.
+func (g GalleryImageVersion) MarshalJSON() ([]byte, error) {
+	objectMap := g.Resource.marshalInternal()
+	populate(objectMap, "properties", g.Properties)
+	return json.Marshal(objectMap)
+}
+
 // GalleryImageVersionList - The List Gallery Image version operation response.
 type GalleryImageVersionList struct {
 	// The uri to fetch the next page of gallery Image Versions. Call ListNext() with this to fetch the next page of gallery Image Versions.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of gallery Image Versions.
-	Value *[]*GalleryImageVersion `json:"value,omitempty"`
+	Value []*GalleryImageVersion `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryImageVersionList.
+func (g GalleryImageVersionList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", g.NextLink)
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GalleryImageVersionListResponse is the response envelope for operations that return a GalleryImageVersionList type.
@@ -2245,13 +2527,22 @@ type GalleryImageVersionResponse struct {
 // GalleryImageVersionStorageProfile - This is the storage profile of a Gallery Image Version.
 type GalleryImageVersionStorageProfile struct {
 	// A list of data disk images.
-	DataDiskImages *[]*GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
+	DataDiskImages []*GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
 
 	// This is the OS disk image.
 	OSDiskImage *GalleryOSDiskImage `json:"osDiskImage,omitempty"`
 
 	// The gallery artifact version source.
 	Source *GalleryArtifactVersionSource `json:"source,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryImageVersionStorageProfile.
+func (g GalleryImageVersionStorageProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDiskImages", g.DataDiskImages)
+	populate(objectMap, "osDiskImage", g.OSDiskImage)
+	populate(objectMap, "source", g.Source)
+	return json.Marshal(objectMap)
 }
 
 // GalleryImageVersionUpdate - Specifies information about the gallery Image Version that you want to update.
@@ -2325,7 +2616,15 @@ type GalleryList struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of galleries.
-	Value *[]*Gallery `json:"value,omitempty"`
+	Value []*Gallery `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GalleryList.
+func (g GalleryList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", g.NextLink)
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GalleryListResponse is the response envelope for operations that return a GalleryList type.
@@ -2429,6 +2728,13 @@ type Image struct {
 	Properties *ImageProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Image.
+func (i Image) MarshalJSON() ([]byte, error) {
+	objectMap := i.Resource.marshalInternal()
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ImageDataDisk - Describes a data disk.
 type ImageDataDisk struct {
 	ImageDisk
@@ -2483,7 +2789,15 @@ type ImageListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of Images.
-	Value *[]*Image `json:"value,omitempty"`
+	Value []*Image `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ImageListResult.
+func (i ImageListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
 }
 
 // ImageListResultResponse is the response envelope for operations that return a ImageListResult type.
@@ -2575,6 +2889,17 @@ type ImageReference struct {
 	Version *string `json:"version,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ImageReference.
+func (i ImageReference) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "exactVersion", i.ExactVersion)
+	populate(objectMap, "offer", i.Offer)
+	populate(objectMap, "publisher", i.Publisher)
+	populate(objectMap, "sku", i.SKU)
+	populate(objectMap, "version", i.Version)
+	return json.Marshal(objectMap)
+}
+
 // ImageResponse is the response envelope for operations that return a Image type.
 type ImageResponse struct {
 	// The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual machine. If SourceImage is provided,
@@ -2590,7 +2915,7 @@ type ImageStorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]*ImageDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*ImageDataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the operating system disk used by the virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
@@ -2600,6 +2925,15 @@ type ImageStorageProfile struct {
 	// Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions that provide Zone Redundant
 	// Storage (ZRS).
 	ZoneResilient *bool `json:"zoneResilient,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ImageStorageProfile.
+func (i ImageStorageProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDisks", i.DataDisks)
+	populate(objectMap, "osDisk", i.OSDisk)
+	populate(objectMap, "zoneResilient", i.ZoneResilient)
+	return json.Marshal(objectMap)
 }
 
 // ImageUpdate - The source user image virtual hard disk. Only tags may be updated.
@@ -2779,7 +3113,15 @@ type ListUsagesResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of compute resource usages.
-	Value *[]*Usage `json:"value,omitempty"`
+	Value []*Usage `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListUsagesResult.
+func (l ListUsagesResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListUsagesResultResponse is the response envelope for operations that return a ListUsagesResult type.
@@ -3014,11 +3356,26 @@ type ManagedDiskParameters struct {
 	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedDiskParameters.
+func (m ManagedDiskParameters) MarshalJSON() ([]byte, error) {
+	objectMap := m.SubResource.marshalInternal()
+	populate(objectMap, "diskEncryptionSet", m.DiskEncryptionSet)
+	populate(objectMap, "storageAccountType", m.StorageAccountType)
+	return json.Marshal(objectMap)
+}
+
 // NetworkInterfaceReference - Describes a network interface reference.
 type NetworkInterfaceReference struct {
 	SubResource
 	// Describes a network interface reference properties.
 	Properties *NetworkInterfaceReferenceProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceReference.
+func (n NetworkInterfaceReference) MarshalJSON() ([]byte, error) {
+	objectMap := n.SubResource.marshalInternal()
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceReferenceProperties - Describes a network interface reference properties.
@@ -3030,7 +3387,14 @@ type NetworkInterfaceReferenceProperties struct {
 // NetworkProfile - Specifies the network interfaces of the virtual machine.
 type NetworkProfile struct {
 	// Specifies the list of resource Ids for the network interfaces associated with the virtual machine.
-	NetworkInterfaces *[]*NetworkInterfaceReference `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces []*NetworkInterfaceReference `json:"networkInterfaces,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
+func (n NetworkProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "networkInterfaces", n.NetworkInterfaces)
+	return json.Marshal(objectMap)
 }
 
 // OSDisk - Specifies information about the operating system disk used by the virtual machine.
@@ -3166,10 +3530,25 @@ type OSProfile struct {
 	RequireGuestProvisionSignal *bool `json:"requireGuestProvisionSignal,omitempty"`
 
 	// Specifies set of certificates that should be installed onto the virtual machine.
-	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// Specifies Windows operating system settings on the virtual machine.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OSProfile.
+func (o OSProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "adminPassword", o.AdminPassword)
+	populate(objectMap, "adminUsername", o.AdminUsername)
+	populate(objectMap, "allowExtensionOperations", o.AllowExtensionOperations)
+	populate(objectMap, "computerName", o.ComputerName)
+	populate(objectMap, "customData", o.CustomData)
+	populate(objectMap, "linuxConfiguration", o.LinuxConfiguration)
+	populate(objectMap, "requireGuestProvisionSignal", o.RequireGuestProvisionSignal)
+	populate(objectMap, "secrets", o.Secrets)
+	populate(objectMap, "windowsConfiguration", o.WindowsConfiguration)
+	return json.Marshal(objectMap)
 }
 
 // OperationsListOptions contains the optional parameters for the Operations.List method.
@@ -3221,13 +3600,28 @@ type ProximityPlacementGroup struct {
 	Properties *ProximityPlacementGroupProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ProximityPlacementGroup.
+func (p ProximityPlacementGroup) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ProximityPlacementGroupListResult - The List Proximity Placement Group operation response.
 type ProximityPlacementGroupListResult struct {
 	// The URI to fetch the next page of proximity placement groups.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of proximity placement groups
-	Value *[]*ProximityPlacementGroup `json:"value,omitempty"`
+	Value []*ProximityPlacementGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProximityPlacementGroupListResult.
+func (p ProximityPlacementGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // ProximityPlacementGroupListResultResponse is the response envelope for operations that return a ProximityPlacementGroupListResult type.
@@ -3242,7 +3636,7 @@ type ProximityPlacementGroupListResultResponse struct {
 // ProximityPlacementGroupProperties - Describes the properties of a Proximity Placement Group.
 type ProximityPlacementGroupProperties struct {
 	// READ-ONLY; A list of references to all availability sets in the proximity placement group.
-	AvailabilitySets *[]*SubResourceWithColocationStatus `json:"availabilitySets,omitempty" azure:"ro"`
+	AvailabilitySets []*SubResourceWithColocationStatus `json:"availabilitySets,omitempty" azure:"ro"`
 
 	// Describes colocation status of the Proximity Placement Group.
 	ColocationStatus *InstanceViewStatus `json:"colocationStatus,omitempty"`
@@ -3254,10 +3648,21 @@ type ProximityPlacementGroupProperties struct {
 	ProximityPlacementGroupType *ProximityPlacementGroupType `json:"proximityPlacementGroupType,omitempty"`
 
 	// READ-ONLY; A list of references to all virtual machine scale sets in the proximity placement group.
-	VirtualMachineScaleSets *[]*SubResourceWithColocationStatus `json:"virtualMachineScaleSets,omitempty" azure:"ro"`
+	VirtualMachineScaleSets []*SubResourceWithColocationStatus `json:"virtualMachineScaleSets,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of references to all virtual machines in the proximity placement group.
-	VirtualMachines *[]*SubResourceWithColocationStatus `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines []*SubResourceWithColocationStatus `json:"virtualMachines,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProximityPlacementGroupProperties.
+func (p ProximityPlacementGroupProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "availabilitySets", p.AvailabilitySets)
+	populate(objectMap, "colocationStatus", p.ColocationStatus)
+	populate(objectMap, "proximityPlacementGroupType", p.ProximityPlacementGroupType)
+	populate(objectMap, "virtualMachineScaleSets", p.VirtualMachineScaleSets)
+	populate(objectMap, "virtualMachines", p.VirtualMachines)
+	return json.Marshal(objectMap)
 }
 
 // ProximityPlacementGroupResponse is the response envelope for operations that return a ProximityPlacementGroup type.
@@ -3365,7 +3770,15 @@ type ReplicationStatus struct {
 	AggregatedState *AggregatedReplicationState `json:"aggregatedState,omitempty" azure:"ro"`
 
 	// READ-ONLY; This is a summary of replication status for each region.
-	Summary *[]*RegionalReplicationStatus `json:"summary,omitempty" azure:"ro"`
+	Summary []*RegionalReplicationStatus `json:"summary,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ReplicationStatus.
+func (r ReplicationStatus) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aggregatedState", r.AggregatedState)
+	populate(objectMap, "summary", r.Summary)
+	return json.Marshal(objectMap)
 }
 
 // RequestRateByIntervalInput - Api request input for LogAnalytics getRequestRateByInterval Api.
@@ -3414,10 +3827,26 @@ type Resource struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Resource.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	objectMap := r.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (r Resource) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", r.ID)
+	populate(objectMap, "location", r.Location)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "tags", r.Tags)
+	populate(objectMap, "type", r.Type)
+	return objectMap
 }
 
 // ResourceRange - Describes the resource range.
@@ -3432,16 +3861,16 @@ type ResourceRange struct {
 // ResourceSKU - Describes an available Compute SKU.
 type ResourceSKU struct {
 	// READ-ONLY; The api versions that support this SKU.
-	APIVersions *[]*string `json:"apiVersions,omitempty" azure:"ro"`
+	APIVersions []*string `json:"apiVersions,omitempty" azure:"ro"`
 
 	// READ-ONLY; A name value pair to describe the capability.
-	Capabilities *[]*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities []*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
 
 	// READ-ONLY; Specifies the number of virtual machines in the scale set.
 	Capacity *ResourceSKUCapacity `json:"capacity,omitempty" azure:"ro"`
 
 	// READ-ONLY; Metadata for retrieving price info.
-	Costs *[]*ResourceSKUCosts `json:"costs,omitempty" azure:"ro"`
+	Costs []*ResourceSKUCosts `json:"costs,omitempty" azure:"ro"`
 
 	// READ-ONLY; The Family of this particular SKU.
 	Family *string `json:"family,omitempty" azure:"ro"`
@@ -3450,10 +3879,10 @@ type ResourceSKU struct {
 	Kind *string `json:"kind,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of locations and availability zones in those locations where the SKU is available.
-	LocationInfo *[]*ResourceSKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
+	LocationInfo []*ResourceSKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The set of locations that the SKU is available.
-	Locations *[]*string `json:"locations,omitempty" azure:"ro"`
+	Locations []*string `json:"locations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The name of SKU.
 	Name *string `json:"name,omitempty" azure:"ro"`
@@ -3462,7 +3891,7 @@ type ResourceSKU struct {
 	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
 
 	// READ-ONLY; The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
-	Restrictions *[]*ResourceSKURestrictions `json:"restrictions,omitempty" azure:"ro"`
+	Restrictions []*ResourceSKURestrictions `json:"restrictions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The Size of the SKU.
 	Size *string `json:"size,omitempty" azure:"ro"`
@@ -3472,6 +3901,25 @@ type ResourceSKU struct {
 	// Standard
 	// Basic
 	Tier *string `json:"tier,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKU.
+func (r ResourceSKU) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "apiVersions", r.APIVersions)
+	populate(objectMap, "capabilities", r.Capabilities)
+	populate(objectMap, "capacity", r.Capacity)
+	populate(objectMap, "costs", r.Costs)
+	populate(objectMap, "family", r.Family)
+	populate(objectMap, "kind", r.Kind)
+	populate(objectMap, "locationInfo", r.LocationInfo)
+	populate(objectMap, "locations", r.Locations)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "resourceType", r.ResourceType)
+	populate(objectMap, "restrictions", r.Restrictions)
+	populate(objectMap, "size", r.Size)
+	populate(objectMap, "tier", r.Tier)
+	return json.Marshal(objectMap)
 }
 
 // ResourceSKUCapabilities - Describes The SKU capabilities object.
@@ -3515,18 +3963,35 @@ type ResourceSKULocationInfo struct {
 	Location *string `json:"location,omitempty" azure:"ro"`
 
 	// READ-ONLY; Details of capabilities available to a SKU in specific zones.
-	ZoneDetails *[]*ResourceSKUZoneDetails `json:"zoneDetails,omitempty" azure:"ro"`
+	ZoneDetails []*ResourceSKUZoneDetails `json:"zoneDetails,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of availability zones where the SKU is supported.
-	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string `json:"zones,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKULocationInfo.
+func (r ResourceSKULocationInfo) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "location", r.Location)
+	populate(objectMap, "zoneDetails", r.ZoneDetails)
+	populate(objectMap, "zones", r.Zones)
+	return json.Marshal(objectMap)
 }
 
 type ResourceSKURestrictionInfo struct {
 	// READ-ONLY; Locations where the SKU is restricted
-	Locations *[]*string `json:"locations,omitempty" azure:"ro"`
+	Locations []*string `json:"locations,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of availability zones where the SKU is restricted.
-	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string `json:"zones,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKURestrictionInfo.
+func (r ResourceSKURestrictionInfo) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "locations", r.Locations)
+	populate(objectMap, "zones", r.Zones)
+	return json.Marshal(objectMap)
 }
 
 // ResourceSKURestrictions - Describes scaling information of a SKU.
@@ -3541,16 +4006,34 @@ type ResourceSKURestrictions struct {
 	Type *ResourceSKURestrictionsType `json:"type,omitempty" azure:"ro"`
 
 	// READ-ONLY; The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.
-	Values *[]*string `json:"values,omitempty" azure:"ro"`
+	Values []*string `json:"values,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKURestrictions.
+func (r ResourceSKURestrictions) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "reasonCode", r.ReasonCode)
+	populate(objectMap, "restrictionInfo", r.RestrictionInfo)
+	populate(objectMap, "type", r.Type)
+	populate(objectMap, "values", r.Values)
+	return json.Marshal(objectMap)
 }
 
 // ResourceSKUZoneDetails - Describes The zonal capabilities of a SKU.
 type ResourceSKUZoneDetails struct {
 	// READ-ONLY; A list of capabilities that are available for the SKU in the specified list of zones.
-	Capabilities *[]*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities []*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
 
 	// READ-ONLY; The set of zones that the SKU is available in with the specified capabilities.
-	Name *[]*string `json:"name,omitempty" azure:"ro"`
+	Name []*string `json:"name,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKUZoneDetails.
+func (r ResourceSKUZoneDetails) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "capabilities", r.Capabilities)
+	populate(objectMap, "name", r.Name)
+	return json.Marshal(objectMap)
 }
 
 // ResourceSKUsListOptions contains the optional parameters for the ResourceSKUs.List method.
@@ -3565,7 +4048,15 @@ type ResourceSKUsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of skus available for the subscription.
-	Value *[]*ResourceSKU `json:"value,omitempty"`
+	Value []*ResourceSKU `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSKUsResult.
+func (r ResourceSKUsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // ResourceSKUsResultResponse is the response envelope for operations that return a ResourceSKUsResult type.
@@ -3693,6 +4184,13 @@ type RollingUpgradeStatusInfo struct {
 	Properties *RollingUpgradeStatusInfoProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RollingUpgradeStatusInfo.
+func (r RollingUpgradeStatusInfo) MarshalJSON() ([]byte, error) {
+	objectMap := r.Resource.marshalInternal()
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
 // RollingUpgradeStatusInfoProperties - The status of the latest virtual machine scale set rolling upgrade.
 type RollingUpgradeStatusInfoProperties struct {
 	// READ-ONLY; Error details for this upgrade, if there are any.
@@ -3721,10 +4219,18 @@ type RollingUpgradeStatusInfoResponse struct {
 type RunCommandDocument struct {
 	RunCommandDocumentBase
 	// The parameters used by the script.
-	Parameters *[]*RunCommandParameterDefinition `json:"parameters,omitempty"`
+	Parameters []*RunCommandParameterDefinition `json:"parameters,omitempty"`
 
 	// The script to be executed.
-	Script *[]*string `json:"script,omitempty"`
+	Script []*string `json:"script,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RunCommandDocument.
+func (r RunCommandDocument) MarshalJSON() ([]byte, error) {
+	objectMap := r.RunCommandDocumentBase.marshalInternal()
+	populate(objectMap, "parameters", r.Parameters)
+	populate(objectMap, "script", r.Script)
+	return json.Marshal(objectMap)
 }
 
 // RunCommandDocumentBase - Describes the properties of a Run Command metadata.
@@ -3745,6 +4251,22 @@ type RunCommandDocumentBase struct {
 	Schema *string `json:"$schema,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RunCommandDocumentBase.
+func (r RunCommandDocumentBase) MarshalJSON() ([]byte, error) {
+	objectMap := r.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (r RunCommandDocumentBase) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", r.Description)
+	populate(objectMap, "id", r.ID)
+	populate(objectMap, "label", r.Label)
+	populate(objectMap, "osType", r.OSType)
+	populate(objectMap, "$schema", r.Schema)
+	return objectMap
+}
+
 // RunCommandDocumentResponse is the response envelope for operations that return a RunCommandDocument type.
 type RunCommandDocumentResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -3760,10 +4282,19 @@ type RunCommandInput struct {
 	CommandID *string `json:"commandId,omitempty"`
 
 	// The run command parameters.
-	Parameters *[]*RunCommandInputParameter `json:"parameters,omitempty"`
+	Parameters []*RunCommandInputParameter `json:"parameters,omitempty"`
 
 	// Optional. The script to be executed. When this value is given, the given script will override the default script of the command.
-	Script *[]*string `json:"script,omitempty"`
+	Script []*string `json:"script,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RunCommandInput.
+func (r RunCommandInput) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "commandId", r.CommandID)
+	populate(objectMap, "parameters", r.Parameters)
+	populate(objectMap, "script", r.Script)
+	return json.Marshal(objectMap)
 }
 
 // RunCommandInputParameter - Describes the properties of a run command parameter.
@@ -3781,7 +4312,15 @@ type RunCommandListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine run commands.
-	Value *[]*RunCommandDocumentBase `json:"value,omitempty"`
+	Value []*RunCommandDocumentBase `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RunCommandListResult.
+func (r RunCommandListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RunCommandListResultResponse is the response envelope for operations that return a RunCommandListResult type.
@@ -3810,7 +4349,14 @@ type RunCommandParameterDefinition struct {
 
 type RunCommandResult struct {
 	// Run command operation response.
-	Value *[]*InstanceViewStatus `json:"value,omitempty"`
+	Value []*InstanceViewStatus `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RunCommandResult.
+func (r RunCommandResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RunCommandResultPollerResponse is the response envelope for operations that asynchronously return a RunCommandResult type.
@@ -3852,7 +4398,14 @@ type SKU struct {
 // SSHConfiguration - SSH configuration for Linux based VMs running on Azure
 type SSHConfiguration struct {
 	// The list of SSH public keys used to authenticate with linux based VMs.
-	PublicKeys *[]*SSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys []*SSHPublicKey `json:"publicKeys,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SSHConfiguration.
+func (s SSHConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "publicKeys", s.PublicKeys)
+	return json.Marshal(objectMap)
 }
 
 // SSHPublicKey - Contains information about SSH certificate public key and the path on the Linux VM where the public key is placed.
@@ -3894,6 +4447,13 @@ type SSHPublicKeyResource struct {
 	Resource
 	// Properties of the SSH public key.
 	Properties *SSHPublicKeyResourceProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SSHPublicKeyResource.
+func (s SSHPublicKeyResource) MarshalJSON() ([]byte, error) {
+	objectMap := s.Resource.marshalInternal()
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
 }
 
 // SSHPublicKeyResourceProperties - Properties of the SSH public key.
@@ -3954,7 +4514,15 @@ type SSHPublicKeysGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of SSH public keys
-	Value *[]*SSHPublicKeyResource `json:"value,omitempty"`
+	Value []*SSHPublicKeyResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SSHPublicKeysGroupListResult.
+func (s SSHPublicKeysGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SSHPublicKeysGroupListResultResponse is the response envelope for operations that return a SSHPublicKeysGroupListResult type.
@@ -3994,7 +4562,14 @@ type ScaleInPolicy struct {
 	// NewestVM When a virtual machine scale set is being scaled-in, the newest virtual machines that are not protected from scale-in will be chosen for removal.
 	// For zonal virtual machine scale sets, the
 	// scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will be chosen for removal.
-	Rules *[]*VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
+	Rules []*VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ScaleInPolicy.
+func (s ScaleInPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "rules", s.Rules)
+	return json.Marshal(objectMap)
 }
 
 type ScheduledEventsProfile struct {
@@ -4020,13 +4595,30 @@ type Snapshot struct {
 	SKU *SnapshotSKU `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Snapshot.
+func (s Snapshot) MarshalJSON() ([]byte, error) {
+	objectMap := s.Resource.marshalInternal()
+	populate(objectMap, "managedBy", s.ManagedBy)
+	populate(objectMap, "properties", s.Properties)
+	populate(objectMap, "sku", s.SKU)
+	return json.Marshal(objectMap)
+}
+
 // SnapshotList - The List Snapshots operation response.
 type SnapshotList struct {
 	// The uri to fetch the next page of snapshots. Call ListNext() with this to fetch the next page of snapshots.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of snapshots.
-	Value *[]*Snapshot `json:"value,omitempty"`
+	Value []*Snapshot `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SnapshotList.
+func (s SnapshotList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SnapshotListResponse is the response envelope for operations that return a SnapshotList type.
@@ -4184,7 +4776,7 @@ type SnapshotUpdate struct {
 	SKU *SnapshotSKU `json:"sku,omitempty"`
 
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SnapshotUpdate.
@@ -4264,7 +4856,7 @@ type StorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]*DataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*DataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This
 	// element is required when you want to use a platform
@@ -4277,14 +4869,41 @@ type StorageProfile struct {
 	OSDisk *OSDisk `json:"osDisk,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type StorageProfile.
+func (s StorageProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDisks", s.DataDisks)
+	populate(objectMap, "imageReference", s.ImageReference)
+	populate(objectMap, "osDisk", s.OSDisk)
+	return json.Marshal(objectMap)
+}
+
 type SubResource struct {
 	// Resource Id
 	ID *string `json:"id,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SubResource.
+func (s SubResource) MarshalJSON() ([]byte, error) {
+	objectMap := s.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (s SubResource) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", s.ID)
+	return objectMap
+}
+
 type SubResourceReadOnly struct {
 	// READ-ONLY; Resource Id
 	ID *string `json:"id,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubResourceReadOnly.
+func (s SubResourceReadOnly) MarshalJSON() ([]byte, error) {
+	objectMap := s.marshalInternal()
+	return json.Marshal(objectMap)
 }
 
 func (s SubResourceReadOnly) marshalInternal() map[string]interface{} {
@@ -4297,6 +4916,13 @@ type SubResourceWithColocationStatus struct {
 	SubResource
 	// Describes colocation status of a resource in the Proximity Placement Group.
 	ColocationStatus *InstanceViewStatus `json:"colocationStatus,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubResourceWithColocationStatus.
+func (s SubResourceWithColocationStatus) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "colocationStatus", s.ColocationStatus)
+	return json.Marshal(objectMap)
 }
 
 // TargetRegion - Describes the target region information.
@@ -4332,7 +4958,13 @@ type ThrottledRequestsInput struct {
 // UpdateResource - The Update Resource model definition.
 type UpdateResource struct {
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type UpdateResource.
+func (u UpdateResource) MarshalJSON() ([]byte, error) {
+	objectMap := u.marshalInternal()
+	return json.Marshal(objectMap)
 }
 
 func (u UpdateResource) marshalInternal() map[string]interface{} {
@@ -4350,10 +4982,16 @@ type UpdateResourceDefinition struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type UpdateResourceDefinition.
+func (u UpdateResourceDefinition) MarshalJSON() ([]byte, error) {
+	objectMap := u.marshalInternal()
+	return json.Marshal(objectMap)
 }
 
 func (u UpdateResourceDefinition) marshalInternal() map[string]interface{} {
@@ -4557,7 +5195,15 @@ type VaultSecretGroup struct {
 	SourceVault *SubResource `json:"sourceVault,omitempty"`
 
 	// The list of key vault references in SourceVault which contain certificates.
-	VaultCertificates *[]*VaultCertificate `json:"vaultCertificates,omitempty"`
+	VaultCertificates []*VaultCertificate `json:"vaultCertificates,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VaultSecretGroup.
+func (v VaultSecretGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "sourceVault", v.SourceVault)
+	populate(objectMap, "vaultCertificates", v.VaultCertificates)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHardDisk - Describes the uri of a disk.
@@ -4583,22 +5229,42 @@ type VirtualMachine struct {
 	Properties *VirtualMachineProperties `json:"properties,omitempty"`
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources *[]*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources []*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
 
 	// The virtual machine zones.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachine.
+func (v VirtualMachine) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "identity", v.Identity)
+	populate(objectMap, "plan", v.Plan)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "resources", v.Resources)
+	populate(objectMap, "zones", v.Zones)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineAgentInstanceView - The instance view of the VM Agent running on the virtual machine.
 type VirtualMachineAgentInstanceView struct {
 	// The virtual machine extension handler instance view.
-	ExtensionHandlers *[]*VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
+	ExtensionHandlers []*VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent full version.
 	VMAgentVersion *string `json:"vmAgentVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineAgentInstanceView.
+func (v VirtualMachineAgentInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "extensionHandlers", v.ExtensionHandlers)
+	populate(objectMap, "statuses", v.Statuses)
+	populate(objectMap, "vmAgentVersion", v.VMAgentVersion)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineCaptureParameters - Capture Virtual Machine parameters.
@@ -4623,10 +5289,20 @@ type VirtualMachineCaptureResult struct {
 	Parameters interface{} `json:"parameters,omitempty" azure:"ro"`
 
 	// READ-ONLY; a list of resource items of the captured virtual machine
-	Resources *[]interface{} `json:"resources,omitempty" azure:"ro"`
+	Resources []interface{} `json:"resources,omitempty" azure:"ro"`
 
 	// READ-ONLY; the schema of the captured virtual machine
 	Schema *string `json:"$schema,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineCaptureResult.
+func (v VirtualMachineCaptureResult) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "contentVersion", v.ContentVersion)
+	populate(objectMap, "parameters", v.Parameters)
+	populate(objectMap, "resources", v.Resources)
+	populate(objectMap, "$schema", v.Schema)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineCaptureResultPollerResponse is the response envelope for operations that asynchronously return a VirtualMachineCaptureResult type.
@@ -4657,6 +5333,13 @@ type VirtualMachineExtension struct {
 	Properties *VirtualMachineExtensionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineExtension.
+func (v VirtualMachineExtension) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineExtensionHandlerInstanceView - The instance view of a virtual machine extension handler.
 type VirtualMachineExtensionHandlerInstanceView struct {
 	// The extension handler status.
@@ -4674,6 +5357,13 @@ type VirtualMachineExtensionImage struct {
 	Resource
 	// Describes the properties of a Virtual Machine Extension Image.
 	Properties *VirtualMachineExtensionImageProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineExtensionImage.
+func (v VirtualMachineExtensionImage) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineExtensionImageArrayResponse is the response envelope for operations that return a []*VirtualMachineExtensionImage type.
@@ -4738,16 +5428,27 @@ type VirtualMachineExtensionInstanceView struct {
 	Name *string `json:"name,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The resource status information.
-	Substatuses *[]*InstanceViewStatus `json:"substatuses,omitempty"`
+	Substatuses []*InstanceViewStatus `json:"substatuses,omitempty"`
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string `json:"type,omitempty"`
 
 	// Specifies the version of the script handler.
 	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineExtensionInstanceView.
+func (v VirtualMachineExtensionInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "statuses", v.Statuses)
+	populate(objectMap, "substatuses", v.Substatuses)
+	populate(objectMap, "type", v.Type)
+	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineExtensionPollerResponse is the response envelope for operations that asynchronously return a VirtualMachineExtension type.
@@ -4873,7 +5574,14 @@ type VirtualMachineExtensionsListOptions struct {
 // VirtualMachineExtensionsListResult - The List Extension operation response
 type VirtualMachineExtensionsListResult struct {
 	// The list of extensions
-	Value *[]*VirtualMachineExtension `json:"value,omitempty"`
+	Value []*VirtualMachineExtension `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineExtensionsListResult.
+func (v VirtualMachineExtensionsListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineExtensionsListResultResponse is the response envelope for operations that return a VirtualMachineExtensionsListResult type.
@@ -4906,7 +5614,17 @@ type VirtualMachineIdentity struct {
 
 	// The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]*UserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*UserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineIdentity.
+func (v VirtualMachineIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "principalId", v.PrincipalID)
+	populate(objectMap, "tenantId", v.TenantID)
+	populate(objectMap, "type", v.Type)
+	populate(objectMap, "userAssignedIdentities", v.UserAssignedIdentities)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineImage - Describes a Virtual Machine Image.
@@ -4916,11 +5634,18 @@ type VirtualMachineImage struct {
 	Properties *VirtualMachineImageProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineImage.
+func (v VirtualMachineImage) MarshalJSON() ([]byte, error) {
+	objectMap := v.VirtualMachineImageResource.marshalInternal()
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineImageProperties - Describes the properties of a Virtual Machine Image.
 type VirtualMachineImageProperties struct {
 	// Describes automatic OS upgrade properties on the image.
 	AutomaticOSUpgradeProperties *AutomaticOSUpgradeProperties `json:"automaticOSUpgradeProperties,omitempty"`
-	DataDiskImages               *[]*DataDiskImage             `json:"dataDiskImages,omitempty"`
+	DataDiskImages               []*DataDiskImage              `json:"dataDiskImages,omitempty"`
 
 	// Specifies the HyperVGeneration Type
 	HyperVGeneration *HyperVGenerationTypes `json:"hyperVGeneration,omitempty"`
@@ -4930,6 +5655,17 @@ type VirtualMachineImageProperties struct {
 
 	// Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 	Plan *PurchasePlan `json:"plan,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineImageProperties.
+func (v VirtualMachineImageProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "automaticOSUpgradeProperties", v.AutomaticOSUpgradeProperties)
+	populate(objectMap, "dataDiskImages", v.DataDiskImages)
+	populate(objectMap, "hyperVGeneration", v.HyperVGeneration)
+	populate(objectMap, "osDiskImage", v.OSDiskImage)
+	populate(objectMap, "plan", v.Plan)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineImageResource - Virtual machine image resource information.
@@ -4943,7 +5679,21 @@ type VirtualMachineImageResource struct {
 
 	// Specifies the tags that are assigned to the virtual machine. For more information about using tags, see Using tags to organize your Azure resources
 	// [https://docs.microsoft.com/azure/azure-resource-manager/resource-group-using-tags.md].
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineImageResource.
+func (v VirtualMachineImageResource) MarshalJSON() ([]byte, error) {
+	objectMap := v.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (v VirtualMachineImageResource) marshalInternal() map[string]interface{} {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "location", v.Location)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "tags", v.Tags)
+	return objectMap
 }
 
 // VirtualMachineImageResourceArrayResponse is the response envelope for operations that return a []*VirtualMachineImageResource type.
@@ -5003,10 +5753,10 @@ type VirtualMachineInstanceView struct {
 	ComputerName *string `json:"computerName,omitempty"`
 
 	// The virtual machine disk information.
-	Disks *[]*DiskInstanceView `json:"disks,omitempty"`
+	Disks []*DiskInstanceView `json:"disks,omitempty"`
 
 	// The extensions information.
-	Extensions *[]*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
 
 	// Specifies the HyperVGeneration Type associated with a resource
 	HyperVGeneration *HyperVGenerationType `json:"hyperVGeneration,omitempty"`
@@ -5030,10 +5780,29 @@ type VirtualMachineInstanceView struct {
 	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent running on the virtual machine.
 	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineInstanceView.
+func (v VirtualMachineInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bootDiagnostics", v.BootDiagnostics)
+	populate(objectMap, "computerName", v.ComputerName)
+	populate(objectMap, "disks", v.Disks)
+	populate(objectMap, "extensions", v.Extensions)
+	populate(objectMap, "hyperVGeneration", v.HyperVGeneration)
+	populate(objectMap, "maintenanceRedeployStatus", v.MaintenanceRedeployStatus)
+	populate(objectMap, "osName", v.OSName)
+	populate(objectMap, "osVersion", v.OSVersion)
+	populate(objectMap, "platformFaultDomain", v.PlatformFaultDomain)
+	populate(objectMap, "platformUpdateDomain", v.PlatformUpdateDomain)
+	populate(objectMap, "rdpThumbPrint", v.RdpThumbPrint)
+	populate(objectMap, "statuses", v.Statuses)
+	populate(objectMap, "vmAgent", v.VMAgent)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineInstanceViewResponse is the response envelope for operations that return a VirtualMachineInstanceView type.
@@ -5051,7 +5820,15 @@ type VirtualMachineListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machines.
-	Value *[]*VirtualMachine `json:"value,omitempty"`
+	Value []*VirtualMachine `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineListResult.
+func (v VirtualMachineListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineListResultResponse is the response envelope for operations that return a VirtualMachineListResult type.
@@ -5166,6 +5943,18 @@ type VirtualMachineReimageParameters struct {
 	TempDisk *bool `json:"tempDisk,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineReimageParameters.
+func (v VirtualMachineReimageParameters) MarshalJSON() ([]byte, error) {
+	objectMap := v.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (v VirtualMachineReimageParameters) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "tempDisk", v.TempDisk)
+	return objectMap
+}
+
 // VirtualMachineResponse is the response envelope for operations that return a VirtualMachine type.
 type VirtualMachineResponse struct {
 	// RawResponse contains the underlying HTTP response.
@@ -5205,7 +5994,18 @@ type VirtualMachineScaleSet struct {
 	SKU *SKU `json:"sku,omitempty"`
 
 	// The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSet.
+func (v VirtualMachineScaleSet) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "identity", v.Identity)
+	populate(objectMap, "plan", v.Plan)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "sku", v.SKU)
+	populate(objectMap, "zones", v.Zones)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetDataDisk - Describes a virtual machine scale set data disk.
@@ -5260,13 +6060,30 @@ type VirtualMachineScaleSetExtension struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetExtension.
+func (v VirtualMachineScaleSetExtension) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResourceReadOnly.marshalInternal()
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "type", v.Type)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetExtensionListResult - The List VM scale set extension operation response.
 type VirtualMachineScaleSetExtensionListResult struct {
 	// The uri to fetch the next page of VM scale set extensions. Call ListNext() with this to fetch the next page of VM scale set extensions.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of VM scale set extensions.
-	Value *[]*VirtualMachineScaleSetExtension `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetExtension `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetExtensionListResult.
+func (v VirtualMachineScaleSetExtensionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetExtensionListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetExtensionListResult type.
@@ -5293,7 +6110,14 @@ type VirtualMachineScaleSetExtensionPollerResponse struct {
 // VirtualMachineScaleSetExtensionProfile - Describes a virtual machine scale set extension profile.
 type VirtualMachineScaleSetExtensionProfile struct {
 	// The virtual machine scale set child extension resources.
-	Extensions *[]*VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetExtensionProfile.
+func (v VirtualMachineScaleSetExtensionProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "extensions", v.Extensions)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetExtensionProperties - Describes the properties of a Virtual Machine Scale Set Extension.
@@ -5311,7 +6135,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	ProtectedSettings interface{} `json:"protectedSettings,omitempty"`
 
 	// Collection of extension names after which this extension needs to be provisioned.
-	ProvisionAfterExtensions *[]*string `json:"provisionAfterExtensions,omitempty"`
+	ProvisionAfterExtensions []*string `json:"provisionAfterExtensions,omitempty"`
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
@@ -5327,6 +6151,21 @@ type VirtualMachineScaleSetExtensionProperties struct {
 
 	// Specifies the version of the script handler.
 	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetExtensionProperties.
+func (v VirtualMachineScaleSetExtensionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
+	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
+	populate(objectMap, "protectedSettings", v.ProtectedSettings)
+	populate(objectMap, "provisionAfterExtensions", v.ProvisionAfterExtensions)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "publisher", v.Publisher)
+	populate(objectMap, "settings", v.Settings)
+	populate(objectMap, "type", v.Type)
+	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetExtensionResponse is the response envelope for operations that return a VirtualMachineScaleSetExtension type.
@@ -5397,25 +6236,33 @@ type VirtualMachineScaleSetIPConfiguration struct {
 	Properties *VirtualMachineScaleSetIPConfigurationProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetIPConfiguration.
+func (v VirtualMachineScaleSetIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetIPConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration properties.
 type VirtualMachineScaleSetIPConfigurationProperties struct {
 	// Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of multiple application
 	// gateways. Multiple scale sets cannot use the
 	// same application gateway.
-	ApplicationGatewayBackendAddressPools *[]*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups *[]*SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*SubResource `json:"applicationSecurityGroups,omitempty"`
 
 	// Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal
 	// load balancer. Multiple scale sets cannot
 	// use the same basic sku load balancer.
-	LoadBalancerBackendAddressPools *[]*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to inbound Nat pools of the load balancers. A scale set can reference inbound nat pools of one public and one internal
 	// load balancer. Multiple scale sets cannot use
 	// the same basic sku load balancer.
-	LoadBalancerInboundNatPools *[]*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools []*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
 
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
 	Primary *bool `json:"primary,omitempty"`
@@ -5429,6 +6276,20 @@ type VirtualMachineScaleSetIPConfigurationProperties struct {
 
 	// Specifies the identifier of the subnet.
 	Subnet *APIEntityReference `json:"subnet,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetIPConfigurationProperties.
+func (v VirtualMachineScaleSetIPConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "applicationGatewayBackendAddressPools", v.ApplicationGatewayBackendAddressPools)
+	populate(objectMap, "applicationSecurityGroups", v.ApplicationSecurityGroups)
+	populate(objectMap, "loadBalancerBackendAddressPools", v.LoadBalancerBackendAddressPools)
+	populate(objectMap, "loadBalancerInboundNatPools", v.LoadBalancerInboundNatPools)
+	populate(objectMap, "primary", v.Primary)
+	populate(objectMap, "privateIPAddressVersion", v.PrivateIPAddressVersion)
+	populate(objectMap, "publicIPAddressConfiguration", v.PublicIPAddressConfiguration)
+	populate(objectMap, "subnet", v.Subnet)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetIPTag - Contains the IP tag associated with the public IP address.
@@ -5456,7 +6317,17 @@ type VirtualMachineScaleSetIdentity struct {
 	// The list of user identities associated with the virtual machine scale set. The user identity dictionary key references will be ARM resource ids in the
 	// form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]*VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetIdentity.
+func (v VirtualMachineScaleSetIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "principalId", v.PrincipalID)
+	populate(objectMap, "tenantId", v.TenantID)
+	populate(objectMap, "type", v.Type)
+	populate(objectMap, "userAssignedIdentities", v.UserAssignedIdentities)
+	return json.Marshal(objectMap)
 }
 
 type VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue struct {
@@ -5470,16 +6341,26 @@ type VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue struct {
 // VirtualMachineScaleSetInstanceView - The instance view of a virtual machine scale set.
 type VirtualMachineScaleSetInstanceView struct {
 	// READ-ONLY; The extensions information.
-	Extensions *[]*VirtualMachineScaleSetVMExtensionsSummary `json:"extensions,omitempty" azure:"ro"`
+	Extensions []*VirtualMachineScaleSetVMExtensionsSummary `json:"extensions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The orchestration services information.
-	OrchestrationServices *[]*OrchestrationServiceSummary `json:"orchestrationServices,omitempty" azure:"ro"`
+	OrchestrationServices []*OrchestrationServiceSummary `json:"orchestrationServices,omitempty" azure:"ro"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// READ-ONLY; The instance view status summary for the virtual machine scale set.
 	VirtualMachine *VirtualMachineScaleSetInstanceViewStatusesSummary `json:"virtualMachine,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetInstanceView.
+func (v VirtualMachineScaleSetInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "extensions", v.Extensions)
+	populate(objectMap, "orchestrationServices", v.OrchestrationServices)
+	populate(objectMap, "statuses", v.Statuses)
+	populate(objectMap, "virtualMachine", v.VirtualMachine)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetInstanceViewResponse is the response envelope for operations that return a VirtualMachineScaleSetInstanceView type.
@@ -5494,7 +6375,14 @@ type VirtualMachineScaleSetInstanceViewResponse struct {
 // VirtualMachineScaleSetInstanceViewStatusesSummary - Instance view statuses summary for virtual machines of a virtual machine scale set.
 type VirtualMachineScaleSetInstanceViewStatusesSummary struct {
 	// READ-ONLY; The extensions information.
-	StatusesSummary *[]*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary []*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetInstanceViewStatusesSummary.
+func (v VirtualMachineScaleSetInstanceViewStatusesSummary) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "statusesSummary", v.StatusesSummary)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetListOSUpgradeHistory - List of Virtual Machine Scale Set OS Upgrade History operation response.
@@ -5503,7 +6391,15 @@ type VirtualMachineScaleSetListOSUpgradeHistory struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of OS upgrades performed on the virtual machine scale set.
-	Value *[]*UpgradeOperationHistoricalStatusInfo `json:"value,omitempty"`
+	Value []*UpgradeOperationHistoricalStatusInfo `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetListOSUpgradeHistory.
+func (v VirtualMachineScaleSetListOSUpgradeHistory) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetListOSUpgradeHistoryResponse is the response envelope for operations that return a VirtualMachineScaleSetListOSUpgradeHistory type.
@@ -5521,7 +6417,15 @@ type VirtualMachineScaleSetListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets.
-	Value *[]*VirtualMachineScaleSet `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetListResult.
+func (v VirtualMachineScaleSetListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListResult type.
@@ -5539,7 +6443,15 @@ type VirtualMachineScaleSetListSKUsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of skus available for the virtual machine scale set.
-	Value *[]*VirtualMachineScaleSetSKU `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetSKU `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetListSKUsResult.
+func (v VirtualMachineScaleSetListSKUsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetListSKUsResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListSKUsResult type.
@@ -5557,7 +6469,15 @@ type VirtualMachineScaleSetListWithLinkResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets.
-	Value *[]*VirtualMachineScaleSet `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetListWithLinkResult.
+func (v VirtualMachineScaleSetListWithLinkResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetListWithLinkResultResponse is the response envelope for operations that return a VirtualMachineScaleSetListWithLinkResult type.
@@ -5588,10 +6508,25 @@ type VirtualMachineScaleSetNetworkConfiguration struct {
 	Properties *VirtualMachineScaleSetNetworkConfigurationProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetNetworkConfiguration.
+func (v VirtualMachineScaleSetNetworkConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetNetworkConfigurationDNSSettings - Describes a virtual machines scale sets network configuration's DNS settings.
 type VirtualMachineScaleSetNetworkConfigurationDNSSettings struct {
 	// List of DNS servers IP addresses
-	DNSServers *[]*string `json:"dnsServers,omitempty"`
+	DNSServers []*string `json:"dnsServers,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetNetworkConfigurationDNSSettings.
+func (v VirtualMachineScaleSetNetworkConfigurationDNSSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsServers", v.DNSServers)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetNetworkConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration.
@@ -5606,13 +6541,25 @@ type VirtualMachineScaleSetNetworkConfigurationProperties struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// Specifies the IP configurations of the network interface.
-	IPConfigurations *[]*VirtualMachineScaleSetIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualMachineScaleSetIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// The network security group.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
 
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
 	Primary *bool `json:"primary,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetNetworkConfigurationProperties.
+func (v VirtualMachineScaleSetNetworkConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", v.DNSSettings)
+	populate(objectMap, "enableAcceleratedNetworking", v.EnableAcceleratedNetworking)
+	populate(objectMap, "enableIPForwarding", v.EnableIPForwarding)
+	populate(objectMap, "ipConfigurations", v.IPConfigurations)
+	populate(objectMap, "networkSecurityGroup", v.NetworkSecurityGroup)
+	populate(objectMap, "primary", v.Primary)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetNetworkProfile - Describes a virtual machine scale set network profile.
@@ -5622,7 +6569,15 @@ type VirtualMachineScaleSetNetworkProfile struct {
 	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetNetworkProfile.
+func (v VirtualMachineScaleSetNetworkProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "healthProbe", v.HealthProbe)
+	populate(objectMap, "networkInterfaceConfigurations", v.NetworkInterfaceConfigurations)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetOSDisk - Describes a virtual machine scale set operating system disk.
@@ -5664,10 +6619,26 @@ type VirtualMachineScaleSetOSDisk struct {
 	OSType *OperatingSystemTypes `json:"osType,omitempty"`
 
 	// Specifies the container urls that are used to store operating system disks for the scale set.
-	VhdContainers *[]*string `json:"vhdContainers,omitempty"`
+	VhdContainers []*string `json:"vhdContainers,omitempty"`
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetOSDisk.
+func (v VirtualMachineScaleSetOSDisk) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "caching", v.Caching)
+	populate(objectMap, "createOption", v.CreateOption)
+	populate(objectMap, "diffDiskSettings", v.DiffDiskSettings)
+	populate(objectMap, "diskSizeGB", v.DiskSizeGB)
+	populate(objectMap, "image", v.Image)
+	populate(objectMap, "managedDisk", v.ManagedDisk)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "osType", v.OSType)
+	populate(objectMap, "vhdContainers", v.VhdContainers)
+	populate(objectMap, "writeAcceleratorEnabled", v.WriteAcceleratorEnabled)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetOSProfile - Describes a virtual machine scale set OS profile.
@@ -5721,10 +6692,23 @@ type VirtualMachineScaleSetOSProfile struct {
 	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
 
 	// Specifies set of certificates that should be installed onto the virtual machines in the scale set.
-	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// Specifies Windows operating system settings on the virtual machine.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetOSProfile.
+func (v VirtualMachineScaleSetOSProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "adminPassword", v.AdminPassword)
+	populate(objectMap, "adminUsername", v.AdminUsername)
+	populate(objectMap, "computerNamePrefix", v.ComputerNamePrefix)
+	populate(objectMap, "customData", v.CustomData)
+	populate(objectMap, "linuxConfiguration", v.LinuxConfiguration)
+	populate(objectMap, "secrets", v.Secrets)
+	populate(objectMap, "windowsConfiguration", v.WindowsConfiguration)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetPollerResponse is the response envelope for operations that asynchronously return a VirtualMachineScaleSet type.
@@ -5810,7 +6794,7 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
 	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings `json:"dnsSettings,omitempty"`
 
 	// The list of IP tags associated with the public IP address.
-	IPTags *[]*VirtualMachineScaleSetIPTag `json:"ipTags,omitempty"`
+	IPTags []*VirtualMachineScaleSetIPTag `json:"ipTags,omitempty"`
 
 	// The idle timeout of the public IP address.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -5823,12 +6807,30 @@ type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
 	PublicIPPrefix *SubResource `json:"publicIPPrefix,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetPublicIPAddressConfigurationProperties.
+func (v VirtualMachineScaleSetPublicIPAddressConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", v.DNSSettings)
+	populate(objectMap, "ipTags", v.IPTags)
+	populate(objectMap, "idleTimeoutInMinutes", v.IdleTimeoutInMinutes)
+	populate(objectMap, "publicIPAddressVersion", v.PublicIPAddressVersion)
+	populate(objectMap, "publicIPPrefix", v.PublicIPPrefix)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetReimageParameters - Describes a Virtual Machine Scale Set VM Reimage Parameters.
 type VirtualMachineScaleSetReimageParameters struct {
 	VirtualMachineScaleSetVMReimageParameters
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual
 	// machines in the virtual machine scale set.
-	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string `json:"instanceIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetReimageParameters.
+func (v VirtualMachineScaleSetReimageParameters) MarshalJSON() ([]byte, error) {
+	objectMap := v.VirtualMachineScaleSetVMReimageParameters.marshalInternal()
+	populate(objectMap, "instanceIds", v.InstanceIDs)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetResponse is the response envelope for operations that return a VirtualMachineScaleSet type.
@@ -5894,7 +6896,7 @@ type VirtualMachineScaleSetStorageProfile struct {
 	// Specifies the parameters that are used to add data disks to the virtual machines in the scale set.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks *[]*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or virtual machine images. This
 	// element is required when you want to use a platform
@@ -5905,6 +6907,15 @@ type VirtualMachineScaleSetStorageProfile struct {
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
 	OSDisk *VirtualMachineScaleSetOSDisk `json:"osDisk,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetStorageProfile.
+func (v VirtualMachineScaleSetStorageProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDisks", v.DataDisks)
+	populate(objectMap, "imageReference", v.ImageReference)
+	populate(objectMap, "osDisk", v.OSDisk)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdate - Describes a Virtual Machine Scale Set.
@@ -5945,19 +6956,27 @@ type VirtualMachineScaleSetUpdateIPConfiguration struct {
 	Properties *VirtualMachineScaleSetUpdateIPConfigurationProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateIPConfiguration.
+func (v VirtualMachineScaleSetUpdateIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetUpdateIPConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration properties.
 type VirtualMachineScaleSetUpdateIPConfigurationProperties struct {
 	// The application gateway backend address pools.
-	ApplicationGatewayBackendAddressPools *[]*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups *[]*SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*SubResource `json:"applicationSecurityGroups,omitempty"`
 
 	// The load balancer backend address pools.
-	LoadBalancerBackendAddressPools *[]*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// The load balancer inbound nat pools.
-	LoadBalancerInboundNatPools *[]*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools []*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
 
 	// Specifies the primary IP Configuration in case the network interface has more than one IP Configuration.
 	Primary *bool `json:"primary,omitempty"`
@@ -5973,6 +6992,20 @@ type VirtualMachineScaleSetUpdateIPConfigurationProperties struct {
 	Subnet *APIEntityReference `json:"subnet,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateIPConfigurationProperties.
+func (v VirtualMachineScaleSetUpdateIPConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "applicationGatewayBackendAddressPools", v.ApplicationGatewayBackendAddressPools)
+	populate(objectMap, "applicationSecurityGroups", v.ApplicationSecurityGroups)
+	populate(objectMap, "loadBalancerBackendAddressPools", v.LoadBalancerBackendAddressPools)
+	populate(objectMap, "loadBalancerInboundNatPools", v.LoadBalancerInboundNatPools)
+	populate(objectMap, "primary", v.Primary)
+	populate(objectMap, "privateIPAddressVersion", v.PrivateIPAddressVersion)
+	populate(objectMap, "publicIPAddressConfiguration", v.PublicIPAddressConfiguration)
+	populate(objectMap, "subnet", v.Subnet)
+	return json.Marshal(objectMap)
+}
+
 // VirtualMachineScaleSetUpdateNetworkConfiguration - Describes a virtual machine scale set network profile's network configurations.
 type VirtualMachineScaleSetUpdateNetworkConfiguration struct {
 	SubResource
@@ -5981,6 +7014,14 @@ type VirtualMachineScaleSetUpdateNetworkConfiguration struct {
 
 	// Describes a virtual machine scale set updatable network profile's IP configuration.Use this object for updating network profile's IP Configuration.
 	Properties *VirtualMachineScaleSetUpdateNetworkConfigurationProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateNetworkConfiguration.
+func (v VirtualMachineScaleSetUpdateNetworkConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateNetworkConfigurationProperties - Describes a virtual machine scale set updatable network profile's IP configuration.Use this
@@ -5996,13 +7037,25 @@ type VirtualMachineScaleSetUpdateNetworkConfigurationProperties struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// The virtual machine scale set IP Configuration.
-	IPConfigurations *[]*VirtualMachineScaleSetUpdateIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualMachineScaleSetUpdateIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// The network security group.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
 
 	// Whether this is a primary NIC on a virtual machine.
 	Primary *bool `json:"primary,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateNetworkConfigurationProperties.
+func (v VirtualMachineScaleSetUpdateNetworkConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", v.DNSSettings)
+	populate(objectMap, "enableAcceleratedNetworking", v.EnableAcceleratedNetworking)
+	populate(objectMap, "enableIPForwarding", v.EnableIPForwarding)
+	populate(objectMap, "ipConfigurations", v.IPConfigurations)
+	populate(objectMap, "networkSecurityGroup", v.NetworkSecurityGroup)
+	populate(objectMap, "primary", v.Primary)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateNetworkProfile - Describes a virtual machine scale set network profile.
@@ -6012,7 +7065,15 @@ type VirtualMachineScaleSetUpdateNetworkProfile struct {
 	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateNetworkProfile.
+func (v VirtualMachineScaleSetUpdateNetworkProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "healthProbe", v.HealthProbe)
+	populate(objectMap, "networkInterfaceConfigurations", v.NetworkInterfaceConfigurations)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateOSDisk - Describes virtual machine scale set operating system disk Update Object. This should be used for Updating VMSS OS
@@ -6034,10 +7095,22 @@ type VirtualMachineScaleSetUpdateOSDisk struct {
 	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
 
 	// The list of virtual hard disk container uris.
-	VhdContainers *[]*string `json:"vhdContainers,omitempty"`
+	VhdContainers []*string `json:"vhdContainers,omitempty"`
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
 	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateOSDisk.
+func (v VirtualMachineScaleSetUpdateOSDisk) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "caching", v.Caching)
+	populate(objectMap, "diskSizeGB", v.DiskSizeGB)
+	populate(objectMap, "image", v.Image)
+	populate(objectMap, "managedDisk", v.ManagedDisk)
+	populate(objectMap, "vhdContainers", v.VhdContainers)
+	populate(objectMap, "writeAcceleratorEnabled", v.WriteAcceleratorEnabled)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateOSProfile - Describes a virtual machine scale set OS profile.
@@ -6049,10 +7122,20 @@ type VirtualMachineScaleSetUpdateOSProfile struct {
 	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
 
 	// The List of certificates for addition to the VM.
-	Secrets *[]*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
 
 	// The Windows Configuration of the OS profile.
 	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateOSProfile.
+func (v VirtualMachineScaleSetUpdateOSProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "customData", v.CustomData)
+	populate(objectMap, "linuxConfiguration", v.LinuxConfiguration)
+	populate(objectMap, "secrets", v.Secrets)
+	populate(objectMap, "windowsConfiguration", v.WindowsConfiguration)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateProperties - Describes the properties of a Virtual Machine Scale Set.
@@ -6113,13 +7196,22 @@ type VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties struct {
 // VirtualMachineScaleSetUpdateStorageProfile - Describes a virtual machine scale set storage profile.
 type VirtualMachineScaleSetUpdateStorageProfile struct {
 	// The data disks.
-	DataDisks *[]*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
 
 	// The image reference.
 	ImageReference *ImageReference `json:"imageReference,omitempty"`
 
 	// The OS disk.
 	OSDisk *VirtualMachineScaleSetUpdateOSDisk `json:"osDisk,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetUpdateStorageProfile.
+func (v VirtualMachineScaleSetUpdateStorageProfile) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataDisks", v.DataDisks)
+	populate(objectMap, "imageReference", v.ImageReference)
+	populate(objectMap, "osDisk", v.OSDisk)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetUpdateVMProfile - Describes a virtual machine scale set virtual machine profile.
@@ -6167,13 +7259,25 @@ type VirtualMachineScaleSetVM struct {
 	Properties *VirtualMachineScaleSetVMProperties `json:"properties,omitempty"`
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources *[]*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources []*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
 
 	// READ-ONLY; The virtual machine SKU.
 	SKU *SKU `json:"sku,omitempty" azure:"ro"`
 
 	// READ-ONLY; The virtual machine zones.
-	Zones *[]*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string `json:"zones,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVM.
+func (v VirtualMachineScaleSetVM) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "instanceId", v.InstanceID)
+	populate(objectMap, "plan", v.Plan)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "resources", v.Resources)
+	populate(objectMap, "sku", v.SKU)
+	populate(objectMap, "zones", v.Zones)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMExtensionsBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensions.BeginCreateOrUpdate
@@ -6210,20 +7314,42 @@ type VirtualMachineScaleSetVMExtensionsSummary struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// READ-ONLY; The extensions information.
-	StatusesSummary *[]*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary []*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMExtensionsSummary.
+func (v VirtualMachineScaleSetVMExtensionsSummary) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "statusesSummary", v.StatusesSummary)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMInstanceIDs - Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceIDs struct {
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation being performed on all virtual
 	// machines in the virtual machine scale set.
-	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string `json:"instanceIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMInstanceIDs.
+func (v VirtualMachineScaleSetVMInstanceIDs) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "instanceIds", v.InstanceIDs)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMInstanceRequiredIDs - Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceRequiredIDs struct {
 	// The virtual machine scale set instance ids.
-	InstanceIDs *[]*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string `json:"instanceIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMInstanceRequiredIDs.
+func (v VirtualMachineScaleSetVMInstanceRequiredIDs) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "instanceIds", v.InstanceIDs)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMInstanceView - The instance view of a virtual machine scale set VM.
@@ -6234,10 +7360,10 @@ type VirtualMachineScaleSetVMInstanceView struct {
 	BootDiagnostics *BootDiagnosticsInstanceView `json:"bootDiagnostics,omitempty"`
 
 	// The disks information.
-	Disks *[]*DiskInstanceView `json:"disks,omitempty"`
+	Disks []*DiskInstanceView `json:"disks,omitempty"`
 
 	// The extensions information.
-	Extensions *[]*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
 
 	// The Maintenance Operation status on the virtual machine.
 	MaintenanceRedeployStatus *MaintenanceRedeployStatus `json:"maintenanceRedeployStatus,omitempty"`
@@ -6255,13 +7381,30 @@ type VirtualMachineScaleSetVMInstanceView struct {
 	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
 
 	// The resource status information.
-	Statuses *[]*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
 
 	// The VM Agent running on the virtual machine.
 	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
 
 	// READ-ONLY; The health status for the VM.
 	VMHealth *VirtualMachineHealthStatus `json:"vmHealth,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMInstanceView.
+func (v VirtualMachineScaleSetVMInstanceView) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bootDiagnostics", v.BootDiagnostics)
+	populate(objectMap, "disks", v.Disks)
+	populate(objectMap, "extensions", v.Extensions)
+	populate(objectMap, "maintenanceRedeployStatus", v.MaintenanceRedeployStatus)
+	populate(objectMap, "placementGroupId", v.PlacementGroupID)
+	populate(objectMap, "platformFaultDomain", v.PlatformFaultDomain)
+	populate(objectMap, "platformUpdateDomain", v.PlatformUpdateDomain)
+	populate(objectMap, "rdpThumbPrint", v.RdpThumbPrint)
+	populate(objectMap, "statuses", v.Statuses)
+	populate(objectMap, "vmAgent", v.VMAgent)
+	populate(objectMap, "vmHealth", v.VMHealth)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMInstanceViewResponse is the response envelope for operations that return a VirtualMachineScaleSetVMInstanceView type.
@@ -6279,7 +7422,15 @@ type VirtualMachineScaleSetVMListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of virtual machine scale sets VMs.
-	Value *[]*VirtualMachineScaleSetVM `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetVM `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMListResult.
+func (v VirtualMachineScaleSetVMListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMListResultResponse is the response envelope for operations that return a VirtualMachineScaleSetVMListResult type.
@@ -6294,7 +7445,14 @@ type VirtualMachineScaleSetVMListResultResponse struct {
 // VirtualMachineScaleSetVMNetworkProfileConfiguration - Describes a virtual machine scale set VM network profile.
 type VirtualMachineScaleSetVMNetworkProfileConfiguration struct {
 	// The list of network configurations.
-	NetworkInterfaceConfigurations *[]*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineScaleSetVMNetworkProfileConfiguration.
+func (v VirtualMachineScaleSetVMNetworkProfileConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "networkInterfaceConfigurations", v.NetworkInterfaceConfigurations)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineScaleSetVMPollerResponse is the response envelope for operations that asynchronously return a VirtualMachineScaleSetVM type.
@@ -6434,6 +7592,11 @@ type VirtualMachineScaleSetVMProtectionPolicy struct {
 // VirtualMachineScaleSetVMReimageParameters - Describes a Virtual Machine Scale Set VM Reimage Parameters.
 type VirtualMachineScaleSetVMReimageParameters struct {
 	VirtualMachineReimageParameters
+}
+
+func (v VirtualMachineScaleSetVMReimageParameters) marshalInternal() map[string]interface{} {
+	objectMap := v.VirtualMachineReimageParameters.marshalInternal()
+	return objectMap
 }
 
 // VirtualMachineScaleSetVMResponse is the response envelope for operations that return a VirtualMachineScaleSetVM type.
@@ -6678,7 +7841,14 @@ type VirtualMachineSize struct {
 // VirtualMachineSizeListResult - The List Virtual Machine operation response.
 type VirtualMachineSizeListResult struct {
 	// The list of virtual machine sizes.
-	Value *[]*VirtualMachineSize `json:"value,omitempty"`
+	Value []*VirtualMachineSize `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualMachineSizeListResult.
+func (v VirtualMachineSizeListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualMachineSizeListResultResponse is the response envelope for operations that return a VirtualMachineSizeListResult type.
@@ -6721,7 +7891,7 @@ type VirtualMachineUpdate struct {
 	Properties *VirtualMachineProperties `json:"properties,omitempty"`
 
 	// The virtual machine zones.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type VirtualMachineUpdate.
@@ -6852,7 +8022,14 @@ type VirtualMachinesSimulateEvictionOptions struct {
 // WinRMConfiguration - Describes Windows Remote Management configuration of the VM
 type WinRMConfiguration struct {
 	// The list of Windows Remote Management listeners
-	Listeners *[]*WinRMListener `json:"listeners,omitempty"`
+	Listeners []*WinRMListener `json:"listeners,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WinRMConfiguration.
+func (w WinRMConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "listeners", w.Listeners)
+	return json.Marshal(objectMap)
 }
 
 // WinRMListener - Describes Protocol and thumbprint of Windows Remote Management listener
@@ -6878,7 +8055,7 @@ type WinRMListener struct {
 // WindowsConfiguration - Specifies Windows operating system settings on the virtual machine.
 type WindowsConfiguration struct {
 	// Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is used by Windows Setup.
-	AdditionalUnattendContent *[]*AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
+	AdditionalUnattendContent []*AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
 
 	// Indicates whether Automatic Updates is enabled for the Windows virtual machine. Default value is true.
 	// For virtual machine scale sets, this property can be updated and updates will take effect on OS reprovisioning.
@@ -6897,6 +8074,17 @@ type WindowsConfiguration struct {
 
 	// Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.
 	WinRM *WinRMConfiguration `json:"winRM,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WindowsConfiguration.
+func (w WindowsConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalUnattendContent", w.AdditionalUnattendContent)
+	populate(objectMap, "enableAutomaticUpdates", w.EnableAutomaticUpdates)
+	populate(objectMap, "provisionVMAgent", w.ProvisionVMAgent)
+	populate(objectMap, "timeZone", w.TimeZone)
+	populate(objectMap, "winRM", w.WinRM)
+	return json.Marshal(objectMap)
 }
 
 func populate(m map[string]interface{}, k string, v interface{}) {

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -31,7 +31,14 @@ type AADAuthenticationParameters struct {
 // AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 type AddressSpace struct {
 	// A list of address blocks reserved for this virtual network in CIDR notation.
-	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AddressSpace.
+func (a AddressSpace) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefixes", a.AddressPrefixes)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGateway - Application gateway resource.
@@ -47,7 +54,17 @@ type ApplicationGateway struct {
 	Properties *ApplicationGatewayPropertiesFormat `json:"properties,omitempty"`
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGateway.
+func (a ApplicationGateway) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "identity", a.Identity)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "zones", a.Zones)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayAuthenticationCertificate - Authentication certificates of an application gateway.
@@ -64,6 +81,16 @@ type ApplicationGatewayAuthenticationCertificate struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayAuthenticationCertificate.
+func (a ApplicationGatewayAuthenticationCertificate) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayAuthenticationCertificatePropertiesFormat - Authentication certificates properties of an application gateway.
@@ -91,19 +118,36 @@ type ApplicationGatewayAvailableSSLOptions struct {
 	Properties *ApplicationGatewayAvailableSSLOptionsPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayAvailableSSLOptions.
+func (a ApplicationGatewayAvailableSSLOptions) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayAvailableSSLOptionsPropertiesFormat - Properties of ApplicationGatewayAvailableSslOptions.
 type ApplicationGatewayAvailableSSLOptionsPropertiesFormat struct {
 	// List of available Ssl cipher suites.
-	AvailableCipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"availableCipherSuites,omitempty"`
+	AvailableCipherSuites []*ApplicationGatewaySSLCipherSuite `json:"availableCipherSuites,omitempty"`
 
 	// List of available Ssl protocols.
-	AvailableProtocols *[]*ApplicationGatewaySSLProtocol `json:"availableProtocols,omitempty"`
+	AvailableProtocols []*ApplicationGatewaySSLProtocol `json:"availableProtocols,omitempty"`
 
 	// Name of the Ssl predefined policy applied by default to application gateway.
 	DefaultPolicy *ApplicationGatewaySSLPolicyName `json:"defaultPolicy,omitempty"`
 
 	// List of available Ssl predefined policy.
-	PredefinedPolicies *[]*SubResource `json:"predefinedPolicies,omitempty"`
+	PredefinedPolicies []*SubResource `json:"predefinedPolicies,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayAvailableSSLOptionsPropertiesFormat.
+func (a ApplicationGatewayAvailableSSLOptionsPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "availableCipherSuites", a.AvailableCipherSuites)
+	populate(objectMap, "availableProtocols", a.AvailableProtocols)
+	populate(objectMap, "defaultPolicy", a.DefaultPolicy)
+	populate(objectMap, "predefinedPolicies", a.PredefinedPolicies)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayAvailableSSLOptionsResponse is the response envelope for operations that return a ApplicationGatewayAvailableSSLOptions type.
@@ -121,7 +165,15 @@ type ApplicationGatewayAvailableSSLPredefinedPolicies struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of available Ssl predefined policy.
-	Value *[]*ApplicationGatewaySSLPredefinedPolicy `json:"value,omitempty"`
+	Value []*ApplicationGatewaySSLPredefinedPolicy `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayAvailableSSLPredefinedPolicies.
+func (a ApplicationGatewayAvailableSSLPredefinedPolicies) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayAvailableSSLPredefinedPoliciesResponse is the response envelope for operations that return a ApplicationGatewayAvailableSSLPredefinedPolicies
@@ -137,7 +189,14 @@ type ApplicationGatewayAvailableSSLPredefinedPoliciesResponse struct {
 // ApplicationGatewayAvailableWafRuleSetsResult - Response for ApplicationGatewayAvailableWafRuleSets API service call.
 type ApplicationGatewayAvailableWafRuleSetsResult struct {
 	// The list of application gateway rule sets.
-	Value *[]*ApplicationGatewayFirewallRuleSet `json:"value,omitempty"`
+	Value []*ApplicationGatewayFirewallRuleSet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayAvailableWafRuleSetsResult.
+func (a ApplicationGatewayAvailableWafRuleSetsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayAvailableWafRuleSetsResultResponse is the response envelope for operations that return a ApplicationGatewayAvailableWafRuleSetsResult
@@ -175,16 +234,35 @@ type ApplicationGatewayBackendAddressPool struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendAddressPool.
+func (a ApplicationGatewayBackendAddressPool) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayBackendAddressPoolPropertiesFormat - Properties of Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
 	// Backend addresses.
-	BackendAddresses *[]*ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendAddresses []*ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
 
 	// READ-ONLY; Collection of references to IPs defined in network interfaces.
-	BackendIPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendAddressPoolPropertiesFormat.
+func (a ApplicationGatewayBackendAddressPoolPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendAddresses", a.BackendAddresses)
+	populate(objectMap, "backendIPConfigurations", a.BackendIPConfigurations)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayBackendHTTPSettings - Backend address pool settings of an application gateway.
@@ -203,13 +281,23 @@ type ApplicationGatewayBackendHTTPSettings struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendHTTPSettings.
+func (a ApplicationGatewayBackendHTTPSettings) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayBackendHTTPSettingsPropertiesFormat - Properties of Backend address pool settings of an application gateway.
 type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
 	// Cookie name to use for the affinity cookie.
 	AffinityCookieName *string `json:"affinityCookieName,omitempty"`
 
 	// Array of references to application gateway authentication certificates.
-	AuthenticationCertificates *[]*SubResource `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates []*SubResource `json:"authenticationCertificates,omitempty"`
 
 	// Connection draining of the backend http settings resource.
 	ConnectionDraining *ApplicationGatewayConnectionDraining `json:"connectionDraining,omitempty"`
@@ -246,13 +334,40 @@ type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
 	RequestTimeout *int32 `json:"requestTimeout,omitempty"`
 
 	// Array of references to application gateway trusted root certificates.
-	TrustedRootCertificates *[]*SubResource `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates []*SubResource `json:"trustedRootCertificates,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendHTTPSettingsPropertiesFormat.
+func (a ApplicationGatewayBackendHTTPSettingsPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "affinityCookieName", a.AffinityCookieName)
+	populate(objectMap, "authenticationCertificates", a.AuthenticationCertificates)
+	populate(objectMap, "connectionDraining", a.ConnectionDraining)
+	populate(objectMap, "cookieBasedAffinity", a.CookieBasedAffinity)
+	populate(objectMap, "hostName", a.HostName)
+	populate(objectMap, "path", a.Path)
+	populate(objectMap, "pickHostNameFromBackendAddress", a.PickHostNameFromBackendAddress)
+	populate(objectMap, "port", a.Port)
+	populate(objectMap, "probe", a.Probe)
+	populate(objectMap, "probeEnabled", a.ProbeEnabled)
+	populate(objectMap, "protocol", a.Protocol)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "requestTimeout", a.RequestTimeout)
+	populate(objectMap, "trustedRootCertificates", a.TrustedRootCertificates)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayBackendHealth - Response for ApplicationGatewayBackendHealth API service call.
 type ApplicationGatewayBackendHealth struct {
 	// A list of ApplicationGatewayBackendHealthPool resources.
-	BackendAddressPools *[]*ApplicationGatewayBackendHealthPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*ApplicationGatewayBackendHealthPool `json:"backendAddressPools,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendHealth.
+func (a ApplicationGatewayBackendHealth) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendAddressPools", a.BackendAddressPools)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayBackendHealthHTTPSettings - Application gateway BackendHealthHttp settings.
@@ -261,7 +376,15 @@ type ApplicationGatewayBackendHealthHTTPSettings struct {
 	BackendHTTPSettings *ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettings,omitempty"`
 
 	// List of ApplicationGatewayBackendHealthServer resources.
-	Servers *[]*ApplicationGatewayBackendHealthServer `json:"servers,omitempty"`
+	Servers []*ApplicationGatewayBackendHealthServer `json:"servers,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendHealthHTTPSettings.
+func (a ApplicationGatewayBackendHealthHTTPSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendHttpSettings", a.BackendHTTPSettings)
+	populate(objectMap, "servers", a.Servers)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayBackendHealthOnDemand - Result of on demand test probe.
@@ -313,7 +436,15 @@ type ApplicationGatewayBackendHealthPool struct {
 	BackendAddressPool *ApplicationGatewayBackendAddressPool `json:"backendAddressPool,omitempty"`
 
 	// List of ApplicationGatewayBackendHealthHttpSettings resources.
-	BackendHTTPSettingsCollection *[]*ApplicationGatewayBackendHealthHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHealthHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayBackendHealthPool.
+func (a ApplicationGatewayBackendHealthPool) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendAddressPool", a.BackendAddressPool)
+	populate(objectMap, "backendHttpSettingsCollection", a.BackendHTTPSettingsCollection)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayBackendHealthResponse is the response envelope for operations that return a ApplicationGatewayBackendHealth type.
@@ -365,7 +496,15 @@ type ApplicationGatewayFirewallDisabledRuleGroup struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// The list of rules that will be disabled. If null, all rules of the rule group will be disabled.
-	Rules *[]*int32 `json:"rules,omitempty"`
+	Rules []*int32 `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFirewallDisabledRuleGroup.
+func (a ApplicationGatewayFirewallDisabledRuleGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "ruleGroupName", a.RuleGroupName)
+	populate(objectMap, "rules", a.Rules)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayFirewallExclusion - Allow to exclude some variable satisfy the condition for the WAF check.
@@ -398,7 +537,16 @@ type ApplicationGatewayFirewallRuleGroup struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// The rules of the web application firewall rule group.
-	Rules *[]*ApplicationGatewayFirewallRule `json:"rules,omitempty"`
+	Rules []*ApplicationGatewayFirewallRule `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFirewallRuleGroup.
+func (a ApplicationGatewayFirewallRuleGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", a.Description)
+	populate(objectMap, "ruleGroupName", a.RuleGroupName)
+	populate(objectMap, "rules", a.Rules)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayFirewallRuleSet - A web application firewall rule set.
@@ -408,19 +556,36 @@ type ApplicationGatewayFirewallRuleSet struct {
 	Properties *ApplicationGatewayFirewallRuleSetPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFirewallRuleSet.
+func (a ApplicationGatewayFirewallRuleSet) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayFirewallRuleSetPropertiesFormat - Properties of the web application firewall rule set.
 type ApplicationGatewayFirewallRuleSetPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the web application firewall rule set.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The rule groups of the web application firewall rule set.
-	RuleGroups *[]*ApplicationGatewayFirewallRuleGroup `json:"ruleGroups,omitempty"`
+	RuleGroups []*ApplicationGatewayFirewallRuleGroup `json:"ruleGroups,omitempty"`
 
 	// The type of the web application firewall rule set.
 	RuleSetType *string `json:"ruleSetType,omitempty"`
 
 	// The version of the web application firewall rule set type.
 	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFirewallRuleSetPropertiesFormat.
+func (a ApplicationGatewayFirewallRuleSetPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "ruleGroups", a.RuleGroups)
+	populate(objectMap, "ruleSetType", a.RuleSetType)
+	populate(objectMap, "ruleSetVersion", a.RuleSetVersion)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayFrontendIPConfiguration - Frontend IP configuration of an application gateway.
@@ -437,6 +602,16 @@ type ApplicationGatewayFrontendIPConfiguration struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFrontendIPConfiguration.
+func (a ApplicationGatewayFrontendIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayFrontendIPConfigurationPropertiesFormat - Properties of Frontend IP configuration of an application gateway.
@@ -473,6 +648,16 @@ type ApplicationGatewayFrontendPort struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayFrontendPort.
+func (a ApplicationGatewayFrontendPort) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayFrontendPortPropertiesFormat - Properties of Frontend port of an application gateway.
 type ApplicationGatewayFrontendPortPropertiesFormat struct {
 	// Frontend port.
@@ -498,10 +683,20 @@ type ApplicationGatewayHTTPListener struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayHTTPListener.
+func (a ApplicationGatewayHTTPListener) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayHTTPListenerPropertiesFormat - Properties of HTTP listener of an application gateway.
 type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 	// Custom error configurations of the HTTP listener.
-	CustomErrorConfigurations *[]*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations []*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
 
 	// Reference to the FirewallPolicy resource.
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
@@ -516,7 +711,7 @@ type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 	HostName *string `json:"hostName,omitempty"`
 
 	// List of Host names for HTTP Listener that allows special wildcard characters as well.
-	HostNames *[]*string `json:"hostNames,omitempty"`
+	HostNames []*string `json:"hostNames,omitempty"`
 
 	// Protocol of the HTTP listener.
 	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
@@ -529,6 +724,22 @@ type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 
 	// SSL certificate resource of an application gateway.
 	SSLCertificate *SubResource `json:"sslCertificate,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayHTTPListenerPropertiesFormat.
+func (a ApplicationGatewayHTTPListenerPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "customErrorConfigurations", a.CustomErrorConfigurations)
+	populate(objectMap, "firewallPolicy", a.FirewallPolicy)
+	populate(objectMap, "frontendIPConfiguration", a.FrontendIPConfiguration)
+	populate(objectMap, "frontendPort", a.FrontendPort)
+	populate(objectMap, "hostName", a.HostName)
+	populate(objectMap, "hostNames", a.HostNames)
+	populate(objectMap, "protocol", a.Protocol)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "requireServerNameIndication", a.RequireServerNameIndication)
+	populate(objectMap, "sslCertificate", a.SSLCertificate)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayHeaderConfiguration - Header configuration of the Actions set in Application Gateway.
@@ -556,6 +767,16 @@ type ApplicationGatewayIPConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayIPConfiguration.
+func (a ApplicationGatewayIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayIPConfigurationPropertiesFormat - Properties of IP configuration of an application gateway.
 type ApplicationGatewayIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the application gateway IP configuration resource.
@@ -571,7 +792,15 @@ type ApplicationGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of an application gateways in a resource group.
-	Value *[]*ApplicationGateway `json:"value,omitempty"`
+	Value []*ApplicationGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayListResult.
+func (a ApplicationGatewayListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayListResultResponse is the response envelope for operations that return a ApplicationGatewayListResult type.
@@ -627,6 +856,16 @@ type ApplicationGatewayPathRule struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayPathRule.
+func (a ApplicationGatewayPathRule) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayPathRulePropertiesFormat - Properties of path rule of an application gateway.
 type ApplicationGatewayPathRulePropertiesFormat struct {
 	// Backend address pool resource of URL path map path rule.
@@ -639,7 +878,7 @@ type ApplicationGatewayPathRulePropertiesFormat struct {
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
 
 	// Path rules of URL path map.
-	Paths *[]*string `json:"paths,omitempty"`
+	Paths []*string `json:"paths,omitempty"`
 
 	// READ-ONLY; The provisioning state of the path rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -649,6 +888,19 @@ type ApplicationGatewayPathRulePropertiesFormat struct {
 
 	// Rewrite rule set resource of URL path map path rule.
 	RewriteRuleSet *SubResource `json:"rewriteRuleSet,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayPathRulePropertiesFormat.
+func (a ApplicationGatewayPathRulePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendAddressPool", a.BackendAddressPool)
+	populate(objectMap, "backendHttpSettings", a.BackendHTTPSettings)
+	populate(objectMap, "firewallPolicy", a.FirewallPolicy)
+	populate(objectMap, "paths", a.Paths)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "redirectConfiguration", a.RedirectConfiguration)
+	populate(objectMap, "rewriteRuleSet", a.RewriteRuleSet)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayPollerResponse is the response envelope for operations that asynchronously return a ApplicationGateway type.
@@ -679,13 +931,31 @@ type ApplicationGatewayProbe struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayProbe.
+func (a ApplicationGatewayProbe) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayProbeHealthResponseMatch - Application gateway probe health response match.
 type ApplicationGatewayProbeHealthResponseMatch struct {
 	// Body that must be contained in the health response. Default value is empty.
 	Body *string `json:"body,omitempty"`
 
 	// Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399.
-	StatusCodes *[]*string `json:"statusCodes,omitempty"`
+	StatusCodes []*string `json:"statusCodes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayProbeHealthResponseMatch.
+func (a ApplicationGatewayProbeHealthResponseMatch) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "body", a.Body)
+	populate(objectMap, "statusCodes", a.StatusCodes)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayProbePropertiesFormat - Properties of probe of an application gateway.
@@ -732,21 +1002,21 @@ type ApplicationGatewayProbePropertiesFormat struct {
 type ApplicationGatewayPropertiesFormat struct {
 	// Authentication certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	AuthenticationCertificates *[]*ApplicationGatewayAuthenticationCertificate `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates []*ApplicationGatewayAuthenticationCertificate `json:"authenticationCertificates,omitempty"`
 
 	// Autoscale Configuration.
 	AutoscaleConfiguration *ApplicationGatewayAutoscaleConfiguration `json:"autoscaleConfiguration,omitempty"`
 
 	// Backend address pool of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendAddressPools *[]*ApplicationGatewayBackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"backendAddressPools,omitempty"`
 
 	// Backend http settings of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendHTTPSettingsCollection *[]*ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
 
 	// Custom error configurations of the application gateway resource.
-	CustomErrorConfigurations *[]*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations []*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
 
 	// Whether FIPS is enabled on the application gateway resource.
 	EnableFips *bool `json:"enableFips,omitempty"`
@@ -762,58 +1032,90 @@ type ApplicationGatewayPropertiesFormat struct {
 
 	// Frontend IP addresses of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendIPConfigurations *[]*ApplicationGatewayFrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*ApplicationGatewayFrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
 
 	// Frontend ports of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendPorts *[]*ApplicationGatewayFrontendPort `json:"frontendPorts,omitempty"`
+	FrontendPorts []*ApplicationGatewayFrontendPort `json:"frontendPorts,omitempty"`
 
 	// Subnets of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	GatewayIPConfigurations *[]*ApplicationGatewayIPConfiguration `json:"gatewayIPConfigurations,omitempty"`
+	GatewayIPConfigurations []*ApplicationGatewayIPConfiguration `json:"gatewayIPConfigurations,omitempty"`
 
 	// Http listeners of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	HTTPListeners *[]*ApplicationGatewayHTTPListener `json:"httpListeners,omitempty"`
+	HTTPListeners []*ApplicationGatewayHTTPListener `json:"httpListeners,omitempty"`
 
 	// READ-ONLY; Operational state of the application gateway resource.
 	OperationalState *ApplicationGatewayOperationalState `json:"operationalState,omitempty" azure:"ro"`
 
 	// Probes of the application gateway resource.
-	Probes *[]*ApplicationGatewayProbe `json:"probes,omitempty"`
+	Probes []*ApplicationGatewayProbe `json:"probes,omitempty"`
 
 	// READ-ONLY; The provisioning state of the application gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Redirect configurations of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	RedirectConfigurations *[]*ApplicationGatewayRedirectConfiguration `json:"redirectConfigurations,omitempty"`
+	RedirectConfigurations []*ApplicationGatewayRedirectConfiguration `json:"redirectConfigurations,omitempty"`
 
 	// Request routing rules of the application gateway resource.
-	RequestRoutingRules *[]*ApplicationGatewayRequestRoutingRule `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules []*ApplicationGatewayRequestRoutingRule `json:"requestRoutingRules,omitempty"`
 
 	// READ-ONLY; The resource GUID property of the application gateway resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// Rewrite rules for the application gateway resource.
-	RewriteRuleSets *[]*ApplicationGatewayRewriteRuleSet `json:"rewriteRuleSets,omitempty"`
+	RewriteRuleSets []*ApplicationGatewayRewriteRuleSet `json:"rewriteRuleSets,omitempty"`
 
 	// SKU of the application gateway resource.
 	SKU *ApplicationGatewaySKU `json:"sku,omitempty"`
 
 	// SSL certificates of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits]
 	// .
-	SSLCertificates *[]*ApplicationGatewaySSLCertificate `json:"sslCertificates,omitempty"`
+	SSLCertificates []*ApplicationGatewaySSLCertificate `json:"sslCertificates,omitempty"`
 
 	// SSL policy of the application gateway resource.
 	SSLPolicy *ApplicationGatewaySSLPolicy `json:"sslPolicy,omitempty"`
 
 	// Trusted Root certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	TrustedRootCertificates *[]*ApplicationGatewayTrustedRootCertificate `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates []*ApplicationGatewayTrustedRootCertificate `json:"trustedRootCertificates,omitempty"`
 
 	// URL path map of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	URLPathMaps *[]*ApplicationGatewayURLPathMap `json:"urlPathMaps,omitempty"`
+	URLPathMaps []*ApplicationGatewayURLPathMap `json:"urlPathMaps,omitempty"`
 
 	// Web application firewall configuration.
 	WebApplicationFirewallConfiguration *ApplicationGatewayWebApplicationFirewallConfiguration `json:"webApplicationFirewallConfiguration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayPropertiesFormat.
+func (a ApplicationGatewayPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationCertificates", a.AuthenticationCertificates)
+	populate(objectMap, "autoscaleConfiguration", a.AutoscaleConfiguration)
+	populate(objectMap, "backendAddressPools", a.BackendAddressPools)
+	populate(objectMap, "backendHttpSettingsCollection", a.BackendHTTPSettingsCollection)
+	populate(objectMap, "customErrorConfigurations", a.CustomErrorConfigurations)
+	populate(objectMap, "enableFips", a.EnableFips)
+	populate(objectMap, "enableHttp2", a.EnableHTTP2)
+	populate(objectMap, "firewallPolicy", a.FirewallPolicy)
+	populate(objectMap, "forceFirewallPolicyAssociation", a.ForceFirewallPolicyAssociation)
+	populate(objectMap, "frontendIPConfigurations", a.FrontendIPConfigurations)
+	populate(objectMap, "frontendPorts", a.FrontendPorts)
+	populate(objectMap, "gatewayIPConfigurations", a.GatewayIPConfigurations)
+	populate(objectMap, "httpListeners", a.HTTPListeners)
+	populate(objectMap, "operationalState", a.OperationalState)
+	populate(objectMap, "probes", a.Probes)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "redirectConfigurations", a.RedirectConfigurations)
+	populate(objectMap, "requestRoutingRules", a.RequestRoutingRules)
+	populate(objectMap, "resourceGuid", a.ResourceGUID)
+	populate(objectMap, "rewriteRuleSets", a.RewriteRuleSets)
+	populate(objectMap, "sku", a.SKU)
+	populate(objectMap, "sslCertificates", a.SSLCertificates)
+	populate(objectMap, "sslPolicy", a.SSLPolicy)
+	populate(objectMap, "trustedRootCertificates", a.TrustedRootCertificates)
+	populate(objectMap, "urlPathMaps", a.URLPathMaps)
+	populate(objectMap, "webApplicationFirewallConfiguration", a.WebApplicationFirewallConfiguration)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayRedirectConfiguration - Redirect configuration of an application gateway.
@@ -832,6 +1134,16 @@ type ApplicationGatewayRedirectConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRedirectConfiguration.
+func (a ApplicationGatewayRedirectConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayRedirectConfigurationPropertiesFormat - Properties of redirect configuration of the application gateway.
 type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	// Include path in the redirected url.
@@ -841,13 +1153,13 @@ type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	IncludeQueryString *bool `json:"includeQueryString,omitempty"`
 
 	// Path rules specifying redirect configuration.
-	PathRules *[]*SubResource `json:"pathRules,omitempty"`
+	PathRules []*SubResource `json:"pathRules,omitempty"`
 
 	// HTTP redirection type.
 	RedirectType *ApplicationGatewayRedirectType `json:"redirectType,omitempty"`
 
 	// Request routing specifying redirect configuration.
-	RequestRoutingRules *[]*SubResource `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules []*SubResource `json:"requestRoutingRules,omitempty"`
 
 	// Reference to a listener to redirect the request to.
 	TargetListener *SubResource `json:"targetListener,omitempty"`
@@ -856,7 +1168,21 @@ type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	TargetURL *string `json:"targetUrl,omitempty"`
 
 	// Url path maps specifying default redirect configuration.
-	URLPathMaps *[]*SubResource `json:"urlPathMaps,omitempty"`
+	URLPathMaps []*SubResource `json:"urlPathMaps,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRedirectConfigurationPropertiesFormat.
+func (a ApplicationGatewayRedirectConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "includePath", a.IncludePath)
+	populate(objectMap, "includeQueryString", a.IncludeQueryString)
+	populate(objectMap, "pathRules", a.PathRules)
+	populate(objectMap, "redirectType", a.RedirectType)
+	populate(objectMap, "requestRoutingRules", a.RequestRoutingRules)
+	populate(objectMap, "targetListener", a.TargetListener)
+	populate(objectMap, "targetUrl", a.TargetURL)
+	populate(objectMap, "urlPathMaps", a.URLPathMaps)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayRequestRoutingRule - Request routing rule of an application gateway.
@@ -873,6 +1199,16 @@ type ApplicationGatewayRequestRoutingRule struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRequestRoutingRule.
+func (a ApplicationGatewayRequestRoutingRule) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayRequestRoutingRulePropertiesFormat - Properties of request routing rule of the application gateway.
@@ -920,7 +1256,7 @@ type ApplicationGatewayRewriteRule struct {
 	ActionSet *ApplicationGatewayRewriteRuleActionSet `json:"actionSet,omitempty"`
 
 	// Conditions based on which the action set execution will be evaluated.
-	Conditions *[]*ApplicationGatewayRewriteRuleCondition `json:"conditions,omitempty"`
+	Conditions []*ApplicationGatewayRewriteRuleCondition `json:"conditions,omitempty"`
 
 	// Name of the rewrite rule that is unique within an Application Gateway.
 	Name *string `json:"name,omitempty"`
@@ -929,16 +1265,35 @@ type ApplicationGatewayRewriteRule struct {
 	RuleSequence *int32 `json:"ruleSequence,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRewriteRule.
+func (a ApplicationGatewayRewriteRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "actionSet", a.ActionSet)
+	populate(objectMap, "conditions", a.Conditions)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "ruleSequence", a.RuleSequence)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayRewriteRuleActionSet - Set of actions in the Rewrite Rule in Application Gateway.
 type ApplicationGatewayRewriteRuleActionSet struct {
 	// Request Header Actions in the Action Set.
-	RequestHeaderConfigurations *[]*ApplicationGatewayHeaderConfiguration `json:"requestHeaderConfigurations,omitempty"`
+	RequestHeaderConfigurations []*ApplicationGatewayHeaderConfiguration `json:"requestHeaderConfigurations,omitempty"`
 
 	// Response Header Actions in the Action Set.
-	ResponseHeaderConfigurations *[]*ApplicationGatewayHeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
+	ResponseHeaderConfigurations []*ApplicationGatewayHeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
 
 	// Url Configuration Action in the Action Set.
 	URLConfiguration *ApplicationGatewayURLConfiguration `json:"urlConfiguration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRewriteRuleActionSet.
+func (a ApplicationGatewayRewriteRuleActionSet) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "requestHeaderConfigurations", a.RequestHeaderConfigurations)
+	populate(objectMap, "responseHeaderConfigurations", a.ResponseHeaderConfigurations)
+	populate(objectMap, "urlConfiguration", a.URLConfiguration)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayRewriteRuleCondition - Set of conditions in the Rewrite Rule in Application Gateway.
@@ -969,13 +1324,30 @@ type ApplicationGatewayRewriteRuleSet struct {
 	Properties *ApplicationGatewayRewriteRuleSetPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRewriteRuleSet.
+func (a ApplicationGatewayRewriteRuleSet) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayRewriteRuleSetPropertiesFormat - Properties of rewrite rule set of the application gateway.
 type ApplicationGatewayRewriteRuleSetPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the rewrite rule set resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Rewrite rules in the rewrite rule set.
-	RewriteRules *[]*ApplicationGatewayRewriteRule `json:"rewriteRules,omitempty"`
+	RewriteRules []*ApplicationGatewayRewriteRule `json:"rewriteRules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayRewriteRuleSetPropertiesFormat.
+func (a ApplicationGatewayRewriteRuleSetPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "rewriteRules", a.RewriteRules)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewaySKU - SKU of an application gateway.
@@ -1006,6 +1378,16 @@ type ApplicationGatewaySSLCertificate struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewaySSLCertificate.
+func (a ApplicationGatewaySSLCertificate) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewaySSLCertificatePropertiesFormat - Properties of SSL certificates of an application gateway.
 type ApplicationGatewaySSLCertificatePropertiesFormat struct {
 	// Base-64 encoded pfx certificate. Only applicable in PUT Request.
@@ -1027,10 +1409,10 @@ type ApplicationGatewaySSLCertificatePropertiesFormat struct {
 // ApplicationGatewaySSLPolicy - Application Gateway Ssl policy.
 type ApplicationGatewaySSLPolicy struct {
 	// Ssl cipher suites to be enabled in the specified order to application gateway.
-	CipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites []*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
 
 	// Ssl protocols to be disabled on application gateway.
-	DisabledSSLProtocols *[]*ApplicationGatewaySSLProtocol `json:"disabledSslProtocols,omitempty"`
+	DisabledSSLProtocols []*ApplicationGatewaySSLProtocol `json:"disabledSslProtocols,omitempty"`
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
 	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
@@ -1040,6 +1422,17 @@ type ApplicationGatewaySSLPolicy struct {
 
 	// Type of Ssl Policy.
 	PolicyType *ApplicationGatewaySSLPolicyType `json:"policyType,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewaySSLPolicy.
+func (a ApplicationGatewaySSLPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "cipherSuites", a.CipherSuites)
+	populate(objectMap, "disabledSslProtocols", a.DisabledSSLProtocols)
+	populate(objectMap, "minProtocolVersion", a.MinProtocolVersion)
+	populate(objectMap, "policyName", a.PolicyName)
+	populate(objectMap, "policyType", a.PolicyType)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewaySSLPredefinedPolicy - An Ssl predefined policy.
@@ -1052,13 +1445,29 @@ type ApplicationGatewaySSLPredefinedPolicy struct {
 	Properties *ApplicationGatewaySSLPredefinedPolicyPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewaySSLPredefinedPolicy.
+func (a ApplicationGatewaySSLPredefinedPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewaySSLPredefinedPolicyPropertiesFormat - Properties of ApplicationGatewaySslPredefinedPolicy.
 type ApplicationGatewaySSLPredefinedPolicyPropertiesFormat struct {
 	// Ssl cipher suites to be enabled in the specified order for application gateway.
-	CipherSuites *[]*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites []*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
 	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewaySSLPredefinedPolicyPropertiesFormat.
+func (a ApplicationGatewaySSLPredefinedPolicyPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "cipherSuites", a.CipherSuites)
+	populate(objectMap, "minProtocolVersion", a.MinProtocolVersion)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewaySSLPredefinedPolicyResponse is the response envelope for operations that return a ApplicationGatewaySSLPredefinedPolicy type.
@@ -1084,6 +1493,16 @@ type ApplicationGatewayTrustedRootCertificate struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayTrustedRootCertificate.
+func (a ApplicationGatewayTrustedRootCertificate) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewayTrustedRootCertificatePropertiesFormat - Trusted Root certificates properties of an application gateway.
@@ -1126,6 +1545,16 @@ type ApplicationGatewayURLPathMap struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayURLPathMap.
+func (a ApplicationGatewayURLPathMap) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayURLPathMapPropertiesFormat - Properties of UrlPathMap of the application gateway.
 type ApplicationGatewayURLPathMapPropertiesFormat struct {
 	// Default backend address pool resource of URL path map.
@@ -1141,22 +1570,34 @@ type ApplicationGatewayURLPathMapPropertiesFormat struct {
 	DefaultRewriteRuleSet *SubResource `json:"defaultRewriteRuleSet,omitempty"`
 
 	// Path rule of URL path map resource.
-	PathRules *[]*ApplicationGatewayPathRule `json:"pathRules,omitempty"`
+	PathRules []*ApplicationGatewayPathRule `json:"pathRules,omitempty"`
 
 	// READ-ONLY; The provisioning state of the URL path map resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayURLPathMapPropertiesFormat.
+func (a ApplicationGatewayURLPathMapPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "defaultBackendAddressPool", a.DefaultBackendAddressPool)
+	populate(objectMap, "defaultBackendHttpSettings", a.DefaultBackendHTTPSettings)
+	populate(objectMap, "defaultRedirectConfiguration", a.DefaultRedirectConfiguration)
+	populate(objectMap, "defaultRewriteRuleSet", a.DefaultRewriteRuleSet)
+	populate(objectMap, "pathRules", a.PathRules)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationGatewayWebApplicationFirewallConfiguration - Application gateway web application firewall configuration.
 type ApplicationGatewayWebApplicationFirewallConfiguration struct {
 	// The disabled rule groups.
-	DisabledRuleGroups *[]*ApplicationGatewayFirewallDisabledRuleGroup `json:"disabledRuleGroups,omitempty"`
+	DisabledRuleGroups []*ApplicationGatewayFirewallDisabledRuleGroup `json:"disabledRuleGroups,omitempty"`
 
 	// Whether the web application firewall is enabled or not.
 	Enabled *bool `json:"enabled,omitempty"`
 
 	// The exclusion list.
-	Exclusions *[]*ApplicationGatewayFirewallExclusion `json:"exclusions,omitempty"`
+	Exclusions []*ApplicationGatewayFirewallExclusion `json:"exclusions,omitempty"`
 
 	// Maximum file upload size in Mb for WAF.
 	FileUploadLimitInMb *int32 `json:"fileUploadLimitInMb,omitempty"`
@@ -1178,6 +1619,22 @@ type ApplicationGatewayWebApplicationFirewallConfiguration struct {
 
 	// The version of the rule set type.
 	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationGatewayWebApplicationFirewallConfiguration.
+func (a ApplicationGatewayWebApplicationFirewallConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "disabledRuleGroups", a.DisabledRuleGroups)
+	populate(objectMap, "enabled", a.Enabled)
+	populate(objectMap, "exclusions", a.Exclusions)
+	populate(objectMap, "fileUploadLimitInMb", a.FileUploadLimitInMb)
+	populate(objectMap, "firewallMode", a.FirewallMode)
+	populate(objectMap, "maxRequestBodySize", a.MaxRequestBodySize)
+	populate(objectMap, "maxRequestBodySizeInKb", a.MaxRequestBodySizeInKb)
+	populate(objectMap, "requestBodyCheck", a.RequestBodyCheck)
+	populate(objectMap, "ruleSetType", a.RuleSetType)
+	populate(objectMap, "ruleSetVersion", a.RuleSetVersion)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationGatewaysBeginBackendHealthOnDemandOptions contains the optional parameters for the ApplicationGateways.BeginBackendHealthOnDemand method.
@@ -1272,22 +1729,22 @@ type ApplicationGatewaysUpdateTagsOptions struct {
 type ApplicationRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
 
 	// List of FQDN Tags for this rule condition.
-	FqdnTags *[]*string `json:"fqdnTags,omitempty"`
+	FqdnTags []*string `json:"fqdnTags,omitempty"`
 
 	// Array of Application Protocols.
-	Protocols *[]*FirewallPolicyRuleConditionApplicationProtocol `json:"protocols,omitempty"`
+	Protocols []*FirewallPolicyRuleConditionApplicationProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
 
 	// List of FQDNs for this rule condition.
-	TargetFqdns *[]*string `json:"targetFqdns,omitempty"`
+	TargetFqdns []*string `json:"targetFqdns,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ApplicationRuleCondition.
@@ -1347,13 +1804,29 @@ type ApplicationSecurityGroup struct {
 	Properties *ApplicationSecurityGroupPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ApplicationSecurityGroup.
+func (a ApplicationSecurityGroup) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ApplicationSecurityGroupListResult - A list of application security groups.
 type ApplicationSecurityGroupListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of application security groups.
-	Value *[]*ApplicationSecurityGroup `json:"value,omitempty"`
+	Value []*ApplicationSecurityGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ApplicationSecurityGroupListResult.
+func (a ApplicationSecurityGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // ApplicationSecurityGroupListResultResponse is the response envelope for operations that return a ApplicationSecurityGroupListResult type.
@@ -1433,7 +1906,15 @@ type AuthorizationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The authorizations in an ExpressRoute Circuit.
-	Value *[]*ExpressRouteCircuitAuthorization `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitAuthorization `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AuthorizationListResult.
+func (a AuthorizationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AuthorizationListResultResponse is the response envelope for operations that return a AuthorizationListResult type.
@@ -1469,7 +1950,15 @@ type AutoApprovedPrivateLinkServicesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of auto approved private link service.
-	Value *[]*AutoApprovedPrivateLinkService `json:"value,omitempty"`
+	Value []*AutoApprovedPrivateLinkService `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AutoApprovedPrivateLinkServicesResult.
+func (a AutoApprovedPrivateLinkServicesResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AutoApprovedPrivateLinkServicesResultResponse is the response envelope for operations that return a AutoApprovedPrivateLinkServicesResult type.
@@ -1496,7 +1985,7 @@ type Availability struct {
 // AvailableDelegation - The serviceName of an AvailableDelegation indicates a possible delegation for a subnet.
 type AvailableDelegation struct {
 	// The actions permitted to the service upon delegation.
-	Actions *[]*string `json:"actions,omitempty"`
+	Actions []*string `json:"actions,omitempty"`
 
 	// A unique identifier of the AvailableDelegation resource.
 	ID *string `json:"id,omitempty"`
@@ -1511,6 +2000,17 @@ type AvailableDelegation struct {
 	Type *string `json:"type,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AvailableDelegation.
+func (a AvailableDelegation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "actions", a.Actions)
+	populate(objectMap, "id", a.ID)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "serviceName", a.ServiceName)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // AvailableDelegationsListOptions contains the optional parameters for the AvailableDelegations.List method.
 type AvailableDelegationsListOptions struct {
 	// placeholder for future optional parameters
@@ -1522,7 +2022,15 @@ type AvailableDelegationsResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available delegations.
-	Value *[]*AvailableDelegation `json:"value,omitempty"`
+	Value []*AvailableDelegation `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableDelegationsResult.
+func (a AvailableDelegationsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AvailableDelegationsResultResponse is the response envelope for operations that return a AvailableDelegationsResult type.
@@ -1570,7 +2078,15 @@ type AvailablePrivateEndpointTypesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available privateEndpoint type.
-	Value *[]*AvailablePrivateEndpointType `json:"value,omitempty"`
+	Value []*AvailablePrivateEndpointType `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailablePrivateEndpointTypesResult.
+func (a AvailablePrivateEndpointTypesResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AvailablePrivateEndpointTypesResultResponse is the response envelope for operations that return a AvailablePrivateEndpointTypesResult type.
@@ -1585,7 +2101,14 @@ type AvailablePrivateEndpointTypesResultResponse struct {
 // AvailableProvidersList - List of available countries with details.
 type AvailableProvidersList struct {
 	// List of available countries.
-	Countries *[]*AvailableProvidersListCountry `json:"countries,omitempty"`
+	Countries []*AvailableProvidersListCountry `json:"countries,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableProvidersList.
+func (a AvailableProvidersList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "countries", a.Countries)
+	return json.Marshal(objectMap)
 }
 
 // AvailableProvidersListCity - City or town details.
@@ -1594,7 +2117,15 @@ type AvailableProvidersListCity struct {
 	CityName *string `json:"cityName,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]*string `json:"providers,omitempty"`
+	Providers []*string `json:"providers,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableProvidersListCity.
+func (a AvailableProvidersListCity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "cityName", a.CityName)
+	populate(objectMap, "providers", a.Providers)
+	return json.Marshal(objectMap)
 }
 
 // AvailableProvidersListCountry - Country details.
@@ -1603,16 +2134,25 @@ type AvailableProvidersListCountry struct {
 	CountryName *string `json:"countryName,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]*string `json:"providers,omitempty"`
+	Providers []*string `json:"providers,omitempty"`
 
 	// List of available states in the country.
-	States *[]*AvailableProvidersListState `json:"states,omitempty"`
+	States []*AvailableProvidersListState `json:"states,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableProvidersListCountry.
+func (a AvailableProvidersListCountry) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "countryName", a.CountryName)
+	populate(objectMap, "providers", a.Providers)
+	populate(objectMap, "states", a.States)
+	return json.Marshal(objectMap)
 }
 
 // AvailableProvidersListParameters - Constraints that determine the list of available Internet service providers.
 type AvailableProvidersListParameters struct {
 	// A list of Azure regions.
-	AzureLocations *[]*string `json:"azureLocations,omitempty"`
+	AzureLocations []*string `json:"azureLocations,omitempty"`
 
 	// The city or town for available providers list.
 	City *string `json:"city,omitempty"`
@@ -1622,6 +2162,16 @@ type AvailableProvidersListParameters struct {
 
 	// The state for available providers list.
 	State *string `json:"state,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableProvidersListParameters.
+func (a AvailableProvidersListParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "azureLocations", a.AzureLocations)
+	populate(objectMap, "city", a.City)
+	populate(objectMap, "country", a.Country)
+	populate(objectMap, "state", a.State)
+	return json.Marshal(objectMap)
 }
 
 // AvailableProvidersListPollerResponse is the response envelope for operations that asynchronously return a AvailableProvidersList type.
@@ -1648,13 +2198,22 @@ type AvailableProvidersListResponse struct {
 // AvailableProvidersListState - State details.
 type AvailableProvidersListState struct {
 	// List of available cities or towns in the state.
-	Cities *[]*AvailableProvidersListCity `json:"cities,omitempty"`
+	Cities []*AvailableProvidersListCity `json:"cities,omitempty"`
 
 	// A list of Internet service providers.
-	Providers *[]*string `json:"providers,omitempty"`
+	Providers []*string `json:"providers,omitempty"`
 
 	// The state name.
 	StateName *string `json:"stateName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableProvidersListState.
+func (a AvailableProvidersListState) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "cities", a.Cities)
+	populate(objectMap, "providers", a.Providers)
+	populate(objectMap, "stateName", a.StateName)
+	return json.Marshal(objectMap)
 }
 
 // AvailableResourceGroupDelegationsListOptions contains the optional parameters for the AvailableResourceGroupDelegations.List method.
@@ -1693,7 +2252,15 @@ type AvailableServiceAliasesResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// An array of available service aliases.
-	Value *[]*AvailableServiceAlias `json:"value,omitempty"`
+	Value []*AvailableServiceAlias `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AvailableServiceAliasesResult.
+func (a AvailableServiceAliasesResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AvailableServiceAliasesResultResponse is the response envelope for operations that return a AvailableServiceAliasesResult type.
@@ -1728,7 +2295,16 @@ type AzureFirewall struct {
 	Properties *AzureFirewallPropertiesFormat `json:"properties,omitempty"`
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewall.
+func (a AzureFirewall) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "zones", a.Zones)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallApplicationRule - Properties of an application rule.
@@ -1737,22 +2313,35 @@ type AzureFirewallApplicationRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of FQDN Tags for this rule.
-	FqdnTags *[]*string `json:"fqdnTags,omitempty"`
+	FqdnTags []*string `json:"fqdnTags,omitempty"`
 
 	// Name of the application rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of ApplicationRuleProtocols.
-	Protocols *[]*AzureFirewallApplicationRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallApplicationRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
 
 	// List of FQDNs for this rule.
-	TargetFqdns *[]*string `json:"targetFqdns,omitempty"`
+	TargetFqdns []*string `json:"targetFqdns,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallApplicationRule.
+func (a AzureFirewallApplicationRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", a.Description)
+	populate(objectMap, "fqdnTags", a.FqdnTags)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "protocols", a.Protocols)
+	populate(objectMap, "sourceAddresses", a.SourceAddresses)
+	populate(objectMap, "sourceIpGroups", a.SourceIPGroups)
+	populate(objectMap, "targetFqdns", a.TargetFqdns)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallApplicationRuleCollection - Application rule collection resource.
@@ -1768,6 +2357,15 @@ type AzureFirewallApplicationRuleCollection struct {
 	Properties *AzureFirewallApplicationRuleCollectionPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallApplicationRuleCollection.
+func (a AzureFirewallApplicationRuleCollection) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // AzureFirewallApplicationRuleCollectionPropertiesFormat - Properties of the application rule collection.
 type AzureFirewallApplicationRuleCollectionPropertiesFormat struct {
 	// The action type of a rule collection.
@@ -1780,7 +2378,17 @@ type AzureFirewallApplicationRuleCollectionPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a application rule collection.
-	Rules *[]*AzureFirewallApplicationRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallApplicationRule `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallApplicationRuleCollectionPropertiesFormat.
+func (a AzureFirewallApplicationRuleCollectionPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "action", a.Action)
+	populate(objectMap, "priority", a.Priority)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "rules", a.Rules)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallApplicationRuleProtocol - Properties of the application rule protocol.
@@ -1802,13 +2410,29 @@ type AzureFirewallFqdnTag struct {
 	Properties *AzureFirewallFqdnTagPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallFqdnTag.
+func (a AzureFirewallFqdnTag) MarshalJSON() ([]byte, error) {
+	objectMap := a.Resource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // AzureFirewallFqdnTagListResult - Response for ListAzureFirewallFqdnTags API service call.
 type AzureFirewallFqdnTagListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Azure Firewall FQDN Tags in a resource group.
-	Value *[]*AzureFirewallFqdnTag `json:"value,omitempty"`
+	Value []*AzureFirewallFqdnTag `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallFqdnTagListResult.
+func (a AzureFirewallFqdnTagListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallFqdnTagListResultResponse is the response envelope for operations that return a AzureFirewallFqdnTagListResult type.
@@ -1850,6 +2474,16 @@ type AzureFirewallIPConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallIPConfiguration.
+func (a AzureFirewallIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	populate(objectMap, "type", a.Type)
+	return json.Marshal(objectMap)
+}
+
 // AzureFirewallIPConfigurationPropertiesFormat - Properties of IP configuration of an Azure Firewall.
 type AzureFirewallIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes.
@@ -1880,7 +2514,15 @@ type AzureFirewallListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Azure Firewalls in a resource group.
-	Value *[]*AzureFirewall `json:"value,omitempty"`
+	Value []*AzureFirewall `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallListResult.
+func (a AzureFirewallListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", a.NextLink)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallListResultResponse is the response envelope for operations that return a AzureFirewallListResult type.
@@ -1904,22 +2546,22 @@ type AzureFirewallNatRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of destination IP addresses for this rule. Supports IP ranges, prefixes, and service tags.
-	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string `json:"destinationPorts,omitempty"`
 
 	// Name of the NAT rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule.
-	Protocols *[]*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
 
 	// The translated address for this NAT rule.
 	TranslatedAddress *string `json:"translatedAddress,omitempty"`
@@ -1929,6 +2571,22 @@ type AzureFirewallNatRule struct {
 
 	// The translated port for this NAT rule.
 	TranslatedPort *string `json:"translatedPort,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNatRule.
+func (a AzureFirewallNatRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", a.Description)
+	populate(objectMap, "destinationAddresses", a.DestinationAddresses)
+	populate(objectMap, "destinationPorts", a.DestinationPorts)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "protocols", a.Protocols)
+	populate(objectMap, "sourceAddresses", a.SourceAddresses)
+	populate(objectMap, "sourceIpGroups", a.SourceIPGroups)
+	populate(objectMap, "translatedAddress", a.TranslatedAddress)
+	populate(objectMap, "translatedFqdn", a.TranslatedFqdn)
+	populate(objectMap, "translatedPort", a.TranslatedPort)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallNatRuleCollection - NAT rule collection resource.
@@ -1944,6 +2602,15 @@ type AzureFirewallNatRuleCollection struct {
 	Properties *AzureFirewallNatRuleCollectionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNatRuleCollection.
+func (a AzureFirewallNatRuleCollection) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // AzureFirewallNatRuleCollectionProperties - Properties of the NAT rule collection.
 type AzureFirewallNatRuleCollectionProperties struct {
 	// The action type of a NAT rule collection.
@@ -1956,7 +2623,17 @@ type AzureFirewallNatRuleCollectionProperties struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a NAT rule collection.
-	Rules *[]*AzureFirewallNatRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallNatRule `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNatRuleCollectionProperties.
+func (a AzureFirewallNatRuleCollectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "action", a.Action)
+	populate(objectMap, "priority", a.Priority)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "rules", a.Rules)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallNetworkRule - Properties of the network rule.
@@ -1965,28 +2642,43 @@ type AzureFirewallNetworkRule struct {
 	Description *string `json:"description,omitempty"`
 
 	// List of destination IP addresses.
-	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination FQDNs.
-	DestinationFqdns *[]*string `json:"destinationFqdns,omitempty"`
+	DestinationFqdns []*string `json:"destinationFqdns,omitempty"`
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups *[]*string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string `json:"destinationPorts,omitempty"`
 
 	// Name of the network rule.
 	Name *string `json:"name,omitempty"`
 
 	// Array of AzureFirewallNetworkRuleProtocols.
-	Protocols *[]*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNetworkRule.
+func (a AzureFirewallNetworkRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", a.Description)
+	populate(objectMap, "destinationAddresses", a.DestinationAddresses)
+	populate(objectMap, "destinationFqdns", a.DestinationFqdns)
+	populate(objectMap, "destinationIpGroups", a.DestinationIPGroups)
+	populate(objectMap, "destinationPorts", a.DestinationPorts)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "protocols", a.Protocols)
+	populate(objectMap, "sourceAddresses", a.SourceAddresses)
+	populate(objectMap, "sourceIpGroups", a.SourceIPGroups)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallNetworkRuleCollection - Network rule collection resource.
@@ -2002,6 +2694,15 @@ type AzureFirewallNetworkRuleCollection struct {
 	Properties *AzureFirewallNetworkRuleCollectionPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNetworkRuleCollection.
+func (a AzureFirewallNetworkRuleCollection) MarshalJSON() ([]byte, error) {
+	objectMap := a.SubResource.marshalInternal()
+	populate(objectMap, "etag", a.Etag)
+	populate(objectMap, "name", a.Name)
+	populate(objectMap, "properties", a.Properties)
+	return json.Marshal(objectMap)
+}
+
 // AzureFirewallNetworkRuleCollectionPropertiesFormat - Properties of the network rule collection.
 type AzureFirewallNetworkRuleCollectionPropertiesFormat struct {
 	// The action type of a rule collection.
@@ -2014,7 +2715,17 @@ type AzureFirewallNetworkRuleCollectionPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of rules used by a network rule collection.
-	Rules *[]*AzureFirewallNetworkRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallNetworkRule `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallNetworkRuleCollectionPropertiesFormat.
+func (a AzureFirewallNetworkRuleCollectionPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "action", a.Action)
+	populate(objectMap, "priority", a.Priority)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "rules", a.Rules)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallPollerResponse is the response envelope for operations that asynchronously return a AzureFirewall type.
@@ -2032,10 +2743,10 @@ type AzureFirewallPollerResponse struct {
 // AzureFirewallPropertiesFormat - Properties of the Azure Firewall.
 type AzureFirewallPropertiesFormat struct {
 	// The additional properties used to further config this azure firewall.
-	AdditionalProperties *map[string]*string `json:"additionalProperties,omitempty"`
+	AdditionalProperties map[string]*string `json:"additionalProperties,omitempty"`
 
 	// Collection of application rule collections used by Azure Firewall.
-	ApplicationRuleCollections *[]*AzureFirewallApplicationRuleCollection `json:"applicationRuleCollections,omitempty"`
+	ApplicationRuleCollections []*AzureFirewallApplicationRuleCollection `json:"applicationRuleCollections,omitempty"`
 
 	// The firewallPolicy associated with this azure firewall.
 	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
@@ -2044,19 +2755,19 @@ type AzureFirewallPropertiesFormat struct {
 	HubIPAddresses *HubIPAddresses `json:"hubIpAddresses,omitempty" azure:"ro"`
 
 	// IP configuration of the Azure Firewall resource.
-	IPConfigurations *[]*AzureFirewallIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*AzureFirewallIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; IpGroups associated with AzureFirewall.
-	IPGroups *[]*AzureFirewallIPGroups `json:"ipGroups,omitempty" azure:"ro"`
+	IPGroups []*AzureFirewallIPGroups `json:"ipGroups,omitempty" azure:"ro"`
 
 	// IP configuration of the Azure Firewall used for management traffic.
 	ManagementIPConfiguration *AzureFirewallIPConfiguration `json:"managementIpConfiguration,omitempty"`
 
 	// Collection of NAT rule collections used by Azure Firewall.
-	NatRuleCollections *[]*AzureFirewallNatRuleCollection `json:"natRuleCollections,omitempty"`
+	NatRuleCollections []*AzureFirewallNatRuleCollection `json:"natRuleCollections,omitempty"`
 
 	// Collection of network rule collections used by Azure Firewall.
-	NetworkRuleCollections *[]*AzureFirewallNetworkRuleCollection `json:"networkRuleCollections,omitempty"`
+	NetworkRuleCollections []*AzureFirewallNetworkRuleCollection `json:"networkRuleCollections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the Azure firewall resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -2069,6 +2780,25 @@ type AzureFirewallPropertiesFormat struct {
 
 	// The virtualHub to which the firewall belongs.
 	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFirewallPropertiesFormat.
+func (a AzureFirewallPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalProperties", a.AdditionalProperties)
+	populate(objectMap, "applicationRuleCollections", a.ApplicationRuleCollections)
+	populate(objectMap, "firewallPolicy", a.FirewallPolicy)
+	populate(objectMap, "hubIpAddresses", a.HubIPAddresses)
+	populate(objectMap, "ipConfigurations", a.IPConfigurations)
+	populate(objectMap, "ipGroups", a.IPGroups)
+	populate(objectMap, "managementIpConfiguration", a.ManagementIPConfiguration)
+	populate(objectMap, "natRuleCollections", a.NatRuleCollections)
+	populate(objectMap, "networkRuleCollections", a.NetworkRuleCollections)
+	populate(objectMap, "provisioningState", a.ProvisioningState)
+	populate(objectMap, "sku", a.SKU)
+	populate(objectMap, "threatIntelMode", a.ThreatIntelMode)
+	populate(objectMap, "virtualHub", a.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // AzureFirewallPublicIPAddress - Public IP Address associated with azure firewall.
@@ -2140,7 +2870,16 @@ type AzureReachabilityReport struct {
 	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
 
 	// List of Azure reachability report items.
-	ReachabilityReport *[]*AzureReachabilityReportItem `json:"reachabilityReport,omitempty"`
+	ReachabilityReport []*AzureReachabilityReportItem `json:"reachabilityReport,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureReachabilityReport.
+func (a AzureReachabilityReport) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aggregationLevel", a.AggregationLevel)
+	populate(objectMap, "providerLocation", a.ProviderLocation)
+	populate(objectMap, "reachabilityReport", a.ReachabilityReport)
+	return json.Marshal(objectMap)
 }
 
 // AzureReachabilityReportItem - Azure reachability report details for a given provider location.
@@ -2149,10 +2888,19 @@ type AzureReachabilityReportItem struct {
 	AzureLocation *string `json:"azureLocation,omitempty"`
 
 	// List of latency details for each of the time series.
-	Latencies *[]*AzureReachabilityReportLatencyInfo `json:"latencies,omitempty"`
+	Latencies []*AzureReachabilityReportLatencyInfo `json:"latencies,omitempty"`
 
 	// The Internet service provider.
 	Provider *string `json:"provider,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureReachabilityReportItem.
+func (a AzureReachabilityReportItem) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "azureLocation", a.AzureLocation)
+	populate(objectMap, "latencies", a.Latencies)
+	populate(objectMap, "provider", a.Provider)
+	return json.Marshal(objectMap)
 }
 
 // AzureReachabilityReportLatencyInfo - Details on latency for a time series.
@@ -2212,7 +2960,7 @@ type AzureReachabilityReportLocation struct {
 // AzureReachabilityReportParameters - Geographic and time constraints for Azure reachability report.
 type AzureReachabilityReportParameters struct {
 	// Optional Azure regions to scope the query to.
-	AzureLocations *[]*string `json:"azureLocations,omitempty"`
+	AzureLocations []*string `json:"azureLocations,omitempty"`
 
 	// The end time for the Azure reachability report.
 	EndTime *time.Time `json:"endTime,omitempty"`
@@ -2221,7 +2969,7 @@ type AzureReachabilityReportParameters struct {
 	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
 
 	// List of Internet service providers.
-	Providers *[]*string `json:"providers,omitempty"`
+	Providers []*string `json:"providers,omitempty"`
 
 	// The start time for the Azure reachability report.
 	StartTime *time.Time `json:"startTime,omitempty"`
@@ -2301,7 +3049,7 @@ type BGPCommunity struct {
 	CommunityName *string `json:"communityName,omitempty"`
 
 	// The prefixes that the bgp community contains.
-	CommunityPrefixes *[]*string `json:"communityPrefixes,omitempty"`
+	CommunityPrefixes []*string `json:"communityPrefixes,omitempty"`
 
 	// The value of the bgp community. For more information: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing.
 	CommunityValue *string `json:"communityValue,omitempty"`
@@ -2314,6 +3062,18 @@ type BGPCommunity struct {
 
 	// The region which the service support. e.g. For O365, region is Global.
 	ServiceSupportedRegion *string `json:"serviceSupportedRegion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BGPCommunity.
+func (b BGPCommunity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "communityName", b.CommunityName)
+	populate(objectMap, "communityPrefixes", b.CommunityPrefixes)
+	populate(objectMap, "communityValue", b.CommunityValue)
+	populate(objectMap, "isAuthorizedToUse", b.IsAuthorizedToUse)
+	populate(objectMap, "serviceGroup", b.ServiceGroup)
+	populate(objectMap, "serviceSupportedRegion", b.ServiceSupportedRegion)
+	return json.Marshal(objectMap)
 }
 
 // BackendAddressPool - Pool of backend IP addresses.
@@ -2332,22 +3092,43 @@ type BackendAddressPool struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BackendAddressPool.
+func (b BackendAddressPool) MarshalJSON() ([]byte, error) {
+	objectMap := b.SubResource.marshalInternal()
+	populate(objectMap, "etag", b.Etag)
+	populate(objectMap, "name", b.Name)
+	populate(objectMap, "properties", b.Properties)
+	populate(objectMap, "type", b.Type)
+	return json.Marshal(objectMap)
+}
+
 // BackendAddressPoolPropertiesFormat - Properties of the backend address pool.
 type BackendAddressPoolPropertiesFormat struct {
 	// READ-ONLY; An array of references to IP addresses defined in network interfaces.
-	BackendIPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*NetworkInterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to load balancing rules that use this backend address pool.
-	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; A reference to an outbound rule that uses this backend address pool.
 	OutboundRule *SubResource `json:"outboundRule,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to outbound rules that use this backend address pool.
-	OutboundRules *[]*SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules []*SubResource `json:"outboundRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BackendAddressPoolPropertiesFormat.
+func (b BackendAddressPoolPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendIPConfigurations", b.BackendIPConfigurations)
+	populate(objectMap, "loadBalancingRules", b.LoadBalancingRules)
+	populate(objectMap, "outboundRule", b.OutboundRule)
+	populate(objectMap, "outboundRules", b.OutboundRules)
+	populate(objectMap, "provisioningState", b.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // BackendAddressPoolResponse is the response envelope for operations that return a BackendAddressPool type.
@@ -2401,7 +3182,15 @@ type BastionActiveSessionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of active sessions on the bastion.
-	Value *[]*BastionActiveSession `json:"value,omitempty"`
+	Value []*BastionActiveSession `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionActiveSessionListResult.
+func (b BastionActiveSessionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BastionActiveSessionListResultPagerPollerResponse is the response envelope for operations that asynchronously return a BastionActiveSessionListResultPager
@@ -2436,6 +3225,14 @@ type BastionHost struct {
 	Properties *BastionHostPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BastionHost.
+func (b BastionHost) MarshalJSON() ([]byte, error) {
+	objectMap := b.Resource.marshalInternal()
+	populate(objectMap, "etag", b.Etag)
+	populate(objectMap, "properties", b.Properties)
+	return json.Marshal(objectMap)
+}
+
 // BastionHostIPConfiguration - IP configuration of an Bastion Host.
 type BastionHostIPConfiguration struct {
 	SubResource
@@ -2450,6 +3247,16 @@ type BastionHostIPConfiguration struct {
 
 	// READ-ONLY; Ip configuration type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionHostIPConfiguration.
+func (b BastionHostIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := b.SubResource.marshalInternal()
+	populate(objectMap, "etag", b.Etag)
+	populate(objectMap, "name", b.Name)
+	populate(objectMap, "properties", b.Properties)
+	populate(objectMap, "type", b.Type)
+	return json.Marshal(objectMap)
 }
 
 // BastionHostIPConfigurationPropertiesFormat - Properties of IP configuration of an Bastion Host.
@@ -2473,7 +3280,15 @@ type BastionHostListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Bastion Hosts in a resource group.
-	Value *[]*BastionHost `json:"value,omitempty"`
+	Value []*BastionHost `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionHostListResult.
+func (b BastionHostListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BastionHostListResultResponse is the response envelope for operations that return a BastionHostListResult type.
@@ -2503,10 +3318,19 @@ type BastionHostPropertiesFormat struct {
 	DNSName *string `json:"dnsName,omitempty"`
 
 	// IP configuration of the Bastion Host resource.
-	IPConfigurations *[]*BastionHostIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*BastionHostIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the bastion host resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionHostPropertiesFormat.
+func (b BastionHostPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsName", b.DNSName)
+	populate(objectMap, "ipConfigurations", b.IPConfigurations)
+	populate(objectMap, "provisioningState", b.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // BastionHostResponse is the response envelope for operations that return a BastionHost type.
@@ -2549,7 +3373,15 @@ type BastionSessionDeleteResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of sessions with their corresponding state.
-	Value *[]*BastionSessionState `json:"value,omitempty"`
+	Value []*BastionSessionState `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionSessionDeleteResult.
+func (b BastionSessionDeleteResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BastionSessionDeleteResultResponse is the response envelope for operations that return a BastionSessionDeleteResult type.
@@ -2591,7 +3423,14 @@ type BastionShareableLink struct {
 // BastionShareableLinkListRequest - Post request for all the Bastion Shareable Link endpoints.
 type BastionShareableLinkListRequest struct {
 	// List of VM references.
-	VMs *[]*BastionShareableLink `json:"vms,omitempty"`
+	VMs []*BastionShareableLink `json:"vms,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionShareableLinkListRequest.
+func (b BastionShareableLinkListRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "vms", b.VMs)
+	return json.Marshal(objectMap)
 }
 
 // BastionShareableLinkListResult - Response for all the Bastion Shareable Link endpoints.
@@ -2600,7 +3439,15 @@ type BastionShareableLinkListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Bastion Shareable Links for the request.
-	Value *[]*BastionShareableLink `json:"value,omitempty"`
+	Value []*BastionShareableLink `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BastionShareableLinkListResult.
+func (b BastionShareableLinkListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BastionShareableLinkListResultPagerPollerResponse is the response envelope for operations that asynchronously return a BastionShareableLinkListResultPager
@@ -2655,7 +3502,14 @@ type BgpPeerStatus struct {
 // BgpPeerStatusListResult - Response for list BGP peer status API service call.
 type BgpPeerStatusListResult struct {
 	// List of BGP peers.
-	Value *[]*BgpPeerStatus `json:"value,omitempty"`
+	Value []*BgpPeerStatus `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BgpPeerStatusListResult.
+func (b BgpPeerStatusListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BgpPeerStatusListResultPollerResponse is the response envelope for operations that asynchronously return a BgpPeerStatusListResult type.
@@ -2691,13 +3545,28 @@ type BgpServiceCommunity struct {
 	Properties *BgpServiceCommunityPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BgpServiceCommunity.
+func (b BgpServiceCommunity) MarshalJSON() ([]byte, error) {
+	objectMap := b.Resource.marshalInternal()
+	populate(objectMap, "properties", b.Properties)
+	return json.Marshal(objectMap)
+}
+
 // BgpServiceCommunityListResult - Response for the ListServiceCommunity API service call.
 type BgpServiceCommunityListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of service community resources.
-	Value *[]*BgpServiceCommunity `json:"value,omitempty"`
+	Value []*BgpServiceCommunity `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BgpServiceCommunityListResult.
+func (b BgpServiceCommunityListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BgpServiceCommunityListResultResponse is the response envelope for operations that return a BgpServiceCommunityListResult type.
@@ -2712,10 +3581,18 @@ type BgpServiceCommunityListResultResponse struct {
 // BgpServiceCommunityPropertiesFormat - Properties of Service Community.
 type BgpServiceCommunityPropertiesFormat struct {
 	// A list of bgp communities.
-	BgpCommunities *[]*BGPCommunity `json:"bgpCommunities,omitempty"`
+	BgpCommunities []*BGPCommunity `json:"bgpCommunities,omitempty"`
 
 	// The name of the bgp community. e.g. Skype.
 	ServiceName *string `json:"serviceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BgpServiceCommunityPropertiesFormat.
+func (b BgpServiceCommunityPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bgpCommunities", b.BgpCommunities)
+	populate(objectMap, "serviceName", b.ServiceName)
+	return json.Marshal(objectMap)
 }
 
 // BgpSettings - BGP settings details.
@@ -2727,10 +3604,20 @@ type BgpSettings struct {
 	BgpPeeringAddress *string `json:"bgpPeeringAddress,omitempty"`
 
 	// BGP peering address with IP configuration ID for virtual network gateway.
-	BgpPeeringAddresses *[]*IPConfigurationBgpPeeringAddress `json:"bgpPeeringAddresses,omitempty"`
+	BgpPeeringAddresses []*IPConfigurationBgpPeeringAddress `json:"bgpPeeringAddresses,omitempty"`
 
 	// The weight added to routes learned from this BGP speaker.
 	PeerWeight *int32 `json:"peerWeight,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BgpSettings.
+func (b BgpSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "asn", b.Asn)
+	populate(objectMap, "bgpPeeringAddress", b.BgpPeeringAddress)
+	populate(objectMap, "bgpPeeringAddresses", b.BgpPeeringAddresses)
+	populate(objectMap, "peerWeight", b.PeerWeight)
+	return json.Marshal(objectMap)
 }
 
 // CheckPrivateLinkServiceVisibilityRequest - Request body of the CheckPrivateLinkServiceVisibility API service call.
@@ -2759,13 +3646,23 @@ type CloudErrorBody struct {
 	Code *string `json:"code,omitempty"`
 
 	// A list of additional details about the error.
-	Details *[]*CloudErrorBody `json:"details,omitempty"`
+	Details []*CloudErrorBody `json:"details,omitempty"`
 
 	// A message describing the error, intended to be suitable for display in a user interface.
 	Message *string `json:"message,omitempty"`
 
 	// The target of the particular error. For example, the name of the property in error.
 	Target *string `json:"target,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CloudErrorBody.
+func (c CloudErrorBody) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "code", c.Code)
+	populate(objectMap, "details", c.Details)
+	populate(objectMap, "message", c.Message)
+	populate(objectMap, "target", c.Target)
+	return json.Marshal(objectMap)
 }
 
 type Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties struct {
@@ -2785,7 +3682,16 @@ type ConnectionMonitor struct {
 	Properties *ConnectionMonitorParameters `json:"properties,omitempty"`
 
 	// Connection monitor tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitor.
+func (c ConnectionMonitor) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "location", c.Location)
+	populate(objectMap, "properties", c.Properties)
+	populate(objectMap, "tags", c.Tags)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorDestination - Describes the destination of connection monitor.
@@ -2818,10 +3724,18 @@ type ConnectionMonitorEndpoint struct {
 // ConnectionMonitorEndpointFilter - Describes the connection monitor endpoint filter.
 type ConnectionMonitorEndpointFilter struct {
 	// List of items in the filter.
-	Items *[]*ConnectionMonitorEndpointFilterItem `json:"items,omitempty"`
+	Items []*ConnectionMonitorEndpointFilterItem `json:"items,omitempty"`
 
 	// The behavior of the endpoint filter. Currently only 'Include' is supported.
 	Type *ConnectionMonitorEndpointFilterType `json:"type,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorEndpointFilter.
+func (c ConnectionMonitorEndpointFilter) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "items", c.Items)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorEndpointFilterItem - Describes the connection monitor endpoint filter item.
@@ -2848,10 +3762,22 @@ type ConnectionMonitorHTTPConfiguration struct {
 	PreferHTTPS *bool `json:"preferHTTPS,omitempty"`
 
 	// The HTTP headers to transmit with the request.
-	RequestHeaders *[]*HTTPHeader `json:"requestHeaders,omitempty"`
+	RequestHeaders []*HTTPHeader `json:"requestHeaders,omitempty"`
 
 	// HTTP status codes to consider successful. For instance, "2xx,301-304,418".
-	ValidStatusCodeRanges *[]*string `json:"validStatusCodeRanges,omitempty"`
+	ValidStatusCodeRanges []*string `json:"validStatusCodeRanges,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorHTTPConfiguration.
+func (c ConnectionMonitorHTTPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "method", c.Method)
+	populate(objectMap, "path", c.Path)
+	populate(objectMap, "port", c.Port)
+	populate(objectMap, "preferHTTPS", c.PreferHTTPS)
+	populate(objectMap, "requestHeaders", c.RequestHeaders)
+	populate(objectMap, "validStatusCodeRanges", c.ValidStatusCodeRanges)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorIcmpConfiguration - Describes the ICMP configuration.
@@ -2863,7 +3789,14 @@ type ConnectionMonitorIcmpConfiguration struct {
 // ConnectionMonitorListResult - List of connection monitors.
 type ConnectionMonitorListResult struct {
 	// Information about connection monitors.
-	Value *[]*ConnectionMonitorResult `json:"value,omitempty"`
+	Value []*ConnectionMonitorResult `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorListResult.
+func (c ConnectionMonitorListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", c.Value)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorListResultResponse is the response envelope for operations that return a ConnectionMonitorListResult type.
@@ -2893,7 +3826,7 @@ type ConnectionMonitorParameters struct {
 	Destination *ConnectionMonitorDestination `json:"destination,omitempty"`
 
 	// List of connection monitor endpoints.
-	Endpoints *[]*ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
+	Endpoints []*ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
 
 	// Monitoring interval in seconds.
 	MonitoringIntervalInSeconds *int32 `json:"monitoringIntervalInSeconds,omitempty"`
@@ -2902,16 +3835,31 @@ type ConnectionMonitorParameters struct {
 	Notes *string `json:"notes,omitempty"`
 
 	// List of connection monitor outputs.
-	Outputs *[]*ConnectionMonitorOutput `json:"outputs,omitempty"`
+	Outputs []*ConnectionMonitorOutput `json:"outputs,omitempty"`
 
 	// Describes the source of connection monitor.
 	Source *ConnectionMonitorSource `json:"source,omitempty"`
 
 	// List of connection monitor test configurations.
-	TestConfigurations *[]*ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
+	TestConfigurations []*ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
 
 	// List of connection monitor test groups.
-	TestGroups *[]*ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
+	TestGroups []*ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorParameters.
+func (c ConnectionMonitorParameters) MarshalJSON() ([]byte, error) {
+	objectMap := c.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ConnectionMonitorParameters.
+func (c *ConnectionMonitorParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	return c.unmarshalInternal(rawMsg)
 }
 
 func (c ConnectionMonitorParameters) marshalInternal() map[string]interface{} {
@@ -2973,7 +3921,15 @@ type ConnectionMonitorQueryResult struct {
 	SourceStatus *ConnectionMonitorSourceStatus `json:"sourceStatus,omitempty"`
 
 	// Information about connection states.
-	States *[]*ConnectionStateSnapshot `json:"states,omitempty"`
+	States []*ConnectionStateSnapshot `json:"states,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorQueryResult.
+func (c ConnectionMonitorQueryResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "sourceStatus", c.SourceStatus)
+	populate(objectMap, "states", c.States)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorQueryResultPollerResponse is the response envelope for operations that asynchronously return a ConnectionMonitorQueryResult type.
@@ -3015,10 +3971,23 @@ type ConnectionMonitorResult struct {
 	Properties *ConnectionMonitorResultProperties `json:"properties,omitempty"`
 
 	// Connection monitor tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Connection monitor type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorResult.
+func (c ConnectionMonitorResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "etag", c.Etag)
+	populate(objectMap, "id", c.ID)
+	populate(objectMap, "location", c.Location)
+	populate(objectMap, "name", c.Name)
+	populate(objectMap, "properties", c.Properties)
+	populate(objectMap, "tags", c.Tags)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorResultPollerResponse is the response envelope for operations that asynchronously return a ConnectionMonitorResult type.
@@ -3156,7 +4125,7 @@ type ConnectionMonitorTestConfiguration struct {
 // ConnectionMonitorTestGroup - Describes the connection monitor test group.
 type ConnectionMonitorTestGroup struct {
 	// List of destination endpoint names.
-	Destinations *[]*string `json:"destinations,omitempty"`
+	Destinations []*string `json:"destinations,omitempty"`
 
 	// Value indicating whether test group is disabled.
 	Disable *bool `json:"disable,omitempty"`
@@ -3165,10 +4134,21 @@ type ConnectionMonitorTestGroup struct {
 	Name *string `json:"name,omitempty"`
 
 	// List of source endpoint names.
-	Sources *[]*string `json:"sources,omitempty"`
+	Sources []*string `json:"sources,omitempty"`
 
 	// List of test configuration names.
-	TestConfigurations *[]*string `json:"testConfigurations,omitempty"`
+	TestConfigurations []*string `json:"testConfigurations,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectionMonitorTestGroup.
+func (c ConnectionMonitorTestGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "destinations", c.Destinations)
+	populate(objectMap, "disable", c.Disable)
+	populate(objectMap, "name", c.Name)
+	populate(objectMap, "sources", c.Sources)
+	populate(objectMap, "testConfigurations", c.TestConfigurations)
+	return json.Marshal(objectMap)
 }
 
 // ConnectionMonitorWorkspaceSettings - Describes the settings for producing output into a log analytics workspace.
@@ -3251,6 +4231,13 @@ type ConnectionSharedKey struct {
 	Value *string `json:"value,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ConnectionSharedKey.
+func (c ConnectionSharedKey) MarshalJSON() ([]byte, error) {
+	objectMap := c.SubResource.marshalInternal()
+	populate(objectMap, "value", c.Value)
+	return json.Marshal(objectMap)
+}
+
 // ConnectionSharedKeyPollerResponse is the response envelope for operations that asynchronously return a ConnectionSharedKey type.
 type ConnectionSharedKeyPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -3287,7 +4274,7 @@ type ConnectionStateSnapshot struct {
 	EvaluationState *EvaluationState `json:"evaluationState,omitempty"`
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops *[]*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops []*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
 
 	// Maximum latency in ms.
 	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty"`
@@ -3393,16 +4380,28 @@ type ConnectivityHop struct {
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of issues.
-	Issues *[]*ConnectivityIssue `json:"issues,omitempty" azure:"ro"`
+	Issues []*ConnectivityIssue `json:"issues,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of next hop identifiers.
-	NextHopIDs *[]*string `json:"nextHopIds,omitempty" azure:"ro"`
+	NextHopIDs []*string `json:"nextHopIds,omitempty" azure:"ro"`
 
 	// READ-ONLY; The ID of the resource corresponding to this hop.
 	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
 
 	// READ-ONLY; The type of the hop.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectivityHop.
+func (c ConnectivityHop) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "address", c.Address)
+	populate(objectMap, "id", c.ID)
+	populate(objectMap, "issues", c.Issues)
+	populate(objectMap, "nextHopIds", c.NextHopIDs)
+	populate(objectMap, "resourceId", c.ResourceID)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
 }
 
 // ConnectivityInformation - Information on the connectivity status.
@@ -3414,7 +4413,7 @@ type ConnectivityInformation struct {
 	ConnectionStatus *ConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops *[]*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops []*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
 
 	// READ-ONLY; Maximum latency in milliseconds.
 	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty" azure:"ro"`
@@ -3427,6 +4426,19 @@ type ConnectivityInformation struct {
 
 	// READ-ONLY; Total number of probes sent.
 	ProbesSent *int32 `json:"probesSent,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectivityInformation.
+func (c ConnectivityInformation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "avgLatencyInMs", c.AvgLatencyInMs)
+	populate(objectMap, "connectionStatus", c.ConnectionStatus)
+	populate(objectMap, "hops", c.Hops)
+	populate(objectMap, "maxLatencyInMs", c.MaxLatencyInMs)
+	populate(objectMap, "minLatencyInMs", c.MinLatencyInMs)
+	populate(objectMap, "probesFailed", c.ProbesFailed)
+	populate(objectMap, "probesSent", c.ProbesSent)
+	return json.Marshal(objectMap)
 }
 
 // ConnectivityInformationPollerResponse is the response envelope for operations that asynchronously return a ConnectivityInformation type.
@@ -3453,7 +4465,7 @@ type ConnectivityInformationResponse struct {
 // ConnectivityIssue - Information about an issue encountered in the process of checking for connectivity.
 type ConnectivityIssue struct {
 	// READ-ONLY; Provides additional context on the issue.
-	Context *[]map[string]*string `json:"context,omitempty" azure:"ro"`
+	Context []map[string]*string `json:"context,omitempty" azure:"ro"`
 
 	// READ-ONLY; The origin of the issue.
 	Origin *Origin `json:"origin,omitempty" azure:"ro"`
@@ -3463,6 +4475,16 @@ type ConnectivityIssue struct {
 
 	// READ-ONLY; The type of issue.
 	Type *IssueType `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ConnectivityIssue.
+func (c ConnectivityIssue) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "context", c.Context)
+	populate(objectMap, "origin", c.Origin)
+	populate(objectMap, "severity", c.Severity)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
 }
 
 // ConnectivityParameters - Parameters that determine how the connectivity check will be performed.
@@ -3513,6 +4535,16 @@ type ContainerNetworkInterface struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ContainerNetworkInterface.
+func (c ContainerNetworkInterface) MarshalJSON() ([]byte, error) {
+	objectMap := c.SubResource.marshalInternal()
+	populate(objectMap, "etag", c.Etag)
+	populate(objectMap, "name", c.Name)
+	populate(objectMap, "properties", c.Properties)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
+}
+
 // ContainerNetworkInterfaceConfiguration - Container network interface configuration child resource.
 type ContainerNetworkInterfaceConfiguration struct {
 	SubResource
@@ -3529,16 +4561,35 @@ type ContainerNetworkInterfaceConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ContainerNetworkInterfaceConfiguration.
+func (c ContainerNetworkInterfaceConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := c.SubResource.marshalInternal()
+	populate(objectMap, "etag", c.Etag)
+	populate(objectMap, "name", c.Name)
+	populate(objectMap, "properties", c.Properties)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
+}
+
 // ContainerNetworkInterfaceConfigurationPropertiesFormat - Container network interface configuration properties.
 type ContainerNetworkInterfaceConfigurationPropertiesFormat struct {
 	// A list of container network interfaces created from this container network interface configuration.
-	ContainerNetworkInterfaces *[]*SubResource `json:"containerNetworkInterfaces,omitempty"`
+	ContainerNetworkInterfaces []*SubResource `json:"containerNetworkInterfaces,omitempty"`
 
 	// A list of ip configurations of the container network interface configuration.
-	IPConfigurations *[]*IPConfigurationProfile `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*IPConfigurationProfile `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the container network interface configuration resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerNetworkInterfaceConfigurationPropertiesFormat.
+func (c ContainerNetworkInterfaceConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "containerNetworkInterfaces", c.ContainerNetworkInterfaces)
+	populate(objectMap, "ipConfigurations", c.IPConfigurations)
+	populate(objectMap, "provisioningState", c.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ContainerNetworkInterfaceIPConfiguration - The ip configuration for a container network interface.
@@ -3571,10 +4622,20 @@ type ContainerNetworkInterfacePropertiesFormat struct {
 	ContainerNetworkInterfaceConfiguration *ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfiguration,omitempty" azure:"ro"`
 
 	// READ-ONLY; Reference to the ip configuration on this container nic.
-	IPConfigurations *[]*ContainerNetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations []*ContainerNetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the container network interface resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ContainerNetworkInterfacePropertiesFormat.
+func (c ContainerNetworkInterfacePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "container", c.Container)
+	populate(objectMap, "containerNetworkInterfaceConfiguration", c.ContainerNetworkInterfaceConfiguration)
+	populate(objectMap, "ipConfigurations", c.IPConfigurations)
+	populate(objectMap, "provisioningState", c.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // CustomDNSConfigPropertiesFormat - Contains custom Dns resolution configuration from customer.
@@ -3583,7 +4644,15 @@ type CustomDNSConfigPropertiesFormat struct {
 	Fqdn *string `json:"fqdn,omitempty"`
 
 	// A list of private ip addresses of the private endpoint.
-	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string `json:"ipAddresses,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CustomDNSConfigPropertiesFormat.
+func (c CustomDNSConfigPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fqdn", c.Fqdn)
+	populate(objectMap, "ipAddresses", c.IPAddresses)
+	return json.Marshal(objectMap)
 }
 
 // DNSNameAvailabilityResult - Response for the CheckDnsNameAvailability API service call.
@@ -3631,6 +4700,14 @@ type DdosCustomPolicy struct {
 	Properties *DdosCustomPolicyPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DdosCustomPolicy.
+func (d DdosCustomPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := d.Resource.marshalInternal()
+	populate(objectMap, "etag", d.Etag)
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
 // DdosCustomPolicyPollerResponse is the response envelope for operations that asynchronously return a DdosCustomPolicy type.
 type DdosCustomPolicyPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -3646,17 +4723,27 @@ type DdosCustomPolicyPollerResponse struct {
 // DdosCustomPolicyPropertiesFormat - DDoS custom policy properties.
 type DdosCustomPolicyPropertiesFormat struct {
 	// The protocol-specific DDoS policy customization parameters.
-	ProtocolCustomSettings *[]*ProtocolCustomSettingsFormat `json:"protocolCustomSettings,omitempty"`
+	ProtocolCustomSettings []*ProtocolCustomSettingsFormat `json:"protocolCustomSettings,omitempty"`
 
 	// READ-ONLY; The provisioning state of the DDoS custom policy resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of public IPs associated with the DDoS custom policy resource. This list is read-only.
-	PublicIPAddresses *[]*SubResource `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses []*SubResource `json:"publicIPAddresses,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the DDoS custom policy resource. It uniquely identifies the resource, even if the user changes its name or migrate
 	// the resource across subscriptions or resource groups.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DdosCustomPolicyPropertiesFormat.
+func (d DdosCustomPolicyPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "protocolCustomSettings", d.ProtocolCustomSettings)
+	populate(objectMap, "provisioningState", d.ProvisioningState)
+	populate(objectMap, "publicIPAddresses", d.PublicIPAddresses)
+	populate(objectMap, "resourceGuid", d.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // DdosCustomPolicyResponse is the response envelope for operations that return a DdosCustomPolicy type.
@@ -3686,10 +4773,23 @@ type DdosProtectionPlan struct {
 	Properties *DdosProtectionPlanPropertiesFormat `json:"properties,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DdosProtectionPlan.
+func (d DdosProtectionPlan) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "etag", d.Etag)
+	populate(objectMap, "id", d.ID)
+	populate(objectMap, "location", d.Location)
+	populate(objectMap, "name", d.Name)
+	populate(objectMap, "properties", d.Properties)
+	populate(objectMap, "tags", d.Tags)
+	populate(objectMap, "type", d.Type)
+	return json.Marshal(objectMap)
 }
 
 // DdosProtectionPlanListResult - A list of DDoS protection plans.
@@ -3698,7 +4798,15 @@ type DdosProtectionPlanListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of DDoS protection plans.
-	Value *[]*DdosProtectionPlan `json:"value,omitempty"`
+	Value []*DdosProtectionPlan `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DdosProtectionPlanListResult.
+func (d DdosProtectionPlanListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DdosProtectionPlanListResultResponse is the response envelope for operations that return a DdosProtectionPlanListResult type.
@@ -3732,7 +4840,16 @@ type DdosProtectionPlanPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of virtual networks associated with the DDoS protection plan resource. This list is read-only.
-	VirtualNetworks *[]*SubResource `json:"virtualNetworks,omitempty" azure:"ro"`
+	VirtualNetworks []*SubResource `json:"virtualNetworks,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DdosProtectionPlanPropertiesFormat.
+func (d DdosProtectionPlanPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "provisioningState", d.ProvisioningState)
+	populate(objectMap, "resourceGuid", d.ResourceGUID)
+	populate(objectMap, "virtualNetworks", d.VirtualNetworks)
+	return json.Marshal(objectMap)
 }
 
 // DdosProtectionPlanResponse is the response envelope for operations that return a DdosProtectionPlan type.
@@ -3809,6 +4926,15 @@ type Delegation struct {
 	Properties *ServiceDelegationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Delegation.
+func (d Delegation) MarshalJSON() ([]byte, error) {
+	objectMap := d.SubResource.marshalInternal()
+	populate(objectMap, "etag", d.Etag)
+	populate(objectMap, "name", d.Name)
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
 // DeviceProperties - List of properties of the device.
 type DeviceProperties struct {
 	// Model of the device.
@@ -3825,7 +4951,14 @@ type DeviceProperties struct {
 // options.
 type DhcpOptions struct {
 	// The list of DNS servers IP addresses.
-	DNSServers *[]*string `json:"dnsServers,omitempty"`
+	DNSServers []*string `json:"dnsServers,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DhcpOptions.
+func (d DhcpOptions) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsServers", d.DNSServers)
+	return json.Marshal(objectMap)
 }
 
 // Dimension of the metric.
@@ -3846,13 +4979,23 @@ type EffectiveNetworkSecurityGroup struct {
 	Association *EffectiveNetworkSecurityGroupAssociation `json:"association,omitempty"`
 
 	// A collection of effective security rules.
-	EffectiveSecurityRules *[]*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules []*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
 
 	// The ID of network security group that is applied.
 	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
 
 	// Mapping of tags to list of IP Addresses included within the tag.
 	TagMap *string `json:"tagMap,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EffectiveNetworkSecurityGroup.
+func (e EffectiveNetworkSecurityGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "association", e.Association)
+	populate(objectMap, "effectiveSecurityRules", e.EffectiveSecurityRules)
+	populate(objectMap, "networkSecurityGroup", e.NetworkSecurityGroup)
+	populate(objectMap, "tagMap", e.TagMap)
+	return json.Marshal(objectMap)
 }
 
 // EffectiveNetworkSecurityGroupAssociation - The effective network security group association.
@@ -3870,7 +5013,15 @@ type EffectiveNetworkSecurityGroupListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of effective network security groups.
-	Value *[]*EffectiveNetworkSecurityGroup `json:"value,omitempty"`
+	Value []*EffectiveNetworkSecurityGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EffectiveNetworkSecurityGroupListResult.
+func (e EffectiveNetworkSecurityGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // EffectiveNetworkSecurityGroupListResultPollerResponse is the response envelope for operations that asynchronously return a EffectiveNetworkSecurityGroupListResult
@@ -3905,23 +5056,23 @@ type EffectiveNetworkSecurityRule struct {
 
 	// The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and
 	// the asterisk (*).
-	DestinationAddressPrefixes *[]*string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes []*string `json:"destinationAddressPrefixes,omitempty"`
 
 	// The destination port or range.
 	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
 
 	// The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk
 	// (*).
-	DestinationPortRanges *[]*string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges []*string `json:"destinationPortRanges,omitempty"`
 
 	// The direction of the rule.
 	Direction *SecurityRuleDirection `json:"direction,omitempty"`
 
 	// Expanded destination address prefix.
-	ExpandedDestinationAddressPrefix *[]*string `json:"expandedDestinationAddressPrefix,omitempty"`
+	ExpandedDestinationAddressPrefix []*string `json:"expandedDestinationAddressPrefix,omitempty"`
 
 	// The expanded source address prefix.
-	ExpandedSourceAddressPrefix *[]*string `json:"expandedSourceAddressPrefix,omitempty"`
+	ExpandedSourceAddressPrefix []*string `json:"expandedSourceAddressPrefix,omitempty"`
 
 	// The name of the security rule specified by the user (if created by the user).
 	Name *string `json:"name,omitempty"`
@@ -3937,19 +5088,40 @@ type EffectiveNetworkSecurityRule struct {
 
 	// The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the
 	// asterisk (*).
-	SourceAddressPrefixes *[]*string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes []*string `json:"sourceAddressPrefixes,omitempty"`
 
 	// The source port or range.
 	SourcePortRange *string `json:"sourcePortRange,omitempty"`
 
 	// The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*).
-	SourcePortRanges *[]*string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges []*string `json:"sourcePortRanges,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EffectiveNetworkSecurityRule.
+func (e EffectiveNetworkSecurityRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "access", e.Access)
+	populate(objectMap, "destinationAddressPrefix", e.DestinationAddressPrefix)
+	populate(objectMap, "destinationAddressPrefixes", e.DestinationAddressPrefixes)
+	populate(objectMap, "destinationPortRange", e.DestinationPortRange)
+	populate(objectMap, "destinationPortRanges", e.DestinationPortRanges)
+	populate(objectMap, "direction", e.Direction)
+	populate(objectMap, "expandedDestinationAddressPrefix", e.ExpandedDestinationAddressPrefix)
+	populate(objectMap, "expandedSourceAddressPrefix", e.ExpandedSourceAddressPrefix)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "priority", e.Priority)
+	populate(objectMap, "protocol", e.Protocol)
+	populate(objectMap, "sourceAddressPrefix", e.SourceAddressPrefix)
+	populate(objectMap, "sourceAddressPrefixes", e.SourceAddressPrefixes)
+	populate(objectMap, "sourcePortRange", e.SourcePortRange)
+	populate(objectMap, "sourcePortRanges", e.SourcePortRanges)
+	return json.Marshal(objectMap)
 }
 
 // EffectiveRoute - Effective Route.
 type EffectiveRoute struct {
 	// The address prefixes of the effective routes in CIDR notation.
-	AddressPrefix *[]*string `json:"addressPrefix,omitempty"`
+	AddressPrefix []*string `json:"addressPrefix,omitempty"`
 
 	// If true, on-premises routes are not propagated to the network interfaces in the subnet.
 	DisableBgpRoutePropagation *bool `json:"disableBgpRoutePropagation,omitempty"`
@@ -3958,7 +5130,7 @@ type EffectiveRoute struct {
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the next hop of the effective route.
-	NextHopIPAddress *[]*string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress []*string `json:"nextHopIpAddress,omitempty"`
 
 	// The type of Azure hop the packet should be sent to.
 	NextHopType *RouteNextHopType `json:"nextHopType,omitempty"`
@@ -3970,13 +5142,34 @@ type EffectiveRoute struct {
 	State *EffectiveRouteState `json:"state,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type EffectiveRoute.
+func (e EffectiveRoute) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefix", e.AddressPrefix)
+	populate(objectMap, "disableBgpRoutePropagation", e.DisableBgpRoutePropagation)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "nextHopIpAddress", e.NextHopIPAddress)
+	populate(objectMap, "nextHopType", e.NextHopType)
+	populate(objectMap, "source", e.Source)
+	populate(objectMap, "state", e.State)
+	return json.Marshal(objectMap)
+}
+
 // EffectiveRouteListResult - Response for list effective route API service call.
 type EffectiveRouteListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of effective routes.
-	Value *[]*EffectiveRoute `json:"value,omitempty"`
+	Value []*EffectiveRoute `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EffectiveRouteListResult.
+func (e EffectiveRouteListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // EffectiveRouteListResultPollerResponse is the response envelope for operations that asynchronously return a EffectiveRouteListResult type.
@@ -4010,13 +5203,29 @@ type EndpointServiceResult struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type EndpointServiceResult.
+func (e EndpointServiceResult) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "type", e.Type)
+	return json.Marshal(objectMap)
+}
+
 // EndpointServicesListResult - Response for the ListAvailableEndpointServices API service call.
 type EndpointServicesListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of available endpoint services in a region.
-	Value *[]*EndpointServiceResult `json:"value,omitempty"`
+	Value []*EndpointServiceResult `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EndpointServicesListResult.
+func (e EndpointServicesListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // EndpointServicesListResultResponse is the response envelope for operations that return a EndpointServicesListResult type.
@@ -4036,7 +5245,7 @@ type Error struct {
 	Code *string `json:"code,omitempty"`
 
 	// Error details.
-	Details *[]*ErrorDetails `json:"details,omitempty"`
+	Details []*ErrorDetails `json:"details,omitempty"`
 
 	// Inner error message.
 	InnerError *string `json:"innerError,omitempty"`
@@ -4092,7 +5301,17 @@ type EvaluatedNetworkSecurityGroup struct {
 	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty"`
 
 	// READ-ONLY; List of network security rules evaluation results.
-	RulesEvaluationResult *[]*NetworkSecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
+	RulesEvaluationResult []*NetworkSecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EvaluatedNetworkSecurityGroup.
+func (e EvaluatedNetworkSecurityGroup) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appliedTo", e.AppliedTo)
+	populate(objectMap, "matchedRule", e.MatchedRule)
+	populate(objectMap, "networkSecurityGroupId", e.NetworkSecurityGroupID)
+	populate(objectMap, "rulesEvaluationResult", e.RulesEvaluationResult)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuit resource.
@@ -4106,6 +5325,15 @@ type ExpressRouteCircuit struct {
 
 	// The SKU.
 	SKU *ExpressRouteCircuitSKU `json:"sku,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuit.
+func (e ExpressRouteCircuit) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "properties", e.Properties)
+	populate(objectMap, "sku", e.SKU)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitArpTable - The ARP table associated with the ExpressRouteCircuit.
@@ -4137,6 +5365,16 @@ type ExpressRouteCircuitAuthorization struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitAuthorization.
+func (e ExpressRouteCircuitAuthorization) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	populate(objectMap, "type", e.Type)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitAuthorizationPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitAuthorization
@@ -4198,6 +5436,16 @@ type ExpressRouteCircuitConnection struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitConnection.
+func (e ExpressRouteCircuitConnection) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	populate(objectMap, "type", e.Type)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteCircuitConnectionListResult - Response for ListConnections API service call retrieves all global reach connections that belongs to a Private
 // Peering for an ExpressRouteCircuit.
 type ExpressRouteCircuitConnectionListResult struct {
@@ -4205,7 +5453,15 @@ type ExpressRouteCircuitConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The global reach connection associated with Private Peering in an ExpressRoute Circuit.
-	Value *[]*ExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitConnectionListResult.
+func (e ExpressRouteCircuitConnectionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitConnectionListResultResponse is the response envelope for operations that return a ExpressRouteCircuitConnectionListResult type.
@@ -4289,7 +5545,15 @@ type ExpressRouteCircuitListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRouteCircuits in a resource group.
-	Value *[]*ExpressRouteCircuit `json:"value,omitempty"`
+	Value []*ExpressRouteCircuit `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitListResult.
+func (e ExpressRouteCircuitListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitListResultResponse is the response envelope for operations that return a ExpressRouteCircuitListResult type.
@@ -4317,13 +5581,23 @@ type ExpressRouteCircuitPeering struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitPeering.
+func (e ExpressRouteCircuitPeering) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	populate(objectMap, "type", e.Type)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteCircuitPeeringConfig - Specifies the peering configuration.
 type ExpressRouteCircuitPeeringConfig struct {
 	// The communities of bgp peering. Specified for microsoft peering.
-	AdvertisedCommunities *[]*string `json:"advertisedCommunities,omitempty"`
+	AdvertisedCommunities []*string `json:"advertisedCommunities,omitempty"`
 
 	// The reference to AdvertisedPublicPrefixes.
-	AdvertisedPublicPrefixes *[]*string `json:"advertisedPublicPrefixes,omitempty"`
+	AdvertisedPublicPrefixes []*string `json:"advertisedPublicPrefixes,omitempty"`
 
 	// READ-ONLY; The advertised public prefix state of the Peering resource.
 	AdvertisedPublicPrefixesState *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState `json:"advertisedPublicPrefixesState,omitempty" azure:"ro"`
@@ -4338,6 +5612,18 @@ type ExpressRouteCircuitPeeringConfig struct {
 	RoutingRegistryName *string `json:"routingRegistryName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitPeeringConfig.
+func (e ExpressRouteCircuitPeeringConfig) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "advertisedCommunities", e.AdvertisedCommunities)
+	populate(objectMap, "advertisedPublicPrefixes", e.AdvertisedPublicPrefixes)
+	populate(objectMap, "advertisedPublicPrefixesState", e.AdvertisedPublicPrefixesState)
+	populate(objectMap, "customerASN", e.CustomerASN)
+	populate(objectMap, "legacyMode", e.LegacyMode)
+	populate(objectMap, "routingRegistryName", e.RoutingRegistryName)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteCircuitPeeringID - ExpressRoute circuit peering identifier.
 type ExpressRouteCircuitPeeringID struct {
 	// The ID of the ExpressRoute circuit peering.
@@ -4350,7 +5636,15 @@ type ExpressRouteCircuitPeeringListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The peerings in an express route circuit.
-	Value *[]*ExpressRouteCircuitPeering `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitPeering `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitPeeringListResult.
+func (e ExpressRouteCircuitPeeringListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitPeeringListResultResponse is the response envelope for operations that return a ExpressRouteCircuitPeeringListResult type.
@@ -4380,7 +5674,7 @@ type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	AzureASN *int32 `json:"azureASN,omitempty"`
 
 	// The list of circuit connections associated with Azure Private Peering for this circuit.
-	Connections *[]*ExpressRouteCircuitConnection `json:"connections,omitempty"`
+	Connections []*ExpressRouteCircuitConnection `json:"connections,omitempty"`
 
 	// The ExpressRoute connection.
 	ExpressRouteConnection *ExpressRouteConnectionID `json:"expressRouteConnection,omitempty"`
@@ -4401,7 +5695,7 @@ type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	PeerASN *int64 `json:"peerASN,omitempty"`
 
 	// READ-ONLY; The list of peered circuit connections associated with Azure Private Peering for this circuit.
-	PeeredConnections *[]*PeerExpressRouteCircuitConnection `json:"peeredConnections,omitempty" azure:"ro"`
+	PeeredConnections []*PeerExpressRouteCircuitConnection `json:"peeredConnections,omitempty" azure:"ro"`
 
 	// The peering type.
 	PeeringType *ExpressRoutePeeringType `json:"peeringType,omitempty"`
@@ -4435,6 +5729,32 @@ type ExpressRouteCircuitPeeringPropertiesFormat struct {
 
 	// The VLAN ID.
 	VlanID *int32 `json:"vlanId,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitPeeringPropertiesFormat.
+func (e ExpressRouteCircuitPeeringPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "azureASN", e.AzureASN)
+	populate(objectMap, "connections", e.Connections)
+	populate(objectMap, "expressRouteConnection", e.ExpressRouteConnection)
+	populate(objectMap, "gatewayManagerEtag", e.GatewayManagerEtag)
+	populate(objectMap, "ipv6PeeringConfig", e.IPv6PeeringConfig)
+	populate(objectMap, "lastModifiedBy", e.LastModifiedBy)
+	populate(objectMap, "microsoftPeeringConfig", e.MicrosoftPeeringConfig)
+	populate(objectMap, "peerASN", e.PeerASN)
+	populate(objectMap, "peeredConnections", e.PeeredConnections)
+	populate(objectMap, "peeringType", e.PeeringType)
+	populate(objectMap, "primaryAzurePort", e.PrimaryAzurePort)
+	populate(objectMap, "primaryPeerAddressPrefix", e.PrimaryPeerAddressPrefix)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "routeFilter", e.RouteFilter)
+	populate(objectMap, "secondaryAzurePort", e.SecondaryAzurePort)
+	populate(objectMap, "secondaryPeerAddressPrefix", e.SecondaryPeerAddressPrefix)
+	populate(objectMap, "sharedKey", e.SharedKey)
+	populate(objectMap, "state", e.State)
+	populate(objectMap, "stats", e.Stats)
+	populate(objectMap, "vlanId", e.VlanID)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitPeeringResponse is the response envelope for operations that return a ExpressRouteCircuitPeering type.
@@ -4484,7 +5804,7 @@ type ExpressRouteCircuitPropertiesFormat struct {
 	AllowClassicOperations *bool `json:"allowClassicOperations,omitempty"`
 
 	// The list of authorizations.
-	Authorizations *[]*ExpressRouteCircuitAuthorization `json:"authorizations,omitempty"`
+	Authorizations []*ExpressRouteCircuitAuthorization `json:"authorizations,omitempty"`
 
 	// The bandwidth of the circuit when the circuit is provisioned on an ExpressRoutePort resource.
 	BandwidthInGbps *float32 `json:"bandwidthInGbps,omitempty"`
@@ -4502,7 +5822,7 @@ type ExpressRouteCircuitPropertiesFormat struct {
 	GlobalReachEnabled *bool `json:"globalReachEnabled,omitempty"`
 
 	// The list of peerings.
-	Peerings *[]*ExpressRouteCircuitPeering `json:"peerings,omitempty"`
+	Peerings []*ExpressRouteCircuitPeering `json:"peerings,omitempty"`
 
 	// READ-ONLY; The provisioning state of the express route circuit resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -4521,6 +5841,26 @@ type ExpressRouteCircuitPropertiesFormat struct {
 
 	// READ-ONLY; The identifier of the circuit traffic. Outer tag for QinQ encapsulation.
 	Stag *int32 `json:"stag,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitPropertiesFormat.
+func (e ExpressRouteCircuitPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowClassicOperations", e.AllowClassicOperations)
+	populate(objectMap, "authorizations", e.Authorizations)
+	populate(objectMap, "bandwidthInGbps", e.BandwidthInGbps)
+	populate(objectMap, "circuitProvisioningState", e.CircuitProvisioningState)
+	populate(objectMap, "expressRoutePort", e.ExpressRoutePort)
+	populate(objectMap, "gatewayManagerEtag", e.GatewayManagerEtag)
+	populate(objectMap, "globalReachEnabled", e.GlobalReachEnabled)
+	populate(objectMap, "peerings", e.Peerings)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "serviceKey", e.ServiceKey)
+	populate(objectMap, "serviceProviderNotes", e.ServiceProviderNotes)
+	populate(objectMap, "serviceProviderProperties", e.ServiceProviderProperties)
+	populate(objectMap, "serviceProviderProvisioningState", e.ServiceProviderProvisioningState)
+	populate(objectMap, "stag", e.Stag)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitReference - Reference to an express route circuit.
@@ -4628,7 +5968,15 @@ type ExpressRouteCircuitsArpTableListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of the ARP tables.
-	Value *[]*ExpressRouteCircuitArpTable `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitArpTable `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitsArpTableListResult.
+func (e ExpressRouteCircuitsArpTableListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitsArpTableListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsArpTableListResult
@@ -4709,7 +6057,15 @@ type ExpressRouteCircuitsRoutesTableListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of routes table.
-	Value *[]*ExpressRouteCircuitRoutesTable `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitRoutesTable `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitsRoutesTableListResult.
+func (e ExpressRouteCircuitsRoutesTableListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitsRoutesTableListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsRoutesTableListResult
@@ -4740,7 +6096,15 @@ type ExpressRouteCircuitsRoutesTableSummaryListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of the routes table.
-	Value *[]*ExpressRouteCircuitRoutesTableSummary `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitRoutesTableSummary `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCircuitsRoutesTableSummaryListResult.
+func (e ExpressRouteCircuitsRoutesTableSummaryListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCircuitsRoutesTableSummaryListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCircuitsRoutesTableSummaryListResult
@@ -4781,6 +6145,14 @@ type ExpressRouteConnection struct {
 	Properties *ExpressRouteConnectionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteConnection.
+func (e ExpressRouteConnection) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteConnectionID - The ID of the ExpressRouteConnection.
 type ExpressRouteConnectionID struct {
 	// READ-ONLY; The ID of the ExpressRouteConnection.
@@ -4790,7 +6162,14 @@ type ExpressRouteConnectionID struct {
 // ExpressRouteConnectionList - ExpressRouteConnection list.
 type ExpressRouteConnectionList struct {
 	// The list of ExpressRoute connections.
-	Value *[]*ExpressRouteConnection `json:"value,omitempty"`
+	Value []*ExpressRouteConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteConnectionList.
+func (e ExpressRouteConnectionList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteConnectionListResponse is the response envelope for operations that return a ExpressRouteConnectionList type.
@@ -4871,13 +6250,29 @@ type ExpressRouteCrossConnection struct {
 	Properties *ExpressRouteCrossConnectionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnection.
+func (e ExpressRouteCrossConnection) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteCrossConnectionListResult - Response for ListExpressRouteCrossConnection API service call.
 type ExpressRouteCrossConnectionListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ExpressRouteCrossConnection resources.
-	Value *[]*ExpressRouteCrossConnection `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnectionListResult.
+func (e ExpressRouteCrossConnectionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCrossConnectionListResultResponse is the response envelope for operations that return a ExpressRouteCrossConnectionListResult type.
@@ -4902,13 +6297,30 @@ type ExpressRouteCrossConnectionPeering struct {
 	Properties *ExpressRouteCrossConnectionPeeringProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnectionPeering.
+func (e ExpressRouteCrossConnectionPeering) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteCrossConnectionPeeringList - Response for ListPeering API service call retrieves all peerings that belong to an ExpressRouteCrossConnection.
 type ExpressRouteCrossConnectionPeeringList struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The peerings in an express route cross connection.
-	Value *[]*ExpressRouteCrossConnectionPeering `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnectionPeering `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnectionPeeringList.
+func (e ExpressRouteCrossConnectionPeeringList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCrossConnectionPeeringListResponse is the response envelope for operations that return a ExpressRouteCrossConnectionPeeringList type.
@@ -5035,7 +6447,7 @@ type ExpressRouteCrossConnectionProperties struct {
 	PeeringLocation *string `json:"peeringLocation,omitempty"`
 
 	// The list of peerings.
-	Peerings *[]*ExpressRouteCrossConnectionPeering `json:"peerings,omitempty"`
+	Peerings []*ExpressRouteCrossConnectionPeering `json:"peerings,omitempty"`
 
 	// READ-ONLY; The name of the primary port.
 	PrimaryAzurePort *string `json:"primaryAzurePort,omitempty" azure:"ro"`
@@ -5054,6 +6466,22 @@ type ExpressRouteCrossConnectionProperties struct {
 
 	// The provisioning state of the circuit in the connectivity provider system.
 	ServiceProviderProvisioningState *ServiceProviderProvisioningState `json:"serviceProviderProvisioningState,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnectionProperties.
+func (e ExpressRouteCrossConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bandwidthInMbps", e.BandwidthInMbps)
+	populate(objectMap, "expressRouteCircuit", e.ExpressRouteCircuit)
+	populate(objectMap, "peeringLocation", e.PeeringLocation)
+	populate(objectMap, "peerings", e.Peerings)
+	populate(objectMap, "primaryAzurePort", e.PrimaryAzurePort)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "sTag", e.STag)
+	populate(objectMap, "secondaryAzurePort", e.SecondaryAzurePort)
+	populate(objectMap, "serviceProviderNotes", e.ServiceProviderNotes)
+	populate(objectMap, "serviceProviderProvisioningState", e.ServiceProviderProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCrossConnectionResponse is the response envelope for operations that return a ExpressRouteCrossConnection type.
@@ -5122,7 +6550,15 @@ type ExpressRouteCrossConnectionsRoutesTableSummaryListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of the routes table.
-	Value *[]*ExpressRouteCrossConnectionRoutesTableSummary `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnectionRoutesTableSummary `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteCrossConnectionsRoutesTableSummaryListResult.
+func (e ExpressRouteCrossConnectionsRoutesTableSummaryListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteCrossConnectionsRoutesTableSummaryListResultPollerResponse is the response envelope for operations that asynchronously return a ExpressRouteCrossConnectionsRoutesTableSummaryListResult
@@ -5163,10 +6599,25 @@ type ExpressRouteGateway struct {
 	Properties *ExpressRouteGatewayProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteGateway.
+func (e ExpressRouteGateway) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteGatewayList - List of ExpressRoute gateways.
 type ExpressRouteGatewayList struct {
 	// List of ExpressRoute gateways.
-	Value *[]*ExpressRouteGateway `json:"value,omitempty"`
+	Value []*ExpressRouteGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteGatewayList.
+func (e ExpressRouteGatewayList) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteGatewayListResponse is the response envelope for operations that return a ExpressRouteGatewayList type.
@@ -5196,13 +6647,23 @@ type ExpressRouteGatewayProperties struct {
 	AutoScaleConfiguration *ExpressRouteGatewayPropertiesAutoScaleConfiguration `json:"autoScaleConfiguration,omitempty"`
 
 	// READ-ONLY; List of ExpressRoute connections to the ExpressRoute gateway.
-	ExpressRouteConnections *[]*ExpressRouteConnection `json:"expressRouteConnections,omitempty" azure:"ro"`
+	ExpressRouteConnections []*ExpressRouteConnection `json:"expressRouteConnections,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the express route gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The Virtual Hub where the ExpressRoute gateway is or will be deployed.
 	VirtualHub *VirtualHubID `json:"virtualHub,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteGatewayProperties.
+func (e ExpressRouteGatewayProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "autoScaleConfiguration", e.AutoScaleConfiguration)
+	populate(objectMap, "expressRouteConnections", e.ExpressRouteConnections)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "virtualHub", e.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteGatewayPropertiesAutoScaleConfiguration - Configuration for auto scaling.
@@ -5267,13 +6728,30 @@ type ExpressRouteLink struct {
 	Properties *ExpressRouteLinkPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteLink.
+func (e ExpressRouteLink) MarshalJSON() ([]byte, error) {
+	objectMap := e.SubResource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "name", e.Name)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteLinkListResult - Response for ListExpressRouteLinks API service call.
 type ExpressRouteLinkListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of ExpressRouteLink sub-resources.
-	Value *[]*ExpressRouteLink `json:"value,omitempty"`
+	Value []*ExpressRouteLink `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteLinkListResult.
+func (e ExpressRouteLinkListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteLinkListResultResponse is the response envelope for operations that return a ExpressRouteLinkListResult type.
@@ -5356,13 +6834,30 @@ type ExpressRoutePort struct {
 	Properties *ExpressRoutePortPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePort.
+func (e ExpressRoutePort) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "etag", e.Etag)
+	populate(objectMap, "identity", e.Identity)
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRoutePortListResult - Response for ListExpressRoutePorts API service call.
 type ExpressRoutePortListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRoutePort resources.
-	Value *[]*ExpressRoutePort `json:"value,omitempty"`
+	Value []*ExpressRoutePort `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePortListResult.
+func (e ExpressRoutePortListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRoutePortListResultResponse is the response envelope for operations that return a ExpressRoutePortListResult type.
@@ -5395,7 +6890,7 @@ type ExpressRoutePortPropertiesFormat struct {
 	BandwidthInGbps *int32 `json:"bandwidthInGbps,omitempty"`
 
 	// READ-ONLY; Reference the ExpressRoute circuit(s) that are provisioned on this ExpressRoutePort resource.
-	Circuits *[]*SubResource `json:"circuits,omitempty" azure:"ro"`
+	Circuits []*SubResource `json:"circuits,omitempty" azure:"ro"`
 
 	// Encapsulation method on physical ports.
 	Encapsulation *ExpressRoutePortsEncapsulation `json:"encapsulation,omitempty"`
@@ -5404,7 +6899,7 @@ type ExpressRoutePortPropertiesFormat struct {
 	EtherType *string `json:"etherType,omitempty" azure:"ro"`
 
 	// The set of physical links of the ExpressRoutePort resource.
-	Links *[]*ExpressRouteLink `json:"links,omitempty"`
+	Links []*ExpressRouteLink `json:"links,omitempty"`
 
 	// READ-ONLY; Maximum transmission unit of the physical port pair(s).
 	Mtu *string `json:"mtu,omitempty" azure:"ro"`
@@ -5420,6 +6915,23 @@ type ExpressRoutePortPropertiesFormat struct {
 
 	// READ-ONLY; The resource GUID property of the express route port resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePortPropertiesFormat.
+func (e ExpressRoutePortPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allocationDate", e.AllocationDate)
+	populate(objectMap, "bandwidthInGbps", e.BandwidthInGbps)
+	populate(objectMap, "circuits", e.Circuits)
+	populate(objectMap, "encapsulation", e.Encapsulation)
+	populate(objectMap, "etherType", e.EtherType)
+	populate(objectMap, "links", e.Links)
+	populate(objectMap, "mtu", e.Mtu)
+	populate(objectMap, "peeringLocation", e.PeeringLocation)
+	populate(objectMap, "provisionedBandwidthInGbps", e.ProvisionedBandwidthInGbps)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	populate(objectMap, "resourceGuid", e.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRoutePortResponse is the response envelope for operations that return a ExpressRoutePort type.
@@ -5463,6 +6975,13 @@ type ExpressRoutePortsLocation struct {
 	Properties *ExpressRoutePortsLocationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePortsLocation.
+func (e ExpressRoutePortsLocation) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRoutePortsLocationBandwidths - Real-time inventory of available ExpressRoute port bandwidths.
 type ExpressRoutePortsLocationBandwidths struct {
 	// READ-ONLY; Bandwidth descriptive name.
@@ -5478,7 +6997,15 @@ type ExpressRoutePortsLocationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of all ExpressRoutePort peering locations.
-	Value *[]*ExpressRoutePortsLocation `json:"value,omitempty"`
+	Value []*ExpressRoutePortsLocation `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePortsLocationListResult.
+func (e ExpressRoutePortsLocationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRoutePortsLocationListResultResponse is the response envelope for operations that return a ExpressRoutePortsLocationListResult type.
@@ -5496,13 +7023,23 @@ type ExpressRoutePortsLocationPropertiesFormat struct {
 	Address *string `json:"address,omitempty" azure:"ro"`
 
 	// The inventory of available ExpressRoutePort bandwidths.
-	AvailableBandwidths *[]*ExpressRoutePortsLocationBandwidths `json:"availableBandwidths,omitempty"`
+	AvailableBandwidths []*ExpressRoutePortsLocationBandwidths `json:"availableBandwidths,omitempty"`
 
 	// READ-ONLY; Contact details of peering locations.
 	Contact *string `json:"contact,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the express route port location resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRoutePortsLocationPropertiesFormat.
+func (e ExpressRoutePortsLocationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "address", e.Address)
+	populate(objectMap, "availableBandwidths", e.AvailableBandwidths)
+	populate(objectMap, "contact", e.Contact)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRoutePortsLocationResponse is the response envelope for operations that return a ExpressRoutePortsLocation type.
@@ -5536,6 +7073,13 @@ type ExpressRouteServiceProvider struct {
 	Properties *ExpressRouteServiceProviderPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteServiceProvider.
+func (e ExpressRouteServiceProvider) MarshalJSON() ([]byte, error) {
+	objectMap := e.Resource.marshalInternal()
+	populate(objectMap, "properties", e.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ExpressRouteServiceProviderBandwidthsOffered - Contains bandwidths offered in ExpressRouteServiceProvider resources.
 type ExpressRouteServiceProviderBandwidthsOffered struct {
 	// The OfferName.
@@ -5551,7 +7095,15 @@ type ExpressRouteServiceProviderListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of ExpressRouteResourceProvider resources.
-	Value *[]*ExpressRouteServiceProvider `json:"value,omitempty"`
+	Value []*ExpressRouteServiceProvider `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteServiceProviderListResult.
+func (e ExpressRouteServiceProviderListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", e.NextLink)
+	populate(objectMap, "value", e.Value)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteServiceProviderListResultResponse is the response envelope for operations that return a ExpressRouteServiceProviderListResult type.
@@ -5566,13 +7118,22 @@ type ExpressRouteServiceProviderListResultResponse struct {
 // ExpressRouteServiceProviderPropertiesFormat - Properties of ExpressRouteServiceProvider.
 type ExpressRouteServiceProviderPropertiesFormat struct {
 	// A list of bandwidths offered.
-	BandwidthsOffered *[]*ExpressRouteServiceProviderBandwidthsOffered `json:"bandwidthsOffered,omitempty"`
+	BandwidthsOffered []*ExpressRouteServiceProviderBandwidthsOffered `json:"bandwidthsOffered,omitempty"`
 
 	// A list of peering locations.
-	PeeringLocations *[]*string `json:"peeringLocations,omitempty"`
+	PeeringLocations []*string `json:"peeringLocations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the express route service provider resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExpressRouteServiceProviderPropertiesFormat.
+func (e ExpressRouteServiceProviderPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bandwidthsOffered", e.BandwidthsOffered)
+	populate(objectMap, "peeringLocations", e.PeeringLocations)
+	populate(objectMap, "provisioningState", e.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ExpressRouteServiceProvidersListOptions contains the optional parameters for the ExpressRouteServiceProviders.List method.
@@ -5616,6 +7177,14 @@ type FirewallPolicy struct {
 	Properties *FirewallPolicyPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicy.
+func (f FirewallPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := f.Resource.marshalInternal()
+	populate(objectMap, "etag", f.Etag)
+	populate(objectMap, "properties", f.Properties)
+	return json.Marshal(objectMap)
+}
+
 // FirewallPolicyFilterRule - Firewall Policy Filter Rule.
 type FirewallPolicyFilterRule struct {
 	FirewallPolicyRule
@@ -5623,7 +7192,7 @@ type FirewallPolicyFilterRule struct {
 	Action *FirewallPolicyFilterRuleAction `json:"action,omitempty"`
 
 	// Collection of rule conditions used by a rule.
-	RuleConditions *[]FirewallPolicyRuleConditionClassification `json:"ruleConditions,omitempty"`
+	RuleConditions []FirewallPolicyRuleConditionClassification `json:"ruleConditions,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type FirewallPolicyFilterRule.
@@ -5669,7 +7238,15 @@ type FirewallPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Firewall Policies in a resource group.
-	Value *[]*FirewallPolicy `json:"value,omitempty"`
+	Value []*FirewallPolicy `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicyListResult.
+func (f FirewallPolicyListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", f.NextLink)
+	populate(objectMap, "value", f.Value)
+	return json.Marshal(objectMap)
 }
 
 // FirewallPolicyListResultResponse is the response envelope for operations that return a FirewallPolicyListResult type.
@@ -5760,19 +7337,31 @@ type FirewallPolicyPropertiesFormat struct {
 	BasePolicy *SubResource `json:"basePolicy,omitempty"`
 
 	// READ-ONLY; List of references to Child Firewall Policies.
-	ChildPolicies *[]*SubResource `json:"childPolicies,omitempty" azure:"ro"`
+	ChildPolicies []*SubResource `json:"childPolicies,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of references to Azure Firewalls that this Firewall Policy is associated with.
-	Firewalls *[]*SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls []*SubResource `json:"firewalls,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the firewall policy resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of references to FirewallPolicyRuleGroups.
-	RuleGroups *[]*SubResource `json:"ruleGroups,omitempty" azure:"ro"`
+	RuleGroups []*SubResource `json:"ruleGroups,omitempty" azure:"ro"`
 
 	// The operation mode for Threat Intelligence.
 	ThreatIntelMode *AzureFirewallThreatIntelMode `json:"threatIntelMode,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicyPropertiesFormat.
+func (f FirewallPolicyPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "basePolicy", f.BasePolicy)
+	populate(objectMap, "childPolicies", f.ChildPolicies)
+	populate(objectMap, "firewalls", f.Firewalls)
+	populate(objectMap, "provisioningState", f.ProvisioningState)
+	populate(objectMap, "ruleGroups", f.RuleGroups)
+	populate(objectMap, "threatIntelMode", f.ThreatIntelMode)
+	return json.Marshal(objectMap)
 }
 
 // FirewallPolicyResponse is the response envelope for operations that return a FirewallPolicy type.
@@ -5937,13 +7526,31 @@ type FirewallPolicyRuleGroup struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicyRuleGroup.
+func (f FirewallPolicyRuleGroup) MarshalJSON() ([]byte, error) {
+	objectMap := f.SubResource.marshalInternal()
+	populate(objectMap, "etag", f.Etag)
+	populate(objectMap, "name", f.Name)
+	populate(objectMap, "properties", f.Properties)
+	populate(objectMap, "type", f.Type)
+	return json.Marshal(objectMap)
+}
+
 // FirewallPolicyRuleGroupListResult - Response for ListFirewallPolicyRuleGroups API service call.
 type FirewallPolicyRuleGroupListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of FirewallPolicyRuleGroups in a FirewallPolicy.
-	Value *[]*FirewallPolicyRuleGroup `json:"value,omitempty"`
+	Value []*FirewallPolicyRuleGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicyRuleGroupListResult.
+func (f FirewallPolicyRuleGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", f.NextLink)
+	populate(objectMap, "value", f.Value)
+	return json.Marshal(objectMap)
 }
 
 // FirewallPolicyRuleGroupListResultResponse is the response envelope for operations that return a FirewallPolicyRuleGroupListResult type.
@@ -5976,7 +7583,16 @@ type FirewallPolicyRuleGroupProperties struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Group of Firewall Policy rules.
-	Rules *[]FirewallPolicyRuleClassification `json:"rules,omitempty"`
+	Rules []FirewallPolicyRuleClassification `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FirewallPolicyRuleGroupProperties.
+func (f FirewallPolicyRuleGroupProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "priority", f.Priority)
+	populate(objectMap, "provisioningState", f.ProvisioningState)
+	populate(objectMap, "rules", f.Rules)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type FirewallPolicyRuleGroupProperties.
@@ -6044,6 +7660,14 @@ type FlowLog struct {
 	Properties *FlowLogPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type FlowLog.
+func (f FlowLog) MarshalJSON() ([]byte, error) {
+	objectMap := f.Resource.marshalInternal()
+	populate(objectMap, "etag", f.Etag)
+	populate(objectMap, "properties", f.Properties)
+	return json.Marshal(objectMap)
+}
+
 // FlowLogFormatParameters - Parameters that define the flow log format.
 type FlowLogFormatParameters struct {
 	// The file type of flow log.
@@ -6092,7 +7716,15 @@ type FlowLogListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// Information about flow log resource.
-	Value *[]*FlowLog `json:"value,omitempty"`
+	Value []*FlowLog `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FlowLogListResult.
+func (f FlowLogListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", f.NextLink)
+	populate(objectMap, "value", f.Value)
+	return json.Marshal(objectMap)
 }
 
 // FlowLogListResultResponse is the response envelope for operations that return a FlowLogListResult type.
@@ -6209,22 +7841,33 @@ type FrontendIPConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FrontendIPConfiguration.
+func (f FrontendIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := f.SubResource.marshalInternal()
+	populate(objectMap, "etag", f.Etag)
+	populate(objectMap, "name", f.Name)
+	populate(objectMap, "properties", f.Properties)
+	populate(objectMap, "type", f.Type)
+	populate(objectMap, "zones", f.Zones)
+	return json.Marshal(objectMap)
 }
 
 // FrontendIPConfigurationPropertiesFormat - Properties of Frontend IP Configuration of the load balancer.
 type FrontendIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; An array of references to inbound pools that use this frontend IP.
-	InboundNatPools *[]*SubResource `json:"inboundNatPools,omitempty" azure:"ro"`
+	InboundNatPools []*SubResource `json:"inboundNatPools,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to inbound rules that use this frontend IP.
-	InboundNatRules *[]*SubResource `json:"inboundNatRules,omitempty" azure:"ro"`
+	InboundNatRules []*SubResource `json:"inboundNatRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to load balancing rules that use this frontend IP.
-	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to outbound rules that use this frontend IP.
-	OutboundRules *[]*SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules []*SubResource `json:"outboundRules,omitempty" azure:"ro"`
 
 	// The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
@@ -6246,6 +7889,23 @@ type FrontendIPConfigurationPropertiesFormat struct {
 
 	// The reference to the subnet resource.
 	Subnet *Subnet `json:"subnet,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FrontendIPConfigurationPropertiesFormat.
+func (f FrontendIPConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "inboundNatPools", f.InboundNatPools)
+	populate(objectMap, "inboundNatRules", f.InboundNatRules)
+	populate(objectMap, "loadBalancingRules", f.LoadBalancingRules)
+	populate(objectMap, "outboundRules", f.OutboundRules)
+	populate(objectMap, "privateIPAddress", f.PrivateIPAddress)
+	populate(objectMap, "privateIPAddressVersion", f.PrivateIPAddressVersion)
+	populate(objectMap, "privateIPAllocationMethod", f.PrivateIPAllocationMethod)
+	populate(objectMap, "provisioningState", f.ProvisioningState)
+	populate(objectMap, "publicIPAddress", f.PublicIPAddress)
+	populate(objectMap, "publicIPPrefix", f.PublicIPPrefix)
+	populate(objectMap, "subnet", f.Subnet)
+	return json.Marshal(objectMap)
 }
 
 // FrontendIPConfigurationResponse is the response envelope for operations that return a FrontendIPConfiguration type.
@@ -6284,7 +7944,14 @@ type GatewayRoute struct {
 // GatewayRouteListResult - List of virtual network gateway routes.
 type GatewayRouteListResult struct {
 	// List of gateway routes.
-	Value *[]*GatewayRoute `json:"value,omitempty"`
+	Value []*GatewayRoute `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GatewayRouteListResult.
+func (g GatewayRouteListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", g.Value)
+	return json.Marshal(objectMap)
 }
 
 // GatewayRouteListResultPollerResponse is the response envelope for operations that asynchronously return a GatewayRouteListResult type.
@@ -6314,19 +7981,36 @@ type GetVPNSitesConfigurationRequest struct {
 	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
 
 	// List of resource-ids of the vpn-sites for which config is to be downloaded.
-	VPNSites *[]*string `json:"vpnSites,omitempty"`
+	VPNSites []*string `json:"vpnSites,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GetVPNSitesConfigurationRequest.
+func (g GetVPNSitesConfigurationRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "outputBlobSasUrl", g.OutputBlobSasURL)
+	populate(objectMap, "vpnSites", g.VPNSites)
+	return json.Marshal(objectMap)
 }
 
 // HTTPConfiguration - HTTP configuration of the connectivity check.
 type HTTPConfiguration struct {
 	// List of HTTP headers.
-	Headers *[]*HTTPHeader `json:"headers,omitempty"`
+	Headers []*HTTPHeader `json:"headers,omitempty"`
 
 	// HTTP method.
 	Method *HTTPMethod `json:"method,omitempty"`
 
 	// Valid status codes.
-	ValidStatusCodes *[]*int32 `json:"validStatusCodes,omitempty"`
+	ValidStatusCodes []*int32 `json:"validStatusCodes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HTTPConfiguration.
+func (h HTTPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "headers", h.Headers)
+	populate(objectMap, "method", h.Method)
+	populate(objectMap, "validStatusCodes", h.ValidStatusCodes)
+	return json.Marshal(objectMap)
 }
 
 // HTTPHeader - The HTTP header.
@@ -6356,7 +8040,15 @@ type HubIPAddresses struct {
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
 
 	// List of Public IP addresses associated with azure firewall.
-	PublicIPAddresses *[]*AzureFirewallPublicIPAddress `json:"publicIPAddresses,omitempty"`
+	PublicIPAddresses []*AzureFirewallPublicIPAddress `json:"publicIPAddresses,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HubIPAddresses.
+func (h HubIPAddresses) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "privateIPAddress", h.PrivateIPAddress)
+	populate(objectMap, "publicIPAddresses", h.PublicIPAddresses)
+	return json.Marshal(objectMap)
 }
 
 // HubVirtualNetworkConnection Resource.
@@ -6370,6 +8062,15 @@ type HubVirtualNetworkConnection struct {
 
 	// Properties of the hub virtual network connection.
 	Properties *HubVirtualNetworkConnectionProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HubVirtualNetworkConnection.
+func (h HubVirtualNetworkConnection) MarshalJSON() ([]byte, error) {
+	objectMap := h.SubResource.marshalInternal()
+	populate(objectMap, "etag", h.Etag)
+	populate(objectMap, "name", h.Name)
+	populate(objectMap, "properties", h.Properties)
+	return json.Marshal(objectMap)
 }
 
 // HubVirtualNetworkConnectionProperties - Parameters for HubVirtualNetworkConnection.
@@ -6415,7 +8116,15 @@ type IPAddressAvailabilityResult struct {
 	Available *bool `json:"available,omitempty"`
 
 	// Contains other available private IP addresses if the asked for address is taken.
-	AvailableIPAddresses *[]*string `json:"availableIPAddresses,omitempty"`
+	AvailableIPAddresses []*string `json:"availableIPAddresses,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPAddressAvailabilityResult.
+func (i IPAddressAvailabilityResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "available", i.Available)
+	populate(objectMap, "availableIPAddresses", i.AvailableIPAddresses)
+	return json.Marshal(objectMap)
 }
 
 // IPAddressAvailabilityResultResponse is the response envelope for operations that return a IPAddressAvailabilityResult type.
@@ -6437,13 +8146,29 @@ type IPAllocation struct {
 	Properties *IPAllocationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type IPAllocation.
+func (i IPAllocation) MarshalJSON() ([]byte, error) {
+	objectMap := i.Resource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
 // IPAllocationListResult - Response for the ListIpAllocations API service call.
 type IPAllocationListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of IpAllocation resources.
-	Value *[]*IPAllocation `json:"value,omitempty"`
+	Value []*IPAllocation `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPAllocationListResult.
+func (i IPAllocationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
 }
 
 // IPAllocationListResultResponse is the response envelope for operations that return a IPAllocationListResult type.
@@ -6470,7 +8195,7 @@ type IPAllocationPollerResponse struct {
 // IPAllocationPropertiesFormat - Properties of the IpAllocation.
 type IPAllocationPropertiesFormat struct {
 	// IpAllocation tags.
-	AllocationTags *map[string]*string `json:"allocationTags,omitempty"`
+	AllocationTags map[string]*string `json:"allocationTags,omitempty"`
 
 	// The IPAM allocation ID.
 	IpamAllocationID *string `json:"ipamAllocationId,omitempty"`
@@ -6492,6 +8217,20 @@ type IPAllocationPropertiesFormat struct {
 
 	// READ-ONLY; The VirtualNetwork that using the prefix of this IpAllocation resource.
 	VirtualNetwork *SubResource `json:"virtualNetwork,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPAllocationPropertiesFormat.
+func (i IPAllocationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allocationTags", i.AllocationTags)
+	populate(objectMap, "ipamAllocationId", i.IpamAllocationID)
+	populate(objectMap, "prefix", i.Prefix)
+	populate(objectMap, "prefixLength", i.PrefixLength)
+	populate(objectMap, "prefixType", i.PrefixType)
+	populate(objectMap, "subnet", i.Subnet)
+	populate(objectMap, "type", i.Type)
+	populate(objectMap, "virtualNetwork", i.VirtualNetwork)
+	return json.Marshal(objectMap)
 }
 
 // IPAllocationResponse is the response envelope for operations that return a IPAllocation type.
@@ -6547,19 +8286,38 @@ type IPConfiguration struct {
 	Properties *IPConfigurationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type IPConfiguration.
+func (i IPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
 // IPConfigurationBgpPeeringAddress - Properties of IPConfigurationBgpPeeringAddress.
 type IPConfigurationBgpPeeringAddress struct {
 	// The list of custom BGP peering addresses which belong to IP configuration.
-	CustomBgpIPAddresses *[]*string `json:"customBgpIpAddresses,omitempty"`
+	CustomBgpIPAddresses []*string `json:"customBgpIpAddresses,omitempty"`
 
 	// READ-ONLY; The list of default BGP peering addresses which belong to IP configuration.
-	DefaultBgpIPAddresses *[]*string `json:"defaultBgpIpAddresses,omitempty" azure:"ro"`
+	DefaultBgpIPAddresses []*string `json:"defaultBgpIpAddresses,omitempty" azure:"ro"`
 
 	// The ID of IP configuration which belongs to gateway.
 	IPConfigurationID *string `json:"ipconfigurationId,omitempty"`
 
 	// READ-ONLY; The list of tunnel public IP addresses which belong to IP configuration.
-	TunnelIPAddresses *[]*string `json:"tunnelIpAddresses,omitempty" azure:"ro"`
+	TunnelIPAddresses []*string `json:"tunnelIpAddresses,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPConfigurationBgpPeeringAddress.
+func (i IPConfigurationBgpPeeringAddress) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "customBgpIpAddresses", i.CustomBgpIPAddresses)
+	populate(objectMap, "defaultBgpIpAddresses", i.DefaultBgpIPAddresses)
+	populate(objectMap, "ipconfigurationId", i.IPConfigurationID)
+	populate(objectMap, "tunnelIpAddresses", i.TunnelIPAddresses)
+	return json.Marshal(objectMap)
 }
 
 // IPConfigurationProfile - IP configuration profile child resource.
@@ -6576,6 +8334,16 @@ type IPConfigurationProfile struct {
 
 	// READ-ONLY; Sub Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPConfigurationProfile.
+func (i IPConfigurationProfile) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
 }
 
 // IPConfigurationProfilePropertiesFormat - IP configuration profile properties.
@@ -6615,13 +8383,29 @@ type IPGroup struct {
 	Properties *IPGroupPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type IPGroup.
+func (i IPGroup) MarshalJSON() ([]byte, error) {
+	objectMap := i.Resource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
 // IPGroupListResult - Response for the ListIpGroups API service call.
 type IPGroupListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list of IpGroups information resources.
-	Value *[]*IPGroup `json:"value,omitempty"`
+	Value []*IPGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPGroupListResult.
+func (i IPGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
 }
 
 // IPGroupListResultResponse is the response envelope for operations that return a IPGroupListResult type.
@@ -6648,13 +8432,22 @@ type IPGroupPollerResponse struct {
 // IPGroupPropertiesFormat - The IpGroups property information.
 type IPGroupPropertiesFormat struct {
 	// READ-ONLY; List of references to Azure resources that this IpGroups is associated with.
-	Firewalls *[]*SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls []*SubResource `json:"firewalls,omitempty" azure:"ro"`
 
 	// IpAddresses/IpAddressPrefixes in the IpGroups resource.
-	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string `json:"ipAddresses,omitempty"`
 
 	// READ-ONLY; The provisioning state of the IpGroups resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IPGroupPropertiesFormat.
+func (i IPGroupPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "firewalls", i.Firewalls)
+	populate(objectMap, "ipAddresses", i.IPAddresses)
+	populate(objectMap, "provisioningState", i.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // IPGroupResponse is the response envelope for operations that return a IPGroup type.
@@ -6776,6 +8569,16 @@ type InboundNatPool struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type InboundNatPool.
+func (i InboundNatPool) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
+}
+
 // InboundNatPoolPropertiesFormat - Properties of Inbound NAT pool.
 type InboundNatPoolPropertiesFormat struct {
 	// The port used for internal connections on the endpoint. Acceptable values are between 1 and 65535.
@@ -6828,13 +8631,31 @@ type InboundNatRule struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type InboundNatRule.
+func (i InboundNatRule) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "etag", i.Etag)
+	populate(objectMap, "name", i.Name)
+	populate(objectMap, "properties", i.Properties)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
+}
+
 // InboundNatRuleListResult - Response for ListInboundNatRule API service call.
 type InboundNatRuleListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of inbound nat rules in a load balancer.
-	Value *[]*InboundNatRule `json:"value,omitempty"`
+	Value []*InboundNatRule `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type InboundNatRuleListResult.
+func (i InboundNatRuleListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
 }
 
 // InboundNatRuleListResultResponse is the response envelope for operations that return a InboundNatRuleListResult type.
@@ -6929,7 +8750,15 @@ type ListHubVirtualNetworkConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of HubVirtualNetworkConnections.
-	Value *[]*HubVirtualNetworkConnection `json:"value,omitempty"`
+	Value []*HubVirtualNetworkConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListHubVirtualNetworkConnectionsResult.
+func (l ListHubVirtualNetworkConnectionsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListHubVirtualNetworkConnectionsResultResponse is the response envelope for operations that return a ListHubVirtualNetworkConnectionsResult type.
@@ -6948,7 +8777,15 @@ type ListP2SVPNGatewaysResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of P2SVpnGateways.
-	Value *[]*P2SVPNGateway `json:"value,omitempty"`
+	Value []*P2SVPNGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListP2SVPNGatewaysResult.
+func (l ListP2SVPNGatewaysResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListP2SVPNGatewaysResultResponse is the response envelope for operations that return a ListP2SVPNGatewaysResult type.
@@ -6967,7 +8804,15 @@ type ListVPNConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Vpn Connections.
-	Value *[]*VPNConnection `json:"value,omitempty"`
+	Value []*VPNConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNConnectionsResult.
+func (l ListVPNConnectionsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNConnectionsResultResponse is the response envelope for operations that return a ListVPNConnectionsResult type.
@@ -6986,7 +8831,15 @@ type ListVPNGatewaysResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnGateways.
-	Value *[]*VPNGateway `json:"value,omitempty"`
+	Value []*VPNGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNGatewaysResult.
+func (l ListVPNGatewaysResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNGatewaysResultResponse is the response envelope for operations that return a ListVPNGatewaysResult type.
@@ -7005,7 +8858,15 @@ type ListVPNServerConfigurationsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnServerConfigurations.
-	Value *[]*VPNServerConfiguration `json:"value,omitempty"`
+	Value []*VPNServerConfiguration `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNServerConfigurationsResult.
+func (l ListVPNServerConfigurationsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNServerConfigurationsResultResponse is the response envelope for operations that return a ListVPNServerConfigurationsResult type.
@@ -7024,7 +8885,15 @@ type ListVPNSiteLinkConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSiteLinkConnections.
-	Value *[]*VPNSiteLinkConnection `json:"value,omitempty"`
+	Value []*VPNSiteLinkConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNSiteLinkConnectionsResult.
+func (l ListVPNSiteLinkConnectionsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNSiteLinkConnectionsResultResponse is the response envelope for operations that return a ListVPNSiteLinkConnectionsResult type.
@@ -7043,7 +8912,15 @@ type ListVPNSiteLinksResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSitesLinks.
-	Value *[]*VPNSiteLink `json:"value,omitempty"`
+	Value []*VPNSiteLink `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNSiteLinksResult.
+func (l ListVPNSiteLinksResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNSiteLinksResultResponse is the response envelope for operations that return a ListVPNSiteLinksResult type.
@@ -7061,7 +8938,15 @@ type ListVPNSitesResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VpnSites.
-	Value *[]*VPNSite `json:"value,omitempty"`
+	Value []*VPNSite `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVPNSitesResult.
+func (l ListVPNSitesResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVPNSitesResultResponse is the response envelope for operations that return a ListVPNSitesResult type.
@@ -7079,7 +8964,15 @@ type ListVirtualHubRouteTableV2SResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualHubRouteTableV2s.
-	Value *[]*VirtualHubRouteTableV2 `json:"value,omitempty"`
+	Value []*VirtualHubRouteTableV2 `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVirtualHubRouteTableV2SResult.
+func (l ListVirtualHubRouteTableV2SResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVirtualHubRouteTableV2SResultResponse is the response envelope for operations that return a ListVirtualHubRouteTableV2SResult type.
@@ -7097,7 +8990,15 @@ type ListVirtualHubsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualHubs.
-	Value *[]*VirtualHub `json:"value,omitempty"`
+	Value []*VirtualHub `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVirtualHubsResult.
+func (l ListVirtualHubsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVirtualHubsResultResponse is the response envelope for operations that return a ListVirtualHubsResult type.
@@ -7115,7 +9016,15 @@ type ListVirtualWANsResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualWANs.
-	Value *[]*VirtualWAN `json:"value,omitempty"`
+	Value []*VirtualWAN `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ListVirtualWANsResult.
+func (l ListVirtualWANsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // ListVirtualWANsResultResponse is the response envelope for operations that return a ListVirtualWANsResult type.
@@ -7140,13 +9049,30 @@ type LoadBalancer struct {
 	SKU *LoadBalancerSKU `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancer.
+func (l LoadBalancer) MarshalJSON() ([]byte, error) {
+	objectMap := l.Resource.marshalInternal()
+	populate(objectMap, "etag", l.Etag)
+	populate(objectMap, "properties", l.Properties)
+	populate(objectMap, "sku", l.SKU)
+	return json.Marshal(objectMap)
+}
+
 // LoadBalancerBackendAddressPoolListResult - Response for ListBackendAddressPool API service call.
 type LoadBalancerBackendAddressPoolListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of backend address pools in a load balancer.
-	Value *[]*BackendAddressPool `json:"value,omitempty"`
+	Value []*BackendAddressPool `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerBackendAddressPoolListResult.
+func (l LoadBalancerBackendAddressPoolListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerBackendAddressPoolListResultResponse is the response envelope for operations that return a LoadBalancerBackendAddressPoolListResult type.
@@ -7174,7 +9100,15 @@ type LoadBalancerFrontendIPConfigurationListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of frontend IP configurations in a load balancer.
-	Value *[]*FrontendIPConfiguration `json:"value,omitempty"`
+	Value []*FrontendIPConfiguration `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerFrontendIPConfigurationListResult.
+func (l LoadBalancerFrontendIPConfigurationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerFrontendIPConfigurationListResultResponse is the response envelope for operations that return a LoadBalancerFrontendIPConfigurationListResult
@@ -7203,7 +9137,15 @@ type LoadBalancerListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancers in a resource group.
-	Value *[]*LoadBalancer `json:"value,omitempty"`
+	Value []*LoadBalancer `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerListResult.
+func (l LoadBalancerListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerListResultResponse is the response envelope for operations that return a LoadBalancerListResult type.
@@ -7221,7 +9163,15 @@ type LoadBalancerLoadBalancingRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancing rules in a load balancer.
-	Value *[]*LoadBalancingRule `json:"value,omitempty"`
+	Value []*LoadBalancingRule `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerLoadBalancingRuleListResult.
+func (l LoadBalancerLoadBalancingRuleListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerLoadBalancingRuleListResultResponse is the response envelope for operations that return a LoadBalancerLoadBalancingRuleListResult type.
@@ -7254,7 +9204,15 @@ type LoadBalancerOutboundRuleListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of outbound rules in a load balancer.
-	Value *[]*OutboundRule `json:"value,omitempty"`
+	Value []*OutboundRule `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerOutboundRuleListResult.
+func (l LoadBalancerOutboundRuleListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerOutboundRuleListResultResponse is the response envelope for operations that return a LoadBalancerOutboundRuleListResult type.
@@ -7294,7 +9252,15 @@ type LoadBalancerProbeListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of probes in a load balancer.
-	Value *[]*Probe `json:"value,omitempty"`
+	Value []*Probe `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerProbeListResult.
+func (l LoadBalancerProbeListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerProbeListResultResponse is the response envelope for operations that return a LoadBalancerProbeListResult type.
@@ -7319,10 +9285,10 @@ type LoadBalancerProbesListOptions struct {
 // LoadBalancerPropertiesFormat - Properties of the load balancer.
 type LoadBalancerPropertiesFormat struct {
 	// Collection of backend address pools used by a load balancer.
-	BackendAddressPools *[]*BackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*BackendAddressPool `json:"backendAddressPools,omitempty"`
 
 	// Object representing the frontend IPs to be used for the load balancer.
-	FrontendIPConfigurations *[]*FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
 
 	// Defines an external port range for inbound NAT to a single backend port on NICs associated with a load balancer. Inbound NAT rules are created automatically
 	// for each NIC associated with the Load
@@ -7330,28 +9296,43 @@ type LoadBalancerPropertiesFormat struct {
 	// Inbound NAT pools are referenced from virtual
 	// machine scale sets. NICs that are associated with individual virtual machines cannot reference an inbound NAT pool. They have to reference individual
 	// inbound NAT rules.
-	InboundNatPools *[]*InboundNatPool `json:"inboundNatPools,omitempty"`
+	InboundNatPools []*InboundNatPool `json:"inboundNatPools,omitempty"`
 
 	// Collection of inbound NAT Rules used by a load balancer. Defining inbound NAT rules on your load balancer is mutually exclusive with defining an inbound
 	// NAT pool. Inbound NAT pools are referenced from
 	// virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an Inbound NAT pool. They have to reference individual
 	// inbound NAT rules.
-	InboundNatRules *[]*InboundNatRule `json:"inboundNatRules,omitempty"`
+	InboundNatRules []*InboundNatRule `json:"inboundNatRules,omitempty"`
 
 	// Object collection representing the load balancing rules Gets the provisioning.
-	LoadBalancingRules *[]*LoadBalancingRule `json:"loadBalancingRules,omitempty"`
+	LoadBalancingRules []*LoadBalancingRule `json:"loadBalancingRules,omitempty"`
 
 	// The outbound rules.
-	OutboundRules *[]*OutboundRule `json:"outboundRules,omitempty"`
+	OutboundRules []*OutboundRule `json:"outboundRules,omitempty"`
 
 	// Collection of probe objects used in the load balancer.
-	Probes *[]*Probe `json:"probes,omitempty"`
+	Probes []*Probe `json:"probes,omitempty"`
 
 	// READ-ONLY; The provisioning state of the load balancer resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the load balancer resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancerPropertiesFormat.
+func (l LoadBalancerPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "backendAddressPools", l.BackendAddressPools)
+	populate(objectMap, "frontendIPConfigurations", l.FrontendIPConfigurations)
+	populate(objectMap, "inboundNatPools", l.InboundNatPools)
+	populate(objectMap, "inboundNatRules", l.InboundNatRules)
+	populate(objectMap, "loadBalancingRules", l.LoadBalancingRules)
+	populate(objectMap, "outboundRules", l.OutboundRules)
+	populate(objectMap, "probes", l.Probes)
+	populate(objectMap, "provisioningState", l.ProvisioningState)
+	populate(objectMap, "resourceGuid", l.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancerResponse is the response envelope for operations that return a LoadBalancer type.
@@ -7414,6 +9395,16 @@ type LoadBalancingRule struct {
 
 	// READ-ONLY; Type of the resource.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LoadBalancingRule.
+func (l LoadBalancingRule) MarshalJSON() ([]byte, error) {
+	objectMap := l.SubResource.marshalInternal()
+	populate(objectMap, "etag", l.Etag)
+	populate(objectMap, "name", l.Name)
+	populate(objectMap, "properties", l.Properties)
+	populate(objectMap, "type", l.Type)
+	return json.Marshal(objectMap)
 }
 
 // LoadBalancingRulePropertiesFormat - Properties of the load balancer.
@@ -7479,13 +9470,29 @@ type LocalNetworkGateway struct {
 	Properties *LocalNetworkGatewayPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type LocalNetworkGateway.
+func (l LocalNetworkGateway) MarshalJSON() ([]byte, error) {
+	objectMap := l.Resource.marshalInternal()
+	populate(objectMap, "etag", l.Etag)
+	populate(objectMap, "properties", l.Properties)
+	return json.Marshal(objectMap)
+}
+
 // LocalNetworkGatewayListResult - Response for ListLocalNetworkGateways API service call.
 type LocalNetworkGatewayListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of local network gateways that exists in a resource group.
-	Value *[]*LocalNetworkGateway `json:"value,omitempty"`
+	Value []*LocalNetworkGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LocalNetworkGatewayListResult.
+func (l LocalNetworkGatewayListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LocalNetworkGatewayListResultResponse is the response envelope for operations that return a LocalNetworkGatewayListResult type.
@@ -7582,7 +9589,15 @@ type ManagedRuleGroupOverride struct {
 	RuleGroupName *string `json:"ruleGroupName,omitempty"`
 
 	// List of rules that will be disabled. If none specified, all rules in the group will be disabled.
-	Rules *[]*ManagedRuleOverride `json:"rules,omitempty"`
+	Rules []*ManagedRuleOverride `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ManagedRuleGroupOverride.
+func (m ManagedRuleGroupOverride) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "ruleGroupName", m.RuleGroupName)
+	populate(objectMap, "rules", m.Rules)
+	return json.Marshal(objectMap)
 }
 
 // ManagedRuleOverride - Defines a managed rule group override setting.
@@ -7597,7 +9612,7 @@ type ManagedRuleOverride struct {
 // ManagedRuleSet - Defines a managed rule set.
 type ManagedRuleSet struct {
 	// Defines the rule group overrides to apply to the rule set.
-	RuleGroupOverrides *[]*ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
+	RuleGroupOverrides []*ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
 
 	// Defines the rule set type to use.
 	RuleSetType *string `json:"ruleSetType,omitempty"`
@@ -7606,13 +9621,30 @@ type ManagedRuleSet struct {
 	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedRuleSet.
+func (m ManagedRuleSet) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "ruleGroupOverrides", m.RuleGroupOverrides)
+	populate(objectMap, "ruleSetType", m.RuleSetType)
+	populate(objectMap, "ruleSetVersion", m.RuleSetVersion)
+	return json.Marshal(objectMap)
+}
+
 // ManagedRulesDefinition - Allow to exclude some variable satisfy the condition for the WAF check.
 type ManagedRulesDefinition struct {
 	// The Exclusions that are applied on the policy.
-	Exclusions *[]*OwaspCrsExclusionEntry `json:"exclusions,omitempty"`
+	Exclusions []*OwaspCrsExclusionEntry `json:"exclusions,omitempty"`
 
 	// The managed rule sets that are associated with the policy.
-	ManagedRuleSets *[]*ManagedRuleSet `json:"managedRuleSets,omitempty"`
+	ManagedRuleSets []*ManagedRuleSet `json:"managedRuleSets,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ManagedRulesDefinition.
+func (m ManagedRulesDefinition) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "exclusions", m.Exclusions)
+	populate(objectMap, "managedRuleSets", m.ManagedRuleSets)
+	return json.Marshal(objectMap)
 }
 
 // ManagedServiceIdentity - Identity for the resource.
@@ -7630,16 +9662,26 @@ type ManagedServiceIdentity struct {
 
 	// The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities *map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties `json:"userAssignedIdentities,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentity.
+func (m ManagedServiceIdentity) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "principalId", m.PrincipalID)
+	populate(objectMap, "tenantId", m.TenantID)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
 }
 
 // MatchCondition - Define match conditions.
 type MatchCondition struct {
 	// Match value.
-	MatchValues *[]*string `json:"matchValues,omitempty"`
+	MatchValues []*string `json:"matchValues,omitempty"`
 
 	// List of match variables.
-	MatchVariables *[]*MatchVariable `json:"matchVariables,omitempty"`
+	MatchVariables []*MatchVariable `json:"matchVariables,omitempty"`
 
 	// Whether this is negate condition or not.
 	NegationConditon *bool `json:"negationConditon,omitempty"`
@@ -7648,7 +9690,18 @@ type MatchCondition struct {
 	Operator *WebApplicationFirewallOperator `json:"operator,omitempty"`
 
 	// List of transforms.
-	Transforms *[]*WebApplicationFirewallTransform `json:"transforms,omitempty"`
+	Transforms []*WebApplicationFirewallTransform `json:"transforms,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MatchCondition.
+func (m MatchCondition) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "matchValues", m.MatchValues)
+	populate(objectMap, "matchVariables", m.MatchVariables)
+	populate(objectMap, "negationConditon", m.NegationConditon)
+	populate(objectMap, "operator", m.Operator)
+	populate(objectMap, "transforms", m.Transforms)
+	return json.Marshal(objectMap)
 }
 
 // MatchVariable - Define match variables.
@@ -7675,10 +9728,10 @@ type MetricSpecification struct {
 	AggregationType *string `json:"aggregationType,omitempty"`
 
 	// List of availability.
-	Availabilities *[]*Availability `json:"availabilities,omitempty"`
+	Availabilities []*Availability `json:"availabilities,omitempty"`
 
 	// List of dimensions.
-	Dimensions *[]*Dimension `json:"dimensions,omitempty"`
+	Dimensions []*Dimension `json:"dimensions,omitempty"`
 
 	// The description of the metric.
 	DisplayDescription *string `json:"displayDescription,omitempty"`
@@ -7714,6 +9767,26 @@ type MetricSpecification struct {
 	Unit *string `json:"unit,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type MetricSpecification.
+func (m MetricSpecification) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aggregationType", m.AggregationType)
+	populate(objectMap, "availabilities", m.Availabilities)
+	populate(objectMap, "dimensions", m.Dimensions)
+	populate(objectMap, "displayDescription", m.DisplayDescription)
+	populate(objectMap, "displayName", m.DisplayName)
+	populate(objectMap, "enableRegionalMdmAccount", m.EnableRegionalMdmAccount)
+	populate(objectMap, "fillGapWithZero", m.FillGapWithZero)
+	populate(objectMap, "isInternal", m.IsInternal)
+	populate(objectMap, "metricFilterPattern", m.MetricFilterPattern)
+	populate(objectMap, "name", m.Name)
+	populate(objectMap, "resourceIdDimensionNameOverride", m.ResourceIDDimensionNameOverride)
+	populate(objectMap, "sourceMdmAccount", m.SourceMdmAccount)
+	populate(objectMap, "sourceMdmNamespace", m.SourceMdmNamespace)
+	populate(objectMap, "unit", m.Unit)
+	return json.Marshal(objectMap)
+}
+
 // NatGateway - Nat Gateway resource.
 type NatGateway struct {
 	Resource
@@ -7727,7 +9800,17 @@ type NatGateway struct {
 	SKU *NatGatewaySKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the zone in which Nat Gateway should be deployed.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NatGateway.
+func (n NatGateway) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "properties", n.Properties)
+	populate(objectMap, "sku", n.SKU)
+	populate(objectMap, "zones", n.Zones)
+	return json.Marshal(objectMap)
 }
 
 // NatGatewayListResult - Response for ListNatGateways API service call.
@@ -7736,7 +9819,15 @@ type NatGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of Nat Gateways that exists in a resource group.
-	Value *[]*NatGateway `json:"value,omitempty"`
+	Value []*NatGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NatGatewayListResult.
+func (n NatGatewayListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NatGatewayListResultResponse is the response envelope for operations that return a NatGatewayListResult type.
@@ -7769,16 +9860,28 @@ type NatGatewayPropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// An array of public ip addresses associated with the nat gateway resource.
-	PublicIPAddresses *[]*SubResource `json:"publicIpAddresses,omitempty"`
+	PublicIPAddresses []*SubResource `json:"publicIpAddresses,omitempty"`
 
 	// An array of public ip prefixes associated with the nat gateway resource.
-	PublicIPPrefixes *[]*SubResource `json:"publicIpPrefixes,omitempty"`
+	PublicIPPrefixes []*SubResource `json:"publicIpPrefixes,omitempty"`
 
 	// READ-ONLY; The resource GUID property of the NAT gateway resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the subnets using this nat gateway resource.
-	Subnets *[]*SubResource `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*SubResource `json:"subnets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NatGatewayPropertiesFormat.
+func (n NatGatewayPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "idleTimeoutInMinutes", n.IdleTimeoutInMinutes)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "publicIpAddresses", n.PublicIPAddresses)
+	populate(objectMap, "publicIpPrefixes", n.PublicIPPrefixes)
+	populate(objectMap, "resourceGuid", n.ResourceGUID)
+	populate(objectMap, "subnets", n.Subnets)
+	return json.Marshal(objectMap)
 }
 
 // NatGatewayResponse is the response envelope for operations that return a NatGateway type.
@@ -7831,19 +9934,19 @@ type NatGatewaysUpdateTagsOptions struct {
 type NatRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string `json:"destinationPorts,omitempty"`
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols *[]*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NatRuleCondition.
@@ -7892,7 +9995,7 @@ func (n *NatRuleCondition) UnmarshalJSON(data []byte) error {
 // NetworkConfigurationDiagnosticParameters - Parameters to get network configuration diagnostic.
 type NetworkConfigurationDiagnosticParameters struct {
 	// List of network configuration diagnostic profiles.
-	Profiles *[]*NetworkConfigurationDiagnosticProfile `json:"profiles,omitempty"`
+	Profiles []*NetworkConfigurationDiagnosticProfile `json:"profiles,omitempty"`
 
 	// The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application
 	// Gateway.
@@ -7900,6 +10003,15 @@ type NetworkConfigurationDiagnosticParameters struct {
 
 	// Verbosity level.
 	VerbosityLevel *VerbosityLevel `json:"verbosityLevel,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkConfigurationDiagnosticParameters.
+func (n NetworkConfigurationDiagnosticParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "profiles", n.Profiles)
+	populate(objectMap, "targetResourceId", n.TargetResourceID)
+	populate(objectMap, "verbosityLevel", n.VerbosityLevel)
+	return json.Marshal(objectMap)
 }
 
 // NetworkConfigurationDiagnosticProfile - Parameters to compare with network configuration.
@@ -7923,7 +10035,14 @@ type NetworkConfigurationDiagnosticProfile struct {
 // NetworkConfigurationDiagnosticResponse - Results of network configuration diagnostic on the target resource.
 type NetworkConfigurationDiagnosticResponse struct {
 	// READ-ONLY; List of network configuration diagnostic results.
-	Results *[]*NetworkConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
+	Results []*NetworkConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkConfigurationDiagnosticResponse.
+func (n NetworkConfigurationDiagnosticResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "results", n.Results)
+	return json.Marshal(objectMap)
 }
 
 // NetworkConfigurationDiagnosticResponsePollerResponse is the response envelope for operations that asynchronously return a NetworkConfigurationDiagnosticResponse
@@ -7964,6 +10083,13 @@ type NetworkIntentPolicy struct {
 	Etag *string `json:"etag,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkIntentPolicy.
+func (n NetworkIntentPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	return json.Marshal(objectMap)
+}
+
 // NetworkIntentPolicyConfiguration - Details of NetworkIntentPolicyConfiguration for PrepareNetworkPoliciesRequest.
 type NetworkIntentPolicyConfiguration struct {
 	// The name of the Network Intent Policy for storing in target subscription.
@@ -7983,13 +10109,29 @@ type NetworkInterface struct {
 	Properties *NetworkInterfacePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterface.
+func (n NetworkInterface) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
+}
+
 // NetworkInterfaceAssociation - Network interface and its custom security rules.
 type NetworkInterfaceAssociation struct {
 	// READ-ONLY; Network interface ID.
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// Collection of custom security rules.
-	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceAssociation.
+func (n NetworkInterfaceAssociation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", n.ID)
+	populate(objectMap, "securityRules", n.SecurityRules)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceDNSSettings - DNS settings of a network interface.
@@ -7997,12 +10139,12 @@ type NetworkInterfaceDNSSettings struct {
 	// READ-ONLY; If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are
 	// part of the Availability Set. This property is what is
 	// configured on each of those VMs.
-	AppliedDNSServers *[]*string `json:"appliedDnsServers,omitempty" azure:"ro"`
+	AppliedDNSServers []*string `json:"appliedDnsServers,omitempty" azure:"ro"`
 
 	// List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with
 	// other IPs, it must be the only value in dnsServers
 	// collection.
-	DNSServers *[]*string `json:"dnsServers,omitempty"`
+	DNSServers []*string `json:"dnsServers,omitempty"`
 
 	// Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
 	InternalDNSNameLabel *string `json:"internalDnsNameLabel,omitempty"`
@@ -8014,6 +10156,17 @@ type NetworkInterfaceDNSSettings struct {
 
 	// READ-ONLY; Fully qualified DNS name supporting internal communications between VMs in the same virtual network.
 	InternalFqdn *string `json:"internalFqdn,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceDNSSettings.
+func (n NetworkInterfaceDNSSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appliedDnsServers", n.AppliedDNSServers)
+	populate(objectMap, "dnsServers", n.DNSServers)
+	populate(objectMap, "internalDnsNameLabel", n.InternalDNSNameLabel)
+	populate(objectMap, "internalDomainNameSuffix", n.InternalDomainNameSuffix)
+	populate(objectMap, "internalFqdn", n.InternalFqdn)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceIPConfiguration - IPConfiguration in a network interface.
@@ -8029,13 +10182,30 @@ type NetworkInterfaceIPConfiguration struct {
 	Properties *NetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfiguration.
+func (n NetworkInterfaceIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := n.SubResource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "name", n.Name)
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
+}
+
 // NetworkInterfaceIPConfigurationListResult - Response for list ip configurations API service call.
 type NetworkInterfaceIPConfigurationListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ip configurations.
-	Value *[]*NetworkInterfaceIPConfiguration `json:"value,omitempty"`
+	Value []*NetworkInterfaceIPConfiguration `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationListResult.
+func (n NetworkInterfaceIPConfigurationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceIPConfigurationListResultResponse is the response envelope for operations that return a NetworkInterfaceIPConfigurationListResult type.
@@ -8050,7 +10220,7 @@ type NetworkInterfaceIPConfigurationListResultResponse struct {
 // NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties - PrivateLinkConnection properties for the network interface.
 type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
 	// READ-ONLY; List of FQDNs for current private link connection.
-	Fqdns *[]*string `json:"fqdns,omitempty" azure:"ro"`
+	Fqdns []*string `json:"fqdns,omitempty" azure:"ro"`
 
 	// READ-ONLY; The group ID for current private link connection.
 	GroupID *string `json:"groupId,omitempty" azure:"ro"`
@@ -8059,19 +10229,28 @@ type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
 	RequiredMemberName *string `json:"requiredMemberName,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties.
+func (n NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fqdns", n.Fqdns)
+	populate(objectMap, "groupId", n.GroupID)
+	populate(objectMap, "requiredMemberName", n.RequiredMemberName)
+	return json.Marshal(objectMap)
+}
+
 // NetworkInterfaceIPConfigurationPropertiesFormat - Properties of IP configuration.
 type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 	// The reference to ApplicationGatewayBackendAddressPool resource.
-	ApplicationGatewayBackendAddressPools *[]*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
 
 	// Application security groups in which the IP configuration is included.
-	ApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
 
 	// The reference to LoadBalancerBackendAddressPool resource.
-	LoadBalancerBackendAddressPools *[]*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
 
 	// A list of references of LoadBalancerInboundNatRules.
-	LoadBalancerInboundNatRules *[]*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
+	LoadBalancerInboundNatRules []*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
 
 	// Whether this is a primary customer address on the network interface.
 	Primary *bool `json:"primary,omitempty"`
@@ -8098,7 +10277,26 @@ type NetworkInterfaceIPConfigurationPropertiesFormat struct {
 	Subnet *Subnet `json:"subnet,omitempty"`
 
 	// The reference to Virtual Network Taps.
-	VirtualNetworkTaps *[]*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
+	VirtualNetworkTaps []*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceIPConfigurationPropertiesFormat.
+func (n NetworkInterfaceIPConfigurationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "applicationGatewayBackendAddressPools", n.ApplicationGatewayBackendAddressPools)
+	populate(objectMap, "applicationSecurityGroups", n.ApplicationSecurityGroups)
+	populate(objectMap, "loadBalancerBackendAddressPools", n.LoadBalancerBackendAddressPools)
+	populate(objectMap, "loadBalancerInboundNatRules", n.LoadBalancerInboundNatRules)
+	populate(objectMap, "primary", n.Primary)
+	populate(objectMap, "privateIPAddress", n.PrivateIPAddress)
+	populate(objectMap, "privateIPAddressVersion", n.PrivateIPAddressVersion)
+	populate(objectMap, "privateIPAllocationMethod", n.PrivateIPAllocationMethod)
+	populate(objectMap, "privateLinkConnectionProperties", n.PrivateLinkConnectionProperties)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "publicIPAddress", n.PublicIPAddress)
+	populate(objectMap, "subnet", n.Subnet)
+	populate(objectMap, "virtualNetworkTaps", n.VirtualNetworkTaps)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceIPConfigurationResponse is the response envelope for operations that return a NetworkInterfaceIPConfiguration type.
@@ -8126,7 +10324,15 @@ type NetworkInterfaceListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of network interfaces in a resource group.
-	Value *[]*NetworkInterface `json:"value,omitempty"`
+	Value []*NetworkInterface `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceListResult.
+func (n NetworkInterfaceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceListResultResponse is the response envelope for operations that return a NetworkInterfaceListResult type.
@@ -8144,7 +10350,15 @@ type NetworkInterfaceLoadBalancerListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of load balancers.
-	Value *[]*LoadBalancer `json:"value,omitempty"`
+	Value []*LoadBalancer `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceLoadBalancerListResult.
+func (n NetworkInterfaceLoadBalancerListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceLoadBalancerListResultResponse is the response envelope for operations that return a NetworkInterfaceLoadBalancerListResult type.
@@ -8185,10 +10399,10 @@ type NetworkInterfacePropertiesFormat struct {
 	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
 
 	// READ-ONLY; A list of references to linked BareMetal resources.
-	HostedWorkloads *[]*string `json:"hostedWorkloads,omitempty" azure:"ro"`
+	HostedWorkloads []*string `json:"hostedWorkloads,omitempty" azure:"ro"`
 
 	// A list of IPConfigurations of the network interface.
-	IPConfigurations *[]*NetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*NetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The MAC address of the network interface.
 	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
@@ -8209,10 +10423,29 @@ type NetworkInterfacePropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// READ-ONLY; A list of TapConfigurations of the network interface.
-	TapConfigurations *[]*NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
+	TapConfigurations []*NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The reference to a virtual machine.
 	VirtualMachine *SubResource `json:"virtualMachine,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfacePropertiesFormat.
+func (n NetworkInterfacePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", n.DNSSettings)
+	populate(objectMap, "enableAcceleratedNetworking", n.EnableAcceleratedNetworking)
+	populate(objectMap, "enableIPForwarding", n.EnableIPForwarding)
+	populate(objectMap, "hostedWorkloads", n.HostedWorkloads)
+	populate(objectMap, "ipConfigurations", n.IPConfigurations)
+	populate(objectMap, "macAddress", n.MacAddress)
+	populate(objectMap, "networkSecurityGroup", n.NetworkSecurityGroup)
+	populate(objectMap, "primary", n.Primary)
+	populate(objectMap, "privateEndpoint", n.PrivateEndpoint)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "resourceGuid", n.ResourceGUID)
+	populate(objectMap, "tapConfigurations", n.TapConfigurations)
+	populate(objectMap, "virtualMachine", n.VirtualMachine)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceResponse is the response envelope for operations that return a NetworkInterface type.
@@ -8240,13 +10473,31 @@ type NetworkInterfaceTapConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceTapConfiguration.
+func (n NetworkInterfaceTapConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := n.SubResource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "name", n.Name)
+	populate(objectMap, "properties", n.Properties)
+	populate(objectMap, "type", n.Type)
+	return json.Marshal(objectMap)
+}
+
 // NetworkInterfaceTapConfigurationListResult - Response for list tap configurations API service call.
 type NetworkInterfaceTapConfigurationListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of tap configurations.
-	Value *[]*NetworkInterfaceTapConfiguration `json:"value,omitempty"`
+	Value []*NetworkInterfaceTapConfiguration `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkInterfaceTapConfigurationListResult.
+func (n NetworkInterfaceTapConfigurationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkInterfaceTapConfigurationListResultResponse is the response envelope for operations that return a NetworkInterfaceTapConfigurationListResult type.
@@ -8439,13 +10690,29 @@ type NetworkProfile struct {
 	Properties *NetworkProfilePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
+func (n NetworkProfile) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
+}
+
 // NetworkProfileListResult - Response for ListNetworkProfiles API service call.
 type NetworkProfileListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of network profiles that exist in a resource group.
-	Value *[]*NetworkProfile `json:"value,omitempty"`
+	Value []*NetworkProfile `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkProfileListResult.
+func (n NetworkProfileListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkProfileListResultResponse is the response envelope for operations that return a NetworkProfileListResult type.
@@ -8460,16 +10727,26 @@ type NetworkProfileListResultResponse struct {
 // NetworkProfilePropertiesFormat - Network profile properties.
 type NetworkProfilePropertiesFormat struct {
 	// List of chid container network interface configurations.
-	ContainerNetworkInterfaceConfigurations *[]*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
+	ContainerNetworkInterfaceConfigurations []*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
 
 	// READ-ONLY; List of child container network interfaces.
-	ContainerNetworkInterfaces *[]*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
+	ContainerNetworkInterfaces []*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the network profile resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the network profile resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkProfilePropertiesFormat.
+func (n NetworkProfilePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "containerNetworkInterfaceConfigurations", n.ContainerNetworkInterfaceConfigurations)
+	populate(objectMap, "containerNetworkInterfaces", n.ContainerNetworkInterfaces)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "resourceGuid", n.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // NetworkProfileResponse is the response envelope for operations that return a NetworkProfile type.
@@ -8516,22 +10793,22 @@ type NetworkProfilesUpdateTagsOptions struct {
 type NetworkRuleCondition struct {
 	FirewallPolicyRuleCondition
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses *[]*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups *[]*string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
 
 	// List of destination ports.
-	DestinationPorts *[]*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string `json:"destinationPorts,omitempty"`
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols *[]*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
 
 	// List of source IP addresses for this rule.
-	SourceAddresses *[]*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups *[]*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NetworkRuleCondition.
@@ -8591,13 +10868,29 @@ type NetworkSecurityGroup struct {
 	Properties *NetworkSecurityGroupPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroup.
+func (n NetworkSecurityGroup) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
+}
+
 // NetworkSecurityGroupListResult - Response for ListNetworkSecurityGroups API service call.
 type NetworkSecurityGroupListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of NetworkSecurityGroup resources.
-	Value *[]*NetworkSecurityGroup `json:"value,omitempty"`
+	Value []*NetworkSecurityGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupListResult.
+func (n NetworkSecurityGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkSecurityGroupListResultResponse is the response envelope for operations that return a NetworkSecurityGroupListResult type.
@@ -8624,13 +10917,13 @@ type NetworkSecurityGroupPollerResponse struct {
 // NetworkSecurityGroupPropertiesFormat - Network Security Group resource.
 type NetworkSecurityGroupPropertiesFormat struct {
 	// READ-ONLY; The default security rules of network security group.
-	DefaultSecurityRules *[]*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
+	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to flow log resources.
-	FlowLogs *[]*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
+	FlowLogs []*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to network interfaces.
-	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the network security group resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -8639,10 +10932,23 @@ type NetworkSecurityGroupPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A collection of security rules of the network security group.
-	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupPropertiesFormat.
+func (n NetworkSecurityGroupPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "defaultSecurityRules", n.DefaultSecurityRules)
+	populate(objectMap, "flowLogs", n.FlowLogs)
+	populate(objectMap, "networkInterfaces", n.NetworkInterfaces)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "resourceGuid", n.ResourceGUID)
+	populate(objectMap, "securityRules", n.SecurityRules)
+	populate(objectMap, "subnets", n.Subnets)
+	return json.Marshal(objectMap)
 }
 
 // NetworkSecurityGroupResponse is the response envelope for operations that return a NetworkSecurityGroup type.
@@ -8657,10 +10963,18 @@ type NetworkSecurityGroupResponse struct {
 // NetworkSecurityGroupResult - Network configuration diagnostic result corresponded provided traffic query.
 type NetworkSecurityGroupResult struct {
 	// READ-ONLY; List of results network security groups diagnostic.
-	EvaluatedNetworkSecurityGroups *[]*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
+	EvaluatedNetworkSecurityGroups []*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
 
 	// The network traffic is allowed or denied.
 	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkSecurityGroupResult.
+func (n NetworkSecurityGroupResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "evaluatedNetworkSecurityGroups", n.EvaluatedNetworkSecurityGroups)
+	populate(objectMap, "securityRuleAccessResult", n.SecurityRuleAccessResult)
+	return json.Marshal(objectMap)
 }
 
 // NetworkSecurityGroupsBeginCreateOrUpdateOptions contains the optional parameters for the NetworkSecurityGroups.BeginCreateOrUpdate method.
@@ -8731,13 +11045,31 @@ type NetworkVirtualAppliance struct {
 	SKU *VirtualApplianceSKUProperties `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualAppliance.
+func (n NetworkVirtualAppliance) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "identity", n.Identity)
+	populate(objectMap, "properties", n.Properties)
+	populate(objectMap, "sku", n.SKU)
+	return json.Marshal(objectMap)
+}
+
 // NetworkVirtualApplianceListResult - Response for ListNetworkVirtualAppliances API service call.
 type NetworkVirtualApplianceListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Network Virtual Appliances.
-	Value *[]*NetworkVirtualAppliance `json:"value,omitempty"`
+	Value []*NetworkVirtualAppliance `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualApplianceListResult.
+func (n NetworkVirtualApplianceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkVirtualApplianceListResultResponse is the response envelope for operations that return a NetworkVirtualApplianceListResult type.
@@ -8764,10 +11096,10 @@ type NetworkVirtualAppliancePollerResponse struct {
 // NetworkVirtualAppliancePropertiesFormat - Network Virtual Appliance definition.
 type NetworkVirtualAppliancePropertiesFormat struct {
 	// BootStrapConfigurationBlob storage URLs.
-	BootStrapConfigurationBlob *[]*string `json:"bootStrapConfigurationBlob,omitempty"`
+	BootStrapConfigurationBlob []*string `json:"bootStrapConfigurationBlob,omitempty"`
 
 	// CloudInitConfigurationBlob storage URLs.
-	CloudInitConfigurationBlob *[]*string `json:"cloudInitConfigurationBlob,omitempty"`
+	CloudInitConfigurationBlob []*string `json:"cloudInitConfigurationBlob,omitempty"`
 
 	// READ-ONLY; The provisioning state of the resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -8776,10 +11108,22 @@ type NetworkVirtualAppliancePropertiesFormat struct {
 	VirtualApplianceAsn *int64 `json:"virtualApplianceAsn,omitempty"`
 
 	// READ-ONLY; List of Virtual Appliance Network Interfaces.
-	VirtualApplianceNics *[]*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
+	VirtualApplianceNics []*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
 
 	// The Virtual Hub where Network Virtual Appliance is being deployed.
 	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkVirtualAppliancePropertiesFormat.
+func (n NetworkVirtualAppliancePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bootStrapConfigurationBlob", n.BootStrapConfigurationBlob)
+	populate(objectMap, "cloudInitConfigurationBlob", n.CloudInitConfigurationBlob)
+	populate(objectMap, "provisioningState", n.ProvisioningState)
+	populate(objectMap, "virtualApplianceAsn", n.VirtualApplianceAsn)
+	populate(objectMap, "virtualApplianceNics", n.VirtualApplianceNics)
+	populate(objectMap, "virtualHub", n.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // NetworkVirtualApplianceResponse is the response envelope for operations that return a NetworkVirtualAppliance type.
@@ -8832,10 +11176,25 @@ type NetworkWatcher struct {
 	Properties *NetworkWatcherPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type NetworkWatcher.
+func (n NetworkWatcher) MarshalJSON() ([]byte, error) {
+	objectMap := n.Resource.marshalInternal()
+	populate(objectMap, "etag", n.Etag)
+	populate(objectMap, "properties", n.Properties)
+	return json.Marshal(objectMap)
+}
+
 // NetworkWatcherListResult - Response for ListNetworkWatchers API service call.
 type NetworkWatcherListResult struct {
 	// List of network watcher resources.
-	Value *[]*NetworkWatcher `json:"value,omitempty"`
+	Value []*NetworkWatcher `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NetworkWatcherListResult.
+func (n NetworkWatcherListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NetworkWatcherListResultResponse is the response envelope for operations that return a NetworkWatcherListResult type.
@@ -9039,7 +11398,15 @@ type OperationListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Network operations supported by the Network resource provider.
-	Value *[]*Operation `json:"value,omitempty"`
+	Value []*Operation `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OperationListResult.
+func (o OperationListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", o.NextLink)
+	populate(objectMap, "value", o.Value)
+	return json.Marshal(objectMap)
 }
 
 // OperationListResultResponse is the response envelope for operations that return a OperationListResult type.
@@ -9060,10 +11427,18 @@ type OperationPropertiesFormat struct {
 // OperationPropertiesFormatServiceSpecification - Specification of the service.
 type OperationPropertiesFormatServiceSpecification struct {
 	// Operation log specification.
-	LogSpecifications *[]*LogSpecification `json:"logSpecifications,omitempty"`
+	LogSpecifications []*LogSpecification `json:"logSpecifications,omitempty"`
 
 	// Operation service specification.
-	MetricSpecifications *[]*MetricSpecification `json:"metricSpecifications,omitempty"`
+	MetricSpecifications []*MetricSpecification `json:"metricSpecifications,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OperationPropertiesFormatServiceSpecification.
+func (o OperationPropertiesFormatServiceSpecification) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "logSpecifications", o.LogSpecifications)
+	populate(objectMap, "metricSpecifications", o.MetricSpecifications)
+	return json.Marshal(objectMap)
 }
 
 // OperationsListOptions contains the optional parameters for the Operations.List method.
@@ -9087,6 +11462,16 @@ type OutboundRule struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type OutboundRule.
+func (o OutboundRule) MarshalJSON() ([]byte, error) {
+	objectMap := o.SubResource.marshalInternal()
+	populate(objectMap, "etag", o.Etag)
+	populate(objectMap, "name", o.Name)
+	populate(objectMap, "properties", o.Properties)
+	populate(objectMap, "type", o.Type)
+	return json.Marshal(objectMap)
+}
+
 // OutboundRulePropertiesFormat - Outbound rule of the load balancer.
 type OutboundRulePropertiesFormat struct {
 	// The number of outbound ports to be used for NAT.
@@ -9100,7 +11485,7 @@ type OutboundRulePropertiesFormat struct {
 	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
 
 	// The Frontend IP addresses of the load balancer.
-	FrontendIPConfigurations *[]*SubResource `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*SubResource `json:"frontendIPConfigurations,omitempty"`
 
 	// The timeout for the TCP idle connection.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -9110,6 +11495,19 @@ type OutboundRulePropertiesFormat struct {
 
 	// READ-ONLY; The provisioning state of the outbound rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OutboundRulePropertiesFormat.
+func (o OutboundRulePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allocatedOutboundPorts", o.AllocatedOutboundPorts)
+	populate(objectMap, "backendAddressPool", o.BackendAddressPool)
+	populate(objectMap, "enableTcpReset", o.EnableTCPReset)
+	populate(objectMap, "frontendIPConfigurations", o.FrontendIPConfigurations)
+	populate(objectMap, "idleTimeoutInMinutes", o.IdleTimeoutInMinutes)
+	populate(objectMap, "protocol", o.Protocol)
+	populate(objectMap, "provisioningState", o.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // OutboundRuleResponse is the response envelope for operations that return a OutboundRule type.
@@ -9146,6 +11544,15 @@ type P2SConnectionConfiguration struct {
 	Properties *P2SConnectionConfigurationProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type P2SConnectionConfiguration.
+func (p P2SConnectionConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
 // P2SConnectionConfigurationProperties - Parameters for P2SConnectionConfiguration.
 type P2SConnectionConfigurationProperties struct {
 	// READ-ONLY; The provisioning state of the P2SConnectionConfiguration resource.
@@ -9179,7 +11586,15 @@ type P2SVPNConnectionHealthRequest struct {
 	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
 
 	// The list of p2s vpn user names whose p2s vpn connection detailed health to retrieve for.
-	VPNUserNamesFilter *[]*string `json:"vpnUserNamesFilter,omitempty"`
+	VPNUserNamesFilter []*string `json:"vpnUserNamesFilter,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type P2SVPNConnectionHealthRequest.
+func (p P2SVPNConnectionHealthRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "outputBlobSasUrl", p.OutputBlobSasURL)
+	populate(objectMap, "vpnUserNamesFilter", p.VPNUserNamesFilter)
+	return json.Marshal(objectMap)
 }
 
 // P2SVPNConnectionHealthResponse is the response envelope for operations that return a P2SVPNConnectionHealth type.
@@ -9194,7 +11609,14 @@ type P2SVPNConnectionHealthResponse struct {
 // P2SVPNConnectionRequest - List of p2s vpn connections to be disconnected.
 type P2SVPNConnectionRequest struct {
 	// List of p2s vpn connection Ids.
-	VPNConnectionIDs *[]*string `json:"vpnConnectionIds,omitempty"`
+	VPNConnectionIDs []*string `json:"vpnConnectionIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type P2SVPNConnectionRequest.
+func (p P2SVPNConnectionRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "vpnConnectionIds", p.VPNConnectionIDs)
+	return json.Marshal(objectMap)
 }
 
 // P2SVPNGateway - P2SVpnGateway Resource.
@@ -9205,6 +11627,14 @@ type P2SVPNGateway struct {
 
 	// Properties of the P2SVpnGateway.
 	Properties *P2SVPNGatewayProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type P2SVPNGateway.
+func (p P2SVPNGateway) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
 }
 
 // P2SVPNGatewayPollerResponse is the response envelope for operations that asynchronously return a P2SVPNGateway type.
@@ -9222,7 +11652,7 @@ type P2SVPNGatewayPollerResponse struct {
 // P2SVPNGatewayProperties - Parameters for P2SVpnGateway.
 type P2SVPNGatewayProperties struct {
 	// List of all p2s connection configurations of the gateway.
-	P2SConnectionConfigurations *[]*P2SConnectionConfiguration `json:"p2SConnectionConfigurations,omitempty"`
+	P2SConnectionConfigurations []*P2SConnectionConfiguration `json:"p2SConnectionConfigurations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the P2S VPN gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -9238,6 +11668,18 @@ type P2SVPNGatewayProperties struct {
 
 	// The VirtualHub to which the gateway belongs.
 	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type P2SVPNGatewayProperties.
+func (p P2SVPNGatewayProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "p2SConnectionConfigurations", p.P2SConnectionConfigurations)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "vpnClientConnectionHealth", p.VPNClientConnectionHealth)
+	populate(objectMap, "vpnGatewayScaleUnit", p.VPNGatewayScaleUnit)
+	populate(objectMap, "vpnServerConfiguration", p.VPNServerConfiguration)
+	populate(objectMap, "virtualHub", p.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // P2SVPNGatewayResponse is the response envelope for operations that return a P2SVPNGateway type.
@@ -9341,7 +11783,14 @@ type PacketCaptureFilter struct {
 // PacketCaptureListResult - List of packet capture sessions.
 type PacketCaptureListResult struct {
 	// Information about packet capture sessions.
-	Value *[]*PacketCaptureResult `json:"value,omitempty"`
+	Value []*PacketCaptureResult `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PacketCaptureListResult.
+func (p PacketCaptureListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PacketCaptureListResultResponse is the response envelope for operations that return a PacketCaptureListResult type.
@@ -9359,7 +11808,7 @@ type PacketCaptureParameters struct {
 	BytesToCapturePerPacket *int32 `json:"bytesToCapturePerPacket,omitempty"`
 
 	// A list of packet capture filters.
-	Filters *[]*PacketCaptureFilter `json:"filters,omitempty"`
+	Filters []*PacketCaptureFilter `json:"filters,omitempty"`
 
 	// The storage location for a packet capture session.
 	StorageLocation *PacketCaptureStorageLocation `json:"storageLocation,omitempty"`
@@ -9374,6 +11823,23 @@ type PacketCaptureParameters struct {
 	TotalBytesPerSession *int32 `json:"totalBytesPerSession,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PacketCaptureParameters.
+func (p PacketCaptureParameters) MarshalJSON() ([]byte, error) {
+	objectMap := p.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (p PacketCaptureParameters) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bytesToCapturePerPacket", p.BytesToCapturePerPacket)
+	populate(objectMap, "filters", p.Filters)
+	populate(objectMap, "storageLocation", p.StorageLocation)
+	populate(objectMap, "target", p.Target)
+	populate(objectMap, "timeLimitInSeconds", p.TimeLimitInSeconds)
+	populate(objectMap, "totalBytesPerSession", p.TotalBytesPerSession)
+	return objectMap
+}
+
 // PacketCaptureQueryStatusResult - Status of packet capture session.
 type PacketCaptureQueryStatusResult struct {
 	// The start time of the packet capture session.
@@ -9386,7 +11852,7 @@ type PacketCaptureQueryStatusResult struct {
 	Name *string `json:"name,omitempty"`
 
 	// List of errors of packet capture session.
-	PacketCaptureError *[]*PcError `json:"packetCaptureError,omitempty"`
+	PacketCaptureError []*PcError `json:"packetCaptureError,omitempty"`
 
 	// The status of the packet capture session.
 	PacketCaptureStatus *PcStatus `json:"packetCaptureStatus,omitempty"`
@@ -9499,6 +11965,13 @@ type PacketCaptureResultProperties struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PacketCaptureResultProperties.
+func (p PacketCaptureResultProperties) MarshalJSON() ([]byte, error) {
+	objectMap := p.PacketCaptureParameters.marshalInternal()
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	return json.Marshal(objectMap)
+}
+
 // PacketCaptureResultResponse is the response envelope for operations that return a PacketCaptureResult type.
 type PacketCaptureResultResponse struct {
 	// Information about packet capture session.
@@ -9565,10 +12038,21 @@ type PatchRouteFilter struct {
 	Properties *RouteFilterPropertiesFormat `json:"properties,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PatchRouteFilter.
+func (p PatchRouteFilter) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "tags", p.Tags)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
 }
 
 // PatchRouteFilterRule - Route Filter Rule Resource.
@@ -9582,6 +12066,15 @@ type PatchRouteFilterRule struct {
 
 	// Properties of the route filter rule.
 	Properties *RouteFilterRulePropertiesFormat `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PatchRouteFilterRule.
+func (p PatchRouteFilterRule) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
 }
 
 // PeerExpressRouteCircuitConnection - Peer Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.
@@ -9600,6 +12093,16 @@ type PeerExpressRouteCircuitConnection struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PeerExpressRouteCircuitConnection.
+func (p PeerExpressRouteCircuitConnection) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
+}
+
 // PeerExpressRouteCircuitConnectionListResult - Response for ListPeeredConnections API service call retrieves all global reach peer circuit connections
 // that belongs to a Private Peering for an ExpressRouteCircuit.
 type PeerExpressRouteCircuitConnectionListResult struct {
@@ -9607,7 +12110,15 @@ type PeerExpressRouteCircuitConnectionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The global reach peer circuit connection associated with Private Peering in an ExpressRoute Circuit.
-	Value *[]*PeerExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value []*PeerExpressRouteCircuitConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PeerExpressRouteCircuitConnectionListResult.
+func (p PeerExpressRouteCircuitConnectionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PeerExpressRouteCircuitConnectionListResultResponse is the response envelope for operations that return a PeerExpressRouteCircuitConnectionListResult
@@ -9684,10 +12195,18 @@ type PolicySettings struct {
 // PrepareNetworkPoliciesRequest - Details of PrepareNetworkPolicies for Subnet.
 type PrepareNetworkPoliciesRequest struct {
 	// A list of NetworkIntentPolicyConfiguration.
-	NetworkIntentPolicyConfigurations *[]*NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
+	NetworkIntentPolicyConfigurations []*NetworkIntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
 
 	// The name of the service for which subnet is being prepared for.
 	ServiceName *string `json:"serviceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrepareNetworkPoliciesRequest.
+func (p PrepareNetworkPoliciesRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "networkIntentPolicyConfigurations", p.NetworkIntentPolicyConfigurations)
+	populate(objectMap, "serviceName", p.ServiceName)
+	return json.Marshal(objectMap)
 }
 
 // PrivateDNSZoneConfig - PrivateDnsZoneConfig resource.
@@ -9712,13 +12231,30 @@ type PrivateDNSZoneGroup struct {
 	Properties *PrivateDNSZoneGroupPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateDNSZoneGroup.
+func (p PrivateDNSZoneGroup) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
 // PrivateDNSZoneGroupListResult - Response for the ListPrivateDnsZoneGroups API service call.
 type PrivateDNSZoneGroupListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of private dns zone group resources in a private endpoint.
-	Value *[]*PrivateDNSZoneGroup `json:"value,omitempty"`
+	Value []*PrivateDNSZoneGroup `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateDNSZoneGroupListResult.
+func (p PrivateDNSZoneGroupListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PrivateDNSZoneGroupListResultResponse is the response envelope for operations that return a PrivateDNSZoneGroupListResult type.
@@ -9745,10 +12281,18 @@ type PrivateDNSZoneGroupPollerResponse struct {
 // PrivateDNSZoneGroupPropertiesFormat - Properties of the private dns zone group.
 type PrivateDNSZoneGroupPropertiesFormat struct {
 	// A collection of private dns zone configurations of the private dns zone group.
-	PrivateDNSZoneConfigs *[]*PrivateDNSZoneConfig `json:"privateDnsZoneConfigs,omitempty"`
+	PrivateDNSZoneConfigs []*PrivateDNSZoneConfig `json:"privateDnsZoneConfigs,omitempty"`
 
 	// READ-ONLY; The provisioning state of the private dns zone group resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateDNSZoneGroupPropertiesFormat.
+func (p PrivateDNSZoneGroupPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "privateDnsZoneConfigs", p.PrivateDNSZoneConfigs)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // PrivateDNSZoneGroupResponse is the response envelope for operations that return a PrivateDNSZoneGroup type.
@@ -9786,7 +12330,15 @@ type PrivateDNSZonePropertiesFormat struct {
 	PrivateDNSZoneID *string `json:"privateDnsZoneId,omitempty"`
 
 	// READ-ONLY; A collection of information regarding a recordSet, holding information to identify private resources.
-	RecordSets *[]*RecordSet `json:"recordSets,omitempty" azure:"ro"`
+	RecordSets []*RecordSet `json:"recordSets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateDNSZonePropertiesFormat.
+func (p PrivateDNSZonePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "privateDnsZoneId", p.PrivateDNSZoneID)
+	populate(objectMap, "recordSets", p.RecordSets)
+	return json.Marshal(objectMap)
 }
 
 // PrivateEndpoint - Private endpoint resource.
@@ -9797,6 +12349,14 @@ type PrivateEndpoint struct {
 
 	// Properties of the private endpoint.
 	Properties *PrivateEndpointProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpoint.
+func (p PrivateEndpoint) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
 }
 
 // PrivateEndpointConnection resource.
@@ -9815,13 +12375,31 @@ type PrivateEndpointConnection struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpointConnection.
+func (p PrivateEndpointConnection) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
+}
+
 // PrivateEndpointConnectionListResult - Response for the ListPrivateEndpointConnection API service call.
 type PrivateEndpointConnectionListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of PrivateEndpointConnection resources for a specific private link service.
-	Value *[]*PrivateEndpointConnection `json:"value,omitempty"`
+	Value []*PrivateEndpointConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpointConnectionListResult.
+func (p PrivateEndpointConnectionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PrivateEndpointConnectionListResultResponse is the response envelope for operations that return a PrivateEndpointConnectionListResult type.
@@ -9863,7 +12441,15 @@ type PrivateEndpointListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of private endpoint resources in a resource group.
-	Value *[]*PrivateEndpoint `json:"value,omitempty"`
+	Value []*PrivateEndpoint `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpointListResult.
+func (p PrivateEndpointListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PrivateEndpointListResultResponse is the response envelope for operations that return a PrivateEndpointListResult type.
@@ -9890,23 +12476,35 @@ type PrivateEndpointPollerResponse struct {
 // PrivateEndpointProperties - Properties of the private endpoint.
 type PrivateEndpointProperties struct {
 	// An array of custom dns configurations.
-	CustomDNSConfigs *[]*CustomDNSConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomDNSConfigs []*CustomDNSConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
 
 	// A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the
 	// remote resource.
-	ManualPrivateLinkServiceConnections *[]*PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+	ManualPrivateLinkServiceConnections []*PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private endpoint.
-	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// A grouping of information about the connection to the remote resource.
-	PrivateLinkServiceConnections *[]*PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
+	PrivateLinkServiceConnections []*PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the private endpoint resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The ID of the subnet from which the private IP will be allocated.
 	Subnet *Subnet `json:"subnet,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpointProperties.
+func (p PrivateEndpointProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "customDnsConfigs", p.CustomDNSConfigs)
+	populate(objectMap, "manualPrivateLinkServiceConnections", p.ManualPrivateLinkServiceConnections)
+	populate(objectMap, "networkInterfaces", p.NetworkInterfaces)
+	populate(objectMap, "privateLinkServiceConnections", p.PrivateLinkServiceConnections)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "subnet", p.Subnet)
+	return json.Marshal(objectMap)
 }
 
 // PrivateEndpointResponse is the response envelope for operations that return a PrivateEndpoint type.
@@ -9954,6 +12552,14 @@ type PrivateLinkService struct {
 	Properties *PrivateLinkServiceProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkService.
+func (p PrivateLinkService) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
 // PrivateLinkServiceConnection resource.
 type PrivateLinkServiceConnection struct {
 	SubResource
@@ -9970,10 +12576,20 @@ type PrivateLinkServiceConnection struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkServiceConnection.
+func (p PrivateLinkServiceConnection) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
+}
+
 // PrivateLinkServiceConnectionProperties - Properties of the PrivateLinkServiceConnection.
 type PrivateLinkServiceConnectionProperties struct {
 	// The ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.
-	GroupIDs *[]*string `json:"groupIds,omitempty"`
+	GroupIDs []*string `json:"groupIds,omitempty"`
 
 	// A collection of read-only information about the state of the connection to the remote resource.
 	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
@@ -9986,6 +12602,17 @@ type PrivateLinkServiceConnectionProperties struct {
 
 	// A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.
 	RequestMessage *string `json:"requestMessage,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkServiceConnectionProperties.
+func (p PrivateLinkServiceConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "groupIds", p.GroupIDs)
+	populate(objectMap, "privateLinkServiceConnectionState", p.PrivateLinkServiceConnectionState)
+	populate(objectMap, "privateLinkServiceId", p.PrivateLinkServiceID)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "requestMessage", p.RequestMessage)
+	return json.Marshal(objectMap)
 }
 
 // PrivateLinkServiceConnectionState - A collection of information about the state of the connection between service consumer and provider.
@@ -10016,6 +12643,16 @@ type PrivateLinkServiceIPConfiguration struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkServiceIPConfiguration.
+func (p PrivateLinkServiceIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
+}
+
 // PrivateLinkServiceIPConfigurationProperties - Properties of private link service IP configuration.
 type PrivateLinkServiceIPConfigurationProperties struct {
 	// Whether the ip configuration is primary or not.
@@ -10043,7 +12680,15 @@ type PrivateLinkServiceListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of PrivateLinkService resources in a resource group.
-	Value *[]*PrivateLinkService `json:"value,omitempty"`
+	Value []*PrivateLinkService `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkServiceListResult.
+func (p PrivateLinkServiceListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PrivateLinkServiceListResultResponse is the response envelope for operations that return a PrivateLinkServiceListResult type.
@@ -10079,25 +12724,41 @@ type PrivateLinkServiceProperties struct {
 	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty"`
 
 	// The list of Fqdn.
-	Fqdns *[]*string `json:"fqdns,omitempty"`
+	Fqdns []*string `json:"fqdns,omitempty"`
 
 	// An array of private link service IP configurations.
-	IPConfigurations *[]*PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// An array of references to the load balancer IP configurations.
-	LoadBalancerFrontendIPConfigurations *[]*FrontendIPConfiguration `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations []*FrontendIPConfiguration `json:"loadBalancerFrontendIpConfigurations,omitempty"`
 
 	// READ-ONLY; An array of references to the network interfaces created for this private link service.
-	NetworkInterfaces *[]*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*NetworkInterface `json:"networkInterfaces,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of list about connections to the private endpoint.
-	PrivateEndpointConnections *[]*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
+	PrivateEndpointConnections []*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the private link service resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The visibility list of the private link service.
 	Visibility *PrivateLinkServicePropertiesVisibility `json:"visibility,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PrivateLinkServiceProperties.
+func (p PrivateLinkServiceProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "alias", p.Alias)
+	populate(objectMap, "autoApproval", p.AutoApproval)
+	populate(objectMap, "enableProxyProtocol", p.EnableProxyProtocol)
+	populate(objectMap, "fqdns", p.Fqdns)
+	populate(objectMap, "ipConfigurations", p.IPConfigurations)
+	populate(objectMap, "loadBalancerFrontendIpConfigurations", p.LoadBalancerFrontendIPConfigurations)
+	populate(objectMap, "networkInterfaces", p.NetworkInterfaces)
+	populate(objectMap, "privateEndpointConnections", p.PrivateEndpointConnections)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "visibility", p.Visibility)
+	return json.Marshal(objectMap)
 }
 
 // PrivateLinkServicePropertiesAutoApproval - The auto-approval list of the private link service.
@@ -10236,6 +12897,16 @@ type Probe struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Probe.
+func (p Probe) MarshalJSON() ([]byte, error) {
+	objectMap := p.SubResource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "name", p.Name)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "type", p.Type)
+	return json.Marshal(objectMap)
+}
+
 // ProbePropertiesFormat - Load balancer probe resource.
 type ProbePropertiesFormat struct {
 	// The interval, in seconds, for how frequently to probe the endpoint for health status. Typically, the interval is slightly less than half the allocated
@@ -10244,7 +12915,7 @@ type ProbePropertiesFormat struct {
 	IntervalInSeconds *int32 `json:"intervalInSeconds,omitempty"`
 
 	// READ-ONLY; The load balancer rules that use this probe.
-	LoadBalancingRules *[]*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
 
 	// The number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints
 	// to be taken out of rotation faster or slower than
@@ -10265,6 +12936,19 @@ type ProbePropertiesFormat struct {
 	// The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default
 	// value.
 	RequestPath *string `json:"requestPath,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ProbePropertiesFormat.
+func (p ProbePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "intervalInSeconds", p.IntervalInSeconds)
+	populate(objectMap, "loadBalancingRules", p.LoadBalancingRules)
+	populate(objectMap, "numberOfProbes", p.NumberOfProbes)
+	populate(objectMap, "port", p.Port)
+	populate(objectMap, "protocol", p.Protocol)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "requestPath", p.RequestPath)
+	return json.Marshal(objectMap)
 }
 
 // ProbeResponse is the response envelope for operations that return a Probe type.
@@ -10312,7 +12996,17 @@ type PublicIPAddress struct {
 	SKU *PublicIPAddressSKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPAddress.
+func (p PublicIPAddress) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "sku", p.SKU)
+	populate(objectMap, "zones", p.Zones)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPAddressDNSSettings - Contains FQDN of the DNS record associated with the public IP address.
@@ -10338,7 +13032,15 @@ type PublicIPAddressListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of public IP addresses that exists in a resource group.
-	Value *[]*PublicIPAddress `json:"value,omitempty"`
+	Value []*PublicIPAddress `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPAddressListResult.
+func (p PublicIPAddressListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPAddressListResultResponse is the response envelope for operations that return a PublicIPAddressListResult type.
@@ -10377,7 +13079,7 @@ type PublicIPAddressPropertiesFormat struct {
 	IPConfiguration *IPConfiguration `json:"ipConfiguration,omitempty" azure:"ro"`
 
 	// The list of tags associated with the public IP address.
-	IPTags *[]*IPTag `json:"ipTags,omitempty"`
+	IPTags []*IPTag `json:"ipTags,omitempty"`
 
 	// The idle timeout of the public IP address.
 	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
@@ -10396,6 +13098,23 @@ type PublicIPAddressPropertiesFormat struct {
 
 	// READ-ONLY; The resource GUID property of the public IP address resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPAddressPropertiesFormat.
+func (p PublicIPAddressPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dnsSettings", p.DNSSettings)
+	populate(objectMap, "ddosSettings", p.DdosSettings)
+	populate(objectMap, "ipAddress", p.IPAddress)
+	populate(objectMap, "ipConfiguration", p.IPConfiguration)
+	populate(objectMap, "ipTags", p.IPTags)
+	populate(objectMap, "idleTimeoutInMinutes", p.IdleTimeoutInMinutes)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "publicIPAddressVersion", p.PublicIPAddressVersion)
+	populate(objectMap, "publicIPAllocationMethod", p.PublicIPAllocationMethod)
+	populate(objectMap, "publicIPPrefix", p.PublicIPPrefix)
+	populate(objectMap, "resourceGuid", p.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPAddressResponse is the response envelope for operations that return a PublicIPAddress type.
@@ -10476,7 +13195,17 @@ type PublicIPPrefix struct {
 	SKU *PublicIPPrefixSKU `json:"sku,omitempty"`
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones *[]*string `json:"zones,omitempty"`
+	Zones []*string `json:"zones,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPPrefix.
+func (p PublicIPPrefix) MarshalJSON() ([]byte, error) {
+	objectMap := p.Resource.marshalInternal()
+	populate(objectMap, "etag", p.Etag)
+	populate(objectMap, "properties", p.Properties)
+	populate(objectMap, "sku", p.SKU)
+	populate(objectMap, "zones", p.Zones)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPPrefixListResult - Response for ListPublicIpPrefixes API service call.
@@ -10485,7 +13214,15 @@ type PublicIPPrefixListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of public IP prefixes that exists in a resource group.
-	Value *[]*PublicIPPrefix `json:"value,omitempty"`
+	Value []*PublicIPPrefix `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPPrefixListResult.
+func (p PublicIPPrefixListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPPrefixListResultResponse is the response envelope for operations that return a PublicIPPrefixListResult type.
@@ -10515,7 +13252,7 @@ type PublicIPPrefixPropertiesFormat struct {
 	IPPrefix *string `json:"ipPrefix,omitempty" azure:"ro"`
 
 	// The list of tags associated with the public IP prefix.
-	IPTags *[]*IPTag `json:"ipTags,omitempty"`
+	IPTags []*IPTag `json:"ipTags,omitempty"`
 
 	// READ-ONLY; The reference to load balancer frontend IP configuration associated with the public IP prefix.
 	LoadBalancerFrontendIPConfiguration *SubResource `json:"loadBalancerFrontendIpConfiguration,omitempty" azure:"ro"`
@@ -10530,10 +13267,24 @@ type PublicIPPrefixPropertiesFormat struct {
 	PublicIPAddressVersion *IPVersion `json:"publicIPAddressVersion,omitempty"`
 
 	// READ-ONLY; The list of all referenced PublicIPAddresses.
-	PublicIPAddresses *[]*ReferencedPublicIPAddress `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses []*ReferencedPublicIPAddress `json:"publicIPAddresses,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the public IP prefix resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PublicIPPrefixPropertiesFormat.
+func (p PublicIPPrefixPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "ipPrefix", p.IPPrefix)
+	populate(objectMap, "ipTags", p.IPTags)
+	populate(objectMap, "loadBalancerFrontendIpConfiguration", p.LoadBalancerFrontendIPConfiguration)
+	populate(objectMap, "prefixLength", p.PrefixLength)
+	populate(objectMap, "provisioningState", p.ProvisioningState)
+	populate(objectMap, "publicIPAddressVersion", p.PublicIPAddressVersion)
+	populate(objectMap, "publicIPAddresses", p.PublicIPAddresses)
+	populate(objectMap, "resourceGuid", p.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // PublicIPPrefixResponse is the response envelope for operations that return a PublicIPPrefix type.
@@ -10606,7 +13357,7 @@ type RecordSet struct {
 	Fqdn *string `json:"fqdn,omitempty"`
 
 	// The private ip address of the private endpoint.
-	IPAddresses *[]*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string `json:"ipAddresses,omitempty"`
 
 	// READ-ONLY; The provisioning state of the recordset.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -10619,6 +13370,18 @@ type RecordSet struct {
 
 	// Recordset time to live.
 	TTL *int32 `json:"ttl,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RecordSet.
+func (r RecordSet) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "fqdn", r.Fqdn)
+	populate(objectMap, "ipAddresses", r.IPAddresses)
+	populate(objectMap, "provisioningState", r.ProvisioningState)
+	populate(objectMap, "recordSetName", r.RecordSetName)
+	populate(objectMap, "recordType", r.RecordType)
+	populate(objectMap, "ttl", r.TTL)
+	return json.Marshal(objectMap)
 }
 
 // ReferencedPublicIPAddress - Reference to a public IP address.
@@ -10639,10 +13402,26 @@ type Resource struct {
 	Name *string `json:"name,omitempty" azure:"ro"`
 
 	// Resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Resource.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	objectMap := r.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (r Resource) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", r.ID)
+	populate(objectMap, "location", r.Location)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "tags", r.Tags)
+	populate(objectMap, "type", r.Type)
+	return objectMap
 }
 
 // ResourceNavigationLink resource.
@@ -10659,6 +13438,16 @@ type ResourceNavigationLink struct {
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceNavigationLink.
+func (r ResourceNavigationLink) MarshalJSON() ([]byte, error) {
+	objectMap := r.SubResource.marshalInternal()
+	populate(objectMap, "etag", r.Etag)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "properties", r.Properties)
+	populate(objectMap, "type", r.Type)
+	return json.Marshal(objectMap)
 }
 
 // ResourceNavigationLinkFormat - Properties of ResourceNavigationLink.
@@ -10684,7 +13473,15 @@ type ResourceNavigationLinksListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The resource navigation links in a subnet.
-	Value *[]*ResourceNavigationLink `json:"value,omitempty"`
+	Value []*ResourceNavigationLink `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceNavigationLinksListResult.
+func (r ResourceNavigationLinksListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // ResourceNavigationLinksListResultResponse is the response envelope for operations that return a ResourceNavigationLinksListResult type.
@@ -10699,7 +13496,19 @@ type ResourceNavigationLinksListResultResponse struct {
 // ResourceSet - The base resource set for visibility and auto-approval.
 type ResourceSet struct {
 	// The list of subscriptions.
-	Subscriptions *[]*string `json:"subscriptions,omitempty"`
+	Subscriptions []*string `json:"subscriptions,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResourceSet.
+func (r ResourceSet) MarshalJSON() ([]byte, error) {
+	objectMap := r.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (r ResourceSet) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "subscriptions", r.Subscriptions)
+	return objectMap
 }
 
 // RetentionPolicyParameters - Parameters that define the retention policy for flow log.
@@ -10724,6 +13533,15 @@ type Route struct {
 	Properties *RoutePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Route.
+func (r Route) MarshalJSON() ([]byte, error) {
+	objectMap := r.SubResource.marshalInternal()
+	populate(objectMap, "etag", r.Etag)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
 // RouteFilter - Route Filter Resource.
 type RouteFilter struct {
 	Resource
@@ -10734,13 +13552,29 @@ type RouteFilter struct {
 	Properties *RouteFilterPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RouteFilter.
+func (r RouteFilter) MarshalJSON() ([]byte, error) {
+	objectMap := r.Resource.marshalInternal()
+	populate(objectMap, "etag", r.Etag)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
 // RouteFilterListResult - Response for the ListRouteFilters API service call.
 type RouteFilterListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of route filters in a resource group.
-	Value *[]*RouteFilter `json:"value,omitempty"`
+	Value []*RouteFilter `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteFilterListResult.
+func (r RouteFilterListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RouteFilterListResultResponse is the response envelope for operations that return a RouteFilterListResult type.
@@ -10767,16 +13601,26 @@ type RouteFilterPollerResponse struct {
 // RouteFilterPropertiesFormat - Route Filter Resource.
 type RouteFilterPropertiesFormat struct {
 	// READ-ONLY; A collection of references to express route circuit ipv6 peerings.
-	IPv6Peerings *[]*ExpressRouteCircuitPeering `json:"ipv6Peerings,omitempty" azure:"ro"`
+	IPv6Peerings []*ExpressRouteCircuitPeering `json:"ipv6Peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; A collection of references to express route circuit peerings.
-	Peerings *[]*ExpressRouteCircuitPeering `json:"peerings,omitempty" azure:"ro"`
+	Peerings []*ExpressRouteCircuitPeering `json:"peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the route filter resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of RouteFilterRules contained within a route filter.
-	Rules *[]*RouteFilterRule `json:"rules,omitempty"`
+	Rules []*RouteFilterRule `json:"rules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteFilterPropertiesFormat.
+func (r RouteFilterPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "ipv6Peerings", r.IPv6Peerings)
+	populate(objectMap, "peerings", r.Peerings)
+	populate(objectMap, "provisioningState", r.ProvisioningState)
+	populate(objectMap, "rules", r.Rules)
+	return json.Marshal(objectMap)
 }
 
 // RouteFilterResponse is the response envelope for operations that return a RouteFilter type.
@@ -10804,13 +13648,31 @@ type RouteFilterRule struct {
 	Properties *RouteFilterRulePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RouteFilterRule.
+func (r RouteFilterRule) MarshalJSON() ([]byte, error) {
+	objectMap := r.SubResource.marshalInternal()
+	populate(objectMap, "etag", r.Etag)
+	populate(objectMap, "location", r.Location)
+	populate(objectMap, "name", r.Name)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
 // RouteFilterRuleListResult - Response for the ListRouteFilterRules API service call.
 type RouteFilterRuleListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of RouteFilterRules in a resource group.
-	Value *[]*RouteFilterRule `json:"value,omitempty"`
+	Value []*RouteFilterRule `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteFilterRuleListResult.
+func (r RouteFilterRuleListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RouteFilterRuleListResultResponse is the response envelope for operations that return a RouteFilterRuleListResult type.
@@ -10840,13 +13702,23 @@ type RouteFilterRulePropertiesFormat struct {
 	Access *Access `json:"access,omitempty"`
 
 	// The collection for bgp community values to filter on. e.g. ['12076:5010','12076:5020'].
-	Communities *[]*string `json:"communities,omitempty"`
+	Communities []*string `json:"communities,omitempty"`
 
 	// READ-ONLY; The provisioning state of the route filter rule resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The rule type of the rule.
 	RouteFilterRuleType *RouteFilterRuleType `json:"routeFilterRuleType,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteFilterRulePropertiesFormat.
+func (r RouteFilterRulePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "access", r.Access)
+	populate(objectMap, "communities", r.Communities)
+	populate(objectMap, "provisioningState", r.ProvisioningState)
+	populate(objectMap, "routeFilterRuleType", r.RouteFilterRuleType)
+	return json.Marshal(objectMap)
 }
 
 // RouteFilterRuleResponse is the response envelope for operations that return a RouteFilterRule type.
@@ -10915,7 +13787,15 @@ type RouteListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of routes in a resource group.
-	Value *[]*Route `json:"value,omitempty"`
+	Value []*Route `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteListResult.
+func (r RouteListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RouteListResultResponse is the response envelope for operations that return a RouteListResult type.
@@ -10973,13 +13853,29 @@ type RouteTable struct {
 	Properties *RouteTablePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RouteTable.
+func (r RouteTable) MarshalJSON() ([]byte, error) {
+	objectMap := r.Resource.marshalInternal()
+	populate(objectMap, "etag", r.Etag)
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
 // RouteTableListResult - Response for the ListRouteTable API service call.
 type RouteTableListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of route tables in a resource group.
-	Value *[]*RouteTable `json:"value,omitempty"`
+	Value []*RouteTable `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteTableListResult.
+func (r RouteTableListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RouteTableListResultResponse is the response envelope for operations that return a RouteTableListResult type.
@@ -11012,10 +13908,20 @@ type RouteTablePropertiesFormat struct {
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Collection of routes contained within a route table.
-	Routes *[]*Route `json:"routes,omitempty"`
+	Routes []*Route `json:"routes,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RouteTablePropertiesFormat.
+func (r RouteTablePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "disableBgpRoutePropagation", r.DisableBgpRoutePropagation)
+	populate(objectMap, "provisioningState", r.ProvisioningState)
+	populate(objectMap, "routes", r.Routes)
+	populate(objectMap, "subnets", r.Subnets)
+	return json.Marshal(objectMap)
 }
 
 // RouteTableResponse is the response envelope for operations that return a RouteTable type.
@@ -11096,7 +14002,14 @@ type SecurityGroupViewParameters struct {
 // SecurityGroupViewResult - The information about security rules applied to the specified VM.
 type SecurityGroupViewResult struct {
 	// List of network interfaces on the specified VM.
-	NetworkInterfaces *[]*SecurityGroupNetworkInterface `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces []*SecurityGroupNetworkInterface `json:"networkInterfaces,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityGroupViewResult.
+func (s SecurityGroupViewResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "networkInterfaces", s.NetworkInterfaces)
+	return json.Marshal(objectMap)
 }
 
 // SecurityGroupViewResultPollerResponse is the response envelope for operations that asynchronously return a SecurityGroupViewResult type.
@@ -11130,13 +14043,29 @@ type SecurityPartnerProvider struct {
 	Properties *SecurityPartnerProviderPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SecurityPartnerProvider.
+func (s SecurityPartnerProvider) MarshalJSON() ([]byte, error) {
+	objectMap := s.Resource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
 // SecurityPartnerProviderListResult - Response for ListSecurityPartnerProviders API service call.
 type SecurityPartnerProviderListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Security Partner Providers in a resource group.
-	Value *[]*SecurityPartnerProvider `json:"value,omitempty"`
+	Value []*SecurityPartnerProvider `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityPartnerProviderListResult.
+func (s SecurityPartnerProviderListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SecurityPartnerProviderListResultResponse is the response envelope for operations that return a SecurityPartnerProviderListResult type.
@@ -11227,13 +14156,22 @@ type SecurityRule struct {
 	Properties *SecurityRulePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SecurityRule.
+func (s SecurityRule) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
 // SecurityRuleAssociations - All security rules associated with the network interface.
 type SecurityRuleAssociations struct {
 	// Collection of default security rules of the network security group.
-	DefaultSecurityRules *[]*SecurityRule `json:"defaultSecurityRules,omitempty"`
+	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty"`
 
 	// Collection of effective security rules.
-	EffectiveSecurityRules *[]*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules []*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
 
 	// Network interface and it's custom security rules.
 	NetworkInterfaceAssociation *NetworkInterfaceAssociation `json:"networkInterfaceAssociation,omitempty"`
@@ -11242,13 +14180,31 @@ type SecurityRuleAssociations struct {
 	SubnetAssociation *SubnetAssociation `json:"subnetAssociation,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SecurityRuleAssociations.
+func (s SecurityRuleAssociations) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "defaultSecurityRules", s.DefaultSecurityRules)
+	populate(objectMap, "effectiveSecurityRules", s.EffectiveSecurityRules)
+	populate(objectMap, "networkInterfaceAssociation", s.NetworkInterfaceAssociation)
+	populate(objectMap, "subnetAssociation", s.SubnetAssociation)
+	return json.Marshal(objectMap)
+}
+
 // SecurityRuleListResult - Response for ListSecurityRule API service call. Retrieves all security rules that belongs to a network security group.
 type SecurityRuleListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The security rules in a network security group.
-	Value *[]*SecurityRule `json:"value,omitempty"`
+	Value []*SecurityRule `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityRuleListResult.
+func (s SecurityRuleListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SecurityRuleListResultResponse is the response envelope for operations that return a SecurityRuleListResult type.
@@ -11286,16 +14242,16 @@ type SecurityRulePropertiesFormat struct {
 	DestinationAddressPrefix *string `json:"destinationAddressPrefix,omitempty"`
 
 	// The destination address prefixes. CIDR or destination IP ranges.
-	DestinationAddressPrefixes *[]*string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes []*string `json:"destinationAddressPrefixes,omitempty"`
 
 	// The application security group specified as destination.
-	DestinationApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationApplicationSecurityGroups []*ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
 
 	// The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
 	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
 
 	// The destination port ranges.
-	DestinationPortRanges *[]*string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges []*string `json:"destinationPortRanges,omitempty"`
 
 	// The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
 	Direction *SecurityRuleDirection `json:"direction,omitempty"`
@@ -11316,16 +14272,38 @@ type SecurityRulePropertiesFormat struct {
 	SourceAddressPrefix *string `json:"sourceAddressPrefix,omitempty"`
 
 	// The CIDR or source IP ranges.
-	SourceAddressPrefixes *[]*string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes []*string `json:"sourceAddressPrefixes,omitempty"`
 
 	// The application security group specified as source.
-	SourceApplicationSecurityGroups *[]*ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourceApplicationSecurityGroups []*ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
 
 	// The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
 	SourcePortRange *string `json:"sourcePortRange,omitempty"`
 
 	// The source port ranges.
-	SourcePortRanges *[]*string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges []*string `json:"sourcePortRanges,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SecurityRulePropertiesFormat.
+func (s SecurityRulePropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "access", s.Access)
+	populate(objectMap, "description", s.Description)
+	populate(objectMap, "destinationAddressPrefix", s.DestinationAddressPrefix)
+	populate(objectMap, "destinationAddressPrefixes", s.DestinationAddressPrefixes)
+	populate(objectMap, "destinationApplicationSecurityGroups", s.DestinationApplicationSecurityGroups)
+	populate(objectMap, "destinationPortRange", s.DestinationPortRange)
+	populate(objectMap, "destinationPortRanges", s.DestinationPortRanges)
+	populate(objectMap, "direction", s.Direction)
+	populate(objectMap, "priority", s.Priority)
+	populate(objectMap, "protocol", s.Protocol)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "sourceAddressPrefix", s.SourceAddressPrefix)
+	populate(objectMap, "sourceAddressPrefixes", s.SourceAddressPrefixes)
+	populate(objectMap, "sourceApplicationSecurityGroups", s.SourceApplicationSecurityGroups)
+	populate(objectMap, "sourcePortRange", s.SourcePortRange)
+	populate(objectMap, "sourcePortRanges", s.SourcePortRanges)
+	return json.Marshal(objectMap)
 }
 
 // SecurityRuleResponse is the response envelope for operations that return a SecurityRule type.
@@ -11373,6 +14351,16 @@ type ServiceAssociationLink struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ServiceAssociationLink.
+func (s ServiceAssociationLink) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "properties", s.Properties)
+	populate(objectMap, "type", s.Type)
+	return json.Marshal(objectMap)
+}
+
 // ServiceAssociationLinkPropertiesFormat - Properties of ServiceAssociationLink.
 type ServiceAssociationLinkPropertiesFormat struct {
 	// If true, the resource can be deleted.
@@ -11385,10 +14373,21 @@ type ServiceAssociationLinkPropertiesFormat struct {
 	LinkedResourceType *string `json:"linkedResourceType,omitempty"`
 
 	// A list of locations.
-	Locations *[]*string `json:"locations,omitempty"`
+	Locations []*string `json:"locations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the service association link resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceAssociationLinkPropertiesFormat.
+func (s ServiceAssociationLinkPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowDelete", s.AllowDelete)
+	populate(objectMap, "link", s.Link)
+	populate(objectMap, "linkedResourceType", s.LinkedResourceType)
+	populate(objectMap, "locations", s.Locations)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	return json.Marshal(objectMap)
 }
 
 // ServiceAssociationLinksListOptions contains the optional parameters for the ServiceAssociationLinks.List method.
@@ -11402,7 +14401,15 @@ type ServiceAssociationLinksListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// The service association links in a subnet.
-	Value *[]*ServiceAssociationLink `json:"value,omitempty"`
+	Value []*ServiceAssociationLink `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceAssociationLinksListResult.
+func (s ServiceAssociationLinksListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // ServiceAssociationLinksListResultResponse is the response envelope for operations that return a ServiceAssociationLinksListResult type.
@@ -11417,13 +14424,22 @@ type ServiceAssociationLinksListResultResponse struct {
 // ServiceDelegationPropertiesFormat - Properties of a service delegation.
 type ServiceDelegationPropertiesFormat struct {
 	// READ-ONLY; The actions permitted to the service upon delegation.
-	Actions *[]*string `json:"actions,omitempty" azure:"ro"`
+	Actions []*string `json:"actions,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the service delegation resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).
 	ServiceName *string `json:"serviceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceDelegationPropertiesFormat.
+func (s ServiceDelegationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "actions", s.Actions)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "serviceName", s.ServiceName)
+	return json.Marshal(objectMap)
 }
 
 // ServiceEndpointPoliciesBeginCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPolicies.BeginCreateOrUpdate method.
@@ -11467,6 +14483,14 @@ type ServiceEndpointPolicy struct {
 	Properties *ServiceEndpointPolicyPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicy.
+func (s ServiceEndpointPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := s.Resource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ServiceEndpointPolicyDefinition - Service Endpoint policy definitions.
 type ServiceEndpointPolicyDefinition struct {
 	SubResource
@@ -11480,6 +14504,15 @@ type ServiceEndpointPolicyDefinition struct {
 	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicyDefinition.
+func (s ServiceEndpointPolicyDefinition) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
 // ServiceEndpointPolicyDefinitionListResult - Response for ListServiceEndpointPolicyDefinition API service call. Retrieves all service endpoint policy
 // definition that belongs to a service endpoint policy.
 type ServiceEndpointPolicyDefinitionListResult struct {
@@ -11487,7 +14520,15 @@ type ServiceEndpointPolicyDefinitionListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The service endpoint policy definition in a service endpoint policy.
-	Value *[]*ServiceEndpointPolicyDefinition `json:"value,omitempty"`
+	Value []*ServiceEndpointPolicyDefinition `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicyDefinitionListResult.
+func (s ServiceEndpointPolicyDefinitionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // ServiceEndpointPolicyDefinitionListResultResponse is the response envelope for operations that return a ServiceEndpointPolicyDefinitionListResult type.
@@ -11524,7 +14565,17 @@ type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
 	Service *string `json:"service,omitempty"`
 
 	// A list of service resources.
-	ServiceResources *[]*string `json:"serviceResources,omitempty"`
+	ServiceResources []*string `json:"serviceResources,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicyDefinitionPropertiesFormat.
+func (s ServiceEndpointPolicyDefinitionPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "description", s.Description)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "service", s.Service)
+	populate(objectMap, "serviceResources", s.ServiceResources)
+	return json.Marshal(objectMap)
 }
 
 // ServiceEndpointPolicyDefinitionResponse is the response envelope for operations that return a ServiceEndpointPolicyDefinition type.
@@ -11564,7 +14615,15 @@ type ServiceEndpointPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of ServiceEndpointPolicy resources.
-	Value *[]*ServiceEndpointPolicy `json:"value,omitempty"`
+	Value []*ServiceEndpointPolicy `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicyListResult.
+func (s ServiceEndpointPolicyListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // ServiceEndpointPolicyListResultResponse is the response envelope for operations that return a ServiceEndpointPolicyListResult type.
@@ -11597,10 +14656,20 @@ type ServiceEndpointPolicyPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A collection of service endpoint policy definitions of the service endpoint policy.
-	ServiceEndpointPolicyDefinitions *[]*ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	ServiceEndpointPolicyDefinitions []*ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets *[]*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPolicyPropertiesFormat.
+func (s ServiceEndpointPolicyPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "resourceGuid", s.ResourceGUID)
+	populate(objectMap, "serviceEndpointPolicyDefinitions", s.ServiceEndpointPolicyDefinitions)
+	populate(objectMap, "subnets", s.Subnets)
+	return json.Marshal(objectMap)
 }
 
 // ServiceEndpointPolicyResponse is the response envelope for operations that return a ServiceEndpointPolicy type.
@@ -11615,13 +14684,22 @@ type ServiceEndpointPolicyResponse struct {
 // ServiceEndpointPropertiesFormat - The service endpoint properties.
 type ServiceEndpointPropertiesFormat struct {
 	// A list of locations.
-	Locations *[]*string `json:"locations,omitempty"`
+	Locations []*string `json:"locations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the service endpoint resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// The type of the endpoint service.
 	Service *string `json:"service,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceEndpointPropertiesFormat.
+func (s ServiceEndpointPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "locations", s.Locations)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "service", s.Service)
+	return json.Marshal(objectMap)
 }
 
 // ServiceTagInformation - The service tag information.
@@ -11639,7 +14717,7 @@ type ServiceTagInformation struct {
 // ServiceTagInformationPropertiesFormat - Properties of the service tag information.
 type ServiceTagInformationPropertiesFormat struct {
 	// READ-ONLY; The list of IP address prefixes.
-	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty" azure:"ro"`
+	AddressPrefixes []*string `json:"addressPrefixes,omitempty" azure:"ro"`
 
 	// READ-ONLY; The iteration number of service tag.
 	ChangeNumber *string `json:"changeNumber,omitempty" azure:"ro"`
@@ -11649,6 +14727,16 @@ type ServiceTagInformationPropertiesFormat struct {
 
 	// READ-ONLY; The name of system service.
 	SystemService *string `json:"systemService,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceTagInformationPropertiesFormat.
+func (s ServiceTagInformationPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefixes", s.AddressPrefixes)
+	populate(objectMap, "changeNumber", s.ChangeNumber)
+	populate(objectMap, "region", s.Region)
+	populate(objectMap, "systemService", s.SystemService)
+	return json.Marshal(objectMap)
 }
 
 // ServiceTagsListOptions contains the optional parameters for the ServiceTags.List method.
@@ -11674,7 +14762,19 @@ type ServiceTagsListResult struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 
 	// READ-ONLY; The list of service tag information resources.
-	Values *[]*ServiceTagInformation `json:"values,omitempty" azure:"ro"`
+	Values []*ServiceTagInformation `json:"values,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceTagsListResult.
+func (s ServiceTagsListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "changeNumber", s.ChangeNumber)
+	populate(objectMap, "cloud", s.Cloud)
+	populate(objectMap, "id", s.ID)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "type", s.Type)
+	populate(objectMap, "values", s.Values)
+	return json.Marshal(objectMap)
 }
 
 // ServiceTagsListResultResponse is the response envelope for operations that return a ServiceTagsListResult type.
@@ -11689,7 +14789,14 @@ type ServiceTagsListResultResponse struct {
 // SessionIDs - List of session IDs.
 type SessionIDs struct {
 	// List of session IDs.
-	SessionIDs *[]*string `json:"sessionIds,omitempty"`
+	SessionIDs []*string `json:"sessionIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SessionIDs.
+func (s SessionIDs) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "sessionIds", s.SessionIDs)
+	return json.Marshal(objectMap)
 }
 
 // StringArrayResponse is the response envelope for operations that return a []*string type.
@@ -11726,6 +14833,18 @@ type SubResource struct {
 	ID *string `json:"id,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SubResource.
+func (s SubResource) MarshalJSON() ([]byte, error) {
+	objectMap := s.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (s SubResource) marshalInternal() map[string]interface{} {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", s.ID)
+	return objectMap
+}
+
 // Subnet in a virtual network resource.
 type Subnet struct {
 	SubResource
@@ -11739,13 +14858,30 @@ type Subnet struct {
 	Properties *SubnetPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Subnet.
+func (s Subnet) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "etag", s.Etag)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
 // SubnetAssociation - Subnet and it's custom security rules.
 type SubnetAssociation struct {
 	// READ-ONLY; Subnet ID.
 	ID *string `json:"id,omitempty" azure:"ro"`
 
 	// Collection of custom security rules.
-	SecurityRules *[]*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubnetAssociation.
+func (s SubnetAssociation) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", s.ID)
+	populate(objectMap, "securityRules", s.SecurityRules)
+	return json.Marshal(objectMap)
 }
 
 // SubnetListResult - Response for ListSubnets API service callRetrieves all subnet that belongs to a virtual network.
@@ -11754,7 +14890,15 @@ type SubnetListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The subnets in a virtual network.
-	Value *[]*Subnet `json:"value,omitempty"`
+	Value []*Subnet `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubnetListResult.
+func (s SubnetListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SubnetListResultResponse is the response envelope for operations that return a SubnetListResult type.
@@ -11784,19 +14928,19 @@ type SubnetPropertiesFormat struct {
 	AddressPrefix *string `json:"addressPrefix,omitempty"`
 
 	// List of address prefixes for the subnet.
-	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
 
 	// An array of references to the delegations on the subnet.
-	Delegations *[]*Delegation `json:"delegations,omitempty"`
+	Delegations []*Delegation `json:"delegations,omitempty"`
 
 	// Array of IpAllocation which reference this subnet.
-	IPAllocations *[]*SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations []*SubResource `json:"ipAllocations,omitempty"`
 
 	// READ-ONLY; Array of IP configuration profiles which reference this subnet.
-	IPConfigurationProfiles *[]*IPConfigurationProfile `json:"ipConfigurationProfiles,omitempty" azure:"ro"`
+	IPConfigurationProfiles []*IPConfigurationProfile `json:"ipConfigurationProfiles,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the network interface IP configurations using subnet.
-	IPConfigurations *[]*IPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations []*IPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
 
 	// Nat gateway associated with this subnet.
 	NatGateway *SubResource `json:"natGateway,omitempty"`
@@ -11808,7 +14952,7 @@ type SubnetPropertiesFormat struct {
 	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty"`
 
 	// READ-ONLY; An array of references to private endpoints.
-	PrivateEndpoints *[]*PrivateEndpoint `json:"privateEndpoints,omitempty" azure:"ro"`
+	PrivateEndpoints []*PrivateEndpoint `json:"privateEndpoints,omitempty" azure:"ro"`
 
 	// Enable or Disable apply network policies on private link service in the subnet.
 	PrivateLinkServiceNetworkPolicies *string `json:"privateLinkServiceNetworkPolicies,omitempty"`
@@ -11820,19 +14964,43 @@ type SubnetPropertiesFormat struct {
 	Purpose *string `json:"purpose,omitempty" azure:"ro"`
 
 	// READ-ONLY; An array of references to the external resources using subnet.
-	ResourceNavigationLinks *[]*ResourceNavigationLink `json:"resourceNavigationLinks,omitempty" azure:"ro"`
+	ResourceNavigationLinks []*ResourceNavigationLink `json:"resourceNavigationLinks,omitempty" azure:"ro"`
 
 	// The reference to the RouteTable resource.
 	RouteTable *RouteTable `json:"routeTable,omitempty"`
 
 	// READ-ONLY; An array of references to services injecting into this subnet.
-	ServiceAssociationLinks *[]*ServiceAssociationLink `json:"serviceAssociationLinks,omitempty" azure:"ro"`
+	ServiceAssociationLinks []*ServiceAssociationLink `json:"serviceAssociationLinks,omitempty" azure:"ro"`
 
 	// An array of service endpoint policies.
-	ServiceEndpointPolicies *[]*ServiceEndpointPolicy `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpointPolicies []*ServiceEndpointPolicy `json:"serviceEndpointPolicies,omitempty"`
 
 	// An array of service endpoints.
-	ServiceEndpoints *[]*ServiceEndpointPropertiesFormat `json:"serviceEndpoints,omitempty"`
+	ServiceEndpoints []*ServiceEndpointPropertiesFormat `json:"serviceEndpoints,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubnetPropertiesFormat.
+func (s SubnetPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefix", s.AddressPrefix)
+	populate(objectMap, "addressPrefixes", s.AddressPrefixes)
+	populate(objectMap, "delegations", s.Delegations)
+	populate(objectMap, "ipAllocations", s.IPAllocations)
+	populate(objectMap, "ipConfigurationProfiles", s.IPConfigurationProfiles)
+	populate(objectMap, "ipConfigurations", s.IPConfigurations)
+	populate(objectMap, "natGateway", s.NatGateway)
+	populate(objectMap, "networkSecurityGroup", s.NetworkSecurityGroup)
+	populate(objectMap, "privateEndpointNetworkPolicies", s.PrivateEndpointNetworkPolicies)
+	populate(objectMap, "privateEndpoints", s.PrivateEndpoints)
+	populate(objectMap, "privateLinkServiceNetworkPolicies", s.PrivateLinkServiceNetworkPolicies)
+	populate(objectMap, "provisioningState", s.ProvisioningState)
+	populate(objectMap, "purpose", s.Purpose)
+	populate(objectMap, "resourceNavigationLinks", s.ResourceNavigationLinks)
+	populate(objectMap, "routeTable", s.RouteTable)
+	populate(objectMap, "serviceAssociationLinks", s.ServiceAssociationLinks)
+	populate(objectMap, "serviceEndpointPolicies", s.ServiceEndpointPolicies)
+	populate(objectMap, "serviceEndpoints", s.ServiceEndpoints)
+	return json.Marshal(objectMap)
 }
 
 // SubnetResponse is the response envelope for operations that return a Subnet type.
@@ -11878,7 +15046,7 @@ type SubnetsListOptions struct {
 // TagsObject - Tags object for patch operations.
 type TagsObject struct {
 	// Resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type TagsObject.
@@ -11900,7 +15068,7 @@ type Topology struct {
 	LastModified *time.Time `json:"lastModified,omitempty" azure:"ro"`
 
 	// A list of topology resources.
-	Resources *[]*TopologyResource `json:"resources,omitempty"`
+	Resources []*TopologyResource `json:"resources,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type Topology.
@@ -11973,7 +15141,7 @@ type TopologyParameters struct {
 // TopologyResource - The network resource topology information for the given resource group.
 type TopologyResource struct {
 	// Holds the associations the resource has with other resources in the resource group.
-	Associations *[]*TopologyAssociation `json:"associations,omitempty"`
+	Associations []*TopologyAssociation `json:"associations,omitempty"`
 
 	// ID of the resource.
 	ID *string `json:"id,omitempty"`
@@ -11983,6 +15151,16 @@ type TopologyResource struct {
 
 	// Name of the resource.
 	Name *string `json:"name,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TopologyResource.
+func (t TopologyResource) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "associations", t.Associations)
+	populate(objectMap, "id", t.ID)
+	populate(objectMap, "location", t.Location)
+	populate(objectMap, "name", t.Name)
+	return json.Marshal(objectMap)
 }
 
 // TopologyResponse is the response envelope for operations that return a Topology type.
@@ -12021,10 +15199,18 @@ type TrafficAnalyticsProperties struct {
 // TrafficSelectorPolicy - An traffic selector policy for a virtual network gateway connection.
 type TrafficSelectorPolicy struct {
 	// A collection of local address spaces in CIDR format.
-	LocalAddressRanges *[]*string `json:"localAddressRanges,omitempty"`
+	LocalAddressRanges []*string `json:"localAddressRanges,omitempty"`
 
 	// A collection of remote address spaces in CIDR format.
-	RemoteAddressRanges *[]*string `json:"remoteAddressRanges,omitempty"`
+	RemoteAddressRanges []*string `json:"remoteAddressRanges,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TrafficSelectorPolicy.
+func (t TrafficSelectorPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "localAddressRanges", t.LocalAddressRanges)
+	populate(objectMap, "remoteAddressRanges", t.RemoteAddressRanges)
+	return json.Marshal(objectMap)
 }
 
 // TroubleshootingDetails - Information gained from troubleshooting of specified resource.
@@ -12039,10 +15225,21 @@ type TroubleshootingDetails struct {
 	ReasonType *string `json:"reasonType,omitempty"`
 
 	// List of recommended actions.
-	RecommendedActions *[]*TroubleshootingRecommendedActions `json:"recommendedActions,omitempty"`
+	RecommendedActions []*TroubleshootingRecommendedActions `json:"recommendedActions,omitempty"`
 
 	// A summary of troubleshooting.
 	Summary *string `json:"summary,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TroubleshootingDetails.
+func (t TroubleshootingDetails) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "detail", t.Detail)
+	populate(objectMap, "id", t.ID)
+	populate(objectMap, "reasonType", t.ReasonType)
+	populate(objectMap, "recommendedActions", t.RecommendedActions)
+	populate(objectMap, "summary", t.Summary)
+	return json.Marshal(objectMap)
 }
 
 // TroubleshootingParameters - Parameters that define the resource to troubleshoot.
@@ -12087,7 +15284,7 @@ type TroubleshootingResult struct {
 	EndTime *time.Time `json:"endTime,omitempty"`
 
 	// Information from troubleshooting.
-	Results *[]*TroubleshootingDetails `json:"results,omitempty"`
+	Results []*TroubleshootingDetails `json:"results,omitempty"`
 
 	// The start time of the troubleshooting.
 	StartTime *time.Time `json:"startTime,omitempty"`
@@ -12219,7 +15416,15 @@ type UsagesListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The list network resource usages.
-	Value *[]*Usage `json:"value,omitempty"`
+	Value []*Usage `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type UsagesListResult.
+func (u UsagesListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", u.NextLink)
+	populate(objectMap, "value", u.Value)
+	return json.Marshal(objectMap)
 }
 
 // UsagesListResultResponse is the response envelope for operations that return a UsagesListResult type.
@@ -12254,28 +15459,45 @@ type VPNClientConfiguration struct {
 	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
 
 	// The radiusServers property for multiple radius server configuration.
-	RadiusServers *[]*RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers []*RadiusServer `json:"radiusServers,omitempty"`
 
 	// The reference to the address space resource which represents Address space for P2S VpnClient.
 	VPNClientAddressPool *AddressSpace `json:"vpnClientAddressPool,omitempty"`
 
 	// VpnClientIpsecPolicies for virtual network gateway P2S client.
-	VPNClientIPSecPolicies *[]*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies []*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
 
 	// VpnClientProtocols for Virtual network gateway.
-	VPNClientProtocols *[]*VPNClientProtocol `json:"vpnClientProtocols,omitempty"`
+	VPNClientProtocols []*VPNClientProtocol `json:"vpnClientProtocols,omitempty"`
 
 	// VpnClientRevokedCertificate for Virtual network gateway.
-	VPNClientRevokedCertificates *[]*VPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates []*VPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
 
 	// VpnClientRootCertificate for virtual network gateway.
-	VPNClientRootCertificates *[]*VPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates []*VPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNClientConfiguration.
+func (v VPNClientConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aadAudience", v.AADAudience)
+	populate(objectMap, "aadIssuer", v.AADIssuer)
+	populate(objectMap, "aadTenant", v.AADTenant)
+	populate(objectMap, "radiusServerAddress", v.RadiusServerAddress)
+	populate(objectMap, "radiusServerSecret", v.RadiusServerSecret)
+	populate(objectMap, "radiusServers", v.RadiusServers)
+	populate(objectMap, "vpnClientAddressPool", v.VPNClientAddressPool)
+	populate(objectMap, "vpnClientIpsecPolicies", v.VPNClientIPSecPolicies)
+	populate(objectMap, "vpnClientProtocols", v.VPNClientProtocols)
+	populate(objectMap, "vpnClientRevokedCertificates", v.VPNClientRevokedCertificates)
+	populate(objectMap, "vpnClientRootCertificates", v.VPNClientRootCertificates)
+	return json.Marshal(objectMap)
 }
 
 // VPNClientConnectionHealth - VpnClientConnectionHealth properties.
 type VPNClientConnectionHealth struct {
 	// List of allocated ip addresses to the connected p2s vpn clients.
-	AllocatedIPAddresses *[]*string `json:"allocatedIpAddresses,omitempty"`
+	AllocatedIPAddresses []*string `json:"allocatedIpAddresses,omitempty"`
 
 	// READ-ONLY; Total of the Egress Bytes Transferred in this connection.
 	TotalEgressBytesTransferred *int64 `json:"totalEgressBytesTransferred,omitempty" azure:"ro"`
@@ -12285,6 +15507,16 @@ type VPNClientConnectionHealth struct {
 
 	// The total of p2s vpn clients connected at this time to this P2SVpnGateway.
 	VPNClientConnectionsCount *int32 `json:"vpnClientConnectionsCount,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNClientConnectionHealth.
+func (v VPNClientConnectionHealth) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allocatedIpAddresses", v.AllocatedIPAddresses)
+	populate(objectMap, "totalEgressBytesTransferred", v.TotalEgressBytesTransferred)
+	populate(objectMap, "totalIngressBytesTransferred", v.TotalIngressBytesTransferred)
+	populate(objectMap, "vpnClientConnectionsCount", v.VPNClientConnectionsCount)
+	return json.Marshal(objectMap)
 }
 
 // VPNClientConnectionHealthDetail - VPN client connection health detail.
@@ -12329,7 +15561,14 @@ type VPNClientConnectionHealthDetail struct {
 // VPNClientConnectionHealthDetailListResult - List of virtual network gateway vpn client connection health.
 type VPNClientConnectionHealthDetailListResult struct {
 	// List of vpn client connection health.
-	Value *[]*VPNClientConnectionHealthDetail `json:"value,omitempty"`
+	Value []*VPNClientConnectionHealthDetail `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNClientConnectionHealthDetailListResult.
+func (v VPNClientConnectionHealthDetailListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VPNClientConnectionHealthDetailListResultPollerResponse is the response envelope for operations that asynchronously return a VPNClientConnectionHealthDetailListResult
@@ -12409,7 +15648,7 @@ type VPNClientParameters struct {
 
 	// A list of client root certificates public certificate data encoded as Base-64 strings. Optional parameter for external radius based authentication with
 	// EAPTLS.
-	ClientRootCertificates *[]*string `json:"clientRootCertificates,omitempty"`
+	ClientRootCertificates []*string `json:"clientRootCertificates,omitempty"`
 
 	// VPN client Processor Architecture.
 	ProcessorArchitecture *ProcessorArchitecture `json:"processorArchitecture,omitempty"`
@@ -12418,6 +15657,16 @@ type VPNClientParameters struct {
 	// has been configured with EAPTLS
 	// authentication.
 	RadiusServerAuthCertificate *string `json:"radiusServerAuthCertificate,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNClientParameters.
+func (v VPNClientParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationMethod", v.AuthenticationMethod)
+	populate(objectMap, "clientRootCertificates", v.ClientRootCertificates)
+	populate(objectMap, "processorArchitecture", v.ProcessorArchitecture)
+	populate(objectMap, "radiusServerAuthCertificate", v.RadiusServerAuthCertificate)
+	return json.Marshal(objectMap)
 }
 
 // VPNClientRevokedCertificate - VPN client revoked certificate of virtual network gateway.
@@ -12431,6 +15680,15 @@ type VPNClientRevokedCertificate struct {
 
 	// Properties of the vpn client revoked certificate.
 	Properties *VPNClientRevokedCertificatePropertiesFormat `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNClientRevokedCertificate.
+func (v VPNClientRevokedCertificate) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VPNClientRevokedCertificatePropertiesFormat - Properties of the revoked VPN client certificate of virtual network gateway.
@@ -12455,6 +15713,15 @@ type VPNClientRootCertificate struct {
 	Properties *VPNClientRootCertificatePropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VPNClientRootCertificate.
+func (v VPNClientRootCertificate) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VPNClientRootCertificatePropertiesFormat - Properties of SSL certificates of application gateway.
 type VPNClientRootCertificatePropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the VPN client root certificate resource.
@@ -12475,6 +15742,15 @@ type VPNConnection struct {
 
 	// Properties of the VPN connection.
 	Properties *VPNConnectionProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNConnection.
+func (v VPNConnection) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VPNConnectionPollerResponse is the response envelope for operations that asynchronously return a VPNConnection type.
@@ -12513,7 +15789,7 @@ type VPNConnectionProperties struct {
 	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; Ingress bytes transferred.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -12540,7 +15816,30 @@ type VPNConnectionProperties struct {
 	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol `json:"vpnConnectionProtocolType,omitempty"`
 
 	// List of all vpn site link connections to the gateway.
-	VPNLinkConnections *[]*VPNSiteLinkConnection `json:"vpnLinkConnections,omitempty"`
+	VPNLinkConnections []*VPNSiteLinkConnection `json:"vpnLinkConnections,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNConnectionProperties.
+func (v VPNConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionBandwidth", v.ConnectionBandwidth)
+	populate(objectMap, "connectionStatus", v.ConnectionStatus)
+	populate(objectMap, "dpdTimeoutSeconds", v.DpdTimeoutSeconds)
+	populate(objectMap, "egressBytesTransferred", v.EgressBytesTransferred)
+	populate(objectMap, "enableBgp", v.EnableBgp)
+	populate(objectMap, "enableInternetSecurity", v.EnableInternetSecurity)
+	populate(objectMap, "enableRateLimiting", v.EnableRateLimiting)
+	populate(objectMap, "ipsecPolicies", v.IPSecPolicies)
+	populate(objectMap, "ingressBytesTransferred", v.IngressBytesTransferred)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "remoteVpnSite", v.RemoteVPNSite)
+	populate(objectMap, "routingWeight", v.RoutingWeight)
+	populate(objectMap, "sharedKey", v.SharedKey)
+	populate(objectMap, "useLocalAzureIpAddress", v.UseLocalAzureIPAddress)
+	populate(objectMap, "usePolicyBasedTrafficSelectors", v.UsePolicyBasedTrafficSelectors)
+	populate(objectMap, "vpnConnectionProtocolType", v.VPNConnectionProtocolType)
+	populate(objectMap, "vpnLinkConnections", v.VPNLinkConnections)
+	return json.Marshal(objectMap)
 }
 
 // VPNConnectionResponse is the response envelope for operations that return a VPNConnection type.
@@ -12594,6 +15893,14 @@ type VPNGateway struct {
 	Properties *VPNGatewayProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VPNGateway.
+func (v VPNGateway) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VPNGatewayPollerResponse is the response envelope for operations that asynchronously return a VPNGateway type.
 type VPNGatewayPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -12612,7 +15919,7 @@ type VPNGatewayProperties struct {
 	BgpSettings *BgpSettings `json:"bgpSettings,omitempty"`
 
 	// List of all vpn connections to the gateway.
-	Connections *[]*VPNConnection `json:"connections,omitempty"`
+	Connections []*VPNConnection `json:"connections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the VPN gateway resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -12622,6 +15929,17 @@ type VPNGatewayProperties struct {
 
 	// The VirtualHub to which the gateway belongs.
 	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNGatewayProperties.
+func (v VPNGatewayProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "bgpSettings", v.BgpSettings)
+	populate(objectMap, "connections", v.Connections)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "vpnGatewayScaleUnit", v.VPNGatewayScaleUnit)
+	populate(objectMap, "virtualHub", v.VirtualHub)
+	return json.Marshal(objectMap)
 }
 
 // VPNGatewayResponse is the response envelope for operations that return a VPNGateway type.
@@ -12776,6 +16094,14 @@ type VPNServerConfiguration struct {
 	Properties *VPNServerConfigurationProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VPNServerConfiguration.
+func (v VPNServerConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VPNServerConfigurationPollerResponse is the response envelope for operations that asynchronously return a VPNServerConfiguration type.
 type VPNServerConfigurationPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -12800,40 +16126,61 @@ type VPNServerConfigurationProperties struct {
 	Name *string `json:"name,omitempty"`
 
 	// READ-ONLY; List of references to P2SVpnGateways.
-	P2SVPNGateways *[]*P2SVPNGateway `json:"p2SVpnGateways,omitempty" azure:"ro"`
+	P2SVPNGateways []*P2SVPNGateway `json:"p2SVpnGateways,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the VpnServerConfiguration resource. Possible values are: 'Updating', 'Deleting', and 'Failed'.
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
 
 	// Radius client root certificate of VpnServerConfiguration.
-	RadiusClientRootCertificates *[]*VPNServerConfigRadiusClientRootCertificate `json:"radiusClientRootCertificates,omitempty"`
+	RadiusClientRootCertificates []*VPNServerConfigRadiusClientRootCertificate `json:"radiusClientRootCertificates,omitempty"`
 
 	// The radius server address property of the VpnServerConfiguration resource for point to site client connection.
 	RadiusServerAddress *string `json:"radiusServerAddress,omitempty"`
 
 	// Radius Server root certificate of VpnServerConfiguration.
-	RadiusServerRootCertificates *[]*VPNServerConfigRadiusServerRootCertificate `json:"radiusServerRootCertificates,omitempty"`
+	RadiusServerRootCertificates []*VPNServerConfigRadiusServerRootCertificate `json:"radiusServerRootCertificates,omitempty"`
 
 	// The radius secret property of the VpnServerConfiguration resource for point to site client connection.
 	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
 
 	// Multiple Radius Server configuration for VpnServerConfiguration.
-	RadiusServers *[]*RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers []*RadiusServer `json:"radiusServers,omitempty"`
 
 	// VPN authentication types for the VpnServerConfiguration.
-	VPNAuthenticationTypes *[]*VPNAuthenticationType `json:"vpnAuthenticationTypes,omitempty"`
+	VPNAuthenticationTypes []*VPNAuthenticationType `json:"vpnAuthenticationTypes,omitempty"`
 
 	// VpnClientIpsecPolicies for VpnServerConfiguration.
-	VPNClientIPSecPolicies *[]*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies []*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
 
 	// VPN client revoked certificate of VpnServerConfiguration.
-	VPNClientRevokedCertificates *[]*VPNServerConfigVPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates []*VPNServerConfigVPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
 
 	// VPN client root certificate of VpnServerConfiguration.
-	VPNClientRootCertificates *[]*VPNServerConfigVPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates []*VPNServerConfigVPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
 
 	// VPN protocols for the VpnServerConfiguration.
-	VPNProtocols *[]*VPNGatewayTunnelingProtocol `json:"vpnProtocols,omitempty"`
+	VPNProtocols []*VPNGatewayTunnelingProtocol `json:"vpnProtocols,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNServerConfigurationProperties.
+func (v VPNServerConfigurationProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aadAuthenticationParameters", v.AADAuthenticationParameters)
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "p2SVpnGateways", v.P2SVPNGateways)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "radiusClientRootCertificates", v.RadiusClientRootCertificates)
+	populate(objectMap, "radiusServerAddress", v.RadiusServerAddress)
+	populate(objectMap, "radiusServerRootCertificates", v.RadiusServerRootCertificates)
+	populate(objectMap, "radiusServerSecret", v.RadiusServerSecret)
+	populate(objectMap, "radiusServers", v.RadiusServers)
+	populate(objectMap, "vpnAuthenticationTypes", v.VPNAuthenticationTypes)
+	populate(objectMap, "vpnClientIpsecPolicies", v.VPNClientIPSecPolicies)
+	populate(objectMap, "vpnClientRevokedCertificates", v.VPNClientRevokedCertificates)
+	populate(objectMap, "vpnClientRootCertificates", v.VPNClientRootCertificates)
+	populate(objectMap, "vpnProtocols", v.VPNProtocols)
+	return json.Marshal(objectMap)
 }
 
 // VPNServerConfigurationResponse is the response envelope for operations that return a VPNServerConfiguration type.
@@ -12879,7 +16226,14 @@ type VPNServerConfigurationsListOptions struct {
 // VPNServerConfigurationsResponse - VpnServerConfigurations list associated with VirtualWan Response.
 type VPNServerConfigurationsResponse struct {
 	// List of VpnServerConfigurations associated with VirtualWan.
-	VPNServerConfigurationResourceIDs *[]*string `json:"vpnServerConfigurationResourceIds,omitempty"`
+	VPNServerConfigurationResourceIDs []*string `json:"vpnServerConfigurationResourceIds,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNServerConfigurationsResponse.
+func (v VPNServerConfigurationsResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "vpnServerConfigurationResourceIds", v.VPNServerConfigurationResourceIDs)
+	return json.Marshal(objectMap)
 }
 
 // VPNServerConfigurationsResponsePollerResponse is the response envelope for operations that asynchronously return a VPNServerConfigurationsResponse type.
@@ -12918,6 +16272,14 @@ type VPNSite struct {
 	Properties *VPNSiteProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VPNSite.
+func (v VPNSite) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VPNSiteID - VpnSite Resource.
 type VPNSiteID struct {
 	// READ-ONLY; The resource-uri of the vpn-site for which config is to be fetched.
@@ -12940,6 +16302,16 @@ type VPNSiteLink struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VPNSiteLink.
+func (v VPNSiteLink) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "type", v.Type)
+	return json.Marshal(objectMap)
+}
+
 // VPNSiteLinkConnection - VpnSiteLinkConnection Resource.
 type VPNSiteLinkConnection struct {
 	SubResource
@@ -12954,6 +16326,16 @@ type VPNSiteLinkConnection struct {
 
 	// READ-ONLY; Resource type.
 	Type *string `json:"type,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNSiteLinkConnection.
+func (v VPNSiteLinkConnection) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "type", v.Type)
+	return json.Marshal(objectMap)
 }
 
 // VPNSiteLinkConnectionProperties - Parameters for VpnConnection.
@@ -12974,7 +16356,7 @@ type VPNSiteLinkConnectionProperties struct {
 	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; Ingress bytes transferred.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -12999,6 +16381,26 @@ type VPNSiteLinkConnectionProperties struct {
 
 	// Id of the connected vpn site link.
 	VPNSiteLink *SubResource `json:"vpnSiteLink,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNSiteLinkConnectionProperties.
+func (v VPNSiteLinkConnectionProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionBandwidth", v.ConnectionBandwidth)
+	populate(objectMap, "connectionStatus", v.ConnectionStatus)
+	populate(objectMap, "egressBytesTransferred", v.EgressBytesTransferred)
+	populate(objectMap, "enableBgp", v.EnableBgp)
+	populate(objectMap, "enableRateLimiting", v.EnableRateLimiting)
+	populate(objectMap, "ipsecPolicies", v.IPSecPolicies)
+	populate(objectMap, "ingressBytesTransferred", v.IngressBytesTransferred)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "routingWeight", v.RoutingWeight)
+	populate(objectMap, "sharedKey", v.SharedKey)
+	populate(objectMap, "useLocalAzureIpAddress", v.UseLocalAzureIPAddress)
+	populate(objectMap, "usePolicyBasedTrafficSelectors", v.UsePolicyBasedTrafficSelectors)
+	populate(objectMap, "vpnConnectionProtocolType", v.VPNConnectionProtocolType)
+	populate(objectMap, "vpnSiteLink", v.VPNSiteLink)
+	return json.Marshal(objectMap)
 }
 
 // VPNSiteLinkConnectionResponse is the response envelope for operations that return a VPNSiteLinkConnection type.
@@ -13088,10 +16490,25 @@ type VPNSiteProperties struct {
 	SiteKey *string `json:"siteKey,omitempty"`
 
 	// List of all vpn site links.
-	VPNSiteLinks *[]*VPNSiteLink `json:"vpnSiteLinks,omitempty"`
+	VPNSiteLinks []*VPNSiteLink `json:"vpnSiteLinks,omitempty"`
 
 	// The VirtualWAN to which the vpnSite belongs.
 	VirtualWan *SubResource `json:"virtualWan,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VPNSiteProperties.
+func (v VPNSiteProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressSpace", v.AddressSpace)
+	populate(objectMap, "bgpProperties", v.BgpProperties)
+	populate(objectMap, "deviceProperties", v.DeviceProperties)
+	populate(objectMap, "ipAddress", v.IPAddress)
+	populate(objectMap, "isSecuritySite", v.IsSecuritySite)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "siteKey", v.SiteKey)
+	populate(objectMap, "vpnSiteLinks", v.VPNSiteLinks)
+	populate(objectMap, "virtualWan", v.VirtualWan)
+	return json.Marshal(objectMap)
 }
 
 // VPNSiteResponse is the response envelope for operations that return a VPNSite type.
@@ -13229,6 +16646,14 @@ type VirtualHub struct {
 	Properties *VirtualHubProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualHub.
+func (v VirtualHub) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualHubID - Virtual Hub identifier.
 type VirtualHubID struct {
 	// The resource URI for the Virtual Hub where the ExpressRoute gateway is or will be deployed. The Virtual Hub resource and the ExpressRoute gateway resource
@@ -13281,13 +16706,32 @@ type VirtualHubProperties struct {
 	VPNGateway *SubResource `json:"vpnGateway,omitempty"`
 
 	// List of all virtual hub route table v2s associated with this VirtualHub.
-	VirtualHubRouteTableV2S *[]*VirtualHubRouteTableV2 `json:"virtualHubRouteTableV2s,omitempty"`
+	VirtualHubRouteTableV2S []*VirtualHubRouteTableV2 `json:"virtualHubRouteTableV2s,omitempty"`
 
 	// List of all vnet connections with this VirtualHub.
-	VirtualNetworkConnections *[]*HubVirtualNetworkConnection `json:"virtualNetworkConnections,omitempty"`
+	VirtualNetworkConnections []*HubVirtualNetworkConnection `json:"virtualNetworkConnections,omitempty"`
 
 	// The VirtualWAN to which the VirtualHub belongs.
 	VirtualWan *SubResource `json:"virtualWan,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubProperties.
+func (v VirtualHubProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefix", v.AddressPrefix)
+	populate(objectMap, "azureFirewall", v.AzureFirewall)
+	populate(objectMap, "expressRouteGateway", v.ExpressRouteGateway)
+	populate(objectMap, "p2SVpnGateway", v.P2SVPNGateway)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "routeTable", v.RouteTable)
+	populate(objectMap, "sku", v.SKU)
+	populate(objectMap, "securityPartnerProvider", v.SecurityPartnerProvider)
+	populate(objectMap, "securityProviderName", v.SecurityProviderName)
+	populate(objectMap, "vpnGateway", v.VPNGateway)
+	populate(objectMap, "virtualHubRouteTableV2s", v.VirtualHubRouteTableV2S)
+	populate(objectMap, "virtualNetworkConnections", v.VirtualNetworkConnections)
+	populate(objectMap, "virtualWan", v.VirtualWan)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHubResponse is the response envelope for operations that return a VirtualHub type.
@@ -13302,16 +16746,31 @@ type VirtualHubResponse struct {
 // VirtualHubRoute - VirtualHub route.
 type VirtualHubRoute struct {
 	// List of all addressPrefixes.
-	AddressPrefixes *[]*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
 
 	// NextHop ip address.
 	NextHopIPAddress *string `json:"nextHopIpAddress,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubRoute.
+func (v VirtualHubRoute) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressPrefixes", v.AddressPrefixes)
+	populate(objectMap, "nextHopIpAddress", v.NextHopIPAddress)
+	return json.Marshal(objectMap)
+}
+
 // VirtualHubRouteTable - VirtualHub route table.
 type VirtualHubRouteTable struct {
 	// List of all routes.
-	Routes *[]*VirtualHubRoute `json:"routes,omitempty"`
+	Routes []*VirtualHubRoute `json:"routes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubRouteTable.
+func (v VirtualHubRouteTable) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "routes", v.Routes)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHubRouteTableV2 Resource.
@@ -13325,6 +16784,15 @@ type VirtualHubRouteTableV2 struct {
 
 	// Properties of the virtual hub route table v2.
 	Properties *VirtualHubRouteTableV2Properties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubRouteTableV2.
+func (v VirtualHubRouteTableV2) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHubRouteTableV2PollerResponse is the response envelope for operations that asynchronously return a VirtualHubRouteTableV2 type.
@@ -13342,13 +16810,22 @@ type VirtualHubRouteTableV2PollerResponse struct {
 // VirtualHubRouteTableV2Properties - Parameters for VirtualHubRouteTableV2.
 type VirtualHubRouteTableV2Properties struct {
 	// List of all connections attached to this route table v2.
-	AttachedConnections *[]*string `json:"attachedConnections,omitempty"`
+	AttachedConnections []*string `json:"attachedConnections,omitempty"`
 
 	// READ-ONLY; The provisioning state of the virtual hub route table v2 resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// List of all routes.
-	Routes *[]*VirtualHubRouteV2 `json:"routes,omitempty"`
+	Routes []*VirtualHubRouteV2 `json:"routes,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubRouteTableV2Properties.
+func (v VirtualHubRouteTableV2Properties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "attachedConnections", v.AttachedConnections)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "routes", v.Routes)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHubRouteTableV2Response is the response envelope for operations that return a VirtualHubRouteTableV2 type.
@@ -13386,13 +16863,23 @@ type VirtualHubRouteV2 struct {
 	DestinationType *string `json:"destinationType,omitempty"`
 
 	// List of all destinations.
-	Destinations *[]*string `json:"destinations,omitempty"`
+	Destinations []*string `json:"destinations,omitempty"`
 
 	// The type of next hops.
 	NextHopType *string `json:"nextHopType,omitempty"`
 
 	// NextHops ip address.
-	NextHops *[]*string `json:"nextHops,omitempty"`
+	NextHops []*string `json:"nextHops,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualHubRouteV2.
+func (v VirtualHubRouteV2) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "destinationType", v.DestinationType)
+	populate(objectMap, "destinations", v.Destinations)
+	populate(objectMap, "nextHopType", v.NextHopType)
+	populate(objectMap, "nextHops", v.NextHops)
+	return json.Marshal(objectMap)
 }
 
 // VirtualHubsBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubs.BeginCreateOrUpdate method.
@@ -13435,6 +16922,14 @@ type VirtualNetwork struct {
 	Properties *VirtualNetworkPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetwork.
+func (v VirtualNetwork) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkBgpCommunities - Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
 type VirtualNetworkBgpCommunities struct {
 	// READ-ONLY; The BGP community associated with the region of the virtual network.
@@ -13460,6 +16955,14 @@ type VirtualNetworkGateway struct {
 	Properties *VirtualNetworkGatewayPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGateway.
+func (v VirtualNetworkGateway) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkGatewayConnection - A common class for general resource information.
 type VirtualNetworkGatewayConnection struct {
 	Resource
@@ -13470,6 +16973,14 @@ type VirtualNetworkGatewayConnection struct {
 	Properties *VirtualNetworkGatewayConnectionPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayConnection.
+func (v VirtualNetworkGatewayConnection) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkGatewayConnectionListEntity - A common class for general resource information.
 type VirtualNetworkGatewayConnectionListEntity struct {
 	Resource
@@ -13478,6 +16989,14 @@ type VirtualNetworkGatewayConnectionListEntity struct {
 
 	// Properties of the virtual network gateway connection.
 	Properties *VirtualNetworkGatewayConnectionListEntityPropertiesFormat `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayConnectionListEntity.
+func (v VirtualNetworkGatewayConnectionListEntity) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayConnectionListEntityPropertiesFormat - VirtualNetworkGatewayConnection properties.
@@ -13504,7 +17023,7 @@ type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -13528,10 +17047,10 @@ type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	SharedKey *string `json:"sharedKey,omitempty"`
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies *[]*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies []*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus *[]*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus []*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
 
 	// Enable policy-based traffic selectors.
 	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
@@ -13543,13 +17062,47 @@ type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	VirtualNetworkGateway2 *VirtualNetworkConnectionGatewayReference `json:"virtualNetworkGateway2,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayConnectionListEntityPropertiesFormat.
+func (v VirtualNetworkGatewayConnectionListEntityPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authorizationKey", v.AuthorizationKey)
+	populate(objectMap, "connectionProtocol", v.ConnectionProtocol)
+	populate(objectMap, "connectionStatus", v.ConnectionStatus)
+	populate(objectMap, "connectionType", v.ConnectionType)
+	populate(objectMap, "egressBytesTransferred", v.EgressBytesTransferred)
+	populate(objectMap, "enableBgp", v.EnableBgp)
+	populate(objectMap, "expressRouteGatewayBypass", v.ExpressRouteGatewayBypass)
+	populate(objectMap, "ipsecPolicies", v.IPSecPolicies)
+	populate(objectMap, "ingressBytesTransferred", v.IngressBytesTransferred)
+	populate(objectMap, "localNetworkGateway2", v.LocalNetworkGateway2)
+	populate(objectMap, "peer", v.Peer)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "resourceGuid", v.ResourceGUID)
+	populate(objectMap, "routingWeight", v.RoutingWeight)
+	populate(objectMap, "sharedKey", v.SharedKey)
+	populate(objectMap, "trafficSelectorPolicies", v.TrafficSelectorPolicies)
+	populate(objectMap, "tunnelConnectionStatus", v.TunnelConnectionStatus)
+	populate(objectMap, "usePolicyBasedTrafficSelectors", v.UsePolicyBasedTrafficSelectors)
+	populate(objectMap, "virtualNetworkGateway1", v.VirtualNetworkGateway1)
+	populate(objectMap, "virtualNetworkGateway2", v.VirtualNetworkGateway2)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkGatewayConnectionListResult - Response for the ListVirtualNetworkGatewayConnections API service call.
 type VirtualNetworkGatewayConnectionListResult struct {
 	// READ-ONLY; The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value *[]*VirtualNetworkGatewayConnection `json:"value,omitempty"`
+	Value []*VirtualNetworkGatewayConnection `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayConnectionListResult.
+func (v VirtualNetworkGatewayConnectionListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayConnectionListResultResponse is the response envelope for operations that return a VirtualNetworkGatewayConnectionListResult type.
@@ -13600,7 +17153,7 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies *[]*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
 	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
@@ -13624,10 +17177,10 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	SharedKey *string `json:"sharedKey,omitempty"`
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies *[]*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies []*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus *[]*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus []*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
 
 	// Use private local Azure IP for the connection.
 	UseLocalAzureIPAddress *bool `json:"useLocalAzureIpAddress,omitempty"`
@@ -13640,6 +17193,34 @@ type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 
 	// The reference to virtual network gateway resource.
 	VirtualNetworkGateway2 *VirtualNetworkGateway `json:"virtualNetworkGateway2,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayConnectionPropertiesFormat.
+func (v VirtualNetworkGatewayConnectionPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authorizationKey", v.AuthorizationKey)
+	populate(objectMap, "connectionProtocol", v.ConnectionProtocol)
+	populate(objectMap, "connectionStatus", v.ConnectionStatus)
+	populate(objectMap, "connectionType", v.ConnectionType)
+	populate(objectMap, "dpdTimeoutSeconds", v.DpdTimeoutSeconds)
+	populate(objectMap, "egressBytesTransferred", v.EgressBytesTransferred)
+	populate(objectMap, "enableBgp", v.EnableBgp)
+	populate(objectMap, "expressRouteGatewayBypass", v.ExpressRouteGatewayBypass)
+	populate(objectMap, "ipsecPolicies", v.IPSecPolicies)
+	populate(objectMap, "ingressBytesTransferred", v.IngressBytesTransferred)
+	populate(objectMap, "localNetworkGateway2", v.LocalNetworkGateway2)
+	populate(objectMap, "peer", v.Peer)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "resourceGuid", v.ResourceGUID)
+	populate(objectMap, "routingWeight", v.RoutingWeight)
+	populate(objectMap, "sharedKey", v.SharedKey)
+	populate(objectMap, "trafficSelectorPolicies", v.TrafficSelectorPolicies)
+	populate(objectMap, "tunnelConnectionStatus", v.TunnelConnectionStatus)
+	populate(objectMap, "useLocalAzureIpAddress", v.UseLocalAzureIPAddress)
+	populate(objectMap, "usePolicyBasedTrafficSelectors", v.UsePolicyBasedTrafficSelectors)
+	populate(objectMap, "virtualNetworkGateway1", v.VirtualNetworkGateway1)
+	populate(objectMap, "virtualNetworkGateway2", v.VirtualNetworkGateway2)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayConnectionResponse is the response envelope for operations that return a VirtualNetworkGatewayConnection type.
@@ -13720,6 +17301,15 @@ type VirtualNetworkGatewayIPConfiguration struct {
 	Properties *VirtualNetworkGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayIPConfiguration.
+func (v VirtualNetworkGatewayIPConfiguration) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkGatewayIPConfigurationPropertiesFormat - Properties of VirtualNetworkGatewayIPConfiguration.
 type VirtualNetworkGatewayIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; Private IP Address for this gateway.
@@ -13744,7 +17334,15 @@ type VirtualNetworkGatewayListConnectionsResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value *[]*VirtualNetworkGatewayConnectionListEntity `json:"value,omitempty"`
+	Value []*VirtualNetworkGatewayConnectionListEntity `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayListConnectionsResult.
+func (v VirtualNetworkGatewayListConnectionsResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayListConnectionsResultResponse is the response envelope for operations that return a VirtualNetworkGatewayListConnectionsResult type.
@@ -13762,7 +17360,15 @@ type VirtualNetworkGatewayListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// A list of VirtualNetworkGateway resources that exists in a resource group.
-	Value *[]*VirtualNetworkGateway `json:"value,omitempty"`
+	Value []*VirtualNetworkGateway `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayListResult.
+func (v VirtualNetworkGatewayListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayListResultResponse is the response envelope for operations that return a VirtualNetworkGatewayListResult type.
@@ -13815,7 +17421,7 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 	GatewayType *VirtualNetworkGatewayType `json:"gatewayType,omitempty"`
 
 	// IP configurations for virtual network gateway.
-	IPConfigurations *[]*VirtualNetworkGatewayIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualNetworkGatewayIPConfiguration `json:"ipConfigurations,omitempty"`
 
 	// READ-ONLY; The IP address allocated by the gateway to which dns requests can be sent.
 	InboundDNSForwardingEndpoint *string `json:"inboundDnsForwardingEndpoint,omitempty" azure:"ro"`
@@ -13837,6 +17443,28 @@ type VirtualNetworkGatewayPropertiesFormat struct {
 
 	// The type of this virtual network gateway.
 	VPNType *VPNType `json:"vpnType,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkGatewayPropertiesFormat.
+func (v VirtualNetworkGatewayPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activeActive", v.Active)
+	populate(objectMap, "bgpSettings", v.BgpSettings)
+	populate(objectMap, "customRoutes", v.CustomRoutes)
+	populate(objectMap, "enableBgp", v.EnableBgp)
+	populate(objectMap, "enableDnsForwarding", v.EnableDNSForwarding)
+	populate(objectMap, "enablePrivateIpAddress", v.EnablePrivateIPAddress)
+	populate(objectMap, "gatewayDefaultSite", v.GatewayDefaultSite)
+	populate(objectMap, "gatewayType", v.GatewayType)
+	populate(objectMap, "ipConfigurations", v.IPConfigurations)
+	populate(objectMap, "inboundDnsForwardingEndpoint", v.InboundDNSForwardingEndpoint)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "resourceGuid", v.ResourceGUID)
+	populate(objectMap, "sku", v.SKU)
+	populate(objectMap, "vpnClientConfiguration", v.VPNClientConfiguration)
+	populate(objectMap, "vpnGatewayGeneration", v.VPNGatewayGeneration)
+	populate(objectMap, "vpnType", v.VPNType)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkGatewayResponse is the response envelope for operations that return a VirtualNetworkGateway type.
@@ -13987,7 +17615,15 @@ type VirtualNetworkListResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of VirtualNetwork resources in a resource group.
-	Value *[]*VirtualNetwork `json:"value,omitempty"`
+	Value []*VirtualNetwork `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkListResult.
+func (v VirtualNetworkListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkListResultResponse is the response envelope for operations that return a VirtualNetworkListResult type.
@@ -14005,7 +17641,15 @@ type VirtualNetworkListUsageResult struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// READ-ONLY; VirtualNetwork usage stats.
-	Value *[]*VirtualNetworkUsage `json:"value,omitempty" azure:"ro"`
+	Value []*VirtualNetworkUsage `json:"value,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkListUsageResult.
+func (v VirtualNetworkListUsageResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkListUsageResultResponse is the response envelope for operations that return a VirtualNetworkListUsageResult type.
@@ -14030,13 +17674,30 @@ type VirtualNetworkPeering struct {
 	Properties *VirtualNetworkPeeringPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkPeering.
+func (v VirtualNetworkPeering) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkPeeringListResult - Response for ListSubnets API service call. Retrieves all subnets that belong to a virtual network.
 type VirtualNetworkPeeringListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// The peerings in a virtual network.
-	Value *[]*VirtualNetworkPeering `json:"value,omitempty"`
+	Value []*VirtualNetworkPeering `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkPeeringListResult.
+func (v VirtualNetworkPeeringListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkPeeringListResultResponse is the response envelope for operations that return a VirtualNetworkPeeringListResult type.
@@ -14154,7 +17815,7 @@ type VirtualNetworkPropertiesFormat struct {
 	EnableVMProtection *bool `json:"enableVmProtection,omitempty"`
 
 	// Array of IpAllocation which reference this VNET.
-	IPAllocations *[]*SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations []*SubResource `json:"ipAllocations,omitempty"`
 
 	// READ-ONLY; The provisioning state of the virtual network resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -14163,10 +17824,27 @@ type VirtualNetworkPropertiesFormat struct {
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
 
 	// A list of subnets in a Virtual Network.
-	Subnets *[]*Subnet `json:"subnets,omitempty"`
+	Subnets []*Subnet `json:"subnets,omitempty"`
 
 	// A list of peerings in a Virtual Network.
-	VirtualNetworkPeerings *[]*VirtualNetworkPeering `json:"virtualNetworkPeerings,omitempty"`
+	VirtualNetworkPeerings []*VirtualNetworkPeering `json:"virtualNetworkPeerings,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkPropertiesFormat.
+func (v VirtualNetworkPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "addressSpace", v.AddressSpace)
+	populate(objectMap, "bgpCommunities", v.BgpCommunities)
+	populate(objectMap, "ddosProtectionPlan", v.DdosProtectionPlan)
+	populate(objectMap, "dhcpOptions", v.DhcpOptions)
+	populate(objectMap, "enableDdosProtection", v.EnableDdosProtection)
+	populate(objectMap, "enableVmProtection", v.EnableVMProtection)
+	populate(objectMap, "ipAllocations", v.IPAllocations)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "resourceGuid", v.ResourceGUID)
+	populate(objectMap, "subnets", v.Subnets)
+	populate(objectMap, "virtualNetworkPeerings", v.VirtualNetworkPeerings)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkResponse is the response envelope for operations that return a VirtualNetwork type.
@@ -14188,13 +17866,29 @@ type VirtualNetworkTap struct {
 	Properties *VirtualNetworkTapPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkTap.
+func (v VirtualNetworkTap) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualNetworkTapListResult - Response for ListVirtualNetworkTap API service call.
 type VirtualNetworkTapListResult struct {
 	// The URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// A list of VirtualNetworkTaps in a resource group.
-	Value *[]*VirtualNetworkTap `json:"value,omitempty"`
+	Value []*VirtualNetworkTap `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkTapListResult.
+func (v VirtualNetworkTapListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkTapListResultResponse is the response envelope for operations that return a VirtualNetworkTapListResult type.
@@ -14230,13 +17924,25 @@ type VirtualNetworkTapPropertiesFormat struct {
 	DestinationPort *int32 `json:"destinationPort,omitempty"`
 
 	// READ-ONLY; Specifies the list of resource IDs for the network interface IP configuration that needs to be tapped.
-	NetworkInterfaceTapConfigurations *[]*NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
+	NetworkInterfaceTapConfigurations []*NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the virtual network tap resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
 
 	// READ-ONLY; The resource GUID property of the virtual network tap resource.
 	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualNetworkTapPropertiesFormat.
+func (v VirtualNetworkTapPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "destinationLoadBalancerFrontEndIPConfiguration", v.DestinationLoadBalancerFrontEndIPConfiguration)
+	populate(objectMap, "destinationNetworkInterfaceIPConfiguration", v.DestinationNetworkInterfaceIPConfiguration)
+	populate(objectMap, "destinationPort", v.DestinationPort)
+	populate(objectMap, "networkInterfaceTapConfigurations", v.NetworkInterfaceTapConfigurations)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "resourceGuid", v.ResourceGUID)
+	return json.Marshal(objectMap)
 }
 
 // VirtualNetworkTapResponse is the response envelope for operations that return a VirtualNetworkTap type.
@@ -14356,13 +18062,29 @@ type VirtualRouter struct {
 	Properties *VirtualRouterPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualRouter.
+func (v VirtualRouter) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualRouterListResult - Response for ListVirtualRouters API service call.
 type VirtualRouterListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Virtual Routers.
-	Value *[]*VirtualRouter `json:"value,omitempty"`
+	Value []*VirtualRouter `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualRouterListResult.
+func (v VirtualRouterListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualRouterListResultResponse is the response envelope for operations that return a VirtualRouterListResult type.
@@ -14390,13 +18112,31 @@ type VirtualRouterPeering struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualRouterPeering.
+func (v VirtualRouterPeering) MarshalJSON() ([]byte, error) {
+	objectMap := v.SubResource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "name", v.Name)
+	populate(objectMap, "properties", v.Properties)
+	populate(objectMap, "type", v.Type)
+	return json.Marshal(objectMap)
+}
+
 // VirtualRouterPeeringListResult - Response for ListVirtualRouterPeerings API service call.
 type VirtualRouterPeeringListResult struct {
 	// URL to get the next set of results.
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of VirtualRouterPeerings in a VirtualRouter.
-	Value *[]*VirtualRouterPeering `json:"value,omitempty"`
+	Value []*VirtualRouterPeering `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualRouterPeeringListResult.
+func (v VirtualRouterPeeringListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", v.NextLink)
+	populate(objectMap, "value", v.Value)
+	return json.Marshal(objectMap)
 }
 
 // VirtualRouterPeeringListResultResponse is the response envelope for operations that return a VirtualRouterPeeringListResult type.
@@ -14482,7 +18222,7 @@ type VirtualRouterPropertiesFormat struct {
 	HostedSubnet *SubResource `json:"hostedSubnet,omitempty"`
 
 	// READ-ONLY; List of references to VirtualRouterPeerings.
-	Peerings *[]*SubResource `json:"peerings,omitempty" azure:"ro"`
+	Peerings []*SubResource `json:"peerings,omitempty" azure:"ro"`
 
 	// READ-ONLY; The provisioning state of the resource.
 	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
@@ -14491,7 +18231,19 @@ type VirtualRouterPropertiesFormat struct {
 	VirtualRouterAsn *int64 `json:"virtualRouterAsn,omitempty"`
 
 	// VirtualRouter IPs.
-	VirtualRouterIPs *[]*string `json:"virtualRouterIps,omitempty"`
+	VirtualRouterIPs []*string `json:"virtualRouterIps,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualRouterPropertiesFormat.
+func (v VirtualRouterPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "hostedGateway", v.HostedGateway)
+	populate(objectMap, "hostedSubnet", v.HostedSubnet)
+	populate(objectMap, "peerings", v.Peerings)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "virtualRouterAsn", v.VirtualRouterAsn)
+	populate(objectMap, "virtualRouterIps", v.VirtualRouterIPs)
+	return json.Marshal(objectMap)
 }
 
 // VirtualRouterResponse is the response envelope for operations that return a VirtualRouter type.
@@ -14539,6 +18291,14 @@ type VirtualWAN struct {
 	Properties *VirtualWanProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type VirtualWAN.
+func (v VirtualWAN) MarshalJSON() ([]byte, error) {
+	objectMap := v.Resource.marshalInternal()
+	populate(objectMap, "etag", v.Etag)
+	populate(objectMap, "properties", v.Properties)
+	return json.Marshal(objectMap)
+}
+
 // VirtualWANPollerResponse is the response envelope for operations that asynchronously return a VirtualWAN type.
 type VirtualWANPollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -14581,10 +18341,24 @@ type VirtualWanProperties struct {
 	Type *string `json:"type,omitempty"`
 
 	// READ-ONLY; List of VpnSites in the VirtualWAN.
-	VPNSites *[]*SubResource `json:"vpnSites,omitempty" azure:"ro"`
+	VPNSites []*SubResource `json:"vpnSites,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of VirtualHubs in the VirtualWAN.
-	VirtualHubs *[]*SubResource `json:"virtualHubs,omitempty" azure:"ro"`
+	VirtualHubs []*SubResource `json:"virtualHubs,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualWanProperties.
+func (v VirtualWanProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowBranchToBranchTraffic", v.AllowBranchToBranchTraffic)
+	populate(objectMap, "allowVnetToVnetTraffic", v.AllowVnetToVnetTraffic)
+	populate(objectMap, "disableVpnEncryption", v.DisableVPNEncryption)
+	populate(objectMap, "office365LocalBreakoutCategory", v.Office365LocalBreakoutCategory)
+	populate(objectMap, "provisioningState", v.ProvisioningState)
+	populate(objectMap, "type", v.Type)
+	populate(objectMap, "vpnSites", v.VPNSites)
+	populate(objectMap, "virtualHubs", v.VirtualHubs)
+	return json.Marshal(objectMap)
 }
 
 // VirtualWanSecurityProvider - Collection of SecurityProviders.
@@ -14602,7 +18376,14 @@ type VirtualWanSecurityProvider struct {
 // VirtualWanSecurityProviders - Collection of SecurityProviders.
 type VirtualWanSecurityProviders struct {
 	// List of VirtualWAN security providers.
-	SupportedProviders *[]*VirtualWanSecurityProvider `json:"supportedProviders,omitempty"`
+	SupportedProviders []*VirtualWanSecurityProvider `json:"supportedProviders,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type VirtualWanSecurityProviders.
+func (v VirtualWanSecurityProviders) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "supportedProviders", v.SupportedProviders)
+	return json.Marshal(objectMap)
 }
 
 // VirtualWanSecurityProvidersResponse is the response envelope for operations that return a VirtualWanSecurityProviders type.
@@ -14662,7 +18443,7 @@ type WebApplicationFirewallCustomRule struct {
 	Etag *string `json:"etag,omitempty" azure:"ro"`
 
 	// List of match conditions.
-	MatchConditions *[]*MatchCondition `json:"matchConditions,omitempty"`
+	MatchConditions []*MatchCondition `json:"matchConditions,omitempty"`
 
 	// The name of the resource that is unique within a policy. This name can be used to access the resource.
 	Name *string `json:"name,omitempty"`
@@ -14672,6 +18453,18 @@ type WebApplicationFirewallCustomRule struct {
 
 	// The rule type.
 	RuleType *WebApplicationFirewallRuleType `json:"ruleType,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WebApplicationFirewallCustomRule.
+func (w WebApplicationFirewallCustomRule) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "action", w.Action)
+	populate(objectMap, "etag", w.Etag)
+	populate(objectMap, "matchConditions", w.MatchConditions)
+	populate(objectMap, "name", w.Name)
+	populate(objectMap, "priority", w.Priority)
+	populate(objectMap, "ruleType", w.RuleType)
+	return json.Marshal(objectMap)
 }
 
 // WebApplicationFirewallPoliciesBeginDeleteOptions contains the optional parameters for the WebApplicationFirewallPolicies.BeginDelete method.
@@ -14709,6 +18502,14 @@ type WebApplicationFirewallPolicy struct {
 	Properties *WebApplicationFirewallPolicyPropertiesFormat `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type WebApplicationFirewallPolicy.
+func (w WebApplicationFirewallPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := w.Resource.marshalInternal()
+	populate(objectMap, "etag", w.Etag)
+	populate(objectMap, "properties", w.Properties)
+	return json.Marshal(objectMap)
+}
+
 // WebApplicationFirewallPolicyListResult - Result of the request to list WebApplicationFirewallPolicies. It contains a list of WebApplicationFirewallPolicy
 // objects and a URL link to get the next set of results.
 type WebApplicationFirewallPolicyListResult struct {
@@ -14716,7 +18517,15 @@ type WebApplicationFirewallPolicyListResult struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of WebApplicationFirewallPolicies within a resource group.
-	Value *[]*WebApplicationFirewallPolicy `json:"value,omitempty" azure:"ro"`
+	Value []*WebApplicationFirewallPolicy `json:"value,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WebApplicationFirewallPolicyListResult.
+func (w WebApplicationFirewallPolicyListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", w.NextLink)
+	populate(objectMap, "value", w.Value)
+	return json.Marshal(objectMap)
 }
 
 // WebApplicationFirewallPolicyListResultResponse is the response envelope for operations that return a WebApplicationFirewallPolicyListResult type.
@@ -14732,19 +18541,19 @@ type WebApplicationFirewallPolicyListResultResponse struct {
 // WebApplicationFirewallPolicyPropertiesFormat - Defines web application firewall policy properties.
 type WebApplicationFirewallPolicyPropertiesFormat struct {
 	// READ-ONLY; A collection of references to application gateways.
-	ApplicationGateways *[]*ApplicationGateway `json:"applicationGateways,omitempty" azure:"ro"`
+	ApplicationGateways []*ApplicationGateway `json:"applicationGateways,omitempty" azure:"ro"`
 
 	// The custom rules inside the policy.
-	CustomRules *[]*WebApplicationFirewallCustomRule `json:"customRules,omitempty"`
+	CustomRules []*WebApplicationFirewallCustomRule `json:"customRules,omitempty"`
 
 	// READ-ONLY; A collection of references to application gateway http listeners.
-	HTTPListeners *[]*SubResource `json:"httpListeners,omitempty" azure:"ro"`
+	HTTPListeners []*SubResource `json:"httpListeners,omitempty" azure:"ro"`
 
 	// Describes the managedRules structure.
 	ManagedRules *ManagedRulesDefinition `json:"managedRules,omitempty"`
 
 	// READ-ONLY; A collection of references to application gateway path rules.
-	PathBasedRules *[]*SubResource `json:"pathBasedRules,omitempty" azure:"ro"`
+	PathBasedRules []*SubResource `json:"pathBasedRules,omitempty" azure:"ro"`
 
 	// The PolicySettings for policy.
 	PolicySettings *PolicySettings `json:"policySettings,omitempty"`
@@ -14754,6 +18563,20 @@ type WebApplicationFirewallPolicyPropertiesFormat struct {
 
 	// READ-ONLY; Resource status of the policy.
 	ResourceState *WebApplicationFirewallPolicyResourceState `json:"resourceState,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WebApplicationFirewallPolicyPropertiesFormat.
+func (w WebApplicationFirewallPolicyPropertiesFormat) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "applicationGateways", w.ApplicationGateways)
+	populate(objectMap, "customRules", w.CustomRules)
+	populate(objectMap, "httpListeners", w.HTTPListeners)
+	populate(objectMap, "managedRules", w.ManagedRules)
+	populate(objectMap, "pathBasedRules", w.PathBasedRules)
+	populate(objectMap, "policySettings", w.PolicySettings)
+	populate(objectMap, "provisioningState", w.ProvisioningState)
+	populate(objectMap, "resourceState", w.ResourceState)
+	return json.Marshal(objectMap)
 }
 
 // WebApplicationFirewallPolicyResponse is the response envelope for operations that return a WebApplicationFirewallPolicy type.

--- a/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
@@ -29,7 +29,7 @@ func unmarshalFirewallPolicyRuleClassification(rawMsg json.RawMessage) (Firewall
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalFirewallPolicyRuleClassificationArray(rawMsg json.RawMessage) (*[]FirewallPolicyRuleClassification, error) {
+func unmarshalFirewallPolicyRuleClassificationArray(rawMsg json.RawMessage) ([]FirewallPolicyRuleClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -45,7 +45,7 @@ func unmarshalFirewallPolicyRuleClassificationArray(rawMsg json.RawMessage) (*[]
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalFirewallPolicyRuleConditionClassification(rawMsg json.RawMessage) (FirewallPolicyRuleConditionClassification, error) {
@@ -70,7 +70,7 @@ func unmarshalFirewallPolicyRuleConditionClassification(rawMsg json.RawMessage) 
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalFirewallPolicyRuleConditionClassificationArray(rawMsg json.RawMessage) (*[]FirewallPolicyRuleConditionClassification, error) {
+func unmarshalFirewallPolicyRuleConditionClassificationArray(rawMsg json.RawMessage) ([]FirewallPolicyRuleConditionClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -86,5 +86,5 @@ func unmarshalFirewallPolicyRuleConditionClassificationArray(rawMsg json.RawMess
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_models.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_models.go
@@ -286,7 +286,22 @@ type AppendPositionAccessConditions struct {
 
 // ArrowConfiguration - arrow configuration
 type ArrowConfiguration struct {
-	Schema *[]*ArrowField `xml:"Schema>Field"`
+	Schema []*ArrowField `xml:"Schema>Field"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type ArrowConfiguration.
+func (a ArrowConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias ArrowConfiguration
+	aux := &struct {
+		*alias
+		Schema *[]*ArrowField `xml:"Schema>Field"`
+	}{
+		alias: (*alias)(&a),
+	}
+	if a.Schema != nil {
+		aux.Schema = &a.Schema
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // ArrowField - field of an arrow schema
@@ -781,7 +796,22 @@ type BlobDownloadResponse struct {
 }
 
 type BlobFlatListSegment struct {
-	BlobItems *[]*BlobItemInternal `xml:"Blob"`
+	BlobItems []*BlobItemInternal `xml:"Blob"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobFlatListSegment.
+func (b BlobFlatListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias BlobFlatListSegment
+	aux := &struct {
+		*alias
+		BlobItems *[]*BlobItemInternal `xml:"Blob"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.BlobItems != nil {
+		aux.BlobItems = &b.BlobItems
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // BlobGetAccessControlOptions contains the optional parameters for the Blob.GetAccessControl method.
@@ -1062,8 +1092,27 @@ type BlobHTTPHeaders struct {
 }
 
 type BlobHierarchyListSegment struct {
-	BlobItems    *[]*BlobItemInternal `xml:"Blob"`
-	BlobPrefixes *[]*BlobPrefix       `xml:"BlobPrefix"`
+	BlobItems    []*BlobItemInternal `xml:"Blob"`
+	BlobPrefixes []*BlobPrefix       `xml:"BlobPrefix"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlobHierarchyListSegment.
+func (b BlobHierarchyListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias BlobHierarchyListSegment
+	aux := &struct {
+		*alias
+		BlobItems    *[]*BlobItemInternal `xml:"Blob"`
+		BlobPrefixes *[]*BlobPrefix       `xml:"BlobPrefix"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.BlobItems != nil {
+		aux.BlobItems = &b.BlobItems
+	}
+	if b.BlobPrefixes != nil {
+		aux.BlobPrefixes = &b.BlobPrefixes
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // BlobItemInternal - An Azure Storage blob
@@ -1076,7 +1125,7 @@ type BlobItemInternal struct {
 	Name             *string       `xml:"Name"`
 
 	// Dictionary of
-	ObjectReplicationMetadata *map[string]*string `xml:"ObjectReplicationMetadata"`
+	ObjectReplicationMetadata map[string]*string `xml:"ObjectReplicationMetadata"`
 
 	// Properties of a blob
 	Properties *BlobPropertiesInternal `xml:"Properties"`
@@ -1089,20 +1138,20 @@ func (b *BlobItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 	type alias BlobItemInternal
 	aux := &struct {
 		*alias
-		ObjectReplicationMetadata *additionalProperties `xml:"ObjectReplicationMetadata"`
+		ObjectReplicationMetadata additionalProperties `xml:"ObjectReplicationMetadata"`
 	}{
 		alias: (*alias)(b),
 	}
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	b.ObjectReplicationMetadata = (*map[string]*string)(aux.ObjectReplicationMetadata)
+	b.ObjectReplicationMetadata = (map[string]*string)(aux.ObjectReplicationMetadata)
 	return nil
 }
 
 type BlobMetadata struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]*string
+	AdditionalProperties map[string]*string
 	Encrypted            *string `xml:"Encrypted,attr"`
 }
 
@@ -1125,7 +1174,7 @@ type BlobPropertiesInternal struct {
 
 	// Size in bytes
 	ContentLength             *int64          `xml:"Content-Length"`
-	ContentMD5                *[]byte         `xml:"Content-MD5"`
+	ContentMD5                []byte          `xml:"Content-MD5"`
 	ContentType               *string         `xml:"Content-Type"`
 	CopyCompletionTime        *time.Time      `xml:"CopyCompletionTime"`
 	CopyID                    *string         `xml:"CopyId"`
@@ -1166,6 +1215,7 @@ func (b BlobPropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElemen
 	aux := &struct {
 		*alias
 		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *[]byte      `xml:"Content-MD5"`
 		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
 		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
 		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
@@ -1184,6 +1234,9 @@ func (b BlobPropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElemen
 		LastAccessedOn:              (*timeRFC1123)(b.LastAccessedOn),
 		LastModified:                (*timeRFC1123)(b.LastModified),
 	}
+	if b.ContentMD5 != nil {
+		aux.ContentMD5 = &b.ContentMD5
+	}
 	return e.EncodeElement(aux, start)
 }
 
@@ -1193,6 +1246,7 @@ func (b *BlobPropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartEle
 	aux := &struct {
 		*alias
 		AccessTierChangeTime        *timeRFC1123 `xml:"AccessTierChangeTime"`
+		ContentMD5                  *[]byte      `xml:"Content-MD5"`
 		CopyCompletionTime          *timeRFC1123 `xml:"CopyCompletionTime"`
 		CreationTime                *timeRFC1123 `xml:"Creation-Time"`
 		DeletedTime                 *timeRFC1123 `xml:"DeletedTime"`
@@ -1822,7 +1876,7 @@ type BlobTag struct {
 
 // BlobTags - Blob tags
 type BlobTags struct {
-	BlobTagSet *[]*BlobTag `xml:"TagSet>Tag"`
+	BlobTagSet []*BlobTag `xml:"TagSet>Tag"`
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlobTags.
@@ -1831,8 +1885,12 @@ func (b BlobTags) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	type alias BlobTags
 	aux := &struct {
 		*alias
+		BlobTagSet *[]*BlobTag `xml:"TagSet>Tag"`
 	}{
 		alias: (*alias)(&b),
+	}
+	if b.BlobTagSet != nil {
+		aux.BlobTagSet = &b.BlobTagSet
 	}
 	return e.EncodeElement(aux, start)
 }
@@ -2200,8 +2258,27 @@ type BlockBlobUploadResponse struct {
 }
 
 type BlockList struct {
-	CommittedBlocks   *[]*Block `xml:"CommittedBlocks>Block"`
-	UncommittedBlocks *[]*Block `xml:"UncommittedBlocks>Block"`
+	CommittedBlocks   []*Block `xml:"CommittedBlocks>Block"`
+	UncommittedBlocks []*Block `xml:"UncommittedBlocks>Block"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type BlockList.
+func (b BlockList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias BlockList
+	aux := &struct {
+		*alias
+		CommittedBlocks   *[]*Block `xml:"CommittedBlocks>Block"`
+		UncommittedBlocks *[]*Block `xml:"UncommittedBlocks>Block"`
+	}{
+		alias: (*alias)(&b),
+	}
+	if b.CommittedBlocks != nil {
+		aux.CommittedBlocks = &b.CommittedBlocks
+	}
+	if b.UncommittedBlocks != nil {
+		aux.UncommittedBlocks = &b.UncommittedBlocks
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // BlockListResponse is the response envelope for operations that return a BlockList type.
@@ -2236,9 +2313,9 @@ type BlockListResponse struct {
 }
 
 type BlockLookupList struct {
-	Committed   *[]*string `xml:"Committed"`
-	Latest      *[]*string `xml:"Latest"`
-	Uncommitted *[]*string `xml:"Uncommitted"`
+	Committed   []*string `xml:"Committed"`
+	Latest      []*string `xml:"Latest"`
+	Uncommitted []*string `xml:"Uncommitted"`
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlockLookupList.
@@ -2247,8 +2324,20 @@ func (b BlockLookupList) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	type alias BlockLookupList
 	aux := &struct {
 		*alias
+		Committed   *[]*string `xml:"Committed"`
+		Latest      *[]*string `xml:"Latest"`
+		Uncommitted *[]*string `xml:"Uncommitted"`
 	}{
 		alias: (*alias)(&b),
+	}
+	if b.Committed != nil {
+		aux.Committed = &b.Committed
+	}
+	if b.Latest != nil {
+		aux.Latest = &b.Latest
+	}
+	if b.Uncommitted != nil {
+		aux.Uncommitted = &b.Uncommitted
 	}
 	return e.EncodeElement(aux, start)
 }
@@ -2558,8 +2647,8 @@ type ContainerItem struct {
 	Deleted *bool `xml:"Deleted"`
 
 	// Dictionary of
-	Metadata *map[string]*string `xml:"Metadata"`
-	Name     *string             `xml:"Name"`
+	Metadata map[string]*string `xml:"Metadata"`
+	Name     *string            `xml:"Name"`
 
 	// Properties of a container
 	Properties *ContainerProperties `xml:"Properties"`
@@ -2571,14 +2660,14 @@ func (c *ContainerItem) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	type alias ContainerItem
 	aux := &struct {
 		*alias
-		Metadata *additionalProperties `xml:"Metadata"`
+		Metadata additionalProperties `xml:"Metadata"`
 	}{
 		alias: (*alias)(c),
 	}
 	if err := d.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.Metadata = (*map[string]*string)(aux.Metadata)
+	c.Metadata = (map[string]*string)(aux.Metadata)
 	return nil
 }
 
@@ -3240,10 +3329,25 @@ type FilterBlobItem struct {
 
 // FilterBlobSegment - The result of a Filter Blobs API call
 type FilterBlobSegment struct {
-	Blobs           *[]*FilterBlobItem `xml:"Blobs>Blob"`
-	NextMarker      *string            `xml:"NextMarker"`
-	ServiceEndpoint *string            `xml:"ServiceEndpoint,attr"`
-	Where           *string            `xml:"Where"`
+	Blobs           []*FilterBlobItem `xml:"Blobs>Blob"`
+	NextMarker      *string           `xml:"NextMarker"`
+	ServiceEndpoint *string           `xml:"ServiceEndpoint,attr"`
+	Where           *string           `xml:"Where"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type FilterBlobSegment.
+func (f FilterBlobSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias FilterBlobSegment
+	aux := &struct {
+		*alias
+		Blobs *[]*FilterBlobItem `xml:"Blobs>Blob"`
+	}{
+		alias: (*alias)(&f),
+	}
+	if f.Blobs != nil {
+		aux.Blobs = &f.Blobs
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // FilterBlobSegmentResponse is the response envelope for operations that return a FilterBlobSegment type.
@@ -3401,12 +3505,27 @@ type ListBlobsHierarchySegmentResponseResponse struct {
 
 // ListContainersSegmentResponse - An enumeration of containers
 type ListContainersSegmentResponse struct {
-	ContainerItems  *[]*ContainerItem `xml:"Containers>Container"`
-	Marker          *string           `xml:"Marker"`
-	MaxResults      *int32            `xml:"MaxResults"`
-	NextMarker      *string           `xml:"NextMarker"`
-	Prefix          *string           `xml:"Prefix"`
-	ServiceEndpoint *string           `xml:"ServiceEndpoint,attr"`
+	ContainerItems  []*ContainerItem `xml:"Containers>Container"`
+	Marker          *string          `xml:"Marker"`
+	MaxResults      *int32           `xml:"MaxResults"`
+	NextMarker      *string          `xml:"NextMarker"`
+	Prefix          *string          `xml:"Prefix"`
+	ServiceEndpoint *string          `xml:"ServiceEndpoint,attr"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type ListContainersSegmentResponse.
+func (l ListContainersSegmentResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias ListContainersSegmentResponse
+	aux := &struct {
+		*alias
+		ContainerItems *[]*ContainerItem `xml:"Containers>Container"`
+	}{
+		alias: (*alias)(&l),
+	}
+	if l.ContainerItems != nil {
+		aux.ContainerItems = &l.ContainerItems
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // ListContainersSegmentResponseResponse is the response envelope for operations that return a ListContainersSegmentResponse type.
@@ -3847,8 +3966,27 @@ type PageBlobUploadPagesResponse struct {
 
 // PageList - the list of pages
 type PageList struct {
-	ClearRange *[]*ClearRange `xml:"ClearRange"`
-	PageRange  *[]*PageRange  `xml:"PageRange"`
+	ClearRange []*ClearRange `xml:"ClearRange"`
+	PageRange  []*PageRange  `xml:"PageRange"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type PageList.
+func (p PageList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias PageList
+	aux := &struct {
+		*alias
+		ClearRange *[]*ClearRange `xml:"ClearRange"`
+		PageRange  *[]*PageRange  `xml:"PageRange"`
+	}{
+		alias: (*alias)(&p),
+	}
+	if p.ClearRange != nil {
+		aux.ClearRange = &p.ClearRange
+	}
+	if p.PageRange != nil {
+		aux.PageRange = &p.PageRange
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // PageListResponse is the response envelope for operations that return a PageList type.
@@ -4181,7 +4319,7 @@ func (e StorageError) Error() string {
 // StorageServiceProperties - Storage Service Properties.
 type StorageServiceProperties struct {
 	// The set of CORS rules.
-	Cors *[]*CorsRule `xml:"Cors>CorsRule"`
+	Cors []*CorsRule `xml:"Cors>CorsRule"`
 
 	// The default version to use for requests to the Blob service if an incoming request's version is not specified. Possible values include version 2008-10-27
 	// and all more recent versions
@@ -4201,6 +4339,21 @@ type StorageServiceProperties struct {
 
 	// The properties that enable an account to host a static website
 	StaticWebsite *StaticWebsite `xml:"StaticWebsite"`
+}
+
+// MarshalXML implements the xml.Marshaller interface for type StorageServiceProperties.
+func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type alias StorageServiceProperties
+	aux := &struct {
+		*alias
+		Cors *[]*CorsRule `xml:"Cors>CorsRule"`
+	}{
+		alias: (*alias)(&s),
+	}
+	if s.Cors != nil {
+		aux.Cors = &s.Cors
+	}
+	return e.EncodeElement(aux, start)
 }
 
 // StorageServicePropertiesResponse is the response envelope for operations that return a StorageServiceProperties type.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -35,10 +35,10 @@ type ActivityClassification interface {
 // Activity - A pipeline activity.
 type Activity struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Activity depends on condition.
-	DependsOn *[]*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
 
 	// Activity description.
 	Description *string `json:"description,omitempty"`
@@ -50,7 +50,7 @@ type Activity struct {
 	Type *string `json:"type,omitempty"`
 
 	// Activity user properties.
-	UserProperties *[]*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty `json:"userProperties,omitempty"`
 }
 
 // GetActivity implements the ActivityClassification interface for type Activity.
@@ -74,7 +74,7 @@ func (a Activity) marshalInternal(discValue string) map[string]interface{} {
 	objectMap["type"] = a.Type
 	populate(objectMap, "userProperties", a.UserProperties)
 	if a.AdditionalProperties != nil {
-		for key, val := range *a.AdditionalProperties {
+		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -102,12 +102,12 @@ func (a *Activity) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 			delete(rawMsg, key)
 		default:
 			if a.AdditionalProperties == nil {
-				a.AdditionalProperties = &map[string]interface{}{}
+				a.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*a.AdditionalProperties)[key] = aux
+				a.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -124,10 +124,10 @@ type ActivityDependency struct {
 	Activity *string `json:"activity,omitempty"`
 
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Match-Condition for the dependency.
-	DependencyConditions *[]*DependencyCondition `json:"dependencyConditions,omitempty"`
+	DependencyConditions []*DependencyCondition `json:"dependencyConditions,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type ActivityDependency.
@@ -136,7 +136,7 @@ func (a ActivityDependency) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "activity", a.Activity)
 	populate(objectMap, "dependencyConditions", a.DependencyConditions)
 	if a.AdditionalProperties != nil {
-		for key, val := range *a.AdditionalProperties {
+		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -160,12 +160,12 @@ func (a *ActivityDependency) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if a.AdditionalProperties == nil {
-				a.AdditionalProperties = &map[string]interface{}{}
+				a.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*a.AdditionalProperties)[key] = aux
+				a.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -179,7 +179,7 @@ func (a *ActivityDependency) UnmarshalJSON(data []byte) error {
 // ActivityPolicy - Execution policy for an activity.
 type ActivityPolicy struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Maximum ordinary retry attempts. Default is 0. Type: integer (or Expression with resultType integer), minimum: 0.
 	Retry interface{} `json:"retry,omitempty"`
@@ -206,7 +206,7 @@ func (a ActivityPolicy) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "secureOutput", a.SecureOutput)
 	populate(objectMap, "timeout", a.Timeout)
 	if a.AdditionalProperties != nil {
-		for key, val := range *a.AdditionalProperties {
+		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -239,12 +239,12 @@ func (a *ActivityPolicy) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if a.AdditionalProperties == nil {
-				a.AdditionalProperties = &map[string]interface{}{}
+				a.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*a.AdditionalProperties)[key] = aux
+				a.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -273,7 +273,7 @@ type ActivityRun struct {
 	ActivityType *string `json:"activityType,omitempty" azure:"ro"`
 
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// READ-ONLY; The duration of the activity run.
 	DurationInMs *int32 `json:"durationInMs,omitempty" azure:"ro"`
@@ -317,7 +317,7 @@ func (a ActivityRun) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "pipelineRunId", a.PipelineRunID)
 	populate(objectMap, "status", a.Status)
 	if a.AdditionalProperties != nil {
-		for key, val := range *a.AdditionalProperties {
+		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -378,12 +378,12 @@ func (a *ActivityRun) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if a.AdditionalProperties == nil {
-				a.AdditionalProperties = &map[string]interface{}{}
+				a.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*a.AdditionalProperties)[key] = aux
+				a.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -400,7 +400,15 @@ type ActivityRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of activity runs.
-	Value *[]*ActivityRun `json:"value,omitempty"`
+	Value []*ActivityRun `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ActivityRunsQueryResponse.
+func (a ActivityRunsQueryResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "continuationToken", a.ContinuationToken)
+	populate(objectMap, "value", a.Value)
+	return json.Marshal(objectMap)
 }
 
 // ActivityRunsQueryResponseResponse is the response envelope for operations that return a ActivityRunsQueryResponse type.
@@ -494,6 +502,22 @@ type AmazonMWSLinkedServiceTypeProperties struct {
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AmazonMWSLinkedServiceTypeProperties.
+func (a AmazonMWSLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessKeyId", a.AccessKeyID)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "endpoint", a.Endpoint)
+	populate(objectMap, "marketplaceID", a.MarketplaceID)
+	populate(objectMap, "mwsAuthToken", a.MwsAuthToken)
+	populate(objectMap, "secretKey", a.SecretKey)
+	populate(objectMap, "sellerID", a.SellerID)
+	populate(objectMap, "useEncryptedEndpoints", a.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", a.UseHostVerification)
+	populate(objectMap, "usePeerVerification", a.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AmazonMWSLinkedServiceTypeProperties.
@@ -666,6 +690,18 @@ type AmazonRedshiftLinkedServiceTypeProperties struct {
 
 	// The username of the Amazon Redshift source. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AmazonRedshiftLinkedServiceTypeProperties.
+func (a AmazonRedshiftLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "database", a.Database)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "password", a.Password)
+	populate(objectMap, "port", a.Port)
+	populate(objectMap, "server", a.Server)
+	populate(objectMap, "username", a.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AmazonRedshiftLinkedServiceTypeProperties.
@@ -842,6 +878,16 @@ type AmazonS3LinkedServiceTypeProperties struct {
 	// endpoint or want to switch between https and
 	// http. Type: string (or Expression with resultType string).
 	ServiceURL interface{} `json:"serviceUrl,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AmazonS3LinkedServiceTypeProperties.
+func (a AmazonS3LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessKeyId", a.AccessKeyID)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "secretAccessKey", a.SecretAccessKey)
+	populate(objectMap, "serviceUrl", a.ServiceURL)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AmazonS3LinkedServiceTypeProperties.
@@ -1103,6 +1149,15 @@ type AvroDatasetTypeProperties struct {
 	Location DatasetLocationClassification `json:"location,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AvroDatasetTypeProperties.
+func (a AvroDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "avroCompressionCodec", a.AvroCompressionCodec)
+	populate(objectMap, "avroCompressionLevel", a.AvroCompressionLevel)
+	populate(objectMap, "location", a.Location)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AvroDatasetTypeProperties.
 func (a *AvroDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -1312,6 +1367,18 @@ type AzureBatchLinkedServiceTypeProperties struct {
 	PoolName interface{} `json:"poolName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureBatchLinkedServiceTypeProperties.
+func (a AzureBatchLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessKey", a.AccessKey)
+	populate(objectMap, "accountName", a.AccountName)
+	populate(objectMap, "batchUri", a.BatchURI)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
+	populate(objectMap, "poolName", a.PoolName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureBatchLinkedServiceTypeProperties.
 func (a *AzureBatchLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -1401,6 +1468,18 @@ type AzureBlobFSLinkedServiceTypeProperties struct {
 
 	// Endpoint for the Azure Data Lake Storage Gen2 service. Type: string (or Expression with resultType string).
 	URL interface{} `json:"url,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureBlobFSLinkedServiceTypeProperties.
+func (a AzureBlobFSLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accountKey", a.AccountKey)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	populate(objectMap, "url", a.URL)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureBlobFSLinkedServiceTypeProperties.
@@ -1722,6 +1801,21 @@ type AzureBlobStorageLinkedServiceTypeProperties struct {
 	Tenant interface{} `json:"tenant,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureBlobStorageLinkedServiceTypeProperties.
+func (a AzureBlobStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accountKey", a.AccountKey)
+	populate(objectMap, "connectionString", a.ConnectionString)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "sasToken", a.SasToken)
+	populate(objectMap, "sasUri", a.SasURI)
+	populate(objectMap, "serviceEndpoint", a.ServiceEndpoint)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureBlobStorageLinkedServiceTypeProperties.
 func (a *AzureBlobStorageLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -2012,6 +2106,17 @@ type AzureDataExplorerLinkedServiceTypeProperties struct {
 	Tenant interface{} `json:"tenant,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerLinkedServiceTypeProperties.
+func (a AzureDataExplorerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "database", a.Database)
+	populate(objectMap, "endpoint", a.Endpoint)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureDataExplorerLinkedServiceTypeProperties.
 func (a *AzureDataExplorerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -2236,6 +2341,20 @@ type AzureDataLakeAnalyticsLinkedServiceTypeProperties struct {
 	Tenant interface{} `json:"tenant,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureDataLakeAnalyticsLinkedServiceTypeProperties.
+func (a AzureDataLakeAnalyticsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accountName", a.AccountName)
+	populate(objectMap, "dataLakeAnalyticsUri", a.DataLakeAnalyticsURI)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "subscriptionId", a.SubscriptionID)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureDataLakeAnalyticsLinkedServiceTypeProperties.
 func (a *AzureDataLakeAnalyticsLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -2337,6 +2456,20 @@ type AzureDataLakeStoreLinkedServiceTypeProperties struct {
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
 	Tenant interface{} `json:"tenant,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreLinkedServiceTypeProperties.
+func (a AzureDataLakeStoreLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accountName", a.AccountName)
+	populate(objectMap, "dataLakeStoreUri", a.DataLakeStoreURI)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "subscriptionId", a.SubscriptionID)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureDataLakeStoreLinkedServiceTypeProperties.
@@ -2600,7 +2733,7 @@ type AzureDatabricksLinkedServiceTypeProperties struct {
 	InstancePoolID interface{} `json:"instancePoolId,omitempty"`
 
 	// Additional tags for cluster resources. This property is ignored in instance pool configurations.
-	NewClusterCustomTags *map[string]interface{} `json:"newClusterCustomTags,omitempty"`
+	NewClusterCustomTags map[string]interface{} `json:"newClusterCustomTags,omitempty"`
 
 	// The driver node type for the new job cluster. This property is ignored in instance pool configurations. Type: string (or Expression with resultType string).
 	NewClusterDriverNodeType interface{} `json:"newClusterDriverNodeType,omitempty"`
@@ -2626,15 +2759,35 @@ type AzureDatabricksLinkedServiceTypeProperties struct {
 	NewClusterNumOfWorker interface{} `json:"newClusterNumOfWorker,omitempty"`
 
 	// A set of optional, user-specified Spark configuration key-value pairs.
-	NewClusterSparkConf *map[string]interface{} `json:"newClusterSparkConf,omitempty"`
+	NewClusterSparkConf map[string]interface{} `json:"newClusterSparkConf,omitempty"`
 
 	// A set of optional, user-specified Spark environment variables key-value pairs.
-	NewClusterSparkEnvVars *map[string]interface{} `json:"newClusterSparkEnvVars,omitempty"`
+	NewClusterSparkEnvVars map[string]interface{} `json:"newClusterSparkEnvVars,omitempty"`
 
 	// If not using an existing interactive cluster, this specifies the Spark version of a new job cluster or instance pool nodes created for each run of this
 	// activity. Required if instancePoolId is
 	// specified. Type: string (or Expression with resultType string).
 	NewClusterVersion interface{} `json:"newClusterVersion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureDatabricksLinkedServiceTypeProperties.
+func (a AzureDatabricksLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", a.AccessToken)
+	populate(objectMap, "domain", a.Domain)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "existingClusterId", a.ExistingClusterID)
+	populate(objectMap, "instancePoolId", a.InstancePoolID)
+	populate(objectMap, "newClusterCustomTags", a.NewClusterCustomTags)
+	populate(objectMap, "newClusterDriverNodeType", a.NewClusterDriverNodeType)
+	populate(objectMap, "newClusterEnableElasticDisk", a.NewClusterEnableElasticDisk)
+	populate(objectMap, "newClusterInitScripts", a.NewClusterInitScripts)
+	populate(objectMap, "newClusterNodeType", a.NewClusterNodeType)
+	populate(objectMap, "newClusterNumOfWorker", a.NewClusterNumOfWorker)
+	populate(objectMap, "newClusterSparkConf", a.NewClusterSparkConf)
+	populate(objectMap, "newClusterSparkEnvVars", a.NewClusterSparkEnvVars)
+	populate(objectMap, "newClusterVersion", a.NewClusterVersion)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureDatabricksLinkedServiceTypeProperties.
@@ -2787,6 +2940,16 @@ type AzureFileStorageLinkedServiceTypeProperties struct {
 
 	// User ID to logon the server. Type: string (or Expression with resultType string).
 	UserID interface{} `json:"userId,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureFileStorageLinkedServiceTypeProperties.
+func (a AzureFileStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "host", a.Host)
+	populate(objectMap, "password", a.Password)
+	populate(objectMap, "userId", a.UserID)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureFileStorageLinkedServiceTypeProperties.
@@ -2997,6 +3160,15 @@ type AzureFunctionLinkedServiceTypeProperties struct {
 	FunctionKey SecretBaseClassification `json:"functionKey,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureFunctionLinkedServiceTypeProperties.
+func (a AzureFunctionLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "functionAppUrl", a.FunctionAppURL)
+	populate(objectMap, "functionKey", a.FunctionKey)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureFunctionLinkedServiceTypeProperties.
 func (a *AzureFunctionLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -3150,17 +3322,26 @@ type AzureMLBatchExecutionActivityTypeProperties struct {
 	// Key,Value pairs to be passed to the Azure ML Batch Execution Service endpoint. Keys must match the names of web service parameters defined in the published
 	// Azure ML web service. Values will be passed
 	// in the GlobalParameters property of the Azure ML batch execution request.
-	GlobalParameters *map[string]interface{} `json:"globalParameters,omitempty"`
+	GlobalParameters map[string]interface{} `json:"globalParameters,omitempty"`
 
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Inputs to AzureMLWebServiceFile objects specifying the input Blob locations.. This
 	// information will be passed in the
 	// WebServiceInputs property of the Azure ML batch execution request.
-	WebServiceInputs *map[string]*AzureMLWebServiceFile `json:"webServiceInputs,omitempty"`
+	WebServiceInputs map[string]*AzureMLWebServiceFile `json:"webServiceInputs,omitempty"`
 
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Outputs to AzureMLWebServiceFile objects specifying the output Blob locations.
 	// This information will be passed in the
 	// WebServiceOutputs property of the Azure ML batch execution request.
-	WebServiceOutputs *map[string]*AzureMLWebServiceFile `json:"webServiceOutputs,omitempty"`
+	WebServiceOutputs map[string]*AzureMLWebServiceFile `json:"webServiceOutputs,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureMLBatchExecutionActivityTypeProperties.
+func (a AzureMLBatchExecutionActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "globalParameters", a.GlobalParameters)
+	populate(objectMap, "webServiceInputs", a.WebServiceInputs)
+	populate(objectMap, "webServiceOutputs", a.WebServiceOutputs)
+	return json.Marshal(objectMap)
 }
 
 // AzureMLExecutePipelineActivity - Azure ML Execute Pipeline activity.
@@ -3283,6 +3464,19 @@ type AzureMLLinkedServiceTypeProperties struct {
 	UpdateResourceEndpoint interface{} `json:"updateResourceEndpoint,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureMLLinkedServiceTypeProperties.
+func (a AzureMLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "apiKey", a.APIKey)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "mlEndpoint", a.MlEndpoint)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	populate(objectMap, "updateResourceEndpoint", a.UpdateResourceEndpoint)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureMLLinkedServiceTypeProperties.
 func (a *AzureMLLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -3379,6 +3573,19 @@ type AzureMLServiceLinkedServiceTypeProperties struct {
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
 	Tenant interface{} `json:"tenant,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureMLServiceLinkedServiceTypeProperties.
+func (a AzureMLServiceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "mlWorkspaceName", a.MlWorkspaceName)
+	populate(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "subscriptionId", a.SubscriptionID)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureMLServiceLinkedServiceTypeProperties.
@@ -3977,6 +4184,18 @@ type AzureSQLDWLinkedServiceTypeProperties struct {
 	Tenant interface{} `json:"tenant,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureSQLDWLinkedServiceTypeProperties.
+func (a AzureSQLDWLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionString", a.ConnectionString)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "password", a.Password)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureSQLDWLinkedServiceTypeProperties.
 func (a *AzureSQLDWLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -4114,6 +4333,18 @@ type AzureSQLDatabaseLinkedServiceTypeProperties struct {
 	Tenant interface{} `json:"tenant,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type AzureSQLDatabaseLinkedServiceTypeProperties.
+func (a AzureSQLDatabaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionString", a.ConnectionString)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "password", a.Password)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureSQLDatabaseLinkedServiceTypeProperties.
 func (a *AzureSQLDatabaseLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -4203,6 +4434,18 @@ type AzureSQLMILinkedServiceTypeProperties struct {
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
 	Tenant interface{} `json:"tenant,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureSQLMILinkedServiceTypeProperties.
+func (a AzureSQLMILinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionString", a.ConnectionString)
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "password", a.Password)
+	populate(objectMap, "servicePrincipalId", a.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
+	populate(objectMap, "tenant", a.Tenant)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureSQLMILinkedServiceTypeProperties.
@@ -4299,7 +4542,7 @@ type AzureSQLSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -4369,7 +4612,7 @@ type AzureSQLSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLSource.
@@ -4576,6 +4819,15 @@ type AzureSearchLinkedServiceTypeProperties struct {
 
 	// URL for Azure Search service. Type: string (or Expression with resultType string).
 	URL interface{} `json:"url,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type AzureSearchLinkedServiceTypeProperties.
+func (a AzureSearchLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populate(objectMap, "key", a.Key)
+	populate(objectMap, "url", a.URL)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type AzureSearchLinkedServiceTypeProperties.
@@ -4843,13 +5095,28 @@ type BigDataPoolResourceInfo struct {
 	Properties *BigDataPoolResourceProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BigDataPoolResourceInfo.
+func (b BigDataPoolResourceInfo) MarshalJSON() ([]byte, error) {
+	objectMap := b.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", b.Properties)
+	return json.Marshal(objectMap)
+}
+
 // BigDataPoolResourceInfoListResult - Collection of Big Data pool information
 type BigDataPoolResourceInfoListResult struct {
 	// Link to the next page of results
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Big Data pools
-	Value *[]*BigDataPoolResourceInfo `json:"value,omitempty"`
+	Value []*BigDataPoolResourceInfo `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BigDataPoolResourceInfoListResult.
+func (b BigDataPoolResourceInfoListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", b.NextLink)
+	populate(objectMap, "value", b.Value)
+	return json.Marshal(objectMap)
 }
 
 // BigDataPoolResourceInfoListResultResponse is the response envelope for operations that return a BigDataPoolResourceInfoListResult type.
@@ -4885,7 +5152,7 @@ type BigDataPoolResourceProperties struct {
 	CreationDate *time.Time `json:"creationDate,omitempty"`
 
 	// List of custom libraries/packages associated with the spark pool.
-	CustomLibraries *[]*LibraryInfo `json:"customLibraries,omitempty"`
+	CustomLibraries []*LibraryInfo `json:"customLibraries,omitempty"`
 
 	// The default folder where Spark logs will be written.
 	DefaultSparkLogFolder *string `json:"defaultSparkLogFolder,omitempty"`
@@ -5079,6 +5346,14 @@ type BinaryDatasetTypeProperties struct {
 	Location DatasetLocationClassification `json:"location,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type BinaryDatasetTypeProperties.
+func (b BinaryDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "compression", b.Compression)
+	populate(objectMap, "location", b.Location)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type BinaryDatasetTypeProperties.
 func (b *BinaryDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -5217,13 +5492,24 @@ type BlobEventsTriggerTypeProperties struct {
 	BlobPathEndsWith *string `json:"blobPathEndsWith,omitempty"`
 
 	// The type of events that cause this trigger to fire.
-	Events *[]*BlobEventType `json:"events,omitempty"`
+	Events []*BlobEventType `json:"events,omitempty"`
 
 	// If set to true, blobs with zero bytes will be ignored.
 	IgnoreEmptyBlobs *bool `json:"ignoreEmptyBlobs,omitempty"`
 
 	// The ARM resource ID of the Storage Account.
 	Scope *string `json:"scope,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type BlobEventsTriggerTypeProperties.
+func (b BlobEventsTriggerTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "blobPathBeginsWith", b.BlobPathBeginsWith)
+	populate(objectMap, "blobPathEndsWith", b.BlobPathEndsWith)
+	populate(objectMap, "events", b.Events)
+	populate(objectMap, "ignoreEmptyBlobs", b.IgnoreEmptyBlobs)
+	populate(objectMap, "scope", b.Scope)
+	return json.Marshal(objectMap)
 }
 
 // BlobSink - A copy activity Azure Blob sink.
@@ -5431,6 +5717,18 @@ type CassandraLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type CassandraLinkedServiceTypeProperties.
+func (c CassandraLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", c.AuthenticationType)
+	populate(objectMap, "encryptedCredential", c.EncryptedCredential)
+	populate(objectMap, "host", c.Host)
+	populate(objectMap, "password", c.Password)
+	populate(objectMap, "port", c.Port)
+	populate(objectMap, "username", c.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type CassandraLinkedServiceTypeProperties.
 func (c *CassandraLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -5599,10 +5897,18 @@ func (c *ChainingTrigger) UnmarshalJSON(data []byte) error {
 // ChainingTriggerTypeProperties - Chaining Trigger properties.
 type ChainingTriggerTypeProperties struct {
 	// Upstream Pipelines.
-	DependsOn *[]*PipelineReference `json:"dependsOn,omitempty"`
+	DependsOn []*PipelineReference `json:"dependsOn,omitempty"`
 
 	// Run Dimension property that needs to be emitted by upstream pipelines.
 	RunDimension *string `json:"runDimension,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ChainingTriggerTypeProperties.
+func (c ChainingTriggerTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dependsOn", c.DependsOn)
+	populate(objectMap, "runDimension", c.RunDimension)
+	return json.Marshal(objectMap)
 }
 
 // CloudError - The object that defines the structure of an Azure Synapse error response.
@@ -5639,7 +5945,7 @@ type CloudErrorBody struct {
 	Code *string `json:"code,omitempty"`
 
 	// Array with additional error details.
-	Details *[]*CloudError `json:"details,omitempty"`
+	Details []*CloudError `json:"details,omitempty"`
 
 	// Error message.
 	Message *string `json:"message,omitempty"`
@@ -5648,19 +5954,39 @@ type CloudErrorBody struct {
 	Target *string `json:"target,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type CloudErrorBody.
+func (c CloudErrorBody) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "code", c.Code)
+	populate(objectMap, "details", c.Details)
+	populate(objectMap, "message", c.Message)
+	populate(objectMap, "target", c.Target)
+	return json.Marshal(objectMap)
+}
+
 // CloudErrorBodyAutoGenerated - The object that defines the structure of an Azure Synapse error.
 type CloudErrorBodyAutoGenerated struct {
 	// Error code.
 	Code *string `json:"code,omitempty"`
 
 	// Array with additional error details.
-	Details *[]*CloudErrorAutoGenerated `json:"details,omitempty"`
+	Details []*CloudErrorAutoGenerated `json:"details,omitempty"`
 
 	// Error message.
 	Message *string `json:"message,omitempty"`
 
 	// Property name/path in request associated with error.
 	Target *string `json:"target,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CloudErrorBodyAutoGenerated.
+func (c CloudErrorBodyAutoGenerated) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "code", c.Code)
+	populate(objectMap, "details", c.Details)
+	populate(objectMap, "message", c.Message)
+	populate(objectMap, "target", c.Target)
+	return json.Marshal(objectMap)
 }
 
 // CommonDataServiceForAppsEntityDataset - The Common Data Service for Apps entity dataset.
@@ -5789,6 +6115,24 @@ type CommonDataServiceForAppsLinkedServiceTypeProperties struct {
 
 	// User name to access the Common Data Service for Apps instance. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CommonDataServiceForAppsLinkedServiceTypeProperties.
+func (c CommonDataServiceForAppsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", c.AuthenticationType)
+	populate(objectMap, "deploymentType", c.DeploymentType)
+	populate(objectMap, "encryptedCredential", c.EncryptedCredential)
+	populate(objectMap, "hostName", c.HostName)
+	populate(objectMap, "organizationName", c.OrganizationName)
+	populate(objectMap, "password", c.Password)
+	populate(objectMap, "port", c.Port)
+	populate(objectMap, "servicePrincipalCredential", c.ServicePrincipalCredential)
+	populate(objectMap, "servicePrincipalCredentialType", c.ServicePrincipalCredentialType)
+	populate(objectMap, "servicePrincipalId", c.ServicePrincipalID)
+	populate(objectMap, "serviceUri", c.ServiceURI)
+	populate(objectMap, "username", c.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type CommonDataServiceForAppsLinkedServiceTypeProperties.
@@ -5988,6 +6332,19 @@ type ConcurLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ConcurLinkedServiceTypeProperties.
+func (c ConcurLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", c.ClientID)
+	populate(objectMap, "encryptedCredential", c.EncryptedCredential)
+	populate(objectMap, "password", c.Password)
+	populate(objectMap, "useEncryptedEndpoints", c.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", c.UseHostVerification)
+	populate(objectMap, "usePeerVerification", c.UsePeerVerification)
+	populate(objectMap, "username", c.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type ConcurLinkedServiceTypeProperties.
 func (c *ConcurLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -6132,10 +6489,10 @@ func (c *ControlActivity) unmarshalInternal(rawMsg map[string]json.RawMessage) e
 type CopyActivity struct {
 	ExecutionActivity
 	// List of inputs for the activity.
-	Inputs *[]*DatasetReference `json:"inputs,omitempty"`
+	Inputs []*DatasetReference `json:"inputs,omitempty"`
 
 	// List of outputs for the activity.
-	Outputs *[]*DatasetReference `json:"outputs,omitempty"`
+	Outputs []*DatasetReference `json:"outputs,omitempty"`
 
 	// Copy activity properties.
 	TypeProperties *CopyActivityTypeProperties `json:"typeProperties,omitempty"`
@@ -6193,10 +6550,10 @@ type CopyActivityTypeProperties struct {
 	ParallelCopies interface{} `json:"parallelCopies,omitempty"`
 
 	// Preserve rules.
-	Preserve *[]interface{} `json:"preserve,omitempty"`
+	Preserve []interface{} `json:"preserve,omitempty"`
 
 	// Preserve Rules.
-	PreserveRules *[]interface{} `json:"preserveRules,omitempty"`
+	PreserveRules []interface{} `json:"preserveRules,omitempty"`
 
 	// Redirect incompatible row settings when EnableSkipIncompatibleRow is true.
 	RedirectIncompatibleRowSettings *RedirectIncompatibleRowSettings `json:"redirectIncompatibleRowSettings,omitempty"`
@@ -6212,6 +6569,23 @@ type CopyActivityTypeProperties struct {
 
 	// Copy activity translator. If not specified, tabular translator is used.
 	Translator interface{} `json:"translator,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CopyActivityTypeProperties.
+func (c CopyActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataIntegrationUnits", c.DataIntegrationUnits)
+	populate(objectMap, "enableSkipIncompatibleRow", c.EnableSkipIncompatibleRow)
+	populate(objectMap, "enableStaging", c.EnableStaging)
+	populate(objectMap, "parallelCopies", c.ParallelCopies)
+	populate(objectMap, "preserve", c.Preserve)
+	populate(objectMap, "preserveRules", c.PreserveRules)
+	populate(objectMap, "redirectIncompatibleRowSettings", c.RedirectIncompatibleRowSettings)
+	populate(objectMap, "sink", c.Sink)
+	populate(objectMap, "source", c.Source)
+	populate(objectMap, "stagingSettings", c.StagingSettings)
+	populate(objectMap, "translator", c.Translator)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type CopyActivityTypeProperties.
@@ -6280,7 +6654,7 @@ type CopySinkClassification interface {
 // CopySink - A copy activity sink.
 type CopySink struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
 	MaxConcurrentConnections interface{} `json:"maxConcurrentConnections,omitempty"`
@@ -6323,7 +6697,7 @@ func (c CopySink) marshalInternal(discValue string) map[string]interface{} {
 	populate(objectMap, "writeBatchSize", c.WriteBatchSize)
 	populate(objectMap, "writeBatchTimeout", c.WriteBatchTimeout)
 	if c.AdditionalProperties != nil {
-		for key, val := range *c.AdditionalProperties {
+		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -6354,12 +6728,12 @@ func (c *CopySink) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 			delete(rawMsg, key)
 		default:
 			if c.AdditionalProperties == nil {
-				c.AdditionalProperties = &map[string]interface{}{}
+				c.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*c.AdditionalProperties)[key] = aux
+				c.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -6394,7 +6768,7 @@ type CopySourceClassification interface {
 // CopySource - A copy activity source.
 type CopySource struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
 	MaxConcurrentConnections interface{} `json:"maxConcurrentConnections,omitempty"`
@@ -6429,7 +6803,7 @@ func (c CopySource) marshalInternal(discValue string) map[string]interface{} {
 	c.Type = &discValue
 	objectMap["type"] = c.Type
 	if c.AdditionalProperties != nil {
-		for key, val := range *c.AdditionalProperties {
+		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -6454,12 +6828,12 @@ func (c *CopySource) unmarshalInternal(rawMsg map[string]json.RawMessage) error 
 			delete(rawMsg, key)
 		default:
 			if c.AdditionalProperties == nil {
-				c.AdditionalProperties = &map[string]interface{}{}
+				c.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*c.AdditionalProperties)[key] = aux
+				c.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -6482,7 +6856,7 @@ type CopyTranslatorClassification interface {
 // CopyTranslator - A copy activity translator.
 type CopyTranslator struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Copy translator type.
 	Type *string `json:"type,omitempty"`
@@ -6505,7 +6879,7 @@ func (c CopyTranslator) marshalInternal(discValue string) map[string]interface{}
 	c.Type = &discValue
 	objectMap["type"] = c.Type
 	if c.AdditionalProperties != nil {
-		for key, val := range *c.AdditionalProperties {
+		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -6521,12 +6895,12 @@ func (c *CopyTranslator) unmarshalInternal(rawMsg map[string]json.RawMessage) er
 			delete(rawMsg, key)
 		default:
 			if c.AdditionalProperties == nil {
-				c.AdditionalProperties = &map[string]interface{}{}
+				c.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*c.AdditionalProperties)[key] = aux
+				c.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -6588,6 +6962,17 @@ type CosmosDbLinkedServiceTypeProperties struct {
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager. Type: string (or Expression
 	// with resultType string).
 	EncryptedCredential interface{} `json:"encryptedCredential,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CosmosDbLinkedServiceTypeProperties.
+func (c CosmosDbLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accountEndpoint", c.AccountEndpoint)
+	populate(objectMap, "accountKey", c.AccountKey)
+	populate(objectMap, "connectionString", c.ConnectionString)
+	populate(objectMap, "database", c.Database)
+	populate(objectMap, "encryptedCredential", c.EncryptedCredential)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type CosmosDbLinkedServiceTypeProperties.
@@ -7137,10 +7522,18 @@ func (c *CustomActivity) UnmarshalJSON(data []byte) error {
 // CustomActivityReferenceObject - Reference objects for custom activity
 type CustomActivityReferenceObject struct {
 	// Dataset references.
-	Datasets *[]*DatasetReference `json:"datasets,omitempty"`
+	Datasets []*DatasetReference `json:"datasets,omitempty"`
 
 	// Linked service references.
-	LinkedServices *[]*LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceReference `json:"linkedServices,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CustomActivityReferenceObject.
+func (c CustomActivityReferenceObject) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "datasets", c.Datasets)
+	populate(objectMap, "linkedServices", c.LinkedServices)
+	return json.Marshal(objectMap)
 }
 
 // CustomActivityTypeProperties - Custom activity properties.
@@ -7150,7 +7543,7 @@ type CustomActivityTypeProperties struct {
 
 	// User defined property bag. There is no restriction on the keys or values that can be used. The user specified custom activity has the full responsibility
 	// to consume and interpret the content defined.
-	ExtendedProperties *map[string]interface{} `json:"extendedProperties,omitempty"`
+	ExtendedProperties map[string]interface{} `json:"extendedProperties,omitempty"`
 
 	// Folder path for resource files Type: string (or Expression with resultType string).
 	FolderPath interface{} `json:"folderPath,omitempty"`
@@ -7163,6 +7556,18 @@ type CustomActivityTypeProperties struct {
 
 	// The retention time for the files submitted for custom activity. Type: double (or Expression with resultType double).
 	RetentionTimeInDays interface{} `json:"retentionTimeInDays,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type CustomActivityTypeProperties.
+func (c CustomActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "command", c.Command)
+	populate(objectMap, "extendedProperties", c.ExtendedProperties)
+	populate(objectMap, "folderPath", c.FolderPath)
+	populate(objectMap, "referenceObjects", c.ReferenceObjects)
+	populate(objectMap, "resourceLinkedService", c.ResourceLinkedService)
+	populate(objectMap, "retentionTimeInDays", c.RetentionTimeInDays)
+	return json.Marshal(objectMap)
 }
 
 // CustomDataSourceLinkedService - Custom linked service.
@@ -7251,37 +7656,6 @@ type CustomSetupBase struct {
 // GetCustomSetupBase implements the CustomSetupBaseClassification interface for type CustomSetupBase.
 func (c *CustomSetupBase) GetCustomSetupBase() *CustomSetupBase { return c }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type CustomSetupBase.
-func (c *CustomSetupBase) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return err
-	}
-	return c.unmarshalInternal(rawMsg)
-}
-
-func (c CustomSetupBase) marshalInternal(discValue string) map[string]interface{} {
-	objectMap := make(map[string]interface{})
-	c.Type = &discValue
-	objectMap["type"] = c.Type
-	return objectMap
-}
-
-func (c *CustomSetupBase) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, &c.Type)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // CustomerManagedKeyDetails - Details of the customer managed key associated with the workspace
 type CustomerManagedKeyDetails struct {
 	// The key object of the workspace
@@ -7305,12 +7679,20 @@ type DWCopyCommandSettings struct {
 	// Additional options directly passed to SQL DW in Copy Command. Type: key value pairs (value should be string type) (or Expression with resultType object).
 	// Example: "additionalOptions": { "MAXERRORS":
 	// "1000", "DATEFORMAT": "'ymd'" }
-	AdditionalOptions *map[string]*string `json:"additionalOptions,omitempty"`
+	AdditionalOptions map[string]*string `json:"additionalOptions,omitempty"`
 
 	// Specifies the default values for each target column in SQL DW. The default values in the property overwrite the DEFAULT constraint set in the DB, and
 	// identity column cannot have a default value. Type:
 	// array of objects (or Expression with resultType array of objects).
-	DefaultValues *[]*DWCopyCommandDefaultValue `json:"defaultValues,omitempty"`
+	DefaultValues []*DWCopyCommandDefaultValue `json:"defaultValues,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DWCopyCommandSettings.
+func (d DWCopyCommandSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalOptions", d.AdditionalOptions)
+	populate(objectMap, "defaultValues", d.DefaultValues)
+	return json.Marshal(objectMap)
 }
 
 // DataFlowClassification provides polymorphic access to related types.
@@ -7325,7 +7707,7 @@ type DataFlowClassification interface {
 // DataFlow - Azure Synapse nested object which contains a flow with data movements and transformations.
 type DataFlow struct {
 	// List of tags that can be used for describing the data flow.
-	Annotations *[]interface{} `json:"annotations,omitempty"`
+	Annotations []interface{} `json:"annotations,omitempty"`
 
 	// The description of the data flow.
 	Description *string `json:"description,omitempty"`
@@ -7447,19 +7829,19 @@ type DataFlowDebugCommandResponseResponse struct {
 // DataFlowDebugPackage - Request body structure for starting data flow debug session.
 type DataFlowDebugPackage struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Data flow instance.
 	DataFlow *DataFlowDebugResource `json:"dataFlow,omitempty"`
 
 	// List of datasets.
-	Datasets *[]*DatasetDebugResource `json:"datasets,omitempty"`
+	Datasets []*DatasetDebugResource `json:"datasets,omitempty"`
 
 	// Data flow debug settings.
 	DebugSettings *DataFlowDebugPackageDebugSettings `json:"debugSettings,omitempty"`
 
 	// List of linked services.
-	LinkedServices *[]*LinkedServiceDebugResource `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceDebugResource `json:"linkedServices,omitempty"`
 
 	// The ID of data flow debug session.
 	SessionID *string `json:"sessionId,omitempty"`
@@ -7478,7 +7860,7 @@ func (d DataFlowDebugPackage) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "sessionId", d.SessionID)
 	populate(objectMap, "staging", d.Staging)
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -7514,12 +7896,12 @@ func (d *DataFlowDebugPackage) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -7536,10 +7918,19 @@ type DataFlowDebugPackageDebugSettings struct {
 	DatasetParameters interface{} `json:"datasetParameters,omitempty"`
 
 	// Data flow parameters.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Source setting for data flow debug.
-	SourceSettings *[]*DataFlowSourceSetting `json:"sourceSettings,omitempty"`
+	SourceSettings []*DataFlowSourceSetting `json:"sourceSettings,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataFlowDebugPackageDebugSettings.
+func (d DataFlowDebugPackageDebugSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "datasetParameters", d.DatasetParameters)
+	populate(objectMap, "parameters", d.Parameters)
+	populate(objectMap, "sourceSettings", d.SourceSettings)
+	return json.Marshal(objectMap)
 }
 
 // DataFlowDebugPreviewDataRequest - Request body structure for data flow preview data.
@@ -7568,6 +7959,33 @@ type DataFlowDebugResource struct {
 	SubResourceDebugResource
 	// Data flow properties.
 	Properties DataFlowClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataFlowDebugResource.
+func (d DataFlowDebugResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.SubResourceDebugResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type DataFlowDebugResource.
+func (d *DataFlowDebugResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			d.Properties, err = unmarshalDataFlowClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return d.SubResourceDebugResource.unmarshalInternal(rawMsg)
 }
 
 // DataFlowDebugResultResponse - Response body structure of data flow result for data preview, statistics or expression preview.
@@ -7603,7 +8021,7 @@ type DataFlowDebugSessionDeleteDataFlowDebugSessionOptions struct {
 // DataFlowDebugSessionInfo - Data flow debug session info.
 type DataFlowDebugSessionInfo struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Compute type of the cluster.
 	ComputeType *string `json:"computeType,omitempty"`
@@ -7646,7 +8064,7 @@ func (d DataFlowDebugSessionInfo) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "startTime", d.StartTime)
 	populate(objectMap, "timeToLiveInMinutes", d.TimeToLiveInMinutes)
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -7691,12 +8109,12 @@ func (d *DataFlowDebugSessionInfo) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -7716,7 +8134,7 @@ type DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceOptions struct {
 // DataFlowDebugStatisticsRequest - Request body structure for data flow statistics.
 type DataFlowDebugStatisticsRequest struct {
 	// List of column names.
-	Columns *[]*string `json:"columns,omitempty"`
+	Columns []*string `json:"columns,omitempty"`
 
 	// The data flow which contains the debug session.
 	DataFlowName *string `json:"dataFlowName,omitempty"`
@@ -7726,6 +8144,16 @@ type DataFlowDebugStatisticsRequest struct {
 
 	// The output stream name.
 	StreamName *string `json:"streamName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataFlowDebugStatisticsRequest.
+func (d DataFlowDebugStatisticsRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "columns", d.Columns)
+	populate(objectMap, "dataFlowName", d.DataFlowName)
+	populate(objectMap, "sessionId", d.SessionID)
+	populate(objectMap, "streamName", d.StreamName)
+	return json.Marshal(objectMap)
 }
 
 // DataFlowFolder - The folder that this data flow is in. If not specified, Data flow will appear at the root level.
@@ -7752,7 +8180,15 @@ type DataFlowListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of data flows.
-	Value *[]*DataFlowResource `json:"value,omitempty"`
+	Value []*DataFlowResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataFlowListResponse.
+func (d DataFlowListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DataFlowListResponseResponse is the response envelope for operations that return a DataFlowListResponse type.
@@ -7767,7 +8203,7 @@ type DataFlowListResponseResponse struct {
 // DataFlowReference - Data flow reference type.
 type DataFlowReference struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Reference data flow parameters from dataset.
 	DatasetParameters interface{} `json:"datasetParameters,omitempty"`
@@ -7786,7 +8222,7 @@ func (d DataFlowReference) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "referenceName", d.ReferenceName)
 	populate(objectMap, "type", d.Type)
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -7813,12 +8249,12 @@ func (d *DataFlowReference) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -7834,6 +8270,33 @@ type DataFlowResource struct {
 	SubResource
 	// Data flow properties.
 	Properties DataFlowClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataFlowResource.
+func (d DataFlowResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.SubResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type DataFlowResource.
+func (d *DataFlowResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			d.Properties, err = unmarshalDataFlowClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return d.SubResource.unmarshalInternal(rawMsg)
 }
 
 // DataFlowResourcePollerResponse is the response envelope for operations that asynchronously return a DataFlowResource type.
@@ -7874,7 +8337,7 @@ type DataFlowSource struct {
 // DataFlowSourceSetting - Definition of data flow source setting for debug.
 type DataFlowSourceSetting struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Defines the row limit of data flow source in debug.
 	RowLimit *int32 `json:"rowLimit,omitempty"`
@@ -7889,7 +8352,7 @@ func (d DataFlowSourceSetting) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "rowLimit", d.RowLimit)
 	populate(objectMap, "sourceName", d.SourceName)
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -7913,12 +8376,12 @@ func (d *DataFlowSourceSetting) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -7981,7 +8444,7 @@ type DataLakeAnalyticsUSQLActivityTypeProperties struct {
 	DegreeOfParallelism interface{} `json:"degreeOfParallelism,omitempty"`
 
 	// Parameters for U-SQL job request.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Determines which jobs out of all that are queued should be selected to run first. The lower the number, the higher the priority. Default value is 1000.
 	// Type: integer (or Expression with resultType
@@ -7996,6 +8459,19 @@ type DataLakeAnalyticsUSQLActivityTypeProperties struct {
 
 	// Case-sensitive path to folder that contains the U-SQL script. Type: string (or Expression with resultType string).
 	ScriptPath interface{} `json:"scriptPath,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DataLakeAnalyticsUSQLActivityTypeProperties.
+func (d DataLakeAnalyticsUSQLActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "compilationMode", d.CompilationMode)
+	populate(objectMap, "degreeOfParallelism", d.DegreeOfParallelism)
+	populate(objectMap, "parameters", d.Parameters)
+	populate(objectMap, "priority", d.Priority)
+	populate(objectMap, "runtimeVersion", d.RuntimeVersion)
+	populate(objectMap, "scriptLinkedService", d.ScriptLinkedService)
+	populate(objectMap, "scriptPath", d.ScriptPath)
+	return json.Marshal(objectMap)
 }
 
 // DataLakeStorageAccountDetails - Details of the data lake storage account associated with the workspace
@@ -8045,14 +8521,23 @@ func (d *DatabricksNotebookActivity) UnmarshalJSON(data []byte) error {
 type DatabricksNotebookActivityTypeProperties struct {
 	// Base parameters to be used for each run of this job.If the notebook takes a parameter that is not specified, the default value from the notebook will
 	// be used.
-	BaseParameters *map[string]interface{} `json:"baseParameters,omitempty"`
+	BaseParameters map[string]interface{} `json:"baseParameters,omitempty"`
 
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries *[]map[string]interface{} `json:"libraries,omitempty"`
+	Libraries []map[string]interface{} `json:"libraries,omitempty"`
 
 	// The absolute path of the notebook to be run in the Databricks Workspace. This path must begin with a slash. Type: string (or Expression with resultType
 	// string).
 	NotebookPath interface{} `json:"notebookPath,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatabricksNotebookActivityTypeProperties.
+func (d DatabricksNotebookActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "baseParameters", d.BaseParameters)
+	populate(objectMap, "libraries", d.Libraries)
+	populate(objectMap, "notebookPath", d.NotebookPath)
+	return json.Marshal(objectMap)
 }
 
 // DatabricksSparkJarActivity - DatabricksSparkJar activity.
@@ -8092,14 +8577,23 @@ func (d *DatabricksSparkJarActivity) UnmarshalJSON(data []byte) error {
 // DatabricksSparkJarActivityTypeProperties - Databricks SparkJar activity properties.
 type DatabricksSparkJarActivityTypeProperties struct {
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries *[]map[string]interface{} `json:"libraries,omitempty"`
+	Libraries []map[string]interface{} `json:"libraries,omitempty"`
 
 	// The full name of the class containing the main method to be executed. This class must be contained in a JAR provided as a library. Type: string (or Expression
 	// with resultType string).
 	MainClassName interface{} `json:"mainClassName,omitempty"`
 
 	// Parameters that will be passed to the main method.
-	Parameters *[]interface{} `json:"parameters,omitempty"`
+	Parameters []interface{} `json:"parameters,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatabricksSparkJarActivityTypeProperties.
+func (d DatabricksSparkJarActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "libraries", d.Libraries)
+	populate(objectMap, "mainClassName", d.MainClassName)
+	populate(objectMap, "parameters", d.Parameters)
+	return json.Marshal(objectMap)
 }
 
 // DatabricksSparkPythonActivity - DatabricksSparkPython activity.
@@ -8139,13 +8633,22 @@ func (d *DatabricksSparkPythonActivity) UnmarshalJSON(data []byte) error {
 // DatabricksSparkPythonActivityTypeProperties - Databricks SparkPython activity properties.
 type DatabricksSparkPythonActivityTypeProperties struct {
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries *[]map[string]interface{} `json:"libraries,omitempty"`
+	Libraries []map[string]interface{} `json:"libraries,omitempty"`
 
 	// Command line parameters that will be passed to the Python file.
-	Parameters *[]interface{} `json:"parameters,omitempty"`
+	Parameters []interface{} `json:"parameters,omitempty"`
 
 	// The URI of the Python file to be executed. DBFS paths are supported. Type: string (or Expression with resultType string).
 	PythonFile interface{} `json:"pythonFile,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatabricksSparkPythonActivityTypeProperties.
+func (d DatabricksSparkPythonActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "libraries", d.Libraries)
+	populate(objectMap, "parameters", d.Parameters)
+	populate(objectMap, "pythonFile", d.PythonFile)
+	return json.Marshal(objectMap)
 }
 
 // DatasetClassification provides polymorphic access to related types.
@@ -8175,10 +8678,10 @@ type DatasetClassification interface {
 // Dataset - The Azure Data Factory nested object which identifies data within different data stores, such as tables, files, folders, and documents.
 type Dataset struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations *[]interface{} `json:"annotations,omitempty"`
+	Annotations []interface{} `json:"annotations,omitempty"`
 
 	// Dataset description.
 	Description *string `json:"description,omitempty"`
@@ -8190,7 +8693,7 @@ type Dataset struct {
 	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
 
 	// Parameters for dataset.
-	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType: DatasetSchemaDataElement.
 	Schema interface{} `json:"schema,omitempty"`
@@ -8226,7 +8729,7 @@ func (d Dataset) marshalInternal(discValue string) map[string]interface{} {
 	d.Type = &discValue
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -8263,12 +8766,12 @@ func (d *Dataset) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -8318,7 +8821,7 @@ type DatasetCompressionClassification interface {
 // DatasetCompression - The compression method used on a dataset.
 type DatasetCompression struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Type of dataset compression.
 	Type *string `json:"type,omitempty"`
@@ -8341,7 +8844,7 @@ func (d DatasetCompression) marshalInternal(discValue string) map[string]interfa
 	d.Type = &discValue
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -8357,12 +8860,12 @@ func (d *DatasetCompression) unmarshalInternal(rawMsg map[string]json.RawMessage
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -8387,6 +8890,33 @@ type DatasetDebugResource struct {
 	SubResourceDebugResource
 	// Dataset properties.
 	Properties DatasetClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatasetDebugResource.
+func (d DatasetDebugResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.SubResourceDebugResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type DatasetDebugResource.
+func (d *DatasetDebugResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			d.Properties, err = unmarshalDatasetClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return d.SubResourceDebugResource.unmarshalInternal(rawMsg)
 }
 
 // DatasetDeflateCompression - The Deflate compression method used on a dataset.
@@ -8481,7 +9011,15 @@ type DatasetListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of datasets.
-	Value *[]*DatasetResource `json:"value,omitempty"`
+	Value []*DatasetResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatasetListResponse.
+func (d DatasetListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", d.NextLink)
+	populate(objectMap, "value", d.Value)
+	return json.Marshal(objectMap)
 }
 
 // DatasetListResponseResponse is the response envelope for operations that return a DatasetListResponse type.
@@ -8507,7 +9045,7 @@ type DatasetLocationClassification interface {
 // DatasetLocation - Dataset location.
 type DatasetLocation struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
 	FileName interface{} `json:"fileName,omitempty"`
@@ -8538,7 +9076,7 @@ func (d DatasetLocation) marshalInternal(discValue string) map[string]interface{
 	d.Type = &discValue
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -8560,12 +9098,12 @@ func (d *DatasetLocation) unmarshalInternal(rawMsg map[string]json.RawMessage) e
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -8579,7 +9117,7 @@ func (d *DatasetLocation) unmarshalInternal(rawMsg map[string]json.RawMessage) e
 // DatasetReference - Dataset reference type.
 type DatasetReference struct {
 	// Arguments for dataset.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Reference dataset name.
 	ReferenceName *string `json:"referenceName,omitempty"`
@@ -8588,11 +9126,47 @@ type DatasetReference struct {
 	Type *DatasetReferenceType `json:"type,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DatasetReference.
+func (d DatasetReference) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "parameters", d.Parameters)
+	populate(objectMap, "referenceName", d.ReferenceName)
+	populate(objectMap, "type", d.Type)
+	return json.Marshal(objectMap)
+}
+
 // DatasetResource - Dataset resource type.
 type DatasetResource struct {
 	SubResource
 	// Dataset properties.
 	Properties DatasetClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DatasetResource.
+func (d DatasetResource) MarshalJSON() ([]byte, error) {
+	objectMap := d.SubResource.marshalInternal()
+	populate(objectMap, "properties", d.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type DatasetResource.
+func (d *DatasetResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			d.Properties, err = unmarshalDatasetClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return d.SubResource.unmarshalInternal(rawMsg)
 }
 
 // DatasetResourcePollerResponse is the response envelope for operations that asynchronously return a DatasetResource type.
@@ -8619,7 +9193,7 @@ type DatasetResourceResponse struct {
 // DatasetSchemaDataElement - Columns that define the physical type schema of the dataset.
 type DatasetSchemaDataElement struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Name of the schema column. Type: string (or Expression with resultType string).
 	Name interface{} `json:"name,omitempty"`
@@ -8634,7 +9208,7 @@ func (d DatasetSchemaDataElement) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "name", d.Name)
 	populate(objectMap, "type", d.Type)
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -8658,12 +9232,12 @@ func (d *DatasetSchemaDataElement) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -8686,7 +9260,7 @@ type DatasetStorageFormatClassification interface {
 // DatasetStorageFormat - The format definition of a storage.
 type DatasetStorageFormat struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Deserializer. Type: string (or Expression with resultType string).
 	Deserializer interface{} `json:"deserializer,omitempty"`
@@ -8717,7 +9291,7 @@ func (d DatasetStorageFormat) marshalInternal(discValue string) map[string]inter
 	d.Type = &discValue
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
-		for key, val := range *d.AdditionalProperties {
+		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -8739,12 +9313,12 @@ func (d *DatasetStorageFormat) unmarshalInternal(rawMsg map[string]json.RawMessa
 			delete(rawMsg, key)
 		default:
 			if d.AdditionalProperties == nil {
-				d.AdditionalProperties = &map[string]interface{}{}
+				d.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*d.AdditionalProperties)[key] = aux
+				d.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -8849,6 +9423,20 @@ type Db2LinkedServiceTypeProperties struct {
 
 	// Username for authentication. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Db2LinkedServiceTypeProperties.
+func (d Db2LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", d.AuthenticationType)
+	populate(objectMap, "certificateCommonName", d.CertificateCommonName)
+	populate(objectMap, "database", d.Database)
+	populate(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populate(objectMap, "packageCollection", d.PackageCollection)
+	populate(objectMap, "password", d.Password)
+	populate(objectMap, "server", d.Server)
+	populate(objectMap, "username", d.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type Db2LinkedServiceTypeProperties.
@@ -9100,6 +9688,22 @@ type DelimitedTextDatasetTypeProperties struct {
 
 	// The row delimiter. Type: string (or Expression with resultType string).
 	RowDelimiter interface{} `json:"rowDelimiter,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DelimitedTextDatasetTypeProperties.
+func (d DelimitedTextDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "columnDelimiter", d.ColumnDelimiter)
+	populate(objectMap, "compressionCodec", d.CompressionCodec)
+	populate(objectMap, "compressionLevel", d.CompressionLevel)
+	populate(objectMap, "encodingName", d.EncodingName)
+	populate(objectMap, "escapeChar", d.EscapeChar)
+	populate(objectMap, "firstRowAsHeader", d.FirstRowAsHeader)
+	populate(objectMap, "location", d.Location)
+	populate(objectMap, "nullValue", d.NullValue)
+	populate(objectMap, "quoteChar", d.QuoteChar)
+	populate(objectMap, "rowDelimiter", d.RowDelimiter)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type DelimitedTextDatasetTypeProperties.
@@ -9691,6 +10295,18 @@ type DynamicsAXLinkedServiceTypeProperties struct {
 	URL interface{} `json:"url,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DynamicsAXLinkedServiceTypeProperties.
+func (d DynamicsAXLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aadResourceId", d.AADResourceID)
+	populate(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populate(objectMap, "servicePrincipalId", d.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", d.ServicePrincipalKey)
+	populate(objectMap, "tenant", d.Tenant)
+	populate(objectMap, "url", d.URL)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type DynamicsAXLinkedServiceTypeProperties.
 func (d *DynamicsAXLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -9924,6 +10540,24 @@ type DynamicsCrmLinkedServiceTypeProperties struct {
 
 	// User name to access the Dynamics CRM instance. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type DynamicsCrmLinkedServiceTypeProperties.
+func (d DynamicsCrmLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", d.AuthenticationType)
+	populate(objectMap, "deploymentType", d.DeploymentType)
+	populate(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populate(objectMap, "hostName", d.HostName)
+	populate(objectMap, "organizationName", d.OrganizationName)
+	populate(objectMap, "password", d.Password)
+	populate(objectMap, "port", d.Port)
+	populate(objectMap, "servicePrincipalCredential", d.ServicePrincipalCredential)
+	populate(objectMap, "servicePrincipalCredentialType", d.ServicePrincipalCredentialType)
+	populate(objectMap, "servicePrincipalId", d.ServicePrincipalID)
+	populate(objectMap, "serviceUri", d.ServiceURI)
+	populate(objectMap, "username", d.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type DynamicsCrmLinkedServiceTypeProperties.
@@ -10188,6 +10822,24 @@ type DynamicsLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type DynamicsLinkedServiceTypeProperties.
+func (d DynamicsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", d.AuthenticationType)
+	populate(objectMap, "deploymentType", d.DeploymentType)
+	populate(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populate(objectMap, "hostName", d.HostName)
+	populate(objectMap, "organizationName", d.OrganizationName)
+	populate(objectMap, "password", d.Password)
+	populate(objectMap, "port", d.Port)
+	populate(objectMap, "servicePrincipalCredential", d.ServicePrincipalCredential)
+	populate(objectMap, "servicePrincipalCredentialType", d.ServicePrincipalCredentialType)
+	populate(objectMap, "servicePrincipalId", d.ServicePrincipalID)
+	populate(objectMap, "serviceUri", d.ServiceURI)
+	populate(objectMap, "username", d.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type DynamicsLinkedServiceTypeProperties.
 func (d *DynamicsLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -10384,6 +11036,19 @@ type EloquaLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type EloquaLinkedServiceTypeProperties.
+func (e EloquaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", e.EncryptedCredential)
+	populate(objectMap, "endpoint", e.Endpoint)
+	populate(objectMap, "password", e.Password)
+	populate(objectMap, "useEncryptedEndpoints", e.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", e.UseHostVerification)
+	populate(objectMap, "usePeerVerification", e.UsePeerVerification)
+	populate(objectMap, "username", e.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type EloquaLinkedServiceTypeProperties.
 func (e *EloquaLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -10535,19 +11200,30 @@ func (e ErrorContract) Error() string {
 // error response format.)
 type ErrorResponse struct {
 	// READ-ONLY; The error additional info.
-	AdditionalInfo *[]*ErrorAdditionalInfo `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo []*ErrorAdditionalInfo `json:"additionalInfo,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error code.
 	Code *string `json:"code,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error details.
-	Details *[]*ErrorResponse `json:"details,omitempty" azure:"ro"`
+	Details []*ErrorResponse `json:"details,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error message.
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// READ-ONLY; The error target.
 	Target *string `json:"target,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ErrorResponse.
+func (e ErrorResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalInfo", e.AdditionalInfo)
+	populate(objectMap, "code", e.Code)
+	populate(objectMap, "details", e.Details)
+	populate(objectMap, "message", e.Message)
+	populate(objectMap, "target", e.Target)
+	return json.Marshal(objectMap)
 }
 
 // EvaluateDataFlowExpressionRequest - Request body structure for data flow expression preview.
@@ -10663,13 +11339,22 @@ func (e *ExecutePipelineActivity) UnmarshalJSON(data []byte) error {
 // ExecutePipelineActivityTypeProperties - Execute pipeline activity properties.
 type ExecutePipelineActivityTypeProperties struct {
 	// Pipeline parameters.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Pipeline reference.
 	Pipeline *PipelineReference `json:"pipeline,omitempty"`
 
 	// Defines whether activity execution will wait for the dependent pipeline execution to finish. Default is false.
 	WaitOnCompletion *bool `json:"waitOnCompletion,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExecutePipelineActivityTypeProperties.
+func (e ExecutePipelineActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "parameters", e.Parameters)
+	populate(objectMap, "pipeline", e.Pipeline)
+	populate(objectMap, "waitOnCompletion", e.WaitOnCompletion)
+	return json.Marshal(objectMap)
 }
 
 // ExecuteSSISPackageActivity - Execute SSIS package activity.
@@ -10724,25 +11409,43 @@ type ExecuteSSISPackageActivityTypeProperties struct {
 	LoggingLevel interface{} `json:"loggingLevel,omitempty"`
 
 	// The package level connection managers to execute the SSIS package.
-	PackageConnectionManagers *map[string]map[string]*SSISExecutionParameter `json:"packageConnectionManagers,omitempty"`
+	PackageConnectionManagers map[string]map[string]*SSISExecutionParameter `json:"packageConnectionManagers,omitempty"`
 
 	// SSIS package location.
 	PackageLocation *SSISPackageLocation `json:"packageLocation,omitempty"`
 
 	// The package level parameters to execute the SSIS package.
-	PackageParameters *map[string]*SSISExecutionParameter `json:"packageParameters,omitempty"`
+	PackageParameters map[string]*SSISExecutionParameter `json:"packageParameters,omitempty"`
 
 	// The project level connection managers to execute the SSIS package.
-	ProjectConnectionManagers *map[string]map[string]*SSISExecutionParameter `json:"projectConnectionManagers,omitempty"`
+	ProjectConnectionManagers map[string]map[string]*SSISExecutionParameter `json:"projectConnectionManagers,omitempty"`
 
 	// The project level parameters to execute the SSIS package.
-	ProjectParameters *map[string]*SSISExecutionParameter `json:"projectParameters,omitempty"`
+	ProjectParameters map[string]*SSISExecutionParameter `json:"projectParameters,omitempty"`
 
 	// The property overrides to execute the SSIS package.
-	PropertyOverrides *map[string]*SSISPropertyOverride `json:"propertyOverrides,omitempty"`
+	PropertyOverrides map[string]*SSISPropertyOverride `json:"propertyOverrides,omitempty"`
 
 	// Specifies the runtime to execute SSIS package. The value should be "x86" or "x64". Type: string (or Expression with resultType string).
 	Runtime interface{} `json:"runtime,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ExecuteSSISPackageActivityTypeProperties.
+func (e ExecuteSSISPackageActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectVia", e.ConnectVia)
+	populate(objectMap, "environmentPath", e.EnvironmentPath)
+	populate(objectMap, "executionCredential", e.ExecutionCredential)
+	populate(objectMap, "logLocation", e.LogLocation)
+	populate(objectMap, "loggingLevel", e.LoggingLevel)
+	populate(objectMap, "packageConnectionManagers", e.PackageConnectionManagers)
+	populate(objectMap, "packageLocation", e.PackageLocation)
+	populate(objectMap, "packageParameters", e.PackageParameters)
+	populate(objectMap, "projectConnectionManagers", e.ProjectConnectionManagers)
+	populate(objectMap, "projectParameters", e.ProjectParameters)
+	populate(objectMap, "propertyOverrides", e.PropertyOverrides)
+	populate(objectMap, "runtime", e.Runtime)
+	return json.Marshal(objectMap)
 }
 
 // ExecutionActivityClassification provides polymorphic access to related types.
@@ -10888,6 +11591,16 @@ type FileServerLinkedServiceTypeProperties struct {
 
 	// User ID to logon the server. Type: string (or Expression with resultType string).
 	UserID interface{} `json:"userId,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type FileServerLinkedServiceTypeProperties.
+func (f FileServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", f.EncryptedCredential)
+	populate(objectMap, "host", f.Host)
+	populate(objectMap, "password", f.Password)
+	populate(objectMap, "userId", f.UserID)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type FileServerLinkedServiceTypeProperties.
@@ -11158,7 +11871,7 @@ func (f *ForEachActivity) UnmarshalJSON(data []byte) error {
 // ForEachActivityTypeProperties - ForEach activity properties.
 type ForEachActivityTypeProperties struct {
 	// List of activities to execute .
-	Activities *[]ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification `json:"activities,omitempty"`
 
 	// Batch count to be used for controlling the number of parallel execution (when isSequential is set to false).
 	BatchCount *int32 `json:"batchCount,omitempty"`
@@ -11168,6 +11881,16 @@ type ForEachActivityTypeProperties struct {
 
 	// Collection to iterate.
 	Items *Expression `json:"items,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ForEachActivityTypeProperties.
+func (f ForEachActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activities", f.Activities)
+	populate(objectMap, "batchCount", f.BatchCount)
+	populate(objectMap, "isSequential", f.IsSequential)
+	populate(objectMap, "items", f.Items)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ForEachActivityTypeProperties.
@@ -11211,7 +11934,7 @@ type FormatReadSettingsClassification interface {
 // FormatReadSettings - Format read settings.
 type FormatReadSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The read setting type.
 	Type *string `json:"type,omitempty"`
@@ -11234,7 +11957,7 @@ func (f FormatReadSettings) marshalInternal(discValue string) map[string]interfa
 	f.Type = &discValue
 	objectMap["type"] = f.Type
 	if f.AdditionalProperties != nil {
-		for key, val := range *f.AdditionalProperties {
+		for key, val := range f.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -11250,12 +11973,12 @@ func (f *FormatReadSettings) unmarshalInternal(rawMsg map[string]json.RawMessage
 			delete(rawMsg, key)
 		default:
 			if f.AdditionalProperties == nil {
-				f.AdditionalProperties = &map[string]interface{}{}
+				f.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*f.AdditionalProperties)[key] = aux
+				f.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -11278,7 +12001,7 @@ type FormatWriteSettingsClassification interface {
 // FormatWriteSettings - Format write settings.
 type FormatWriteSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The write setting type.
 	Type *string `json:"type,omitempty"`
@@ -11301,7 +12024,7 @@ func (f FormatWriteSettings) marshalInternal(discValue string) map[string]interf
 	f.Type = &discValue
 	objectMap["type"] = f.Type
 	if f.AdditionalProperties != nil {
-		for key, val := range *f.AdditionalProperties {
+		for key, val := range f.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -11317,12 +12040,12 @@ func (f *FormatWriteSettings) unmarshalInternal(rawMsg map[string]json.RawMessag
 			delete(rawMsg, key)
 		default:
 			if f.AdditionalProperties == nil {
-				f.AdditionalProperties = &map[string]interface{}{}
+				f.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*f.AdditionalProperties)[key] = aux
+				f.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -11452,6 +12175,20 @@ type FtpServerLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type FtpServerLinkedServiceTypeProperties.
+func (f FtpServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", f.AuthenticationType)
+	populate(objectMap, "enableSsl", f.EnableSSL)
+	populate(objectMap, "enableServerCertificateValidation", f.EnableServerCertificateValidation)
+	populate(objectMap, "encryptedCredential", f.EncryptedCredential)
+	populate(objectMap, "host", f.Host)
+	populate(objectMap, "password", f.Password)
+	populate(objectMap, "port", f.Port)
+	populate(objectMap, "userName", f.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type FtpServerLinkedServiceTypeProperties.
 func (f *FtpServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -11550,7 +12287,15 @@ type GetMetadataActivityTypeProperties struct {
 	Dataset *DatasetReference `json:"dataset,omitempty"`
 
 	// Fields of metadata to get from dataset.
-	FieldList *[]interface{} `json:"fieldList,omitempty"`
+	FieldList []interface{} `json:"fieldList,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GetMetadataActivityTypeProperties.
+func (g GetMetadataActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataset", g.Dataset)
+	populate(objectMap, "fieldList", g.FieldList)
+	return json.Marshal(objectMap)
 }
 
 // GetSsisObjectMetadataRequest - The request payload of get SSIS object metadata.
@@ -11653,6 +12398,23 @@ type GoogleAdWordsLinkedServiceTypeProperties struct {
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is false.
 	UseSystemTrustStore interface{} `json:"useSystemTrustStore,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GoogleAdWordsLinkedServiceTypeProperties.
+func (g GoogleAdWordsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", g.AuthenticationType)
+	populate(objectMap, "clientCustomerID", g.ClientCustomerID)
+	populate(objectMap, "clientId", g.ClientID)
+	populate(objectMap, "clientSecret", g.ClientSecret)
+	populate(objectMap, "developerToken", g.DeveloperToken)
+	populate(objectMap, "email", g.Email)
+	populate(objectMap, "encryptedCredential", g.EncryptedCredential)
+	populate(objectMap, "keyFilePath", g.KeyFilePath)
+	populate(objectMap, "refreshToken", g.RefreshToken)
+	populate(objectMap, "trustedCertPath", g.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", g.UseSystemTrustStore)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type GoogleAdWordsLinkedServiceTypeProperties.
@@ -11862,6 +12624,24 @@ type GoogleBigQueryLinkedServiceTypeProperties struct {
 	UseSystemTrustStore interface{} `json:"useSystemTrustStore,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type GoogleBigQueryLinkedServiceTypeProperties.
+func (g GoogleBigQueryLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalProjects", g.AdditionalProjects)
+	populate(objectMap, "authenticationType", g.AuthenticationType)
+	populate(objectMap, "clientId", g.ClientID)
+	populate(objectMap, "clientSecret", g.ClientSecret)
+	populate(objectMap, "email", g.Email)
+	populate(objectMap, "encryptedCredential", g.EncryptedCredential)
+	populate(objectMap, "keyFilePath", g.KeyFilePath)
+	populate(objectMap, "project", g.Project)
+	populate(objectMap, "refreshToken", g.RefreshToken)
+	populate(objectMap, "requestGoogleDriveScope", g.RequestGoogleDriveScope)
+	populate(objectMap, "trustedCertPath", g.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", g.UseSystemTrustStore)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type GoogleBigQueryLinkedServiceTypeProperties.
 func (g *GoogleBigQueryLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -12033,6 +12813,16 @@ type GoogleCloudStorageLinkedServiceTypeProperties struct {
 	// a different service endpoint or want to switch
 	// between https and http. Type: string (or Expression with resultType string).
 	ServiceURL interface{} `json:"serviceUrl,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type GoogleCloudStorageLinkedServiceTypeProperties.
+func (g GoogleCloudStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessKeyId", g.AccessKeyID)
+	populate(objectMap, "encryptedCredential", g.EncryptedCredential)
+	populate(objectMap, "secretAccessKey", g.SecretAccessKey)
+	populate(objectMap, "serviceUrl", g.ServiceURL)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type GoogleCloudStorageLinkedServiceTypeProperties.
@@ -12381,6 +13171,23 @@ type HBaseLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type HBaseLinkedServiceTypeProperties.
+func (h HBaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", h.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", h.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", h.AuthenticationType)
+	populate(objectMap, "enableSsl", h.EnableSSL)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "httpPath", h.HTTPPath)
+	populate(objectMap, "host", h.Host)
+	populate(objectMap, "password", h.Password)
+	populate(objectMap, "port", h.Port)
+	populate(objectMap, "trustedCertPath", h.TrustedCertPath)
+	populate(objectMap, "username", h.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type HBaseLinkedServiceTypeProperties.
 func (h *HBaseLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -12536,10 +13343,10 @@ func (h *HDInsightHiveActivity) UnmarshalJSON(data []byte) error {
 // HDInsightHiveActivityTypeProperties - HDInsight Hive activity properties.
 type HDInsightHiveActivityTypeProperties struct {
 	// User specified arguments to HDInsightActivity.
-	Arguments *[]interface{} `json:"arguments,omitempty"`
+	Arguments []interface{} `json:"arguments,omitempty"`
 
 	// Allows user to specify defines for Hive job request.
-	Defines *map[string]interface{} `json:"defines,omitempty"`
+	Defines map[string]interface{} `json:"defines,omitempty"`
 
 	// Debug info option.
 	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
@@ -12554,10 +13361,24 @@ type HDInsightHiveActivityTypeProperties struct {
 	ScriptPath interface{} `json:"scriptPath,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
 
 	// User specified arguments under hivevar namespace.
-	Variables *[]interface{} `json:"variables,omitempty"`
+	Variables []interface{} `json:"variables,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightHiveActivityTypeProperties.
+func (h HDInsightHiveActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "arguments", h.Arguments)
+	populate(objectMap, "defines", h.Defines)
+	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
+	populate(objectMap, "queryTimeout", h.QueryTimeout)
+	populate(objectMap, "scriptLinkedService", h.ScriptLinkedService)
+	populate(objectMap, "scriptPath", h.ScriptPath)
+	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
+	populate(objectMap, "variables", h.Variables)
+	return json.Marshal(objectMap)
 }
 
 // HDInsightLinkedService - HDInsight linked service.
@@ -12620,6 +13441,20 @@ type HDInsightLinkedServiceTypeProperties struct {
 
 	// HDInsight cluster user name. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightLinkedServiceTypeProperties.
+func (h HDInsightLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clusterUri", h.ClusterURI)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "fileSystem", h.FileSystem)
+	populate(objectMap, "hcatalogLinkedServiceName", h.HcatalogLinkedServiceName)
+	populate(objectMap, "isEspEnabled", h.IsEspEnabled)
+	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
+	populate(objectMap, "password", h.Password)
+	populate(objectMap, "userName", h.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type HDInsightLinkedServiceTypeProperties.
@@ -12700,13 +13535,13 @@ func (h *HDInsightMapReduceActivity) UnmarshalJSON(data []byte) error {
 // HDInsightMapReduceActivityTypeProperties - HDInsight MapReduce activity properties.
 type HDInsightMapReduceActivityTypeProperties struct {
 	// User specified arguments to HDInsightActivity.
-	Arguments *[]interface{} `json:"arguments,omitempty"`
+	Arguments []interface{} `json:"arguments,omitempty"`
 
 	// Class name. Type: string (or Expression with resultType string).
 	ClassName interface{} `json:"className,omitempty"`
 
 	// Allows user to specify defines for the MapReduce job request.
-	Defines *map[string]interface{} `json:"defines,omitempty"`
+	Defines map[string]interface{} `json:"defines,omitempty"`
 
 	// Debug info option.
 	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
@@ -12715,13 +13550,27 @@ type HDInsightMapReduceActivityTypeProperties struct {
 	JarFilePath interface{} `json:"jarFilePath,omitempty"`
 
 	// Jar libs.
-	JarLibs *[]interface{} `json:"jarLibs,omitempty"`
+	JarLibs []interface{} `json:"jarLibs,omitempty"`
 
 	// Jar linked service reference.
 	JarLinkedService *LinkedServiceReference `json:"jarLinkedService,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightMapReduceActivityTypeProperties.
+func (h HDInsightMapReduceActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "arguments", h.Arguments)
+	populate(objectMap, "className", h.ClassName)
+	populate(objectMap, "defines", h.Defines)
+	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
+	populate(objectMap, "jarFilePath", h.JarFilePath)
+	populate(objectMap, "jarLibs", h.JarLibs)
+	populate(objectMap, "jarLinkedService", h.JarLinkedService)
+	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
+	return json.Marshal(objectMap)
 }
 
 // HDInsightOnDemandLinkedService - HDInsight ondemand linked service.
@@ -12761,7 +13610,7 @@ func (h *HDInsightOnDemandLinkedService) UnmarshalJSON(data []byte) error {
 // HDInsightOnDemandLinkedServiceTypeProperties - HDInsight ondemand linked service properties.
 type HDInsightOnDemandLinkedServiceTypeProperties struct {
 	// Specifies additional storage accounts for the HDInsight linked service so that the Data Factory service can register them on your behalf.
-	AdditionalLinkedServiceNames *[]*LinkedServiceReference `json:"additionalLinkedServiceNames,omitempty"`
+	AdditionalLinkedServiceNames []*LinkedServiceReference `json:"additionalLinkedServiceNames,omitempty"`
 
 	// The prefix of cluster name, postfix will be distinct with timestamp. Type: string (or Expression with resultType string).
 	ClusterNamePrefix interface{} `json:"clusterNamePrefix,omitempty"`
@@ -12827,7 +13676,7 @@ type HDInsightOnDemandLinkedServiceTypeProperties struct {
 
 	// Custom script actions to run on HDI ondemand cluster once it's up. Please refer to
 	// https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-customize-cluster-linux?toc=%2Fen-us%2Fazure%2Fhdinsight%2Fr-server%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json#understanding-script-actions.
-	ScriptActions *[]*ScriptAction `json:"scriptActions,omitempty"`
+	ScriptActions []*ScriptAction `json:"scriptActions,omitempty"`
 
 	// The service principal id for the hostSubscriptionId. Type: string (or Expression with resultType string).
 	ServicePrincipalID interface{} `json:"servicePrincipalId,omitempty"`
@@ -12864,6 +13713,45 @@ type HDInsightOnDemandLinkedServiceTypeProperties struct {
 
 	// Specifies the size of the Zoo Keeper node for the HDInsight cluster.
 	ZookeeperNodeSize interface{} `json:"zookeeperNodeSize,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightOnDemandLinkedServiceTypeProperties.
+func (h HDInsightOnDemandLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "additionalLinkedServiceNames", h.AdditionalLinkedServiceNames)
+	populate(objectMap, "clusterNamePrefix", h.ClusterNamePrefix)
+	populate(objectMap, "clusterPassword", h.ClusterPassword)
+	populate(objectMap, "clusterResourceGroup", h.ClusterResourceGroup)
+	populate(objectMap, "clusterSshPassword", h.ClusterSSHPassword)
+	populate(objectMap, "clusterSshUserName", h.ClusterSSHUserName)
+	populate(objectMap, "clusterSize", h.ClusterSize)
+	populate(objectMap, "clusterType", h.ClusterType)
+	populate(objectMap, "clusterUserName", h.ClusterUserName)
+	populate(objectMap, "coreConfiguration", h.CoreConfiguration)
+	populate(objectMap, "dataNodeSize", h.DataNodeSize)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "hBaseConfiguration", h.HBaseConfiguration)
+	populate(objectMap, "hcatalogLinkedServiceName", h.HcatalogLinkedServiceName)
+	populate(objectMap, "hdfsConfiguration", h.HdfsConfiguration)
+	populate(objectMap, "headNodeSize", h.HeadNodeSize)
+	populate(objectMap, "hiveConfiguration", h.HiveConfiguration)
+	populate(objectMap, "hostSubscriptionId", h.HostSubscriptionID)
+	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
+	populate(objectMap, "mapReduceConfiguration", h.MapReduceConfiguration)
+	populate(objectMap, "oozieConfiguration", h.OozieConfiguration)
+	populate(objectMap, "scriptActions", h.ScriptActions)
+	populate(objectMap, "servicePrincipalId", h.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", h.ServicePrincipalKey)
+	populate(objectMap, "sparkVersion", h.SparkVersion)
+	populate(objectMap, "stormConfiguration", h.StormConfiguration)
+	populate(objectMap, "subnetName", h.SubnetName)
+	populate(objectMap, "tenant", h.Tenant)
+	populate(objectMap, "timeToLive", h.TimeToLive)
+	populate(objectMap, "version", h.Version)
+	populate(objectMap, "virtualNetworkId", h.VirtualNetworkID)
+	populate(objectMap, "yarnConfiguration", h.YarnConfiguration)
+	populate(objectMap, "zookeeperNodeSize", h.ZookeeperNodeSize)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type HDInsightOnDemandLinkedServiceTypeProperties.
@@ -13022,7 +13910,7 @@ type HDInsightPigActivityTypeProperties struct {
 	Arguments interface{} `json:"arguments,omitempty"`
 
 	// Allows user to specify defines for Pig job request.
-	Defines *map[string]interface{} `json:"defines,omitempty"`
+	Defines map[string]interface{} `json:"defines,omitempty"`
 
 	// Debug info option.
 	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
@@ -13034,7 +13922,19 @@ type HDInsightPigActivityTypeProperties struct {
 	ScriptPath interface{} `json:"scriptPath,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightPigActivityTypeProperties.
+func (h HDInsightPigActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "arguments", h.Arguments)
+	populate(objectMap, "defines", h.Defines)
+	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
+	populate(objectMap, "scriptLinkedService", h.ScriptLinkedService)
+	populate(objectMap, "scriptPath", h.ScriptPath)
+	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
+	return json.Marshal(objectMap)
 }
 
 // HDInsightSparkActivity - HDInsight Spark activity.
@@ -13074,7 +13974,7 @@ func (h *HDInsightSparkActivity) UnmarshalJSON(data []byte) error {
 // HDInsightSparkActivityTypeProperties - HDInsight spark activity properties.
 type HDInsightSparkActivityTypeProperties struct {
 	// The user-specified arguments to HDInsightSparkActivity.
-	Arguments *[]interface{} `json:"arguments,omitempty"`
+	Arguments []interface{} `json:"arguments,omitempty"`
 
 	// The application's Java/Spark main class.
 	ClassName *string `json:"className,omitempty"`
@@ -13092,10 +13992,24 @@ type HDInsightSparkActivityTypeProperties struct {
 	RootPath interface{} `json:"rootPath,omitempty"`
 
 	// Spark configuration property.
-	SparkConfig *map[string]interface{} `json:"sparkConfig,omitempty"`
+	SparkConfig map[string]interface{} `json:"sparkConfig,omitempty"`
 
 	// The storage linked service for uploading the entry file and dependencies, and for receiving logs.
 	SparkJobLinkedService *LinkedServiceReference `json:"sparkJobLinkedService,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightSparkActivityTypeProperties.
+func (h HDInsightSparkActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "arguments", h.Arguments)
+	populate(objectMap, "className", h.ClassName)
+	populate(objectMap, "entryFilePath", h.EntryFilePath)
+	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
+	populate(objectMap, "proxyUser", h.ProxyUser)
+	populate(objectMap, "rootPath", h.RootPath)
+	populate(objectMap, "sparkConfig", h.SparkConfig)
+	populate(objectMap, "sparkJobLinkedService", h.SparkJobLinkedService)
+	return json.Marshal(objectMap)
 }
 
 // HDInsightStreamingActivity - HDInsight streaming activity type.
@@ -13135,22 +14049,22 @@ func (h *HDInsightStreamingActivity) UnmarshalJSON(data []byte) error {
 // HDInsightStreamingActivityTypeProperties - HDInsight streaming activity properties.
 type HDInsightStreamingActivityTypeProperties struct {
 	// User specified arguments to HDInsightActivity.
-	Arguments *[]interface{} `json:"arguments,omitempty"`
+	Arguments []interface{} `json:"arguments,omitempty"`
 
 	// Combiner executable name. Type: string (or Expression with resultType string).
 	Combiner interface{} `json:"combiner,omitempty"`
 
 	// Command line environment values.
-	CommandEnvironment *[]interface{} `json:"commandEnvironment,omitempty"`
+	CommandEnvironment []interface{} `json:"commandEnvironment,omitempty"`
 
 	// Allows user to specify defines for streaming job request.
-	Defines *map[string]interface{} `json:"defines,omitempty"`
+	Defines map[string]interface{} `json:"defines,omitempty"`
 
 	// Linked service reference where the files are located.
 	FileLinkedService *LinkedServiceReference `json:"fileLinkedService,omitempty"`
 
 	// Paths to streaming job files. Can be directories.
-	FilePaths *[]interface{} `json:"filePaths,omitempty"`
+	FilePaths []interface{} `json:"filePaths,omitempty"`
 
 	// Debug info option.
 	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
@@ -13168,7 +14082,25 @@ type HDInsightStreamingActivityTypeProperties struct {
 	Reducer interface{} `json:"reducer,omitempty"`
 
 	// Storage linked service references.
-	StorageLinkedServices *[]*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HDInsightStreamingActivityTypeProperties.
+func (h HDInsightStreamingActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "arguments", h.Arguments)
+	populate(objectMap, "combiner", h.Combiner)
+	populate(objectMap, "commandEnvironment", h.CommandEnvironment)
+	populate(objectMap, "defines", h.Defines)
+	populate(objectMap, "fileLinkedService", h.FileLinkedService)
+	populate(objectMap, "filePaths", h.FilePaths)
+	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
+	populate(objectMap, "input", h.Input)
+	populate(objectMap, "mapper", h.Mapper)
+	populate(objectMap, "output", h.Output)
+	populate(objectMap, "reducer", h.Reducer)
+	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
+	return json.Marshal(objectMap)
 }
 
 // HTTPLinkedService - Linked service for an HTTP source.
@@ -13235,6 +14167,20 @@ type HTTPLinkedServiceTypeProperties struct {
 
 	// User name for Basic, Digest, or Windows authentication. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HTTPLinkedServiceTypeProperties.
+func (h HTTPLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", h.AuthenticationType)
+	populate(objectMap, "certThumbprint", h.CertThumbprint)
+	populate(objectMap, "embeddedCertData", h.EmbeddedCertData)
+	populate(objectMap, "enableServerCertificateValidation", h.EnableServerCertificateValidation)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "password", h.Password)
+	populate(objectMap, "url", h.URL)
+	populate(objectMap, "userName", h.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type HTTPLinkedServiceTypeProperties.
@@ -13466,6 +14412,17 @@ type HdfsLinkedServiceTypeProperties struct {
 
 	// User name for Windows authentication. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type HdfsLinkedServiceTypeProperties.
+func (h HdfsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", h.AuthenticationType)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "password", h.Password)
+	populate(objectMap, "url", h.URL)
+	populate(objectMap, "userName", h.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type HdfsLinkedServiceTypeProperties.
@@ -13731,6 +14688,29 @@ type HiveLinkedServiceTypeProperties struct {
 	ZooKeeperNameSpace interface{} `json:"zooKeeperNameSpace,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type HiveLinkedServiceTypeProperties.
+func (h HiveLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", h.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", h.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", h.AuthenticationType)
+	populate(objectMap, "enableSsl", h.EnableSSL)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "httpPath", h.HTTPPath)
+	populate(objectMap, "host", h.Host)
+	populate(objectMap, "password", h.Password)
+	populate(objectMap, "port", h.Port)
+	populate(objectMap, "serverType", h.ServerType)
+	populate(objectMap, "serviceDiscoveryMode", h.ServiceDiscoveryMode)
+	populate(objectMap, "thriftTransportProtocol", h.ThriftTransportProtocol)
+	populate(objectMap, "trustedCertPath", h.TrustedCertPath)
+	populate(objectMap, "useNativeQuery", h.UseNativeQuery)
+	populate(objectMap, "useSystemTrustStore", h.UseSystemTrustStore)
+	populate(objectMap, "username", h.Username)
+	populate(objectMap, "zooKeeperNameSpace", h.ZooKeeperNameSpace)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type HiveLinkedServiceTypeProperties.
 func (h *HiveLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -13930,6 +14910,20 @@ type HubspotLinkedServiceTypeProperties struct {
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type HubspotLinkedServiceTypeProperties.
+func (h HubspotLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", h.AccessToken)
+	populate(objectMap, "clientId", h.ClientID)
+	populate(objectMap, "clientSecret", h.ClientSecret)
+	populate(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populate(objectMap, "refreshToken", h.RefreshToken)
+	populate(objectMap, "useEncryptedEndpoints", h.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", h.UseHostVerification)
+	populate(objectMap, "usePeerVerification", h.UsePeerVerification)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type HubspotLinkedServiceTypeProperties.
 func (h *HubspotLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -14082,11 +15076,20 @@ type IfConditionActivityTypeProperties struct {
 
 	// List of activities to execute if expression is evaluated to false. This is an optional property and if not provided, the activity will exit without any
 	// action.
-	IfFalseActivities *[]ActivityClassification `json:"ifFalseActivities,omitempty"`
+	IfFalseActivities []ActivityClassification `json:"ifFalseActivities,omitempty"`
 
 	// List of activities to execute if expression is evaluated to true. This is an optional property and if not provided, the activity will exit without any
 	// action.
-	IfTrueActivities *[]ActivityClassification `json:"ifTrueActivities,omitempty"`
+	IfTrueActivities []ActivityClassification `json:"ifTrueActivities,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IfConditionActivityTypeProperties.
+func (i IfConditionActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "expression", i.Expression)
+	populate(objectMap, "ifFalseActivities", i.IfFalseActivities)
+	populate(objectMap, "ifTrueActivities", i.IfTrueActivities)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type IfConditionActivityTypeProperties.
@@ -14198,6 +15201,23 @@ type ImpalaLinkedServiceTypeProperties struct {
 
 	// The user name used to access the Impala server. The default value is anonymous when using SASLUsername.
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ImpalaLinkedServiceTypeProperties.
+func (i ImpalaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", i.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", i.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", i.AuthenticationType)
+	populate(objectMap, "enableSsl", i.EnableSSL)
+	populate(objectMap, "encryptedCredential", i.EncryptedCredential)
+	populate(objectMap, "host", i.Host)
+	populate(objectMap, "password", i.Password)
+	populate(objectMap, "port", i.Port)
+	populate(objectMap, "trustedCertPath", i.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", i.UseSystemTrustStore)
+	populate(objectMap, "username", i.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ImpalaLinkedServiceTypeProperties.
@@ -14375,6 +15395,18 @@ type InformixLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type InformixLinkedServiceTypeProperties.
+func (i InformixLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", i.AuthenticationType)
+	populate(objectMap, "connectionString", i.ConnectionString)
+	populate(objectMap, "credential", i.Credential)
+	populate(objectMap, "encryptedCredential", i.EncryptedCredential)
+	populate(objectMap, "password", i.Password)
+	populate(objectMap, "userName", i.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type InformixLinkedServiceTypeProperties.
 func (i *InformixLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -14530,7 +15562,7 @@ type IntegrationRuntimeClassification interface {
 // IntegrationRuntime - Azure Synapse nested object which serves as a compute resource for activities.
 type IntegrationRuntime struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Integration runtime description.
 	Description *string `json:"description,omitempty"`
@@ -14557,7 +15589,7 @@ func (i IntegrationRuntime) marshalInternal(discValue IntegrationRuntimeType) ma
 	i.Type = &discValue
 	objectMap["type"] = i.Type
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -14576,12 +15608,12 @@ func (i *IntegrationRuntime) unmarshalInternal(rawMsg map[string]json.RawMessage
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -14595,7 +15627,7 @@ func (i *IntegrationRuntime) unmarshalInternal(rawMsg map[string]json.RawMessage
 // IntegrationRuntimeComputeProperties - The compute resource properties for managed integration runtime.
 type IntegrationRuntimeComputeProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Data flow properties for managed integration runtime.
 	DataFlowProperties *IntegrationRuntimeDataFlowProperties `json:"dataFlowProperties,omitempty"`
@@ -14626,7 +15658,7 @@ func (i IntegrationRuntimeComputeProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "numberOfNodes", i.NumberOfNodes)
 	populate(objectMap, "vNetProperties", i.VNetProperties)
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -14662,12 +15694,12 @@ func (i *IntegrationRuntimeComputeProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -14690,7 +15722,7 @@ type IntegrationRuntimeCustomSetupScriptProperties struct {
 // IntegrationRuntimeDataFlowProperties - Data flow properties for managed integration runtime.
 type IntegrationRuntimeDataFlowProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Compute type of the cluster which will execute data flow job.
 	ComputeType *DataFlowComputeType `json:"computeType,omitempty"`
@@ -14709,7 +15741,7 @@ func (i IntegrationRuntimeDataFlowProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "coreCount", i.CoreCount)
 	populate(objectMap, "timeToLive", i.TimeToLive)
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -14736,12 +15768,12 @@ func (i *IntegrationRuntimeDataFlowProperties) UnmarshalJSON(data []byte) error 
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -14770,7 +15802,15 @@ type IntegrationRuntimeListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of integration runtimes.
-	Value *[]*IntegrationRuntimeResource `json:"value,omitempty"`
+	Value []*IntegrationRuntimeResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IntegrationRuntimeListResponse.
+func (i IntegrationRuntimeListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", i.NextLink)
+	populate(objectMap, "value", i.Value)
+	return json.Marshal(objectMap)
 }
 
 // IntegrationRuntimeListResponseResponse is the response envelope for operations that return a IntegrationRuntimeListResponse type.
@@ -14785,7 +15825,7 @@ type IntegrationRuntimeListResponseResponse struct {
 // IntegrationRuntimeReference - Integration runtime reference type.
 type IntegrationRuntimeReference struct {
 	// Arguments for integration runtime.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Reference integration runtime name.
 	ReferenceName *string `json:"referenceName,omitempty"`
@@ -14794,11 +15834,47 @@ type IntegrationRuntimeReference struct {
 	Type *IntegrationRuntimeReferenceType `json:"type,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type IntegrationRuntimeReference.
+func (i IntegrationRuntimeReference) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "parameters", i.Parameters)
+	populate(objectMap, "referenceName", i.ReferenceName)
+	populate(objectMap, "type", i.Type)
+	return json.Marshal(objectMap)
+}
+
 // IntegrationRuntimeResource - Integration runtime resource type.
 type IntegrationRuntimeResource struct {
 	SubResource
 	// Integration runtime properties.
 	Properties IntegrationRuntimeClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type IntegrationRuntimeResource.
+func (i IntegrationRuntimeResource) MarshalJSON() ([]byte, error) {
+	objectMap := i.SubResource.marshalInternal()
+	populate(objectMap, "properties", i.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type IntegrationRuntimeResource.
+func (i *IntegrationRuntimeResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			i.Properties, err = unmarshalIntegrationRuntimeClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return i.SubResource.unmarshalInternal(rawMsg)
 }
 
 // IntegrationRuntimeResourceResponse is the response envelope for operations that return a IntegrationRuntimeResource type.
@@ -14813,7 +15889,7 @@ type IntegrationRuntimeResourceResponse struct {
 // IntegrationRuntimeSsisCatalogInfo - Catalog information for managed dedicated integration runtime.
 type IntegrationRuntimeSsisCatalogInfo struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The password of the administrator user account of the catalog database.
 	CatalogAdminPassword *SecureString `json:"catalogAdminPassword,omitempty"`
@@ -14836,7 +15912,7 @@ func (i IntegrationRuntimeSsisCatalogInfo) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "catalogPricingTier", i.CatalogPricingTier)
 	populate(objectMap, "catalogServerEndpoint", i.CatalogServerEndpoint)
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -14866,12 +15942,12 @@ func (i *IntegrationRuntimeSsisCatalogInfo) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -14885,7 +15961,7 @@ func (i *IntegrationRuntimeSsisCatalogInfo) UnmarshalJSON(data []byte) error {
 // IntegrationRuntimeSsisProperties - SSIS properties for managed integration runtime.
 type IntegrationRuntimeSsisProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Catalog information for managed dedicated integration runtime.
 	CatalogInfo *IntegrationRuntimeSsisCatalogInfo `json:"catalogInfo,omitempty"`
@@ -14900,7 +15976,7 @@ type IntegrationRuntimeSsisProperties struct {
 	Edition *IntegrationRuntimeEdition `json:"edition,omitempty"`
 
 	// Custom setup without script properties for a SSIS integration runtime.
-	ExpressCustomSetupProperties *[]CustomSetupBaseClassification `json:"expressCustomSetupProperties,omitempty"`
+	ExpressCustomSetupProperties []CustomSetupBaseClassification `json:"expressCustomSetupProperties,omitempty"`
 
 	// License type for bringing your own license scenario.
 	LicenseType *IntegrationRuntimeLicenseType `json:"licenseType,omitempty"`
@@ -14916,7 +15992,7 @@ func (i IntegrationRuntimeSsisProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "expressCustomSetupProperties", i.ExpressCustomSetupProperties)
 	populate(objectMap, "licenseType", i.LicenseType)
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -14952,12 +16028,12 @@ func (i *IntegrationRuntimeSsisProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -14971,10 +16047,10 @@ func (i *IntegrationRuntimeSsisProperties) UnmarshalJSON(data []byte) error {
 // IntegrationRuntimeVNetProperties - VNet properties for managed integration runtime.
 type IntegrationRuntimeVNetProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Resource IDs of the public IP addresses that this integration runtime will use.
-	PublicIPs *[]*string `json:"publicIPs,omitempty"`
+	PublicIPs []*string `json:"publicIPs,omitempty"`
 
 	// The name of the subnet this integration runtime will join.
 	Subnet *string `json:"subnet,omitempty"`
@@ -14990,7 +16066,7 @@ func (i IntegrationRuntimeVNetProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "subnet", i.Subnet)
 	populate(objectMap, "vNetId", i.VNetID)
 	if i.AdditionalProperties != nil {
-		for key, val := range *i.AdditionalProperties {
+		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -15017,12 +16093,12 @@ func (i *IntegrationRuntimeVNetProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if i.AdditionalProperties == nil {
-				i.AdditionalProperties = &map[string]interface{}{}
+				i.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*i.AdditionalProperties)[key] = aux
+				i.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -15089,6 +16165,15 @@ type JSONDatasetTypeProperties struct {
 
 	// The location of the json data storage.
 	Location DatasetLocationClassification `json:"location,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type JSONDatasetTypeProperties.
+func (j JSONDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "compression", j.Compression)
+	populate(objectMap, "encodingName", j.EncodingName)
+	populate(objectMap, "location", j.Location)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type JSONDatasetTypeProperties.
@@ -15358,6 +16443,20 @@ type JiraLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type JiraLinkedServiceTypeProperties.
+func (j JiraLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", j.EncryptedCredential)
+	populate(objectMap, "host", j.Host)
+	populate(objectMap, "password", j.Password)
+	populate(objectMap, "port", j.Port)
+	populate(objectMap, "useEncryptedEndpoints", j.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", j.UseHostVerification)
+	populate(objectMap, "usePeerVerification", j.UsePeerVerification)
+	populate(objectMap, "username", j.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type JiraLinkedServiceTypeProperties.
 func (j *JiraLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -15587,7 +16686,15 @@ type LibraryListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Library.
-	Value *[]*LibraryResource `json:"value,omitempty"`
+	Value []*LibraryResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LibraryListResponse.
+func (l LibraryListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LibraryListResponseResponse is the response envelope for operations that return a LibraryListResponse type.
@@ -15653,6 +16760,33 @@ type LibraryResource struct {
 	SubResource
 	// Library/package properties.
 	Properties *LibraryResourceProperties `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LibraryResource.
+func (l LibraryResource) MarshalJSON() ([]byte, error) {
+	objectMap := l.SubResource.marshalInternal()
+	populate(objectMap, "properties", l.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type LibraryResource.
+func (l *LibraryResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			err = unpopulate(val, &l.Properties)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return l.SubResource.unmarshalInternal(rawMsg)
 }
 
 // LibraryResourceInfo - Library resource info
@@ -15889,10 +17023,10 @@ type LinkedServiceClassification interface {
 // resource.
 type LinkedService struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// List of tags that can be used for describing the linked service.
-	Annotations *[]interface{} `json:"annotations,omitempty"`
+	Annotations []interface{} `json:"annotations,omitempty"`
 
 	// The integration runtime reference.
 	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
@@ -15901,7 +17035,7 @@ type LinkedService struct {
 	Description *string `json:"description,omitempty"`
 
 	// Parameters for linked service.
-	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Type of linked service.
 	Type *string `json:"type,omitempty"`
@@ -15928,7 +17062,7 @@ func (l LinkedService) marshalInternal(discValue string) map[string]interface{} 
 	l.Type = &discValue
 	objectMap["type"] = l.Type
 	if l.AdditionalProperties != nil {
-		for key, val := range *l.AdditionalProperties {
+		for key, val := range l.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -15956,12 +17090,12 @@ func (l *LinkedService) unmarshalInternal(rawMsg map[string]json.RawMessage) err
 			delete(rawMsg, key)
 		default:
 			if l.AdditionalProperties == nil {
-				l.AdditionalProperties = &map[string]interface{}{}
+				l.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*l.AdditionalProperties)[key] = aux
+				l.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -15995,6 +17129,33 @@ type LinkedServiceDebugResource struct {
 	Properties LinkedServiceClassification `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type LinkedServiceDebugResource.
+func (l LinkedServiceDebugResource) MarshalJSON() ([]byte, error) {
+	objectMap := l.SubResourceDebugResource.marshalInternal()
+	populate(objectMap, "properties", l.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type LinkedServiceDebugResource.
+func (l *LinkedServiceDebugResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			l.Properties, err = unmarshalLinkedServiceClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return l.SubResourceDebugResource.unmarshalInternal(rawMsg)
+}
+
 // LinkedServiceGetLinkedServiceOptions contains the optional parameters for the LinkedService.GetLinkedService method.
 type LinkedServiceGetLinkedServiceOptions struct {
 	// ETag of the linked service entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was provided, then no content
@@ -16013,7 +17174,15 @@ type LinkedServiceListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of linked services.
-	Value *[]*LinkedServiceResource `json:"value,omitempty"`
+	Value []*LinkedServiceResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LinkedServiceListResponse.
+func (l LinkedServiceListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", l.NextLink)
+	populate(objectMap, "value", l.Value)
+	return json.Marshal(objectMap)
 }
 
 // LinkedServiceListResponseResponse is the response envelope for operations that return a LinkedServiceListResponse type.
@@ -16028,7 +17197,7 @@ type LinkedServiceListResponseResponse struct {
 // LinkedServiceReference - Linked service reference type.
 type LinkedServiceReference struct {
 	// Arguments for LinkedService.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Reference LinkedService name.
 	ReferenceName *string `json:"referenceName,omitempty"`
@@ -16037,11 +17206,47 @@ type LinkedServiceReference struct {
 	Type *Type `json:"type,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type LinkedServiceReference.
+func (l LinkedServiceReference) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "parameters", l.Parameters)
+	populate(objectMap, "referenceName", l.ReferenceName)
+	populate(objectMap, "type", l.Type)
+	return json.Marshal(objectMap)
+}
+
 // LinkedServiceResource - Linked service resource type.
 type LinkedServiceResource struct {
 	SubResource
 	// Properties of linked service.
 	Properties LinkedServiceClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LinkedServiceResource.
+func (l LinkedServiceResource) MarshalJSON() ([]byte, error) {
+	objectMap := l.SubResource.marshalInternal()
+	populate(objectMap, "properties", l.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type LinkedServiceResource.
+func (l *LinkedServiceResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			l.Properties, err = unmarshalLinkedServiceClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return l.SubResource.unmarshalInternal(rawMsg)
 }
 
 // LinkedServiceResourcePollerResponse is the response envelope for operations that asynchronously return a LinkedServiceResource type.
@@ -16068,7 +17273,7 @@ type LinkedServiceResourceResponse struct {
 // LogStorageSettings - Log storage settings.
 type LogStorageSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Log storage linked service reference.
 	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
@@ -16083,7 +17288,7 @@ func (l LogStorageSettings) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "linkedServiceName", l.LinkedServiceName)
 	populate(objectMap, "path", l.Path)
 	if l.AdditionalProperties != nil {
-		for key, val := range *l.AdditionalProperties {
+		for key, val := range l.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -16107,12 +17312,12 @@ func (l *LogStorageSettings) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if l.AdditionalProperties == nil {
-				l.AdditionalProperties = &map[string]interface{}{}
+				l.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*l.AdditionalProperties)[key] = aux
+				l.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -16167,6 +17372,15 @@ type LookupActivityTypeProperties struct {
 
 	// Dataset-specific source properties, same as copy activity source.
 	Source CopySourceClassification `json:"source,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type LookupActivityTypeProperties.
+func (l LookupActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataset", l.Dataset)
+	populate(objectMap, "firstRowOnly", l.FirstRowOnly)
+	populate(objectMap, "source", l.Source)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type LookupActivityTypeProperties.
@@ -16250,6 +17464,18 @@ type MagentoLinkedServiceTypeProperties struct {
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MagentoLinkedServiceTypeProperties.
+func (m MagentoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", m.AccessToken)
+	populate(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populate(objectMap, "host", m.Host)
+	populate(objectMap, "useEncryptedEndpoints", m.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", m.UseHostVerification)
+	populate(objectMap, "usePeerVerification", m.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type MagentoLinkedServiceTypeProperties.
@@ -16420,13 +17646,22 @@ type ManagedIntegrationRuntimeTypeProperties struct {
 // ManagedVirtualNetworkSettings - Managed Virtual Network Settings
 type ManagedVirtualNetworkSettings struct {
 	// Allowed Aad Tenant Ids For Linking
-	AllowedAADTenantIDsForLinking *[]*string `json:"allowedAadTenantIdsForLinking,omitempty"`
+	AllowedAADTenantIDsForLinking []*string `json:"allowedAadTenantIdsForLinking,omitempty"`
 
 	// Linked Access Check On Target Resource
 	LinkedAccessCheckOnTargetResource *bool `json:"linkedAccessCheckOnTargetResource,omitempty"`
 
 	// Prevent Data Exfiltration
 	PreventDataExfiltration *bool `json:"preventDataExfiltration,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ManagedVirtualNetworkSettings.
+func (m ManagedVirtualNetworkSettings) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowedAadTenantIdsForLinking", m.AllowedAADTenantIDsForLinking)
+	populate(objectMap, "linkedAccessCheckOnTargetResource", m.LinkedAccessCheckOnTargetResource)
+	populate(objectMap, "preventDataExfiltration", m.PreventDataExfiltration)
+	return json.Marshal(objectMap)
 }
 
 // MappingDataFlow - Mapping data flow.
@@ -16469,13 +17704,23 @@ type MappingDataFlowTypeProperties struct {
 	Script *string `json:"script,omitempty"`
 
 	// List of sinks in data flow.
-	Sinks *[]*DataFlowSink `json:"sinks,omitempty"`
+	Sinks []*DataFlowSink `json:"sinks,omitempty"`
 
 	// List of sources in data flow.
-	Sources *[]*DataFlowSource `json:"sources,omitempty"`
+	Sources []*DataFlowSource `json:"sources,omitempty"`
 
 	// List of transformations in data flow.
-	Transformations *[]*Transformation `json:"transformations,omitempty"`
+	Transformations []*Transformation `json:"transformations,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MappingDataFlowTypeProperties.
+func (m MappingDataFlowTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "script", m.Script)
+	populate(objectMap, "sinks", m.Sinks)
+	populate(objectMap, "sources", m.Sources)
+	populate(objectMap, "transformations", m.Transformations)
+	return json.Marshal(objectMap)
 }
 
 // MariaDBLinkedService - MariaDB server linked service.
@@ -16653,6 +17898,19 @@ type MarketoLinkedServiceTypeProperties struct {
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type MarketoLinkedServiceTypeProperties.
+func (m MarketoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", m.ClientID)
+	populate(objectMap, "clientSecret", m.ClientSecret)
+	populate(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populate(objectMap, "endpoint", m.Endpoint)
+	populate(objectMap, "useEncryptedEndpoints", m.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", m.UseHostVerification)
+	populate(objectMap, "usePeerVerification", m.UsePeerVerification)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type MarketoLinkedServiceTypeProperties.
 func (m *MarketoLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -16814,6 +18072,18 @@ type MicrosoftAccessLinkedServiceTypeProperties struct {
 
 	// User name for Basic authentication. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MicrosoftAccessLinkedServiceTypeProperties.
+func (m MicrosoftAccessLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", m.AuthenticationType)
+	populate(objectMap, "connectionString", m.ConnectionString)
+	populate(objectMap, "credential", m.Credential)
+	populate(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populate(objectMap, "password", m.Password)
+	populate(objectMap, "userName", m.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type MicrosoftAccessLinkedServiceTypeProperties.
@@ -17002,7 +18272,7 @@ type MongoDbCollectionDatasetTypeProperties struct {
 // MongoDbCursorMethodsProperties - Cursor methods for Mongodb query
 type MongoDbCursorMethodsProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Specifies the maximum number of documents the server returns. limit() is analogous to the LIMIT statement in a SQL database. Type: integer (or Expression
 	// with resultType integer).
@@ -17030,7 +18300,7 @@ func (m MongoDbCursorMethodsProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "skip", m.Skip)
 	populate(objectMap, "sort", m.Sort)
 	if m.AdditionalProperties != nil {
-		for key, val := range *m.AdditionalProperties {
+		for key, val := range m.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -17060,12 +18330,12 @@ func (m *MongoDbCursorMethodsProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if m.AdditionalProperties == nil {
-				m.AdditionalProperties = &map[string]interface{}{}
+				m.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*m.AdditionalProperties)[key] = aux
+				m.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -17143,6 +18413,22 @@ type MongoDbLinkedServiceTypeProperties struct {
 
 	// Username for authentication. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type MongoDbLinkedServiceTypeProperties.
+func (m MongoDbLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowSelfSignedServerCert", m.AllowSelfSignedServerCert)
+	populate(objectMap, "authSource", m.AuthSource)
+	populate(objectMap, "authenticationType", m.AuthenticationType)
+	populate(objectMap, "databaseName", m.DatabaseName)
+	populate(objectMap, "enableSsl", m.EnableSSL)
+	populate(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populate(objectMap, "password", m.Password)
+	populate(objectMap, "port", m.Port)
+	populate(objectMap, "server", m.Server)
+	populate(objectMap, "username", m.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type MongoDbLinkedServiceTypeProperties.
@@ -17381,7 +18667,7 @@ type MultiplePipelineTriggerClassification interface {
 type MultiplePipelineTrigger struct {
 	Trigger
 	// Pipelines that need to be started.
-	Pipelines *[]*TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines []*TriggerPipelineReference `json:"pipelines,omitempty"`
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type MultiplePipelineTrigger.
@@ -17702,13 +18988,13 @@ type NetezzaTableDatasetTypeProperties struct {
 // Notebook.
 type Notebook struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Big data pool reference.
 	BigDataPool *BigDataPoolReference `json:"bigDataPool,omitempty"`
 
 	// Array of cells of the current notebook.
-	Cells *[]*NotebookCell `json:"cells,omitempty"`
+	Cells []*NotebookCell `json:"cells,omitempty"`
 
 	// The description of the notebook.
 	Description *string `json:"description,omitempty"`
@@ -17737,7 +19023,7 @@ func (n Notebook) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "nbformat_minor", n.NbformatMinor)
 	populate(objectMap, "sessionProperties", n.SessionProperties)
 	if n.AdditionalProperties != nil {
-		for key, val := range *n.AdditionalProperties {
+		for key, val := range n.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -17776,12 +19062,12 @@ func (n *Notebook) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if n.AdditionalProperties == nil {
-				n.AdditionalProperties = &map[string]interface{}{}
+				n.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*n.AdditionalProperties)[key] = aux
+				n.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -17811,7 +19097,7 @@ type NotebookBeginRenameNotebookOptions struct {
 // NotebookCell - Notebook cell.
 type NotebookCell struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Attachments associated with the cell.
 	Attachments interface{} `json:"attachments,omitempty"`
@@ -17823,10 +19109,10 @@ type NotebookCell struct {
 	Metadata interface{} `json:"metadata,omitempty"`
 
 	// Cell-level output items.
-	Outputs *[]*NotebookCellOutputItem `json:"outputs,omitempty"`
+	Outputs []*NotebookCellOutputItem `json:"outputs,omitempty"`
 
 	// Contents of the cell, represented as an array of lines.
-	Source *[]*string `json:"source,omitempty"`
+	Source []*string `json:"source,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type NotebookCell.
@@ -17838,7 +19124,7 @@ func (n NotebookCell) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "outputs", n.Outputs)
 	populate(objectMap, "source", n.Source)
 	if n.AdditionalProperties != nil {
-		for key, val := range *n.AdditionalProperties {
+		for key, val := range n.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -17871,12 +19157,12 @@ func (n *NotebookCell) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if n.AdditionalProperties == nil {
-				n.AdditionalProperties = &map[string]interface{}{}
+				n.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*n.AdditionalProperties)[key] = aux
+				n.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -17928,7 +19214,7 @@ type NotebookGetNotebooksByWorkspaceOptions struct {
 // NotebookKernelSpec - Kernel information.
 type NotebookKernelSpec struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Name to display in UI.
 	DisplayName *string `json:"display_name,omitempty"`
@@ -17943,7 +19229,7 @@ func (n NotebookKernelSpec) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "display_name", n.DisplayName)
 	populate(objectMap, "name", n.Name)
 	if n.AdditionalProperties != nil {
-		for key, val := range *n.AdditionalProperties {
+		for key, val := range n.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -17967,12 +19253,12 @@ func (n *NotebookKernelSpec) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if n.AdditionalProperties == nil {
-				n.AdditionalProperties = &map[string]interface{}{}
+				n.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*n.AdditionalProperties)[key] = aux
+				n.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -17986,7 +19272,7 @@ func (n *NotebookKernelSpec) UnmarshalJSON(data []byte) error {
 // NotebookLanguageInfo - Language info.
 type NotebookLanguageInfo struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The codemirror mode to use for code in this language.
 	CodemirrorMode *string `json:"codemirror_mode,omitempty"`
@@ -18001,7 +19287,7 @@ func (n NotebookLanguageInfo) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "codemirror_mode", n.CodemirrorMode)
 	populate(objectMap, "name", n.Name)
 	if n.AdditionalProperties != nil {
-		for key, val := range *n.AdditionalProperties {
+		for key, val := range n.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -18025,12 +19311,12 @@ func (n *NotebookLanguageInfo) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if n.AdditionalProperties == nil {
-				n.AdditionalProperties = &map[string]interface{}{}
+				n.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*n.AdditionalProperties)[key] = aux
+				n.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -18047,7 +19333,15 @@ type NotebookListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of Notebooks.
-	Value *[]*NotebookResource `json:"value,omitempty"`
+	Value []*NotebookResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type NotebookListResponse.
+func (n NotebookListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", n.NextLink)
+	populate(objectMap, "value", n.Value)
+	return json.Marshal(objectMap)
 }
 
 // NotebookListResponseResponse is the response envelope for operations that return a NotebookListResponse type.
@@ -18062,7 +19356,7 @@ type NotebookListResponseResponse struct {
 // NotebookMetadata - Notebook root-level metadata.
 type NotebookMetadata struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Kernel information.
 	Kernelspec *NotebookKernelSpec `json:"kernelspec,omitempty"`
@@ -18077,7 +19371,7 @@ func (n NotebookMetadata) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "kernelspec", n.Kernelspec)
 	populate(objectMap, "language_info", n.LanguageInfo)
 	if n.AdditionalProperties != nil {
-		for key, val := range *n.AdditionalProperties {
+		for key, val := range n.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -18101,12 +19395,12 @@ func (n *NotebookMetadata) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if n.AdditionalProperties == nil {
-				n.AdditionalProperties = &map[string]interface{}{}
+				n.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*n.AdditionalProperties)[key] = aux
+				n.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -18247,6 +19541,24 @@ type ODataLinkedServiceTypeProperties struct {
 
 	// User name of the OData service. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ODataLinkedServiceTypeProperties.
+func (o ODataLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aadResourceId", o.AADResourceID)
+	populate(objectMap, "aadServicePrincipalCredentialType", o.AADServicePrincipalCredentialType)
+	populate(objectMap, "authenticationType", o.AuthenticationType)
+	populate(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populate(objectMap, "password", o.Password)
+	populate(objectMap, "servicePrincipalEmbeddedCert", o.ServicePrincipalEmbeddedCert)
+	populate(objectMap, "servicePrincipalEmbeddedCertPassword", o.ServicePrincipalEmbeddedCertPassword)
+	populate(objectMap, "servicePrincipalId", o.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", o.ServicePrincipalKey)
+	populate(objectMap, "tenant", o.Tenant)
+	populate(objectMap, "url", o.URL)
+	populate(objectMap, "userName", o.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ODataLinkedServiceTypeProperties.
@@ -18431,6 +19743,18 @@ type OdbcLinkedServiceTypeProperties struct {
 
 	// User name for Basic authentication. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OdbcLinkedServiceTypeProperties.
+func (o OdbcLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", o.AuthenticationType)
+	populate(objectMap, "connectionString", o.ConnectionString)
+	populate(objectMap, "credential", o.Credential)
+	populate(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populate(objectMap, "password", o.Password)
+	populate(objectMap, "userName", o.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type OdbcLinkedServiceTypeProperties.
@@ -18670,6 +19994,17 @@ type Office365LinkedServiceTypeProperties struct {
 
 	// Specify the tenant information under which your Azure AD web application resides. Type: string (or Expression with resultType string).
 	ServicePrincipalTenantID interface{} `json:"servicePrincipalTenantId,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Office365LinkedServiceTypeProperties.
+func (o Office365LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populate(objectMap, "office365TenantId", o.Office365TenantID)
+	populate(objectMap, "servicePrincipalId", o.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", o.ServicePrincipalKey)
+	populate(objectMap, "servicePrincipalTenantId", o.ServicePrincipalTenantID)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type Office365LinkedServiceTypeProperties.
@@ -18916,6 +20251,19 @@ type OracleServiceCloudLinkedServiceTypeProperties struct {
 
 	// The user name that you use to access Oracle Service Cloud server.
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type OracleServiceCloudLinkedServiceTypeProperties.
+func (o OracleServiceCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populate(objectMap, "host", o.Host)
+	populate(objectMap, "password", o.Password)
+	populate(objectMap, "useEncryptedEndpoints", o.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", o.UseHostVerification)
+	populate(objectMap, "usePeerVerification", o.UsePeerVerification)
+	populate(objectMap, "username", o.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type OracleServiceCloudLinkedServiceTypeProperties.
@@ -19200,6 +20548,14 @@ type OrcDatasetTypeProperties struct {
 	OrcCompressionCodec *OrcCompressionCodec          `json:"orcCompressionCodec,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type OrcDatasetTypeProperties.
+func (o OrcDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "location", o.Location)
+	populate(objectMap, "orcCompressionCodec", o.OrcCompressionCodec)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type OrcDatasetTypeProperties.
 func (o *OrcDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -19351,6 +20707,14 @@ type ParquetDatasetTypeProperties struct {
 
 	// The location of the parquet storage.
 	Location DatasetLocationClassification `json:"location,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ParquetDatasetTypeProperties.
+func (p ParquetDatasetTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "compressionCodec", p.CompressionCodec)
+	populate(objectMap, "location", p.Location)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ParquetDatasetTypeProperties.
@@ -19513,6 +20877,19 @@ type PaypalLinkedServiceTypeProperties struct {
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PaypalLinkedServiceTypeProperties.
+func (p PaypalLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", p.ClientID)
+	populate(objectMap, "clientSecret", p.ClientSecret)
+	populate(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populate(objectMap, "host", p.Host)
+	populate(objectMap, "useEncryptedEndpoints", p.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", p.UseHostVerification)
+	populate(objectMap, "usePeerVerification", p.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type PaypalLinkedServiceTypeProperties.
@@ -19709,6 +21086,24 @@ type PhoenixLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PhoenixLinkedServiceTypeProperties.
+func (p PhoenixLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", p.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", p.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", p.AuthenticationType)
+	populate(objectMap, "enableSsl", p.EnableSSL)
+	populate(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populate(objectMap, "httpPath", p.HTTPPath)
+	populate(objectMap, "host", p.Host)
+	populate(objectMap, "password", p.Password)
+	populate(objectMap, "port", p.Port)
+	populate(objectMap, "trustedCertPath", p.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", p.UseSystemTrustStore)
+	populate(objectMap, "username", p.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type PhoenixLinkedServiceTypeProperties.
 func (p *PhoenixLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -19833,10 +21228,10 @@ func (p *PhoenixSource) UnmarshalJSON(data []byte) error {
 // Pipeline - A workspace pipeline.
 type Pipeline struct {
 	// List of activities in pipeline.
-	Activities *[]ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification `json:"activities,omitempty"`
 
 	// List of tags that can be used for describing the Pipeline.
-	Annotations *[]interface{} `json:"annotations,omitempty"`
+	Annotations []interface{} `json:"annotations,omitempty"`
 
 	// The max number of concurrent runs for the pipeline.
 	Concurrency *int32 `json:"concurrency,omitempty"`
@@ -19848,13 +21243,27 @@ type Pipeline struct {
 	Folder *PipelineFolder `json:"folder,omitempty"`
 
 	// List of parameters for pipeline.
-	Parameters *map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
 
 	// Dimensions emitted by Pipeline.
-	RunDimensions *map[string]interface{} `json:"runDimensions,omitempty"`
+	RunDimensions map[string]interface{} `json:"runDimensions,omitempty"`
 
 	// List of variables for pipeline.
-	Variables *map[string]*VariableSpecification `json:"variables,omitempty"`
+	Variables map[string]*VariableSpecification `json:"variables,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type Pipeline.
+func (p Pipeline) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activities", p.Activities)
+	populate(objectMap, "annotations", p.Annotations)
+	populate(objectMap, "concurrency", p.Concurrency)
+	populate(objectMap, "description", p.Description)
+	populate(objectMap, "folder", p.Folder)
+	populate(objectMap, "parameters", p.Parameters)
+	populate(objectMap, "runDimensions", p.RunDimensions)
+	populate(objectMap, "variables", p.Variables)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type Pipeline.
@@ -19950,7 +21359,15 @@ type PipelineListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of pipelines.
-	Value *[]*PipelineResource `json:"value,omitempty"`
+	Value []*PipelineResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PipelineListResponse.
+func (p PipelineListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", p.NextLink)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PipelineListResponseResponse is the response envelope for operations that return a PipelineListResponse type.
@@ -19978,7 +21395,7 @@ type PipelineReference struct {
 type PipelineResource struct {
 	SubResource
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Properties of the pipeline.
 	Properties *Pipeline `json:"properties,omitempty"`
@@ -19989,7 +21406,7 @@ func (p PipelineResource) MarshalJSON() ([]byte, error) {
 	objectMap := p.SubResource.marshalInternal()
 	populate(objectMap, "properties", p.Properties)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -20019,12 +21436,12 @@ func (p *PipelineResource) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		if p.AdditionalProperties == nil {
-			p.AdditionalProperties = &map[string]interface{}{}
+			p.AdditionalProperties = map[string]interface{}{}
 		}
 		if val != nil {
 			var aux interface{}
 			err = json.Unmarshal(val, &aux)
-			(*p.AdditionalProperties)[key] = aux
+			p.AdditionalProperties[key] = aux
 		}
 		delete(rawMsg, key)
 		if err != nil {
@@ -20058,7 +21475,7 @@ type PipelineResourceResponse struct {
 // PipelineRun - Information about a pipeline run.
 type PipelineRun struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// READ-ONLY; The duration of a pipeline run.
 	DurationInMs *int32 `json:"durationInMs,omitempty" azure:"ro"`
@@ -20076,7 +21493,7 @@ type PipelineRun struct {
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// READ-ONLY; The full or partial list of parameter name, value pair used in the pipeline run.
-	Parameters *map[string]*string `json:"parameters,omitempty" azure:"ro"`
+	Parameters map[string]*string `json:"parameters,omitempty" azure:"ro"`
 
 	// READ-ONLY; The pipeline name.
 	PipelineName *string `json:"pipelineName,omitempty" azure:"ro"`
@@ -20113,7 +21530,7 @@ func (p PipelineRun) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "runStart", (*timeRFC3339)(p.RunStart))
 	populate(objectMap, "status", p.Status)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -20173,12 +21590,12 @@ func (p *PipelineRun) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]interface{}{}
+				p.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				p.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -20237,7 +21654,15 @@ type PipelineRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of pipeline runs.
-	Value *[]*PipelineRun `json:"value,omitempty"`
+	Value []*PipelineRun `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type PipelineRunsQueryResponse.
+func (p PipelineRunsQueryResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "continuationToken", p.ContinuationToken)
+	populate(objectMap, "value", p.Value)
+	return json.Marshal(objectMap)
 }
 
 // PipelineRunsQueryResponseResponse is the response envelope for operations that return a PipelineRunsQueryResponse type.
@@ -20252,7 +21677,7 @@ type PipelineRunsQueryResponseResponse struct {
 // PolybaseSettings - PolyBase settings.
 type PolybaseSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Determines the number of rows to attempt to retrieve before the PolyBase recalculates the percentage of rejected rows. Type: integer (or Expression with
 	// resultType integer), minimum: 0.
@@ -20278,7 +21703,7 @@ func (p PolybaseSettings) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "rejectValue", p.RejectValue)
 	populate(objectMap, "useTypeDefault", p.UseTypeDefault)
 	if p.AdditionalProperties != nil {
-		for key, val := range *p.AdditionalProperties {
+		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -20308,12 +21733,12 @@ func (p *PolybaseSettings) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if p.AdditionalProperties == nil {
-				p.AdditionalProperties = &map[string]interface{}{}
+				p.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*p.AdditionalProperties)[key] = aux
+				p.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -20546,6 +21971,26 @@ type PrestoLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrestoLinkedServiceTypeProperties.
+func (p PrestoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", p.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", p.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", p.AuthenticationType)
+	populate(objectMap, "catalog", p.Catalog)
+	populate(objectMap, "enableSsl", p.EnableSSL)
+	populate(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populate(objectMap, "host", p.Host)
+	populate(objectMap, "password", p.Password)
+	populate(objectMap, "port", p.Port)
+	populate(objectMap, "serverVersion", p.ServerVersion)
+	populate(objectMap, "timeZoneID", p.TimeZoneID)
+	populate(objectMap, "trustedCertPath", p.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", p.UseSystemTrustStore)
+	populate(objectMap, "username", p.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type PrestoLinkedServiceTypeProperties.
 func (p *PrestoLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -20686,6 +22131,13 @@ type PrivateEndpointConnection struct {
 	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PrivateEndpointConnection.
+func (p PrivateEndpointConnection) MarshalJSON() ([]byte, error) {
+	objectMap := p.ProxyResource.marshalInternal()
+	populate(objectMap, "properties", p.Properties)
+	return json.Marshal(objectMap)
+}
+
 // PrivateEndpointConnectionProperties - Properties of a private endpoint connection.
 type PrivateEndpointConnectionProperties struct {
 	// The private endpoint which the connection belongs to.
@@ -20715,6 +22167,11 @@ type ProxyResource struct {
 	Resource
 }
 
+func (p ProxyResource) marshalInternal() map[string]interface{} {
+	objectMap := p.Resource.marshalInternal()
+	return objectMap
+}
+
 // PurviewConfiguration - Purview Configuration
 type PurviewConfiguration struct {
 	// Purview Resource ID
@@ -20727,7 +22184,15 @@ type QueryDataFlowDebugSessionsResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// Array with all active debug sessions.
-	Value *[]*DataFlowDebugSessionInfo `json:"value,omitempty"`
+	Value []*DataFlowDebugSessionInfo `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type QueryDataFlowDebugSessionsResponse.
+func (q QueryDataFlowDebugSessionsResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", q.NextLink)
+	populate(objectMap, "value", q.Value)
+	return json.Marshal(objectMap)
 }
 
 // QueryDataFlowDebugSessionsResponseResponse is the response envelope for operations that return a QueryDataFlowDebugSessionsResponse type.
@@ -20799,6 +22264,20 @@ type QuickBooksLinkedServiceTypeProperties struct {
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
 	UseEncryptedEndpoints interface{} `json:"useEncryptedEndpoints,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type QuickBooksLinkedServiceTypeProperties.
+func (q QuickBooksLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", q.AccessToken)
+	populate(objectMap, "accessTokenSecret", q.AccessTokenSecret)
+	populate(objectMap, "companyId", q.CompanyID)
+	populate(objectMap, "consumerKey", q.ConsumerKey)
+	populate(objectMap, "consumerSecret", q.ConsumerSecret)
+	populate(objectMap, "encryptedCredential", q.EncryptedCredential)
+	populate(objectMap, "endpoint", q.Endpoint)
+	populate(objectMap, "useEncryptedEndpoints", q.UseEncryptedEndpoints)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type QuickBooksLinkedServiceTypeProperties.
@@ -20913,22 +22392,22 @@ func (q *QuickBooksSource) UnmarshalJSON(data []byte) error {
 // RecurrenceSchedule - The recurrence schedule.
 type RecurrenceSchedule struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The hours.
-	Hours *[]*int32 `json:"hours,omitempty"`
+	Hours []*int32 `json:"hours,omitempty"`
 
 	// The minutes.
-	Minutes *[]*int32 `json:"minutes,omitempty"`
+	Minutes []*int32 `json:"minutes,omitempty"`
 
 	// The month days.
-	MonthDays *[]*int32 `json:"monthDays,omitempty"`
+	MonthDays []*int32 `json:"monthDays,omitempty"`
 
 	// The monthly occurrences.
-	MonthlyOccurrences *[]*RecurrenceScheduleOccurrence `json:"monthlyOccurrences,omitempty"`
+	MonthlyOccurrences []*RecurrenceScheduleOccurrence `json:"monthlyOccurrences,omitempty"`
 
 	// The days of the week.
-	WeekDays *[]*DayOfWeek `json:"weekDays,omitempty"`
+	WeekDays []*DayOfWeek `json:"weekDays,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RecurrenceSchedule.
@@ -20940,7 +22419,7 @@ func (r RecurrenceSchedule) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "monthlyOccurrences", r.MonthlyOccurrences)
 	populate(objectMap, "weekDays", r.WeekDays)
 	if r.AdditionalProperties != nil {
-		for key, val := range *r.AdditionalProperties {
+		for key, val := range r.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -20973,12 +22452,12 @@ func (r *RecurrenceSchedule) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if r.AdditionalProperties == nil {
-				r.AdditionalProperties = &map[string]interface{}{}
+				r.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*r.AdditionalProperties)[key] = aux
+				r.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -20992,7 +22471,7 @@ func (r *RecurrenceSchedule) UnmarshalJSON(data []byte) error {
 // RecurrenceScheduleOccurrence - The recurrence schedule occurrence.
 type RecurrenceScheduleOccurrence struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The day of the week.
 	Day *DayOfWeek `json:"day,omitempty"`
@@ -21007,7 +22486,7 @@ func (r RecurrenceScheduleOccurrence) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "day", r.Day)
 	populate(objectMap, "occurrence", r.Occurrence)
 	if r.AdditionalProperties != nil {
-		for key, val := range *r.AdditionalProperties {
+		for key, val := range r.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -21031,12 +22510,12 @@ func (r *RecurrenceScheduleOccurrence) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if r.AdditionalProperties == nil {
-				r.AdditionalProperties = &map[string]interface{}{}
+				r.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*r.AdditionalProperties)[key] = aux
+				r.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -21050,7 +22529,7 @@ func (r *RecurrenceScheduleOccurrence) UnmarshalJSON(data []byte) error {
 // RedirectIncompatibleRowSettings - Redirect incompatible row settings
 type RedirectIncompatibleRowSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Name of the Azure Storage, Storage SAS, or Azure Data Lake Store linked service used for redirecting incompatible row. Must be specified if redirectIncompatibleRowSettings
 	// is specified. Type: string
@@ -21067,7 +22546,7 @@ func (r RedirectIncompatibleRowSettings) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "linkedServiceName", r.LinkedServiceName)
 	populate(objectMap, "path", r.Path)
 	if r.AdditionalProperties != nil {
-		for key, val := range *r.AdditionalProperties {
+		for key, val := range r.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -21091,12 +22570,12 @@ func (r *RedirectIncompatibleRowSettings) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if r.AdditionalProperties == nil {
-				r.AdditionalProperties = &map[string]interface{}{}
+				r.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*r.AdditionalProperties)[key] = aux
+				r.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -21200,7 +22679,15 @@ type RerunTriggerListResponse struct {
 	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
 
 	// List of rerun triggers.
-	Value *[]*RerunTriggerResource `json:"value,omitempty"`
+	Value []*RerunTriggerResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RerunTriggerListResponse.
+func (r RerunTriggerListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", r.NextLink)
+	populate(objectMap, "value", r.Value)
+	return json.Marshal(objectMap)
 }
 
 // RerunTriggerResource - RerunTrigger resource type.
@@ -21208,6 +22695,33 @@ type RerunTriggerResource struct {
 	SubResource
 	// Properties of the rerun trigger.
 	Properties *RerunTumblingWindowTrigger `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RerunTriggerResource.
+func (r RerunTriggerResource) MarshalJSON() ([]byte, error) {
+	objectMap := r.SubResource.marshalInternal()
+	populate(objectMap, "properties", r.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type RerunTriggerResource.
+func (r *RerunTriggerResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			err = unpopulate(val, &r.Properties)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return r.SubResource.unmarshalInternal(rawMsg)
 }
 
 // RerunTumblingWindowTrigger - Trigger that schedules pipeline reruns for all fixed time interval windows from a requested start time to requested end
@@ -21366,6 +22880,21 @@ type Resource struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Resource.
+func (r Resource) MarshalJSON() ([]byte, error) {
+	objectMap := r.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type Resource.
+func (r *Resource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	return r.unmarshalInternal(rawMsg)
+}
+
 func (r Resource) marshalInternal() map[string]interface{} {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "id", r.ID)
@@ -21455,6 +22984,19 @@ type ResponsysLinkedServiceTypeProperties struct {
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true. Type: boolean (or Expression with resultType
 	// boolean).
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ResponsysLinkedServiceTypeProperties.
+func (r ResponsysLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", r.ClientID)
+	populate(objectMap, "clientSecret", r.ClientSecret)
+	populate(objectMap, "encryptedCredential", r.EncryptedCredential)
+	populate(objectMap, "endpoint", r.Endpoint)
+	populate(objectMap, "useEncryptedEndpoints", r.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", r.UseHostVerification)
+	populate(objectMap, "usePeerVerification", r.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ResponsysLinkedServiceTypeProperties.
@@ -21684,6 +23226,22 @@ type RestServiceLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type RestServiceLinkedServiceTypeProperties.
+func (r RestServiceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "aadResourceId", r.AADResourceID)
+	populate(objectMap, "authenticationType", r.AuthenticationType)
+	populate(objectMap, "enableServerCertificateValidation", r.EnableServerCertificateValidation)
+	populate(objectMap, "encryptedCredential", r.EncryptedCredential)
+	populate(objectMap, "password", r.Password)
+	populate(objectMap, "servicePrincipalId", r.ServicePrincipalID)
+	populate(objectMap, "servicePrincipalKey", r.ServicePrincipalKey)
+	populate(objectMap, "tenant", r.Tenant)
+	populate(objectMap, "url", r.URL)
+	populate(objectMap, "userName", r.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type RestServiceLinkedServiceTypeProperties.
 func (r *RestServiceLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -21817,7 +23375,7 @@ type RunFilterParameters struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of filters.
-	Filters *[]*RunQueryFilter `json:"filters,omitempty"`
+	Filters []*RunQueryFilter `json:"filters,omitempty"`
 
 	// The time at or after which the run event was updated in 'ISO 8601' format.
 	LastUpdatedAfter *time.Time `json:"lastUpdatedAfter,omitempty"`
@@ -21826,7 +23384,7 @@ type RunFilterParameters struct {
 	LastUpdatedBefore *time.Time `json:"lastUpdatedBefore,omitempty"`
 
 	// List of OrderBy option.
-	OrderBy *[]*RunQueryOrderBy `json:"orderBy,omitempty"`
+	OrderBy []*RunQueryOrderBy `json:"orderBy,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type RunFilterParameters.
@@ -21887,7 +23445,16 @@ type RunQueryFilter struct {
 	Operator *RunQueryFilterOperator `json:"operator,omitempty"`
 
 	// List of filter values.
-	Values *[]*string `json:"values,omitempty"`
+	Values []*string `json:"values,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type RunQueryFilter.
+func (r RunQueryFilter) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "operand", r.Operand)
+	populate(objectMap, "operator", r.Operator)
+	populate(objectMap, "values", r.Values)
+	return json.Marshal(objectMap)
 }
 
 // RunQueryOrderBy - An object to provide order by options for listing runs.
@@ -21916,7 +23483,7 @@ type SKU struct {
 // SQLConnection - The connection used to execute the SQL script.
 type SQLConnection struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The identifier of the connection.
 	Name *string `json:"name,omitempty"`
@@ -21931,7 +23498,7 @@ func (s SQLConnection) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "name", s.Name)
 	populate(objectMap, "type", s.Type)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -21955,12 +23522,12 @@ func (s *SQLConnection) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -22103,7 +23670,7 @@ type SQLMISink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -22173,7 +23740,7 @@ type SQLMISource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLMISource.
@@ -22225,13 +23792,29 @@ type SQLPool struct {
 	SKU *SKU `json:"sku,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SQLPool.
+func (s SQLPool) MarshalJSON() ([]byte, error) {
+	objectMap := s.TrackedResource.marshalInternal()
+	populate(objectMap, "properties", s.Properties)
+	populate(objectMap, "sku", s.SKU)
+	return json.Marshal(objectMap)
+}
+
 // SQLPoolInfoListResult - List of SQL pools
 type SQLPoolInfoListResult struct {
 	// Link to the next page of results
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of SQL pools
-	Value *[]*SQLPool `json:"value,omitempty"`
+	Value []*SQLPool `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SQLPoolInfoListResult.
+func (s SQLPoolInfoListResult) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SQLPoolInfoListResultResponse is the response envelope for operations that return a SQLPoolInfoListResult type.
@@ -22399,7 +23982,15 @@ type SQLPoolStoredProcedureActivityTypeProperties struct {
 	StoredProcedureName interface{} `json:"storedProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SQLPoolStoredProcedureActivityTypeProperties.
+func (s SQLPoolStoredProcedureActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "storedProcedureName", s.StoredProcedureName)
+	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
+	return json.Marshal(objectMap)
 }
 
 // SQLPoolsGetOptions contains the optional parameters for the SQLPools.Get method.
@@ -22415,7 +24006,7 @@ type SQLPoolsListOptions struct {
 // SQLScript - SQL script.
 type SQLScript struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The content of the SQL script.
 	Content *SQLScriptContent `json:"content,omitempty"`
@@ -22434,7 +24025,7 @@ func (s SQLScript) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "description", s.Description)
 	populate(objectMap, "type", s.Type)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -22461,12 +24052,12 @@ func (s *SQLScript) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -22496,7 +24087,7 @@ type SQLScriptBeginRenameSQLScriptOptions struct {
 // SQLScriptContent - The content of the SQL script.
 type SQLScriptContent struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The connection used to execute the SQL script.
 	CurrentConnection *SQLConnection `json:"currentConnection,omitempty"`
@@ -22515,7 +24106,7 @@ func (s SQLScriptContent) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "metadata", s.Metadata)
 	populate(objectMap, "query", s.Query)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -22542,12 +24133,12 @@ func (s *SQLScriptContent) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -22573,7 +24164,7 @@ type SQLScriptGetSQLScriptsByWorkspaceOptions struct {
 // SQLScriptMetadata - The metadata of the SQL script.
 type SQLScriptMetadata struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The language of the SQL script.
 	Language *string `json:"language,omitempty"`
@@ -22584,7 +24175,7 @@ func (s SQLScriptMetadata) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "language", s.Language)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -22605,12 +24196,12 @@ func (s *SQLScriptMetadata) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -22666,7 +24257,15 @@ type SQLScriptsListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of sql scripts.
-	Value *[]*SQLScriptResource `json:"value,omitempty"`
+	Value []*SQLScriptResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SQLScriptsListResponse.
+func (s SQLScriptsListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SQLScriptsListResponseResponse is the response envelope for operations that return a SQLScriptsListResponse type.
@@ -22728,6 +24327,16 @@ type SQLServerLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SQLServerLinkedServiceTypeProperties.
+func (s SQLServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "connectionString", s.ConnectionString)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SQLServerLinkedServiceTypeProperties.
 func (s *SQLServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -22770,7 +24379,7 @@ type SQLServerSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -22840,7 +24449,7 @@ type SQLServerSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLServerSource.
@@ -22922,7 +24531,15 @@ type SQLServerStoredProcedureActivityTypeProperties struct {
 	StoredProcedureName interface{} `json:"storedProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SQLServerStoredProcedureActivityTypeProperties.
+func (s SQLServerStoredProcedureActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "storedProcedureName", s.StoredProcedureName)
+	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
+	return json.Marshal(objectMap)
 }
 
 // SQLServerTableDataset - The on-premises SQL Server dataset.
@@ -22984,7 +24601,7 @@ type SQLSink struct {
 	SQLWriterTableType interface{} `json:"sqlWriterTableType,omitempty"`
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
 	StoredProcedureTableTypeParameterName interface{} `json:"storedProcedureTableTypeParameterName,omitempty"`
@@ -23051,7 +24668,7 @@ type SQLSource struct {
 	SQLReaderStoredProcedureName interface{} `json:"sqlReaderStoredProcedureName,omitempty"`
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters *map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type SQLSource.
@@ -23099,6 +24716,15 @@ type SSISAccessCredential struct {
 
 	// UseName for windows authentication.
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SSISAccessCredential.
+func (s SSISAccessCredential) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "domain", s.Domain)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SSISAccessCredential.
@@ -23199,7 +24825,7 @@ type SSISPackageLocationTypeProperties struct {
 	AccessCredential *SSISAccessCredential `json:"accessCredential,omitempty"`
 
 	// The embedded child package list.
-	ChildPackages *[]*SSISChildPackage `json:"childPackages,omitempty"`
+	ChildPackages []*SSISChildPackage `json:"childPackages,omitempty"`
 
 	// The configuration file of the package execution. Type: string (or Expression with resultType string).
 	ConfigurationPath interface{} `json:"configurationPath,omitempty"`
@@ -23215,6 +24841,19 @@ type SSISPackageLocationTypeProperties struct {
 
 	// Password of the package.
 	PackagePassword SecretBaseClassification `json:"packagePassword,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SSISPackageLocationTypeProperties.
+func (s SSISPackageLocationTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessCredential", s.AccessCredential)
+	populate(objectMap, "childPackages", s.ChildPackages)
+	populate(objectMap, "configurationPath", s.ConfigurationPath)
+	populate(objectMap, "packageContent", s.PackageContent)
+	populate(objectMap, "packageLastModifiedDate", s.PackageLastModifiedDate)
+	populate(objectMap, "packageName", s.PackageName)
+	populate(objectMap, "packagePassword", s.PackagePassword)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SSISPackageLocationTypeProperties.
@@ -23319,6 +24958,17 @@ type SalesforceLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SalesforceLinkedServiceTypeProperties.
+func (s SalesforceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "environmentUrl", s.EnvironmentURL)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "securityToken", s.SecurityToken)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SalesforceLinkedServiceTypeProperties.
 func (s *SalesforceLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -23408,6 +25058,18 @@ type SalesforceMarketingCloudLinkedServiceTypeProperties struct {
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true. Type: boolean (or Expression with resultType
 	// boolean).
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SalesforceMarketingCloudLinkedServiceTypeProperties.
+func (s SalesforceMarketingCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "clientSecret", s.ClientSecret)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", s.UseHostVerification)
+	populate(objectMap, "usePeerVerification", s.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SalesforceMarketingCloudLinkedServiceTypeProperties.
@@ -23609,6 +25271,18 @@ type SalesforceServiceCloudLinkedServiceTypeProperties struct {
 
 	// The username for Basic authentication of the Salesforce instance. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SalesforceServiceCloudLinkedServiceTypeProperties.
+func (s SalesforceServiceCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "environmentUrl", s.EnvironmentURL)
+	populate(objectMap, "extendedProperties", s.ExtendedProperties)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "securityToken", s.SecurityToken)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SalesforceServiceCloudLinkedServiceTypeProperties.
@@ -23929,6 +25603,18 @@ type SapBWLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SapBWLinkedServiceTypeProperties.
+func (s SapBWLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "server", s.Server)
+	populate(objectMap, "systemNumber", s.SystemNumber)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapBWLinkedServiceTypeProperties.
 func (s *SapBWLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -24059,6 +25745,16 @@ type SapCloudForCustomerLinkedServiceTypeProperties struct {
 
 	// The username for Basic authentication. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SapCloudForCustomerLinkedServiceTypeProperties.
+func (s SapCloudForCustomerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "url", s.URL)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapCloudForCustomerLinkedServiceTypeProperties.
@@ -24249,6 +25945,16 @@ type SapEccLinkedServiceTypeProperties struct {
 	Username *string `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SapEccLinkedServiceTypeProperties.
+func (s SapEccLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "url", s.URL)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapEccLinkedServiceTypeProperties.
 func (s *SapEccLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -24406,6 +26112,18 @@ type SapHanaLinkedServiceProperties struct {
 
 	// Username to access the SAP HANA server. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SapHanaLinkedServiceProperties.
+func (s SapHanaLinkedServiceProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", s.AuthenticationType)
+	populate(objectMap, "connectionString", s.ConnectionString)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "server", s.Server)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapHanaLinkedServiceProperties.
@@ -24606,6 +26324,19 @@ type SapOpenHubLinkedServiceTypeProperties struct {
 
 	// Username to access the SAP BW server where the open hub destination is located. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SapOpenHubLinkedServiceTypeProperties.
+func (s SapOpenHubLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "language", s.Language)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "server", s.Server)
+	populate(objectMap, "systemNumber", s.SystemNumber)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapOpenHubLinkedServiceTypeProperties.
@@ -24824,6 +26555,28 @@ type SapTableLinkedServiceTypeProperties struct {
 
 	// Username to access the SAP server where the table is located. Type: string (or Expression with resultType string).
 	UserName interface{} `json:"userName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SapTableLinkedServiceTypeProperties.
+func (s SapTableLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "language", s.Language)
+	populate(objectMap, "logonGroup", s.LogonGroup)
+	populate(objectMap, "messageServer", s.MessageServer)
+	populate(objectMap, "messageServerService", s.MessageServerService)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "server", s.Server)
+	populate(objectMap, "sncLibraryPath", s.SncLibraryPath)
+	populate(objectMap, "sncMode", s.SncMode)
+	populate(objectMap, "sncMyName", s.SncMyName)
+	populate(objectMap, "sncPartnerName", s.SncPartnerName)
+	populate(objectMap, "sncQop", s.SncQop)
+	populate(objectMap, "systemId", s.SystemID)
+	populate(objectMap, "systemNumber", s.SystemNumber)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SapTableLinkedServiceTypeProperties.
@@ -25069,7 +26822,7 @@ func (s *ScheduleTrigger) UnmarshalJSON(data []byte) error {
 // ScheduleTriggerRecurrence - The workflow trigger recurrence.
 type ScheduleTriggerRecurrence struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The end time.
 	EndTime *time.Time `json:"endTime,omitempty"`
@@ -25100,7 +26853,7 @@ func (s ScheduleTriggerRecurrence) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "startTime", (*timeRFC3339)(s.StartTime))
 	populate(objectMap, "timeZone", s.TimeZone)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -25140,12 +26893,12 @@ func (s *ScheduleTriggerRecurrence) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -25341,6 +27094,13 @@ type SelfHostedIntegrationRuntimeTypeProperties struct {
 	LinkedInfo LinkedIntegrationRuntimeTypeClassification `json:"linkedInfo,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SelfHostedIntegrationRuntimeTypeProperties.
+func (s SelfHostedIntegrationRuntimeTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "linkedInfo", s.LinkedInfo)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SelfHostedIntegrationRuntimeTypeProperties.
 func (s *SelfHostedIntegrationRuntimeTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -25428,6 +27188,22 @@ type ServiceNowLinkedServiceTypeProperties struct {
 
 	// The user name used to connect to the ServiceNow server for Basic and OAuth2 authentication.
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ServiceNowLinkedServiceTypeProperties.
+func (s ServiceNowLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", s.AuthenticationType)
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "clientSecret", s.ClientSecret)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "endpoint", s.Endpoint)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", s.UseHostVerification)
+	populate(objectMap, "usePeerVerification", s.UsePeerVerification)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ServiceNowLinkedServiceTypeProperties.
@@ -25738,6 +27514,23 @@ type SftpServerLinkedServiceTypeProperties struct {
 	UserName interface{} `json:"userName,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SftpServerLinkedServiceTypeProperties.
+func (s SftpServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", s.AuthenticationType)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "host", s.Host)
+	populate(objectMap, "hostKeyFingerprint", s.HostKeyFingerprint)
+	populate(objectMap, "passPhrase", s.PassPhrase)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "port", s.Port)
+	populate(objectMap, "privateKeyContent", s.PrivateKeyContent)
+	populate(objectMap, "privateKeyPath", s.PrivateKeyPath)
+	populate(objectMap, "skipHostKeyValidation", s.SkipHostKeyValidation)
+	populate(objectMap, "userName", s.UserName)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SftpServerLinkedServiceTypeProperties.
 func (s *SftpServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -25879,6 +27672,18 @@ type ShopifyLinkedServiceTypeProperties struct {
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ShopifyLinkedServiceTypeProperties.
+func (s ShopifyLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", s.AccessToken)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "host", s.Host)
+	populate(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", s.UseHostVerification)
+	populate(objectMap, "usePeerVerification", s.UsePeerVerification)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type ShopifyLinkedServiceTypeProperties.
 func (s *ShopifyLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -25987,13 +27792,13 @@ type SparkBatchJob struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// The detailed application info.
-	AppInfo *map[string]*string `json:"appInfo,omitempty"`
+	AppInfo map[string]*string `json:"appInfo,omitempty"`
 
 	// The artifact identifier.
 	ArtifactID *string `json:"artifactId,omitempty"`
 
 	// The error information.
-	Errors *[]*SparkServiceError `json:"errorInfo,omitempty"`
+	Errors []*SparkServiceError `json:"errorInfo,omitempty"`
 
 	// The session Id.
 	ID *int32 `json:"id,omitempty"`
@@ -26003,7 +27808,7 @@ type SparkBatchJob struct {
 	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
 
 	// The log lines.
-	LogLines *[]*string `json:"log,omitempty"`
+	LogLines []*string `json:"log,omitempty"`
 
 	// The batch name.
 	Name *string `json:"name,omitempty"`
@@ -26030,10 +27835,34 @@ type SparkBatchJob struct {
 	SubmitterName *string `json:"submitterName,omitempty"`
 
 	// The tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// The workspace name.
 	WorkspaceName *string `json:"workspaceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkBatchJob.
+func (s SparkBatchJob) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appId", s.AppID)
+	populate(objectMap, "appInfo", s.AppInfo)
+	populate(objectMap, "artifactId", s.ArtifactID)
+	populate(objectMap, "errorInfo", s.Errors)
+	populate(objectMap, "id", s.ID)
+	populate(objectMap, "jobType", s.JobType)
+	populate(objectMap, "livyInfo", s.LivyInfo)
+	populate(objectMap, "log", s.LogLines)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pluginInfo", s.Plugin)
+	populate(objectMap, "result", s.Result)
+	populate(objectMap, "schedulerInfo", s.Scheduler)
+	populate(objectMap, "sparkPoolName", s.SparkPoolName)
+	populate(objectMap, "state", s.State)
+	populate(objectMap, "submitterId", s.SubmitterID)
+	populate(objectMap, "submitterName", s.SubmitterName)
+	populate(objectMap, "tags", s.Tags)
+	populate(objectMap, "workspaceName", s.WorkspaceName)
+	return json.Marshal(objectMap)
 }
 
 // SparkBatchJobPollerResponse is the response envelope for operations that asynchronously return a SparkBatchJob type.
@@ -26170,7 +27999,7 @@ type SparkDatasetTypeProperties struct {
 // SparkJobDefinition - Spark job definition.
 type SparkJobDefinition struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The description of the Spark job definition.
 	Description *string `json:"description,omitempty"`
@@ -26197,7 +28026,7 @@ func (s SparkJobDefinition) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "requiredSparkVersion", s.RequiredSparkVersion)
 	populate(objectMap, "targetBigDataPool", s.TargetBigDataPool)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -26230,12 +28059,12 @@ func (s *SparkJobDefinition) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -26294,6 +28123,33 @@ type SparkJobDefinitionResource struct {
 	Properties *SparkJobDefinition `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SparkJobDefinitionResource.
+func (s SparkJobDefinitionResource) MarshalJSON() ([]byte, error) {
+	objectMap := s.SubResource.marshalInternal()
+	populate(objectMap, "properties", s.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SparkJobDefinitionResource.
+func (s *SparkJobDefinitionResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			err = unpopulate(val, &s.Properties)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return s.SubResource.unmarshalInternal(rawMsg)
+}
+
 // SparkJobDefinitionResourcePollerResponse is the response envelope for operations that asynchronously return a SparkJobDefinitionResource type.
 type SparkJobDefinitionResourcePollerResponse struct {
 	// PollUntilDone will poll the service endpoint until a terminal state is reached or an error is received
@@ -26321,7 +28177,15 @@ type SparkJobDefinitionsListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of spark job definitions.
-	Value *[]*SparkJobDefinitionResource `json:"value,omitempty"`
+	Value []*SparkJobDefinitionResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkJobDefinitionsListResponse.
+func (s SparkJobDefinitionsListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", s.NextLink)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // SparkJobDefinitionsListResponseResponse is the response envelope for operations that return a SparkJobDefinitionsListResponse type.
@@ -26336,13 +28200,13 @@ type SparkJobDefinitionsListResponseResponse struct {
 // SparkJobProperties - The properties of the Spark job.
 type SparkJobProperties struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Archives to be used in this job.
-	Archives *[]*string `json:"archives,omitempty"`
+	Archives []*string `json:"archives,omitempty"`
 
 	// Command line arguments for the application.
-	Args *[]*string `json:"args,omitempty"`
+	Args []*string `json:"args,omitempty"`
 
 	// Main class for Java/Scala application.
 	ClassName *string `json:"className,omitempty"`
@@ -26366,10 +28230,10 @@ type SparkJobProperties struct {
 	File *string `json:"file,omitempty"`
 
 	// files to be used in this job.
-	Files *[]*string `json:"files,omitempty"`
+	Files []*string `json:"files,omitempty"`
 
 	// Jars to be used in this job.
-	Jars *[]*string `json:"jars,omitempty"`
+	Jars []*string `json:"jars,omitempty"`
 
 	// The name of the job.
 	Name *string `json:"name,omitempty"`
@@ -26395,7 +28259,7 @@ func (s SparkJobProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "name", s.Name)
 	populate(objectMap, "numExecutors", s.NumExecutors)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -26452,12 +28316,12 @@ func (s *SparkJobProperties) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -26548,6 +28412,26 @@ type SparkLinkedServiceTypeProperties struct {
 
 	// The user name that you use to access Spark Server.
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkLinkedServiceTypeProperties.
+func (s SparkLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "allowHostNameCNMismatch", s.AllowHostNameCNMismatch)
+	populate(objectMap, "allowSelfSignedServerCert", s.AllowSelfSignedServerCert)
+	populate(objectMap, "authenticationType", s.AuthenticationType)
+	populate(objectMap, "enableSsl", s.EnableSSL)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "httpPath", s.HTTPPath)
+	populate(objectMap, "host", s.Host)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "port", s.Port)
+	populate(objectMap, "serverType", s.ServerType)
+	populate(objectMap, "thriftTransportProtocol", s.ThriftTransportProtocol)
+	populate(objectMap, "trustedCertPath", s.TrustedCertPath)
+	populate(objectMap, "useSystemTrustStore", s.UseSystemTrustStore)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SparkLinkedServiceTypeProperties.
@@ -26644,22 +28528,42 @@ func (s *SparkObjectDataset) UnmarshalJSON(data []byte) error {
 }
 
 type SparkRequest struct {
-	Archives  *[]*string `json:"archives,omitempty"`
-	Arguments *[]*string `json:"args,omitempty"`
-	ClassName *string    `json:"className,omitempty"`
+	Archives  []*string `json:"archives,omitempty"`
+	Arguments []*string `json:"args,omitempty"`
+	ClassName *string   `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32              `json:"driverCores,omitempty"`
-	DriverMemory   *string             `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32              `json:"executorCores,omitempty"`
-	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
-	ExecutorMemory *string             `json:"executorMemory,omitempty"`
-	File           *string             `json:"file,omitempty"`
-	Files          *[]*string          `json:"files,omitempty"`
-	Jars           *[]*string          `json:"jars,omitempty"`
-	Name           *string             `json:"name,omitempty"`
-	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32             `json:"driverCores,omitempty"`
+	DriverMemory   *string            `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32             `json:"executorCores,omitempty"`
+	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
+	ExecutorMemory *string            `json:"executorMemory,omitempty"`
+	File           *string            `json:"file,omitempty"`
+	Files          []*string          `json:"files,omitempty"`
+	Jars           []*string          `json:"jars,omitempty"`
+	Name           *string            `json:"name,omitempty"`
+	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkRequest.
+func (s SparkRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "archives", s.Archives)
+	populate(objectMap, "args", s.Arguments)
+	populate(objectMap, "className", s.ClassName)
+	populate(objectMap, "conf", s.Configuration)
+	populate(objectMap, "driverCores", s.DriverCores)
+	populate(objectMap, "driverMemory", s.DriverMemory)
+	populate(objectMap, "executorCores", s.ExecutorCores)
+	populate(objectMap, "numExecutors", s.ExecutorCount)
+	populate(objectMap, "executorMemory", s.ExecutorMemory)
+	populate(objectMap, "file", s.File)
+	populate(objectMap, "files", s.Files)
+	populate(objectMap, "jars", s.Jars)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pyFiles", s.PythonFiles)
+	return json.Marshal(objectMap)
 }
 
 type SparkScheduler struct {
@@ -26890,6 +28794,20 @@ type SquareLinkedServiceTypeProperties struct {
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SquareLinkedServiceTypeProperties.
+func (s SquareLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "clientId", s.ClientID)
+	populate(objectMap, "clientSecret", s.ClientSecret)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "host", s.Host)
+	populate(objectMap, "redirectUri", s.RedirectURI)
+	populate(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", s.UseHostVerification)
+	populate(objectMap, "usePeerVerification", s.UsePeerVerification)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type SquareLinkedServiceTypeProperties.
 func (s *SquareLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -27017,7 +28935,7 @@ type SsisObjectMetadataStatusResponse struct {
 // StagingSettings - Staging settings.
 type StagingSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// Specifies whether to use compression when copying data via an interim staging. Default value is false. Type: boolean (or Expression with resultType boolean).
 	EnableCompression interface{} `json:"enableCompression,omitempty"`
@@ -27036,7 +28954,7 @@ func (s StagingSettings) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "path", s.Path)
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -27063,12 +28981,12 @@ func (s *StagingSettings) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -27085,7 +29003,7 @@ type StartDataFlowDebugSessionRequest struct {
 	DataFlow *DataFlowResource `json:"dataFlow,omitempty"`
 
 	// List of datasets.
-	Datasets *[]*DatasetResource `json:"datasets,omitempty"`
+	Datasets []*DatasetResource `json:"datasets,omitempty"`
 
 	// Data flow debug settings.
 	DebugSettings interface{} `json:"debugSettings,omitempty"`
@@ -27094,13 +29012,26 @@ type StartDataFlowDebugSessionRequest struct {
 	IncrementalDebug *bool `json:"incrementalDebug,omitempty"`
 
 	// List of linked services.
-	LinkedServices *[]*LinkedServiceResource `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceResource `json:"linkedServices,omitempty"`
 
 	// The ID of data flow debug session.
 	SessionID *string `json:"sessionId,omitempty"`
 
 	// Staging info for debug session.
 	Staging interface{} `json:"staging,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type StartDataFlowDebugSessionRequest.
+func (s StartDataFlowDebugSessionRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "dataFlow", s.DataFlow)
+	populate(objectMap, "datasets", s.Datasets)
+	populate(objectMap, "debugSettings", s.DebugSettings)
+	populate(objectMap, "incrementalDebug", s.IncrementalDebug)
+	populate(objectMap, "linkedServices", s.LinkedServices)
+	populate(objectMap, "sessionId", s.SessionID)
+	populate(objectMap, "staging", s.Staging)
+	return json.Marshal(objectMap)
 }
 
 // StartDataFlowDebugSessionResponse - Response body structure for starting data flow debug session.
@@ -27123,7 +29054,7 @@ type StoreReadSettingsClassification interface {
 // StoreReadSettings - Connector read setting.
 type StoreReadSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
 	MaxConcurrentConnections interface{} `json:"maxConcurrentConnections,omitempty"`
@@ -27150,7 +29081,7 @@ func (s StoreReadSettings) marshalInternal(discValue string) map[string]interfac
 	s.Type = &discValue
 	objectMap["type"] = s.Type
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -27169,12 +29100,12 @@ func (s *StoreReadSettings) unmarshalInternal(rawMsg map[string]json.RawMessage)
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -27198,7 +29129,7 @@ type StoreWriteSettingsClassification interface {
 // StoreWriteSettings - Connector write settings.
 type StoreWriteSettings struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// The type of copy behavior for copy sink.
 	CopyBehavior interface{} `json:"copyBehavior,omitempty"`
@@ -27229,7 +29160,7 @@ func (s StoreWriteSettings) marshalInternal(discValue string) map[string]interfa
 	s.Type = &discValue
 	objectMap["type"] = s.Type
 	if s.AdditionalProperties != nil {
-		for key, val := range *s.AdditionalProperties {
+		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -27251,12 +29182,12 @@ func (s *StoreWriteSettings) unmarshalInternal(rawMsg map[string]json.RawMessage
 			delete(rawMsg, key)
 		default:
 			if s.AdditionalProperties == nil {
-				s.AdditionalProperties = &map[string]interface{}{}
+				s.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*s.AdditionalProperties)[key] = aux
+				s.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -27294,6 +29225,21 @@ func (s *SubResource) unmarshalInternal(rawMsg map[string]json.RawMessage) error
 type SubResourceDebugResource struct {
 	// The resource name.
 	Name *string `json:"name,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SubResourceDebugResource.
+func (s SubResourceDebugResource) MarshalJSON() ([]byte, error) {
+	objectMap := s.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SubResourceDebugResource.
+func (s *SubResourceDebugResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	return s.unmarshalInternal(rawMsg)
 }
 
 func (s SubResourceDebugResource) marshalInternal() map[string]interface{} {
@@ -27356,14 +29302,23 @@ func (s *SwitchActivity) UnmarshalJSON(data []byte) error {
 type SwitchActivityTypeProperties struct {
 	// List of cases that correspond to expected values of the 'on' property. This is an optional property and if not provided, the activity will execute activities
 	// provided in defaultActivities.
-	Cases *[]*SwitchCase `json:"cases,omitempty"`
+	Cases []*SwitchCase `json:"cases,omitempty"`
 
 	// List of activities to execute if no case condition is satisfied. This is an optional property and if not provided, the activity will exit without any
 	// action.
-	DefaultActivities *[]ActivityClassification `json:"defaultActivities,omitempty"`
+	DefaultActivities []ActivityClassification `json:"defaultActivities,omitempty"`
 
 	// An expression that would evaluate to a string or integer. This is used to determine the block of activities in cases that will be executed.
 	On *Expression `json:"on,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SwitchActivityTypeProperties.
+func (s SwitchActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "cases", s.Cases)
+	populate(objectMap, "defaultActivities", s.DefaultActivities)
+	populate(objectMap, "on", s.On)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SwitchActivityTypeProperties.
@@ -27395,10 +29350,18 @@ func (s *SwitchActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // SwitchCase - Switch cases with have a value and corresponding activities.
 type SwitchCase struct {
 	// List of activities to execute for satisfied case condition.
-	Activities *[]ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification `json:"activities,omitempty"`
 
 	// Expected value that satisfies the expression result of the 'on' property.
 	Value *string `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SwitchCase.
+func (s SwitchCase) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activities", s.Activities)
+	populate(objectMap, "value", s.Value)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SwitchCase.
@@ -27481,6 +29444,19 @@ type SybaseLinkedServiceTypeProperties struct {
 
 	// Username for authentication. Type: string (or Expression with resultType string).
 	Username interface{} `json:"username,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SybaseLinkedServiceTypeProperties.
+func (s SybaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", s.AuthenticationType)
+	populate(objectMap, "database", s.Database)
+	populate(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populate(objectMap, "password", s.Password)
+	populate(objectMap, "schema", s.Schema)
+	populate(objectMap, "server", s.Server)
+	populate(objectMap, "username", s.Username)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type SybaseLinkedServiceTypeProperties.
@@ -27635,7 +29611,15 @@ type SynapseNotebookActivityTypeProperties struct {
 	Notebook *SynapseNotebookReference `json:"notebook,omitempty"`
 
 	// Notebook parameters.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SynapseNotebookActivityTypeProperties.
+func (s SynapseNotebookActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "notebook", s.Notebook)
+	populate(objectMap, "parameters", s.Parameters)
+	return json.Marshal(objectMap)
 }
 
 // SynapseNotebookReference - Synapse notebook reference type.
@@ -27884,6 +29868,18 @@ type TeradataLinkedServiceTypeProperties struct {
 	Username interface{} `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type TeradataLinkedServiceTypeProperties.
+func (t TeradataLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authenticationType", t.AuthenticationType)
+	populate(objectMap, "connectionString", t.ConnectionString)
+	populate(objectMap, "encryptedCredential", t.EncryptedCredential)
+	populate(objectMap, "password", t.Password)
+	populate(objectMap, "server", t.Server)
+	populate(objectMap, "username", t.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type TeradataLinkedServiceTypeProperties.
 func (t *TeradataLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -28125,7 +30121,20 @@ type TrackedResource struct {
 	Location *string `json:"location,omitempty"`
 
 	// Resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TrackedResource.
+func (t TrackedResource) MarshalJSON() ([]byte, error) {
+	objectMap := t.marshalInternal()
+	return json.Marshal(objectMap)
+}
+
+func (t TrackedResource) marshalInternal() map[string]interface{} {
+	objectMap := t.Resource.marshalInternal()
+	populate(objectMap, "location", t.Location)
+	populate(objectMap, "tags", t.Tags)
+	return objectMap
 }
 
 // Transformation - A data flow transformation.
@@ -28150,10 +30159,10 @@ type TriggerClassification interface {
 // Trigger - Azure Synapse nested object which contains information about creating pipeline run
 type Trigger struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// List of tags that can be used for describing the trigger.
-	Annotations *[]interface{} `json:"annotations,omitempty"`
+	Annotations []interface{} `json:"annotations,omitempty"`
 
 	// Trigger description.
 	Description *string `json:"description,omitempty"`
@@ -28185,7 +30194,7 @@ func (t Trigger) marshalInternal(discValue string) map[string]interface{} {
 	t.Type = &discValue
 	objectMap["type"] = t.Type
 	if t.AdditionalProperties != nil {
-		for key, val := range *t.AdditionalProperties {
+		for key, val := range t.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -28210,12 +30219,12 @@ func (t *Trigger) unmarshalInternal(rawMsg map[string]json.RawMessage) error {
 			delete(rawMsg, key)
 		default:
 			if t.AdditionalProperties == nil {
-				t.AdditionalProperties = &map[string]interface{}{}
+				t.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*t.AdditionalProperties)[key] = aux
+				t.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -28347,7 +30356,15 @@ type TriggerListResponse struct {
 	NextLink *string `json:"nextLink,omitempty"`
 
 	// List of triggers.
-	Value *[]*TriggerResource `json:"value,omitempty"`
+	Value []*TriggerResource `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TriggerListResponse.
+func (t TriggerListResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "nextLink", t.NextLink)
+	populate(objectMap, "value", t.Value)
+	return json.Marshal(objectMap)
 }
 
 // TriggerListResponseResponse is the response envelope for operations that return a TriggerListResponse type.
@@ -28362,10 +30379,18 @@ type TriggerListResponseResponse struct {
 // TriggerPipelineReference - Pipeline that needs to be triggered with the given parameters.
 type TriggerPipelineReference struct {
 	// Pipeline parameters.
-	Parameters *map[string]interface{} `json:"parameters,omitempty"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 
 	// Pipeline reference.
 	PipelineReference *PipelineReference `json:"pipelineReference,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TriggerPipelineReference.
+func (t TriggerPipelineReference) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "parameters", t.Parameters)
+	populate(objectMap, "pipelineReference", t.PipelineReference)
+	return json.Marshal(objectMap)
 }
 
 // TriggerReference - Trigger reference type.
@@ -28382,6 +30407,33 @@ type TriggerResource struct {
 	SubResource
 	// Properties of the trigger.
 	Properties TriggerClassification `json:"properties,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TriggerResource.
+func (t TriggerResource) MarshalJSON() ([]byte, error) {
+	objectMap := t.SubResource.marshalInternal()
+	populate(objectMap, "properties", t.Properties)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type TriggerResource.
+func (t *TriggerResource) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "properties":
+			t.Properties, err = unmarshalTriggerClassification(val)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return t.SubResource.unmarshalInternal(rawMsg)
 }
 
 // TriggerResourcePollerResponse is the response envelope for operations that asynchronously return a TriggerResource type.
@@ -28408,13 +30460,13 @@ type TriggerResourceResponse struct {
 // TriggerRun - Trigger runs.
 type TriggerRun struct {
 	// Contains additional key/value pairs not defined in the schema.
-	AdditionalProperties *map[string]interface{}
+	AdditionalProperties map[string]interface{}
 
 	// READ-ONLY; Trigger error message.
 	Message *string `json:"message,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of property name and value related to trigger run. Name, value pair depends on type of trigger.
-	Properties *map[string]*string `json:"properties,omitempty" azure:"ro"`
+	Properties map[string]*string `json:"properties,omitempty" azure:"ro"`
 
 	// READ-ONLY; Trigger run status.
 	Status *TriggerRunStatus `json:"status,omitempty" azure:"ro"`
@@ -28432,7 +30484,7 @@ type TriggerRun struct {
 	TriggerType *string `json:"triggerType,omitempty" azure:"ro"`
 
 	// READ-ONLY; List of pipeline name and run Id triggered by the trigger run.
-	TriggeredPipelines *map[string]*string `json:"triggeredPipelines,omitempty" azure:"ro"`
+	TriggeredPipelines map[string]*string `json:"triggeredPipelines,omitempty" azure:"ro"`
 }
 
 // MarshalJSON implements the json.Marshaller interface for type TriggerRun.
@@ -28447,7 +30499,7 @@ func (t TriggerRun) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "triggerType", t.TriggerType)
 	populate(objectMap, "triggeredPipelines", t.TriggeredPipelines)
 	if t.AdditionalProperties != nil {
-		for key, val := range *t.AdditionalProperties {
+		for key, val := range t.AdditionalProperties {
 			objectMap[key] = val
 		}
 	}
@@ -28491,12 +30543,12 @@ func (t *TriggerRun) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		default:
 			if t.AdditionalProperties == nil {
-				t.AdditionalProperties = &map[string]interface{}{}
+				t.AdditionalProperties = map[string]interface{}{}
 			}
 			if val != nil {
 				var aux interface{}
 				err = json.Unmarshal(val, &aux)
-				(*t.AdditionalProperties)[key] = aux
+				t.AdditionalProperties[key] = aux
 			}
 			delete(rawMsg, key)
 		}
@@ -28528,7 +30580,15 @@ type TriggerRunsQueryResponse struct {
 	ContinuationToken *string `json:"continuationToken,omitempty"`
 
 	// List of trigger runs.
-	Value *[]*TriggerRun `json:"value,omitempty"`
+	Value []*TriggerRun `json:"value,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TriggerRunsQueryResponse.
+func (t TriggerRunsQueryResponse) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "continuationToken", t.ContinuationToken)
+	populate(objectMap, "value", t.Value)
+	return json.Marshal(objectMap)
 }
 
 // TriggerRunsQueryResponseResponse is the response envelope for operations that return a TriggerRunsQueryResponse type.
@@ -28662,7 +30722,7 @@ type TumblingWindowTriggerTypeProperties struct {
 	Delay interface{} `json:"delay,omitempty"`
 
 	// Triggers that this trigger depends on. Only tumbling window triggers are supported.
-	DependsOn *[]DependencyReferenceClassification `json:"dependsOn,omitempty"`
+	DependsOn []DependencyReferenceClassification `json:"dependsOn,omitempty"`
 
 	// The end time for the time period for the trigger during which events are fired for windows that are ready. Only UTC time is currently supported.
 	EndTime *time.Time `json:"endTime,omitempty"`
@@ -28779,7 +30839,7 @@ func (u *UntilActivity) UnmarshalJSON(data []byte) error {
 // UntilActivityTypeProperties - Until activity properties.
 type UntilActivityTypeProperties struct {
 	// List of activities to execute.
-	Activities *[]ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification `json:"activities,omitempty"`
 
 	// An expression that would evaluate to Boolean. The loop will continue until this expression evaluates to true
 	Expression *Expression `json:"expression,omitempty"`
@@ -28788,6 +30848,15 @@ type UntilActivityTypeProperties struct {
 	// Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])). Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
 	Timeout interface{} `json:"timeout,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type UntilActivityTypeProperties.
+func (u UntilActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "activities", u.Activities)
+	populate(objectMap, "expression", u.Expression)
+	populate(objectMap, "timeout", u.Timeout)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type UntilActivityTypeProperties.
@@ -29116,6 +31185,17 @@ type WebActivityAuthentication struct {
 	Username *string `json:"username,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type WebActivityAuthentication.
+func (w WebActivityAuthentication) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "password", w.Password)
+	populate(objectMap, "pfx", w.Pfx)
+	populate(objectMap, "resource", w.Resource)
+	populate(objectMap, "type", w.Type)
+	populate(objectMap, "username", w.Username)
+	return json.Marshal(objectMap)
+}
+
 // UnmarshalJSON implements the json.Unmarshaller interface for type WebActivityAuthentication.
 func (w *WebActivityAuthentication) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
@@ -29161,7 +31241,7 @@ type WebActivityTypeProperties struct {
 	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
 
 	// List of datasets passed to web endpoint.
-	Datasets *[]*DatasetReference `json:"datasets,omitempty"`
+	Datasets []*DatasetReference `json:"datasets,omitempty"`
 
 	// Represents the headers that will be sent to the request. For example, to set the language and type on a request: "headers" : { "Accept-Language": "en-us",
 	// "Content-Type": "application/json" }. Type:
@@ -29169,13 +31249,27 @@ type WebActivityTypeProperties struct {
 	Headers interface{} `json:"headers,omitempty"`
 
 	// List of linked services passed to web endpoint.
-	LinkedServices *[]*LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceReference `json:"linkedServices,omitempty"`
 
 	// Rest API method for target endpoint.
 	Method *WebActivityMethod `json:"method,omitempty"`
 
 	// Web activity target endpoint and path. Type: string (or Expression with resultType string).
 	URL interface{} `json:"url,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WebActivityTypeProperties.
+func (w WebActivityTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "authentication", w.Authentication)
+	populate(objectMap, "body", w.Body)
+	populate(objectMap, "connectVia", w.ConnectVia)
+	populate(objectMap, "datasets", w.Datasets)
+	populate(objectMap, "headers", w.Headers)
+	populate(objectMap, "linkedServices", w.LinkedServices)
+	populate(objectMap, "method", w.Method)
+	populate(objectMap, "url", w.URL)
+	return json.Marshal(objectMap)
 }
 
 // WebAnonymousAuthentication - A WebLinkedService that uses anonymous authentication to communicate with an HTTP endpoint.
@@ -29493,6 +31587,14 @@ type Workspace struct {
 	Properties *WorkspaceProperties `json:"properties,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaller interface for type Workspace.
+func (w Workspace) MarshalJSON() ([]byte, error) {
+	objectMap := w.TrackedResource.marshalInternal()
+	populate(objectMap, "identity", w.Identity)
+	populate(objectMap, "properties", w.Properties)
+	return json.Marshal(objectMap)
+}
+
 // WorkspaceGetOptions contains the optional parameters for the Workspace.Get method.
 type WorkspaceGetOptions struct {
 	// placeholder for future optional parameters
@@ -29531,7 +31633,7 @@ type WorkspaceProperties struct {
 	AdlaResourceID *string `json:"adlaResourceId,omitempty" azure:"ro"`
 
 	// Connectivity endpoints
-	ConnectivityEndpoints *map[string]*string `json:"connectivityEndpoints,omitempty"`
+	ConnectivityEndpoints map[string]*string `json:"connectivityEndpoints,omitempty"`
 
 	// Workspace default data lake storage account details
 	DefaultDataLakeStorage *DataLakeStorageAccountDetails `json:"defaultDataLakeStorage,omitempty"`
@@ -29540,7 +31642,7 @@ type WorkspaceProperties struct {
 	Encryption *EncryptionDetails `json:"encryption,omitempty"`
 
 	// READ-ONLY; Workspace level configs and feature flags
-	ExtraProperties *map[string]interface{} `json:"extraProperties,omitempty" azure:"ro"`
+	ExtraProperties map[string]interface{} `json:"extraProperties,omitempty" azure:"ro"`
 
 	// Workspace managed resource group. The resource group name uniquely identifies the resource group within the user subscriptionId. The resource group name
 	// must be no longer than 90 characters long, and
@@ -29554,7 +31656,7 @@ type WorkspaceProperties struct {
 	ManagedVirtualNetworkSettings *ManagedVirtualNetworkSettings `json:"managedVirtualNetworkSettings,omitempty"`
 
 	// Private endpoint connections to the workspace
-	PrivateEndpointConnections *[]*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	PrivateEndpointConnections []*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
 
 	// READ-ONLY; Resource provisioning state
 	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
@@ -29576,6 +31678,28 @@ type WorkspaceProperties struct {
 
 	// READ-ONLY; The workspace unique identifier
 	WorkspaceUID *string `json:"workspaceUID,omitempty" azure:"ro"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WorkspaceProperties.
+func (w WorkspaceProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "adlaResourceId", w.AdlaResourceID)
+	populate(objectMap, "connectivityEndpoints", w.ConnectivityEndpoints)
+	populate(objectMap, "defaultDataLakeStorage", w.DefaultDataLakeStorage)
+	populate(objectMap, "encryption", w.Encryption)
+	populate(objectMap, "extraProperties", w.ExtraProperties)
+	populate(objectMap, "managedResourceGroupName", w.ManagedResourceGroupName)
+	populate(objectMap, "managedVirtualNetwork", w.ManagedVirtualNetwork)
+	populate(objectMap, "managedVirtualNetworkSettings", w.ManagedVirtualNetworkSettings)
+	populate(objectMap, "privateEndpointConnections", w.PrivateEndpointConnections)
+	populate(objectMap, "provisioningState", w.ProvisioningState)
+	populate(objectMap, "purviewConfiguration", w.PurviewConfiguration)
+	populate(objectMap, "sqlAdministratorLogin", w.SQLAdministratorLogin)
+	populate(objectMap, "sqlAdministratorLoginPassword", w.SQLAdministratorLoginPassword)
+	populate(objectMap, "virtualNetworkProfile", w.VirtualNetworkProfile)
+	populate(objectMap, "workspaceRepositoryConfiguration", w.WorkspaceRepositoryConfiguration)
+	populate(objectMap, "workspaceUID", w.WorkspaceUID)
+	return json.Marshal(objectMap)
 }
 
 // WorkspaceRepositoryConfiguration - Git integration settings
@@ -29623,7 +31747,15 @@ type WorkspaceUpdateParameters struct {
 	Identity *WorkspaceIdentity `json:"identity,omitempty"`
 
 	// The resource tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type WorkspaceUpdateParameters.
+func (w WorkspaceUpdateParameters) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "identity", w.Identity)
+	populate(objectMap, "tags", w.Tags)
+	return json.Marshal(objectMap)
 }
 
 // XeroLinkedService - Xero Service linked service.
@@ -29685,6 +31817,19 @@ type XeroLinkedServiceTypeProperties struct {
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type XeroLinkedServiceTypeProperties.
+func (x XeroLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "consumerKey", x.ConsumerKey)
+	populate(objectMap, "encryptedCredential", x.EncryptedCredential)
+	populate(objectMap, "host", x.Host)
+	populate(objectMap, "privateKey", x.PrivateKey)
+	populate(objectMap, "useEncryptedEndpoints", x.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", x.UseHostVerification)
+	populate(objectMap, "usePeerVerification", x.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type XeroLinkedServiceTypeProperties.
@@ -29848,6 +31993,18 @@ type ZohoLinkedServiceTypeProperties struct {
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
 	UsePeerVerification interface{} `json:"usePeerVerification,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type ZohoLinkedServiceTypeProperties.
+func (z ZohoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "accessToken", z.AccessToken)
+	populate(objectMap, "encryptedCredential", z.EncryptedCredential)
+	populate(objectMap, "endpoint", z.Endpoint)
+	populate(objectMap, "useEncryptedEndpoints", z.UseEncryptedEndpoints)
+	populate(objectMap, "useHostVerification", z.UseHostVerification)
+	populate(objectMap, "usePeerVerification", z.UsePeerVerification)
+	return json.Marshal(objectMap)
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type ZohoLinkedServiceTypeProperties.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
@@ -103,7 +103,7 @@ func unmarshalActivityClassification(rawMsg json.RawMessage) (ActivityClassifica
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalActivityClassificationArray(rawMsg json.RawMessage) (*[]ActivityClassification, error) {
+func unmarshalActivityClassificationArray(rawMsg json.RawMessage) ([]ActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -119,7 +119,7 @@ func unmarshalActivityClassificationArray(rawMsg json.RawMessage) (*[]ActivityCl
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalControlActivityClassification(rawMsg json.RawMessage) (ControlActivityClassification, error) {
@@ -160,7 +160,7 @@ func unmarshalControlActivityClassification(rawMsg json.RawMessage) (ControlActi
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalControlActivityClassificationArray(rawMsg json.RawMessage) (*[]ControlActivityClassification, error) {
+func unmarshalControlActivityClassificationArray(rawMsg json.RawMessage) ([]ControlActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -176,7 +176,7 @@ func unmarshalControlActivityClassificationArray(rawMsg json.RawMessage) (*[]Con
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalCopySinkClassification(rawMsg json.RawMessage) (CopySinkClassification, error) {
@@ -263,7 +263,7 @@ func unmarshalCopySinkClassification(rawMsg json.RawMessage) (CopySinkClassifica
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalCopySinkClassificationArray(rawMsg json.RawMessage) (*[]CopySinkClassification, error) {
+func unmarshalCopySinkClassificationArray(rawMsg json.RawMessage) ([]CopySinkClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -279,7 +279,7 @@ func unmarshalCopySinkClassificationArray(rawMsg json.RawMessage) (*[]CopySinkCl
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalCopySourceClassification(rawMsg json.RawMessage) (CopySourceClassification, error) {
@@ -472,7 +472,7 @@ func unmarshalCopySourceClassification(rawMsg json.RawMessage) (CopySourceClassi
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalCopySourceClassificationArray(rawMsg json.RawMessage) (*[]CopySourceClassification, error) {
+func unmarshalCopySourceClassificationArray(rawMsg json.RawMessage) ([]CopySourceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -488,7 +488,7 @@ func unmarshalCopySourceClassificationArray(rawMsg json.RawMessage) (*[]CopySour
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalCopyTranslatorClassification(rawMsg json.RawMessage) (CopyTranslatorClassification, error) {
@@ -509,7 +509,7 @@ func unmarshalCopyTranslatorClassification(rawMsg json.RawMessage) (CopyTranslat
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalCopyTranslatorClassificationArray(rawMsg json.RawMessage) (*[]CopyTranslatorClassification, error) {
+func unmarshalCopyTranslatorClassificationArray(rawMsg json.RawMessage) ([]CopyTranslatorClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -525,7 +525,7 @@ func unmarshalCopyTranslatorClassificationArray(rawMsg json.RawMessage) (*[]Copy
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalCustomSetupBaseClassification(rawMsg json.RawMessage) (CustomSetupBaseClassification, error) {
@@ -544,7 +544,7 @@ func unmarshalCustomSetupBaseClassification(rawMsg json.RawMessage) (CustomSetup
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalCustomSetupBaseClassificationArray(rawMsg json.RawMessage) (*[]CustomSetupBaseClassification, error) {
+func unmarshalCustomSetupBaseClassificationArray(rawMsg json.RawMessage) ([]CustomSetupBaseClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -560,7 +560,7 @@ func unmarshalCustomSetupBaseClassificationArray(rawMsg json.RawMessage) (*[]Cus
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDataFlowClassification(rawMsg json.RawMessage) (DataFlowClassification, error) {
@@ -581,7 +581,7 @@ func unmarshalDataFlowClassification(rawMsg json.RawMessage) (DataFlowClassifica
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDataFlowClassificationArray(rawMsg json.RawMessage) (*[]DataFlowClassification, error) {
+func unmarshalDataFlowClassificationArray(rawMsg json.RawMessage) ([]DataFlowClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -597,7 +597,7 @@ func unmarshalDataFlowClassificationArray(rawMsg json.RawMessage) (*[]DataFlowCl
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDatasetClassification(rawMsg json.RawMessage) (DatasetClassification, error) {
@@ -778,7 +778,7 @@ func unmarshalDatasetClassification(rawMsg json.RawMessage) (DatasetClassificati
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDatasetClassificationArray(rawMsg json.RawMessage) (*[]DatasetClassification, error) {
+func unmarshalDatasetClassificationArray(rawMsg json.RawMessage) ([]DatasetClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -794,7 +794,7 @@ func unmarshalDatasetClassificationArray(rawMsg json.RawMessage) (*[]DatasetClas
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDatasetCompressionClassification(rawMsg json.RawMessage) (DatasetCompressionClassification, error) {
@@ -821,7 +821,7 @@ func unmarshalDatasetCompressionClassification(rawMsg json.RawMessage) (DatasetC
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDatasetCompressionClassificationArray(rawMsg json.RawMessage) (*[]DatasetCompressionClassification, error) {
+func unmarshalDatasetCompressionClassificationArray(rawMsg json.RawMessage) ([]DatasetCompressionClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -837,7 +837,7 @@ func unmarshalDatasetCompressionClassificationArray(rawMsg json.RawMessage) (*[]
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDatasetLocationClassification(rawMsg json.RawMessage) (DatasetLocationClassification, error) {
@@ -878,7 +878,7 @@ func unmarshalDatasetLocationClassification(rawMsg json.RawMessage) (DatasetLoca
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDatasetLocationClassificationArray(rawMsg json.RawMessage) (*[]DatasetLocationClassification, error) {
+func unmarshalDatasetLocationClassificationArray(rawMsg json.RawMessage) ([]DatasetLocationClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -894,7 +894,7 @@ func unmarshalDatasetLocationClassificationArray(rawMsg json.RawMessage) (*[]Dat
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDatasetStorageFormatClassification(rawMsg json.RawMessage) (DatasetStorageFormatClassification, error) {
@@ -923,7 +923,7 @@ func unmarshalDatasetStorageFormatClassification(rawMsg json.RawMessage) (Datase
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDatasetStorageFormatClassificationArray(rawMsg json.RawMessage) (*[]DatasetStorageFormatClassification, error) {
+func unmarshalDatasetStorageFormatClassificationArray(rawMsg json.RawMessage) ([]DatasetStorageFormatClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -939,7 +939,7 @@ func unmarshalDatasetStorageFormatClassificationArray(rawMsg json.RawMessage) (*
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalDependencyReferenceClassification(rawMsg json.RawMessage) (DependencyReferenceClassification, error) {
@@ -964,7 +964,7 @@ func unmarshalDependencyReferenceClassification(rawMsg json.RawMessage) (Depende
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalDependencyReferenceClassificationArray(rawMsg json.RawMessage) (*[]DependencyReferenceClassification, error) {
+func unmarshalDependencyReferenceClassificationArray(rawMsg json.RawMessage) ([]DependencyReferenceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -980,7 +980,7 @@ func unmarshalDependencyReferenceClassificationArray(rawMsg json.RawMessage) (*[
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalExecutionActivityClassification(rawMsg json.RawMessage) (ExecutionActivityClassification, error) {
@@ -1049,7 +1049,7 @@ func unmarshalExecutionActivityClassification(rawMsg json.RawMessage) (Execution
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalExecutionActivityClassificationArray(rawMsg json.RawMessage) (*[]ExecutionActivityClassification, error) {
+func unmarshalExecutionActivityClassificationArray(rawMsg json.RawMessage) ([]ExecutionActivityClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1065,7 +1065,7 @@ func unmarshalExecutionActivityClassificationArray(rawMsg json.RawMessage) (*[]E
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalFormatReadSettingsClassification(rawMsg json.RawMessage) (FormatReadSettingsClassification, error) {
@@ -1086,7 +1086,7 @@ func unmarshalFormatReadSettingsClassification(rawMsg json.RawMessage) (FormatRe
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalFormatReadSettingsClassificationArray(rawMsg json.RawMessage) (*[]FormatReadSettingsClassification, error) {
+func unmarshalFormatReadSettingsClassificationArray(rawMsg json.RawMessage) ([]FormatReadSettingsClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1102,7 +1102,7 @@ func unmarshalFormatReadSettingsClassificationArray(rawMsg json.RawMessage) (*[]
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalFormatWriteSettingsClassification(rawMsg json.RawMessage) (FormatWriteSettingsClassification, error) {
@@ -1127,7 +1127,7 @@ func unmarshalFormatWriteSettingsClassification(rawMsg json.RawMessage) (FormatW
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalFormatWriteSettingsClassificationArray(rawMsg json.RawMessage) (*[]FormatWriteSettingsClassification, error) {
+func unmarshalFormatWriteSettingsClassificationArray(rawMsg json.RawMessage) ([]FormatWriteSettingsClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1143,7 +1143,7 @@ func unmarshalFormatWriteSettingsClassificationArray(rawMsg json.RawMessage) (*[
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalIntegrationRuntimeClassification(rawMsg json.RawMessage) (IntegrationRuntimeClassification, error) {
@@ -1166,7 +1166,7 @@ func unmarshalIntegrationRuntimeClassification(rawMsg json.RawMessage) (Integrat
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalIntegrationRuntimeClassificationArray(rawMsg json.RawMessage) (*[]IntegrationRuntimeClassification, error) {
+func unmarshalIntegrationRuntimeClassificationArray(rawMsg json.RawMessage) ([]IntegrationRuntimeClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1182,7 +1182,7 @@ func unmarshalIntegrationRuntimeClassificationArray(rawMsg json.RawMessage) (*[]
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalLinkedIntegrationRuntimeTypeClassification(rawMsg json.RawMessage) (LinkedIntegrationRuntimeTypeClassification, error) {
@@ -1205,7 +1205,7 @@ func unmarshalLinkedIntegrationRuntimeTypeClassification(rawMsg json.RawMessage)
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalLinkedIntegrationRuntimeTypeClassificationArray(rawMsg json.RawMessage) (*[]LinkedIntegrationRuntimeTypeClassification, error) {
+func unmarshalLinkedIntegrationRuntimeTypeClassificationArray(rawMsg json.RawMessage) ([]LinkedIntegrationRuntimeTypeClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1221,7 +1221,7 @@ func unmarshalLinkedIntegrationRuntimeTypeClassificationArray(rawMsg json.RawMes
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalLinkedServiceClassification(rawMsg json.RawMessage) (LinkedServiceClassification, error) {
@@ -1428,7 +1428,7 @@ func unmarshalLinkedServiceClassification(rawMsg json.RawMessage) (LinkedService
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalLinkedServiceClassificationArray(rawMsg json.RawMessage) (*[]LinkedServiceClassification, error) {
+func unmarshalLinkedServiceClassificationArray(rawMsg json.RawMessage) ([]LinkedServiceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1444,7 +1444,7 @@ func unmarshalLinkedServiceClassificationArray(rawMsg json.RawMessage) (*[]Linke
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalMultiplePipelineTriggerClassification(rawMsg json.RawMessage) (MultiplePipelineTriggerClassification, error) {
@@ -1469,7 +1469,7 @@ func unmarshalMultiplePipelineTriggerClassification(rawMsg json.RawMessage) (Mul
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg json.RawMessage) (*[]MultiplePipelineTriggerClassification, error) {
+func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg json.RawMessage) ([]MultiplePipelineTriggerClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1485,7 +1485,7 @@ func unmarshalMultiplePipelineTriggerClassificationArray(rawMsg json.RawMessage)
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalSecretBaseClassification(rawMsg json.RawMessage) (SecretBaseClassification, error) {
@@ -1508,7 +1508,7 @@ func unmarshalSecretBaseClassification(rawMsg json.RawMessage) (SecretBaseClassi
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalSecretBaseClassificationArray(rawMsg json.RawMessage) (*[]SecretBaseClassification, error) {
+func unmarshalSecretBaseClassificationArray(rawMsg json.RawMessage) ([]SecretBaseClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1524,7 +1524,7 @@ func unmarshalSecretBaseClassificationArray(rawMsg json.RawMessage) (*[]SecretBa
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalStoreReadSettingsClassification(rawMsg json.RawMessage) (StoreReadSettingsClassification, error) {
@@ -1565,7 +1565,7 @@ func unmarshalStoreReadSettingsClassification(rawMsg json.RawMessage) (StoreRead
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalStoreReadSettingsClassificationArray(rawMsg json.RawMessage) (*[]StoreReadSettingsClassification, error) {
+func unmarshalStoreReadSettingsClassificationArray(rawMsg json.RawMessage) ([]StoreReadSettingsClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1581,7 +1581,7 @@ func unmarshalStoreReadSettingsClassificationArray(rawMsg json.RawMessage) (*[]S
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalStoreWriteSettingsClassification(rawMsg json.RawMessage) (StoreWriteSettingsClassification, error) {
@@ -1610,7 +1610,7 @@ func unmarshalStoreWriteSettingsClassification(rawMsg json.RawMessage) (StoreWri
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalStoreWriteSettingsClassificationArray(rawMsg json.RawMessage) (*[]StoreWriteSettingsClassification, error) {
+func unmarshalStoreWriteSettingsClassificationArray(rawMsg json.RawMessage) ([]StoreWriteSettingsClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1626,7 +1626,7 @@ func unmarshalStoreWriteSettingsClassificationArray(rawMsg json.RawMessage) (*[]
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalTabularSourceClassification(rawMsg json.RawMessage) (TabularSourceClassification, error) {
@@ -1759,7 +1759,7 @@ func unmarshalTabularSourceClassification(rawMsg json.RawMessage) (TabularSource
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalTabularSourceClassificationArray(rawMsg json.RawMessage) (*[]TabularSourceClassification, error) {
+func unmarshalTabularSourceClassificationArray(rawMsg json.RawMessage) ([]TabularSourceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1775,7 +1775,7 @@ func unmarshalTabularSourceClassificationArray(rawMsg json.RawMessage) (*[]Tabul
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalTriggerClassification(rawMsg json.RawMessage) (TriggerClassification, error) {
@@ -1808,7 +1808,7 @@ func unmarshalTriggerClassification(rawMsg json.RawMessage) (TriggerClassificati
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalTriggerClassificationArray(rawMsg json.RawMessage) (*[]TriggerClassification, error) {
+func unmarshalTriggerClassificationArray(rawMsg json.RawMessage) ([]TriggerClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1824,7 +1824,7 @@ func unmarshalTriggerClassificationArray(rawMsg json.RawMessage) (*[]TriggerClas
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalTriggerDependencyReferenceClassification(rawMsg json.RawMessage) (TriggerDependencyReferenceClassification, error) {
@@ -1845,7 +1845,7 @@ func unmarshalTriggerDependencyReferenceClassification(rawMsg json.RawMessage) (
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg json.RawMessage) (*[]TriggerDependencyReferenceClassification, error) {
+func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg json.RawMessage) ([]TriggerDependencyReferenceClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1861,7 +1861,7 @@ func unmarshalTriggerDependencyReferenceClassificationArray(rawMsg json.RawMessa
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }
 
 func unmarshalWebLinkedServiceTypePropertiesClassification(rawMsg json.RawMessage) (WebLinkedServiceTypePropertiesClassification, error) {
@@ -1886,7 +1886,7 @@ func unmarshalWebLinkedServiceTypePropertiesClassification(rawMsg json.RawMessag
 	return b, json.Unmarshal(rawMsg, b)
 }
 
-func unmarshalWebLinkedServiceTypePropertiesClassificationArray(rawMsg json.RawMessage) (*[]WebLinkedServiceTypePropertiesClassification, error) {
+func unmarshalWebLinkedServiceTypePropertiesClassificationArray(rawMsg json.RawMessage) ([]WebLinkedServiceTypePropertiesClassification, error) {
 	if rawMsg == nil {
 		return nil, nil
 	}
@@ -1902,5 +1902,5 @@ func unmarshalWebLinkedServiceTypePropertiesClassificationArray(rawMsg json.RawM
 		}
 		fArray[index] = f
 	}
-	return &fArray, nil
+	return fArray, nil
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -48,13 +48,13 @@ type SparkBatchJob struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// The detailed application info.
-	AppInfo *map[string]*string `json:"appInfo,omitempty"`
+	AppInfo map[string]*string `json:"appInfo,omitempty"`
 
 	// The artifact identifier.
 	ArtifactID *string `json:"artifactId,omitempty"`
 
 	// The error information.
-	Errors *[]*SparkServiceError `json:"errorInfo,omitempty"`
+	Errors []*SparkServiceError `json:"errorInfo,omitempty"`
 
 	// The session Id.
 	ID *int32 `json:"id,omitempty"`
@@ -64,7 +64,7 @@ type SparkBatchJob struct {
 	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
 
 	// The log lines.
-	LogLines *[]*string `json:"log,omitempty"`
+	LogLines []*string `json:"log,omitempty"`
 
 	// The batch name.
 	Name *string `json:"name,omitempty"`
@@ -91,10 +91,34 @@ type SparkBatchJob struct {
 	SubmitterName *string `json:"submitterName,omitempty"`
 
 	// The tags.
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
 
 	// The workspace name.
 	WorkspaceName *string `json:"workspaceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkBatchJob.
+func (s SparkBatchJob) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appId", s.AppID)
+	populate(objectMap, "appInfo", s.AppInfo)
+	populate(objectMap, "artifactId", s.ArtifactID)
+	populate(objectMap, "errorInfo", s.Errors)
+	populate(objectMap, "id", s.ID)
+	populate(objectMap, "jobType", s.JobType)
+	populate(objectMap, "livyInfo", s.LivyInfo)
+	populate(objectMap, "log", s.LogLines)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pluginInfo", s.Plugin)
+	populate(objectMap, "result", s.Result)
+	populate(objectMap, "schedulerInfo", s.Scheduler)
+	populate(objectMap, "sparkPoolName", s.SparkPoolName)
+	populate(objectMap, "state", s.State)
+	populate(objectMap, "submitterId", s.SubmitterID)
+	populate(objectMap, "submitterName", s.SubmitterName)
+	populate(objectMap, "tags", s.Tags)
+	populate(objectMap, "workspaceName", s.WorkspaceName)
+	return json.Marshal(objectMap)
 }
 
 // SparkBatchJobCollection - Response for batch list operation.
@@ -103,10 +127,19 @@ type SparkBatchJobCollection struct {
 	From *int32 `json:"from,omitempty"`
 
 	// Batch list
-	Sessions *[]*SparkBatchJob `json:"sessions,omitempty"`
+	Sessions []*SparkBatchJob `json:"sessions,omitempty"`
 
 	// Number of sessions fetched.
 	Total *int32 `json:"total,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkBatchJobCollection.
+func (s SparkBatchJobCollection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "from", s.From)
+	populate(objectMap, "sessions", s.Sessions)
+	populate(objectMap, "total", s.Total)
+	return json.Marshal(objectMap)
 }
 
 // SparkBatchJobCollectionResponse is the response envelope for operations that return a SparkBatchJobCollection type.
@@ -119,26 +152,48 @@ type SparkBatchJobCollectionResponse struct {
 }
 
 type SparkBatchJobOptions struct {
-	Archives   *[]*string `json:"archives,omitempty"`
-	Arguments  *[]*string `json:"args,omitempty"`
-	ArtifactID *string    `json:"artifactId,omitempty"`
-	ClassName  *string    `json:"className,omitempty"`
+	Archives   []*string `json:"archives,omitempty"`
+	Arguments  []*string `json:"args,omitempty"`
+	ArtifactID *string   `json:"artifactId,omitempty"`
+	ClassName  *string   `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32              `json:"driverCores,omitempty"`
-	DriverMemory   *string             `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32              `json:"executorCores,omitempty"`
-	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
-	ExecutorMemory *string             `json:"executorMemory,omitempty"`
-	File           *string             `json:"file,omitempty"`
-	Files          *[]*string          `json:"files,omitempty"`
-	Jars           *[]*string          `json:"jars,omitempty"`
-	Name           *string             `json:"name,omitempty"`
-	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32             `json:"driverCores,omitempty"`
+	DriverMemory   *string            `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32             `json:"executorCores,omitempty"`
+	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
+	ExecutorMemory *string            `json:"executorMemory,omitempty"`
+	File           *string            `json:"file,omitempty"`
+	Files          []*string          `json:"files,omitempty"`
+	Jars           []*string          `json:"jars,omitempty"`
+	Name           *string            `json:"name,omitempty"`
+	PythonFiles    []*string          `json:"pyFiles,omitempty"`
 
 	// Dictionary of
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkBatchJobOptions.
+func (s SparkBatchJobOptions) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "archives", s.Archives)
+	populate(objectMap, "args", s.Arguments)
+	populate(objectMap, "artifactId", s.ArtifactID)
+	populate(objectMap, "className", s.ClassName)
+	populate(objectMap, "conf", s.Configuration)
+	populate(objectMap, "driverCores", s.DriverCores)
+	populate(objectMap, "driverMemory", s.DriverMemory)
+	populate(objectMap, "executorCores", s.ExecutorCores)
+	populate(objectMap, "numExecutors", s.ExecutorCount)
+	populate(objectMap, "executorMemory", s.ExecutorMemory)
+	populate(objectMap, "file", s.File)
+	populate(objectMap, "files", s.Files)
+	populate(objectMap, "jars", s.Jars)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pyFiles", s.PythonFiles)
+	populate(objectMap, "tags", s.Tags)
+	return json.Marshal(objectMap)
 }
 
 // SparkBatchJobResponse is the response envelope for operations that return a SparkBatchJob type.
@@ -249,22 +304,42 @@ func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
 }
 
 type SparkRequest struct {
-	Archives  *[]*string `json:"archives,omitempty"`
-	Arguments *[]*string `json:"args,omitempty"`
-	ClassName *string    `json:"className,omitempty"`
+	Archives  []*string `json:"archives,omitempty"`
+	Arguments []*string `json:"args,omitempty"`
+	ClassName *string   `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32              `json:"driverCores,omitempty"`
-	DriverMemory   *string             `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32              `json:"executorCores,omitempty"`
-	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
-	ExecutorMemory *string             `json:"executorMemory,omitempty"`
-	File           *string             `json:"file,omitempty"`
-	Files          *[]*string          `json:"files,omitempty"`
-	Jars           *[]*string          `json:"jars,omitempty"`
-	Name           *string             `json:"name,omitempty"`
-	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32             `json:"driverCores,omitempty"`
+	DriverMemory   *string            `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32             `json:"executorCores,omitempty"`
+	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
+	ExecutorMemory *string            `json:"executorMemory,omitempty"`
+	File           *string            `json:"file,omitempty"`
+	Files          []*string          `json:"files,omitempty"`
+	Jars           []*string          `json:"jars,omitempty"`
+	Name           *string            `json:"name,omitempty"`
+	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkRequest.
+func (s SparkRequest) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "archives", s.Archives)
+	populate(objectMap, "args", s.Arguments)
+	populate(objectMap, "className", s.ClassName)
+	populate(objectMap, "conf", s.Configuration)
+	populate(objectMap, "driverCores", s.DriverCores)
+	populate(objectMap, "driverMemory", s.DriverMemory)
+	populate(objectMap, "executorCores", s.ExecutorCores)
+	populate(objectMap, "numExecutors", s.ExecutorCount)
+	populate(objectMap, "executorMemory", s.ExecutorMemory)
+	populate(objectMap, "file", s.File)
+	populate(objectMap, "files", s.Files)
+	populate(objectMap, "jars", s.Jars)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pyFiles", s.PythonFiles)
+	return json.Marshal(objectMap)
 }
 
 type SparkScheduler struct {
@@ -402,15 +477,15 @@ type SparkSession struct {
 	AppID *string `json:"appId,omitempty"`
 
 	// Dictionary of
-	AppInfo    *map[string]*string   `json:"appInfo,omitempty"`
-	ArtifactID *string               `json:"artifactId,omitempty"`
-	Errors     *[]*SparkServiceError `json:"errorInfo,omitempty"`
-	ID         *int32                `json:"id,omitempty"`
+	AppInfo    map[string]*string   `json:"appInfo,omitempty"`
+	ArtifactID *string              `json:"artifactId,omitempty"`
+	Errors     []*SparkServiceError `json:"errorInfo,omitempty"`
+	ID         *int32               `json:"id,omitempty"`
 
 	// The job type.
 	JobType       *SparkJobType           `json:"jobType,omitempty"`
 	LivyInfo      *SparkSessionState      `json:"livyInfo,omitempty"`
-	LogLines      *[]*string              `json:"log,omitempty"`
+	LogLines      []*string               `json:"log,omitempty"`
 	Name          *string                 `json:"name,omitempty"`
 	Plugin        *SparkServicePlugin     `json:"pluginInfo,omitempty"`
 	Result        *SparkSessionResultType `json:"result,omitempty"`
@@ -421,8 +496,32 @@ type SparkSession struct {
 	SubmitterName *string                 `json:"submitterName,omitempty"`
 
 	// Dictionary of
-	Tags          *map[string]*string `json:"tags,omitempty"`
-	WorkspaceName *string             `json:"workspaceName,omitempty"`
+	Tags          map[string]*string `json:"tags,omitempty"`
+	WorkspaceName *string            `json:"workspaceName,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkSession.
+func (s SparkSession) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "appId", s.AppID)
+	populate(objectMap, "appInfo", s.AppInfo)
+	populate(objectMap, "artifactId", s.ArtifactID)
+	populate(objectMap, "errorInfo", s.Errors)
+	populate(objectMap, "id", s.ID)
+	populate(objectMap, "jobType", s.JobType)
+	populate(objectMap, "livyInfo", s.LivyInfo)
+	populate(objectMap, "log", s.LogLines)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pluginInfo", s.Plugin)
+	populate(objectMap, "result", s.Result)
+	populate(objectMap, "schedulerInfo", s.Scheduler)
+	populate(objectMap, "sparkPoolName", s.SparkPoolName)
+	populate(objectMap, "state", s.State)
+	populate(objectMap, "submitterId", s.SubmitterID)
+	populate(objectMap, "submitterName", s.SubmitterName)
+	populate(objectMap, "tags", s.Tags)
+	populate(objectMap, "workspaceName", s.WorkspaceName)
+	return json.Marshal(objectMap)
 }
 
 // SparkSessionCancelSparkSessionOptions contains the optional parameters for the SparkSession.CancelSparkSession method.
@@ -436,9 +535,18 @@ type SparkSessionCancelSparkStatementOptions struct {
 }
 
 type SparkSessionCollection struct {
-	From     *int32           `json:"from,omitempty"`
-	Sessions *[]*SparkSession `json:"sessions,omitempty"`
-	Total    *int32           `json:"total,omitempty"`
+	From     *int32          `json:"from,omitempty"`
+	Sessions []*SparkSession `json:"sessions,omitempty"`
+	Total    *int32          `json:"total,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkSessionCollection.
+func (s SparkSessionCollection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "from", s.From)
+	populate(objectMap, "sessions", s.Sessions)
+	populate(objectMap, "total", s.Total)
+	return json.Marshal(objectMap)
 }
 
 // SparkSessionCollectionResponse is the response envelope for operations that return a SparkSessionCollection type.
@@ -487,26 +595,48 @@ type SparkSessionGetSparkStatementsOptions struct {
 }
 
 type SparkSessionOptions struct {
-	Archives   *[]*string `json:"archives,omitempty"`
-	Arguments  *[]*string `json:"args,omitempty"`
-	ArtifactID *string    `json:"artifactId,omitempty"`
-	ClassName  *string    `json:"className,omitempty"`
+	Archives   []*string `json:"archives,omitempty"`
+	Arguments  []*string `json:"args,omitempty"`
+	ArtifactID *string   `json:"artifactId,omitempty"`
+	ClassName  *string   `json:"className,omitempty"`
 
 	// Dictionary of
-	Configuration  *map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32              `json:"driverCores,omitempty"`
-	DriverMemory   *string             `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32              `json:"executorCores,omitempty"`
-	ExecutorCount  *int32              `json:"numExecutors,omitempty"`
-	ExecutorMemory *string             `json:"executorMemory,omitempty"`
-	File           *string             `json:"file,omitempty"`
-	Files          *[]*string          `json:"files,omitempty"`
-	Jars           *[]*string          `json:"jars,omitempty"`
-	Name           *string             `json:"name,omitempty"`
-	PythonFiles    *[]*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string `json:"conf,omitempty"`
+	DriverCores    *int32             `json:"driverCores,omitempty"`
+	DriverMemory   *string            `json:"driverMemory,omitempty"`
+	ExecutorCores  *int32             `json:"executorCores,omitempty"`
+	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
+	ExecutorMemory *string            `json:"executorMemory,omitempty"`
+	File           *string            `json:"file,omitempty"`
+	Files          []*string          `json:"files,omitempty"`
+	Jars           []*string          `json:"jars,omitempty"`
+	Name           *string            `json:"name,omitempty"`
+	PythonFiles    []*string          `json:"pyFiles,omitempty"`
 
 	// Dictionary of
-	Tags *map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string `json:"tags,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkSessionOptions.
+func (s SparkSessionOptions) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "archives", s.Archives)
+	populate(objectMap, "args", s.Arguments)
+	populate(objectMap, "artifactId", s.ArtifactID)
+	populate(objectMap, "className", s.ClassName)
+	populate(objectMap, "conf", s.Configuration)
+	populate(objectMap, "driverCores", s.DriverCores)
+	populate(objectMap, "driverMemory", s.DriverMemory)
+	populate(objectMap, "executorCores", s.ExecutorCores)
+	populate(objectMap, "numExecutors", s.ExecutorCount)
+	populate(objectMap, "executorMemory", s.ExecutorMemory)
+	populate(objectMap, "file", s.File)
+	populate(objectMap, "files", s.Files)
+	populate(objectMap, "jars", s.Jars)
+	populate(objectMap, "name", s.Name)
+	populate(objectMap, "pyFiles", s.PythonFiles)
+	populate(objectMap, "tags", s.Tags)
+	return json.Marshal(objectMap)
 }
 
 // SparkSessionResetSparkSessionTimeoutOptions contains the optional parameters for the SparkSession.ResetSparkSessionTimeout method.
@@ -640,8 +770,16 @@ type SparkStatementCancellationResultResponse struct {
 }
 
 type SparkStatementCollection struct {
-	Statements *[]*SparkStatement `json:"statements,omitempty"`
-	Total      *int32             `json:"total_statements,omitempty"`
+	Statements []*SparkStatement `json:"statements,omitempty"`
+	Total      *int32            `json:"total_statements,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkStatementCollection.
+func (s SparkStatementCollection) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "statements", s.Statements)
+	populate(objectMap, "total_statements", s.Total)
+	return json.Marshal(objectMap)
 }
 
 // SparkStatementCollectionResponse is the response envelope for operations that return a SparkStatementCollection type.
@@ -663,7 +801,19 @@ type SparkStatementOutput struct {
 	ErrorValue     *string     `json:"evalue,omitempty"`
 	ExecutionCount *int32      `json:"execution_count,omitempty"`
 	Status         *string     `json:"status,omitempty"`
-	Traceback      *[]*string  `json:"traceback,omitempty"`
+	Traceback      []*string   `json:"traceback,omitempty"`
+}
+
+// MarshalJSON implements the json.Marshaller interface for type SparkStatementOutput.
+func (s SparkStatementOutput) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "data", s.Data)
+	populate(objectMap, "ename", s.ErrorName)
+	populate(objectMap, "evalue", s.ErrorValue)
+	populate(objectMap, "execution_count", s.ExecutionCount)
+	populate(objectMap, "status", s.Status)
+	populate(objectMap, "traceback", s.Traceback)
+	return json.Marshal(objectMap)
 }
 
 // SparkStatementResponse is the response envelope for operations that return a SparkStatement type.


### PR DESCRIPTION
This requires custom marshallers to distinguish between a nil value
(don't send anything) and an empty value (send empty map/slice).
Refactored marshalling detection logic which also fixed some broken
corner-cases.
Added custom XML marshaller to handle nested elements for slices.