### PR TITLE
Omit response handlers for LROs

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -51,7 +51,10 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
       }
       opText += generateOperation(op, imports);
       opText += createProtocolRequest(session.model, op, imports);
-      opText += createProtocolResponse(op, imports);
+      if (!isLROOperation(op)) {
+        // LRO responses are handled elsewhere
+        opText += createProtocolResponse(op, imports);
+      }
       opText += createProtocolErrHandler(op, imports);
     }
     // stitch it all together

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -298,15 +298,6 @@ func (client *LRORetrysClient) deleteProvisioning202Accepted200SucceededCreateRe
 	return req, nil
 }
 
-// deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
-func (client *LRORetrysClient) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LRORetrysClient) deleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -602,15 +593,6 @@ func (client *LRORetrysClient) put201CreatingSucceeded200CreateRequest(ctx conte
 	return req, nil
 }
 
-// put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
-func (client *LRORetrysClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LRORetrysClient) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -708,15 +690,6 @@ func (client *LRORetrysClient) putAsyncRelativeRetrySucceededCreateRequest(ctx c
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncRelativeRetrySucceededHandleResponse handles the PutAsyncRelativeRetrySucceeded response.
-func (client *LRORetrysClient) putAsyncRelativeRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetrySucceededHandleError handles the PutAsyncRelativeRetrySucceeded error response.

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -108,15 +108,6 @@ func (client *LROsClient) delete202NoRetry204CreateRequest(ctx context.Context, 
 	return req, nil
 }
 
-// delete202NoRetry204HandleResponse handles the Delete202NoRetry204 response.
-func (client *LROsClient) delete202NoRetry204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // delete202NoRetry204HandleError handles the Delete202NoRetry204 error response.
 func (client *LROsClient) delete202NoRetry204HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -209,15 +200,6 @@ func (client *LROsClient) delete202Retry200CreateRequest(ctx context.Context, op
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// delete202Retry200HandleResponse handles the Delete202Retry200 response.
-func (client *LROsClient) delete202Retry200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // delete202Retry200HandleError handles the Delete202Retry200 error response.
@@ -972,15 +954,6 @@ func (client *LROsClient) deleteProvisioning202Accepted200SucceededCreateRequest
 	return req, nil
 }
 
-// deleteProvisioning202Accepted200SucceededHandleResponse handles the DeleteProvisioning202Accepted200Succeeded response.
-func (client *LROsClient) deleteProvisioning202Accepted200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // deleteProvisioning202Accepted200SucceededHandleError handles the DeleteProvisioning202Accepted200Succeeded error response.
 func (client *LROsClient) deleteProvisioning202Accepted200SucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1075,15 +1048,6 @@ func (client *LROsClient) deleteProvisioning202DeletingFailed200CreateRequest(ct
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// deleteProvisioning202DeletingFailed200HandleResponse handles the DeleteProvisioning202DeletingFailed200 response.
-func (client *LROsClient) deleteProvisioning202DeletingFailed200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // deleteProvisioning202DeletingFailed200HandleError handles the DeleteProvisioning202DeletingFailed200 error response.
@@ -1182,15 +1146,6 @@ func (client *LROsClient) deleteProvisioning202Deletingcanceled200CreateRequest(
 	return req, nil
 }
 
-// deleteProvisioning202Deletingcanceled200HandleResponse handles the DeleteProvisioning202Deletingcanceled200 response.
-func (client *LROsClient) deleteProvisioning202Deletingcanceled200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // deleteProvisioning202Deletingcanceled200HandleError handles the DeleteProvisioning202Deletingcanceled200 error response.
 func (client *LROsClient) deleteProvisioning202Deletingcanceled200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1283,15 +1238,6 @@ func (client *LROsClient) post200WithPayloadCreateRequest(ctx context.Context, o
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// post200WithPayloadHandleResponse handles the Post200WithPayload response.
-func (client *LROsClient) post200WithPayloadHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	var val *SKU
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SKUResponse{}, err
-	}
-	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
 }
 
 // post200WithPayloadHandleError handles the Post200WithPayload error response.
@@ -1388,15 +1334,6 @@ func (client *LROsClient) post202ListCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
-// post202ListHandleResponse handles the Post202List response.
-func (client *LROsClient) post202ListHandleResponse(resp *azcore.Response) (ProductArrayResponse, error) {
-	var val []*Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductArrayResponse{}, err
-	}
-	return ProductArrayResponse{RawResponse: resp.Response, ProductArray: val}, nil
-}
-
 // post202ListHandleError handles the Post202List error response.
 func (client *LROsClient) post202ListHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1491,15 +1428,6 @@ func (client *LROsClient) post202NoRetry204CreateRequest(ctx context.Context, op
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// post202NoRetry204HandleResponse handles the Post202NoRetry204 response.
-func (client *LROsClient) post202NoRetry204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // post202NoRetry204HandleError handles the Post202NoRetry204 error response.
@@ -1696,15 +1624,6 @@ func (client *LROsClient) postAsyncNoRetrySucceededCreateRequest(ctx context.Con
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// postAsyncNoRetrySucceededHandleResponse handles the PostAsyncNoRetrySucceeded response.
-func (client *LROsClient) postAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postAsyncNoRetrySucceededHandleError handles the PostAsyncNoRetrySucceeded error response.
@@ -1905,15 +1824,6 @@ func (client *LROsClient) postAsyncRetrySucceededCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// postAsyncRetrySucceededHandleResponse handles the PostAsyncRetrySucceeded response.
-func (client *LROsClient) postAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // postAsyncRetrySucceededHandleError handles the PostAsyncRetrySucceeded error response.
 func (client *LROsClient) postAsyncRetrySucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2107,15 +2017,6 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetCreateRequest(ctx 
 	return req, nil
 }
 
-// postDoubleHeadersFinalAzureHeaderGetHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGet response.
-func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // postDoubleHeadersFinalAzureHeaderGetHandleError handles the PostDoubleHeadersFinalAzureHeaderGet error response.
 func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2212,15 +2113,6 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetDefaultCreateReque
 	return req, nil
 }
 
-// postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse handles the PostDoubleHeadersFinalAzureHeaderGetDefault response.
-func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetDefaultHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // postDoubleHeadersFinalAzureHeaderGetDefaultHandleError handles the PostDoubleHeadersFinalAzureHeaderGetDefault error response.
 func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetDefaultHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2313,15 +2205,6 @@ func (client *LROsClient) postDoubleHeadersFinalLocationGetCreateRequest(ctx con
 	req.Telemetry(telemetryInfo)
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// postDoubleHeadersFinalLocationGetHandleResponse handles the PostDoubleHeadersFinalLocationGet response.
-func (client *LROsClient) postDoubleHeadersFinalLocationGetHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // postDoubleHeadersFinalLocationGetHandleError handles the PostDoubleHeadersFinalLocationGet error response.
@@ -2423,15 +2306,6 @@ func (client *LROsClient) put200Acceptedcanceled200CreateRequest(ctx context.Con
 	return req, nil
 }
 
-// put200Acceptedcanceled200HandleResponse handles the Put200Acceptedcanceled200 response.
-func (client *LROsClient) put200Acceptedcanceled200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put200Acceptedcanceled200HandleError handles the Put200Acceptedcanceled200 error response.
 func (client *LROsClient) put200Acceptedcanceled200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2527,15 +2401,6 @@ func (client *LROsClient) put200SucceededCreateRequest(ctx context.Context, opti
 	return req, nil
 }
 
-// put200SucceededHandleResponse handles the Put200Succeeded response.
-func (client *LROsClient) put200SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put200SucceededHandleError handles the Put200Succeeded error response.
 func (client *LROsClient) put200SucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2629,15 +2494,6 @@ func (client *LROsClient) put200SucceededNoStateCreateRequest(ctx context.Contex
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// put200SucceededNoStateHandleResponse handles the Put200SucceededNoState response.
-func (client *LROsClient) put200SucceededNoStateHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put200SucceededNoStateHandleError handles the Put200SucceededNoState error response.
@@ -2739,15 +2595,6 @@ func (client *LROsClient) put200UpdatingSucceeded204CreateRequest(ctx context.Co
 	return req, nil
 }
 
-// put200UpdatingSucceeded204HandleResponse handles the Put200UpdatingSucceeded204 response.
-func (client *LROsClient) put200UpdatingSucceeded204HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put200UpdatingSucceeded204HandleError handles the Put200UpdatingSucceeded204 error response.
 func (client *LROsClient) put200UpdatingSucceeded204HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2845,15 +2692,6 @@ func (client *LROsClient) put201CreatingFailed200CreateRequest(ctx context.Conte
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// put201CreatingFailed200HandleResponse handles the Put201CreatingFailed200 response.
-func (client *LROsClient) put201CreatingFailed200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201CreatingFailed200HandleError handles the Put201CreatingFailed200 error response.
@@ -2955,15 +2793,6 @@ func (client *LROsClient) put201CreatingSucceeded200CreateRequest(ctx context.Co
 	return req, nil
 }
 
-// put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
-func (client *LROsClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LROsClient) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3057,15 +2886,6 @@ func (client *LROsClient) put201SucceededCreateRequest(ctx context.Context, opti
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// put201SucceededHandleResponse handles the Put201Succeeded response.
-func (client *LROsClient) put201SucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // put201SucceededHandleError handles the Put201Succeeded error response.
@@ -3165,15 +2985,6 @@ func (client *LROsClient) put202Retry200CreateRequest(ctx context.Context, optio
 	return req, nil
 }
 
-// put202Retry200HandleResponse handles the Put202Retry200 response.
-func (client *LROsClient) put202Retry200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put202Retry200HandleError handles the Put202Retry200 error response.
 func (client *LROsClient) put202Retry200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3269,15 +3080,6 @@ func (client *LROsClient) putAsyncNoHeaderInRetryCreateRequest(ctx context.Conte
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncNoHeaderInRetryHandleResponse handles the PutAsyncNoHeaderInRetry response.
-func (client *LROsClient) putAsyncNoHeaderInRetryHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncNoHeaderInRetryHandleError handles the PutAsyncNoHeaderInRetry error response.
@@ -3379,15 +3181,6 @@ func (client *LROsClient) putAsyncNoRetrySucceededCreateRequest(ctx context.Cont
 	return req, nil
 }
 
-// putAsyncNoRetrySucceededHandleResponse handles the PutAsyncNoRetrySucceeded response.
-func (client *LROsClient) putAsyncNoRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncNoRetrySucceededHandleError handles the PutAsyncNoRetrySucceeded error response.
 func (client *LROsClient) putAsyncNoRetrySucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3487,15 +3280,6 @@ func (client *LROsClient) putAsyncNoRetrycanceledCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// putAsyncNoRetrycanceledHandleResponse handles the PutAsyncNoRetrycanceled response.
-func (client *LROsClient) putAsyncNoRetrycanceledHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncNoRetrycanceledHandleError handles the PutAsyncNoRetrycanceled error response.
 func (client *LROsClient) putAsyncNoRetrycanceledHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3589,15 +3373,6 @@ func (client *LROsClient) putAsyncNonResourceCreateRequest(ctx context.Context, 
 		return req, req.MarshalAsJSON(options.SKU)
 	}
 	return req, nil
-}
-
-// putAsyncNonResourceHandleResponse handles the PutAsyncNonResource response.
-func (client *LROsClient) putAsyncNonResourceHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	var val *SKU
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SKUResponse{}, err
-	}
-	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
 }
 
 // putAsyncNonResourceHandleError handles the PutAsyncNonResource error response.
@@ -3699,15 +3474,6 @@ func (client *LROsClient) putAsyncRetryFailedCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
-// putAsyncRetryFailedHandleResponse handles the PutAsyncRetryFailed response.
-func (client *LROsClient) putAsyncRetryFailedHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncRetryFailedHandleError handles the PutAsyncRetryFailed error response.
 func (client *LROsClient) putAsyncRetryFailedHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3807,15 +3573,6 @@ func (client *LROsClient) putAsyncRetrySucceededCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// putAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
-func (client *LROsClient) putAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.
 func (client *LROsClient) putAsyncRetrySucceededHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -3909,15 +3666,6 @@ func (client *LROsClient) putAsyncSubResourceCreateRequest(ctx context.Context, 
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncSubResourceHandleResponse handles the PutAsyncSubResource response.
-func (client *LROsClient) putAsyncSubResourceHandleResponse(resp *azcore.Response) (SubProductResponse, error) {
-	var val *SubProduct
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SubProductResponse{}, err
-	}
-	return SubProductResponse{RawResponse: resp.Response, SubProduct: val}, nil
 }
 
 // putAsyncSubResourceHandleError handles the PutAsyncSubResource error response.
@@ -4017,15 +3765,6 @@ func (client *LROsClient) putNoHeaderInRetryCreateRequest(ctx context.Context, o
 	return req, nil
 }
 
-// putNoHeaderInRetryHandleResponse handles the PutNoHeaderInRetry response.
-func (client *LROsClient) putNoHeaderInRetryHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putNoHeaderInRetryHandleError handles the PutNoHeaderInRetry error response.
 func (client *LROsClient) putNoHeaderInRetryHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -4121,15 +3860,6 @@ func (client *LROsClient) putNonResourceCreateRequest(ctx context.Context, optio
 	return req, nil
 }
 
-// putNonResourceHandleResponse handles the PutNonResource response.
-func (client *LROsClient) putNonResourceHandleResponse(resp *azcore.Response) (SKUResponse, error) {
-	var val *SKU
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SKUResponse{}, err
-	}
-	return SKUResponse{RawResponse: resp.Response, SKU: val}, nil
-}
-
 // putNonResourceHandleError handles the PutNonResource error response.
 func (client *LROsClient) putNonResourceHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -4223,15 +3953,6 @@ func (client *LROsClient) putSubResourceCreateRequest(ctx context.Context, optio
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putSubResourceHandleResponse handles the PutSubResource response.
-func (client *LROsClient) putSubResourceHandleResponse(resp *azcore.Response) (SubProductResponse, error) {
-	var val *SubProduct
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SubProductResponse{}, err
-	}
-	return SubProductResponse{RawResponse: resp.Response, SubProduct: val}, nil
 }
 
 // putSubResourceHandleError handles the PutSubResource error response.

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -1629,15 +1629,6 @@ func (client *LROSADsClient) put200InvalidJSONCreateRequest(ctx context.Context,
 	return req, nil
 }
 
-// put200InvalidJSONHandleResponse handles the Put200InvalidJSON response.
-func (client *LROSADsClient) put200InvalidJSONHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put200InvalidJSONHandleError handles the Put200InvalidJSON error response.
 func (client *LROSADsClient) put200InvalidJSONHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1735,15 +1726,6 @@ func (client *LROSADsClient) putAsyncRelativeRetry400CreateRequest(ctx context.C
 	return req, nil
 }
 
-// putAsyncRelativeRetry400HandleResponse handles the PutAsyncRelativeRetry400 response.
-func (client *LROSADsClient) putAsyncRelativeRetry400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncRelativeRetry400HandleError handles the PutAsyncRelativeRetry400 error response.
 func (client *LROSADsClient) putAsyncRelativeRetry400HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1839,15 +1821,6 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidHeaderCreateRequest(ctx
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncRelativeRetryInvalidHeaderHandleResponse handles the PutAsyncRelativeRetryInvalidHeader response.
-func (client *LROSADsClient) putAsyncRelativeRetryInvalidHeaderHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryInvalidHeaderHandleError handles the PutAsyncRelativeRetryInvalidHeader error response.
@@ -1949,15 +1922,6 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPollingCreateReques
 	return req, nil
 }
 
-// putAsyncRelativeRetryInvalidJSONPollingHandleResponse handles the PutAsyncRelativeRetryInvalidJSONPolling response.
-func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPollingHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncRelativeRetryInvalidJSONPollingHandleError handles the PutAsyncRelativeRetryInvalidJSONPolling error response.
 func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPollingHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2055,15 +2019,6 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusCreateRequest(ctx cont
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncRelativeRetryNoStatusHandleResponse handles the PutAsyncRelativeRetryNoStatus response.
-func (client *LROSADsClient) putAsyncRelativeRetryNoStatusHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRelativeRetryNoStatusHandleError handles the PutAsyncRelativeRetryNoStatus error response.
@@ -2165,15 +2120,6 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayloadCreateRequest(c
 	return req, nil
 }
 
-// putAsyncRelativeRetryNoStatusPayloadHandleResponse handles the PutAsyncRelativeRetryNoStatusPayload response.
-func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayloadHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putAsyncRelativeRetryNoStatusPayloadHandleError handles the PutAsyncRelativeRetryNoStatusPayload error response.
 func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayloadHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2269,15 +2215,6 @@ func (client *LROSADsClient) putError201NoProvisioningStatePayloadCreateRequest(
 	return req, nil
 }
 
-// putError201NoProvisioningStatePayloadHandleResponse handles the PutError201NoProvisioningStatePayload response.
-func (client *LROSADsClient) putError201NoProvisioningStatePayloadHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putError201NoProvisioningStatePayloadHandleError handles the PutError201NoProvisioningStatePayload error response.
 func (client *LROSADsClient) putError201NoProvisioningStatePayloadHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2371,15 +2308,6 @@ func (client *LROSADsClient) putNonRetry201Creating400CreateRequest(ctx context.
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putNonRetry201Creating400HandleResponse handles the PutNonRetry201Creating400 response.
-func (client *LROSADsClient) putNonRetry201Creating400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNonRetry201Creating400HandleError handles the PutNonRetry201Creating400 error response.
@@ -2478,15 +2406,6 @@ func (client *LROSADsClient) putNonRetry201Creating400InvalidJSONCreateRequest(c
 	return req, nil
 }
 
-// putNonRetry201Creating400InvalidJSONHandleResponse handles the PutNonRetry201Creating400InvalidJSON response.
-func (client *LROSADsClient) putNonRetry201Creating400InvalidJSONHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // putNonRetry201Creating400InvalidJSONHandleError handles the PutNonRetry201Creating400InvalidJSON error response.
 func (client *LROSADsClient) putNonRetry201Creating400InvalidJSONHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2580,15 +2499,6 @@ func (client *LROSADsClient) putNonRetry400CreateRequest(ctx context.Context, op
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putNonRetry400HandleResponse handles the PutNonRetry400 response.
-func (client *LROSADsClient) putNonRetry400HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putNonRetry400HandleError handles the PutNonRetry400 error response.

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -311,15 +311,6 @@ func (client *LROsCustomHeaderClient) put201CreatingSucceeded200CreateRequest(ct
 	return req, nil
 }
 
-// put201CreatingSucceeded200HandleResponse handles the Put201CreatingSucceeded200 response.
-func (client *LROsCustomHeaderClient) put201CreatingSucceeded200HandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
-}
-
 // put201CreatingSucceeded200HandleError handles the Put201CreatingSucceeded200 error response.
 func (client *LROsCustomHeaderClient) put201CreatingSucceeded200HandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -417,15 +408,6 @@ func (client *LROsCustomHeaderClient) putAsyncRetrySucceededCreateRequest(ctx co
 		return req, req.MarshalAsJSON(options.Product)
 	}
 	return req, nil
-}
-
-// putAsyncRetrySucceededHandleResponse handles the PutAsyncRetrySucceeded response.
-func (client *LROsCustomHeaderClient) putAsyncRetrySucceededHandleResponse(resp *azcore.Response) (ProductResponse, error) {
-	var val *Product
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResponse{}, err
-	}
-	return ProductResponse{RawResponse: resp.Response, Product: val}, nil
 }
 
 // putAsyncRetrySucceededHandleError handles the PutAsyncRetrySucceeded error response.

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -419,15 +419,6 @@ func (client *PagingClient) getMultiplePagesLROCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// getMultiplePagesLROHandleResponse handles the GetMultiplePagesLRO response.
-func (client *PagingClient) getMultiplePagesLROHandleResponse(resp *azcore.Response) (ProductResultResponse, error) {
-	var val *ProductResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ProductResultResponse{}, err
-	}
-	return ProductResultResponse{RawResponse: resp.Response, ProductResult: val}, nil
-}
-
 // getMultiplePagesLROHandleError handles the GetMultiplePagesLRO error response.
 func (client *PagingClient) getMultiplePagesLROHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -124,15 +124,6 @@ func (client *ContainerServicesClient) createOrUpdateCreateRequest(ctx context.C
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ContainerServicesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ContainerServiceResponse, error) {
-	var val *ContainerService
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ContainerServiceResponse{}, err
-	}
-	return ContainerServiceResponse{RawResponse: resp.Response, ContainerService: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ContainerServicesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -128,15 +128,6 @@ func (client *DedicatedHostsClient) createOrUpdateCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *DedicatedHostsClient) createOrUpdateHandleResponse(resp *azcore.Response) (DedicatedHostResponse, error) {
-	var val *DedicatedHost
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DedicatedHostResponse{}, err
-	}
-	return DedicatedHostResponse{RawResponse: resp.Response, DedicatedHost: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DedicatedHostsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -492,15 +483,6 @@ func (client *DedicatedHostsClient) updateCreateRequest(ctx context.Context, res
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *DedicatedHostsClient) updateHandleResponse(resp *azcore.Response) (DedicatedHostResponse, error) {
-	var val *DedicatedHost
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DedicatedHostResponse{}, err
-	}
-	return DedicatedHostResponse{RawResponse: resp.Response, DedicatedHost: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -125,15 +125,6 @@ func (client *DiskEncryptionSetsClient) createOrUpdateCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(diskEncryptionSet)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *DiskEncryptionSetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (DiskEncryptionSetResponse, error) {
-	var val *DiskEncryptionSet
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DiskEncryptionSetResponse{}, err
-	}
-	return DiskEncryptionSetResponse{RawResponse: resp.Response, DiskEncryptionSet: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DiskEncryptionSetsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -532,15 +523,6 @@ func (client *DiskEncryptionSetsClient) updateCreateRequest(ctx context.Context,
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(diskEncryptionSet)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *DiskEncryptionSetsClient) updateHandleResponse(resp *azcore.Response) (DiskEncryptionSetResponse, error) {
-	var val *DiskEncryptionSet
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DiskEncryptionSetResponse{}, err
-	}
-	return DiskEncryptionSetResponse{RawResponse: resp.Response, DiskEncryptionSet: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -124,15 +124,6 @@ func (client *DisksClient) createOrUpdateCreateRequest(ctx context.Context, reso
 	return req, req.MarshalAsJSON(disk)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *DisksClient) createOrUpdateHandleResponse(resp *azcore.Response) (DiskResponse, error) {
-	var val *Disk
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DiskResponse{}, err
-	}
-	return DiskResponse{RawResponse: resp.Response, Disk: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DisksClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -407,15 +398,6 @@ func (client *DisksClient) grantAccessCreateRequest(ctx context.Context, resourc
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(grantAccessData)
-}
-
-// grantAccessHandleResponse handles the GrantAccess response.
-func (client *DisksClient) grantAccessHandleResponse(resp *azcore.Response) (AccessURIResponse, error) {
-	var val *AccessURI
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AccessURIResponse{}, err
-	}
-	return AccessURIResponse{RawResponse: resp.Response, AccessURI: val}, nil
 }
 
 // grantAccessHandleError handles the GrantAccess error response.
@@ -745,15 +727,6 @@ func (client *DisksClient) updateCreateRequest(ctx context.Context, resourceGrou
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(disk)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *DisksClient) updateHandleResponse(resp *azcore.Response) (DiskResponse, error) {
-	var val *Disk
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DiskResponse{}, err
-	}
-	return DiskResponse{RawResponse: resp.Response, Disk: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -125,15 +125,6 @@ func (client *GalleriesClient) createOrUpdateCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(gallery)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *GalleriesClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryResponse, error) {
-	var val *Gallery
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryResponse{}, err
-	}
-	return GalleryResponse{RawResponse: resp.Response, Gallery: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *GalleriesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -532,15 +523,6 @@ func (client *GalleriesClient) updateCreateRequest(ctx context.Context, resource
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(gallery)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *GalleriesClient) updateHandleResponse(resp *azcore.Response) (GalleryResponse, error) {
-	var val *Gallery
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryResponse{}, err
-	}
-	return GalleryResponse{RawResponse: resp.Response, Gallery: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -129,15 +129,6 @@ func (client *GalleryApplicationsClient) createOrUpdateCreateRequest(ctx context
 	return req, req.MarshalAsJSON(galleryApplication)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *GalleryApplicationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryApplicationResponse, error) {
-	var val *GalleryApplication
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryApplicationResponse{}, err
-	}
-	return GalleryApplicationResponse{RawResponse: resp.Response, GalleryApplication: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *GalleryApplicationsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -494,15 +485,6 @@ func (client *GalleryApplicationsClient) updateCreateRequest(ctx context.Context
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(galleryApplication)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *GalleryApplicationsClient) updateHandleResponse(resp *azcore.Response) (GalleryApplicationResponse, error) {
-	var val *GalleryApplication
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryApplicationResponse{}, err
-	}
-	return GalleryApplicationResponse{RawResponse: resp.Response, GalleryApplication: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -133,15 +133,6 @@ func (client *GalleryApplicationVersionsClient) createOrUpdateCreateRequest(ctx 
 	return req, req.MarshalAsJSON(galleryApplicationVersion)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *GalleryApplicationVersionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryApplicationVersionResponse, error) {
-	var val *GalleryApplicationVersion
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryApplicationVersionResponse{}, err
-	}
-	return GalleryApplicationVersionResponse{RawResponse: resp.Response, GalleryApplicationVersion: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *GalleryApplicationVersionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -517,15 +508,6 @@ func (client *GalleryApplicationVersionsClient) updateCreateRequest(ctx context.
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(galleryApplicationVersion)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *GalleryApplicationVersionsClient) updateHandleResponse(resp *azcore.Response) (GalleryApplicationVersionResponse, error) {
-	var val *GalleryApplicationVersion
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryApplicationVersionResponse{}, err
-	}
-	return GalleryApplicationVersionResponse{RawResponse: resp.Response, GalleryApplicationVersion: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -129,15 +129,6 @@ func (client *GalleryImagesClient) createOrUpdateCreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(galleryImage)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *GalleryImagesClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryImageResponse, error) {
-	var val *GalleryImage
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryImageResponse{}, err
-	}
-	return GalleryImageResponse{RawResponse: resp.Response, GalleryImage: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *GalleryImagesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -494,15 +485,6 @@ func (client *GalleryImagesClient) updateCreateRequest(ctx context.Context, reso
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(galleryImage)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *GalleryImagesClient) updateHandleResponse(resp *azcore.Response) (GalleryImageResponse, error) {
-	var val *GalleryImage
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryImageResponse{}, err
-	}
-	return GalleryImageResponse{RawResponse: resp.Response, GalleryImage: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -133,15 +133,6 @@ func (client *GalleryImageVersionsClient) createOrUpdateCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(galleryImageVersion)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *GalleryImageVersionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (GalleryImageVersionResponse, error) {
-	var val *GalleryImageVersion
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryImageVersionResponse{}, err
-	}
-	return GalleryImageVersionResponse{RawResponse: resp.Response, GalleryImageVersion: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *GalleryImageVersionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -517,15 +508,6 @@ func (client *GalleryImageVersionsClient) updateCreateRequest(ctx context.Contex
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(galleryImageVersion)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *GalleryImageVersionsClient) updateHandleResponse(resp *azcore.Response) (GalleryImageVersionResponse, error) {
-	var val *GalleryImageVersion
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GalleryImageVersionResponse{}, err
-	}
-	return GalleryImageVersionResponse{RawResponse: resp.Response, GalleryImageVersion: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -124,15 +124,6 @@ func (client *ImagesClient) createOrUpdateCreateRequest(ctx context.Context, res
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ImagesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ImageResponse, error) {
-	var val *Image
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ImageResponse{}, err
-	}
-	return ImageResponse{RawResponse: resp.Response, Image: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ImagesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -529,15 +520,6 @@ func (client *ImagesClient) updateCreateRequest(ctx context.Context, resourceGro
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *ImagesClient) updateHandleResponse(resp *azcore.Response) (ImageResponse, error) {
-	var val *Image
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ImageResponse{}, err
-	}
-	return ImageResponse{RawResponse: resp.Response, Image: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
@@ -120,15 +120,6 @@ func (client *LogAnalyticsClient) exportRequestRateByIntervalCreateRequest(ctx c
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// exportRequestRateByIntervalHandleResponse handles the ExportRequestRateByInterval response.
-func (client *LogAnalyticsClient) exportRequestRateByIntervalHandleResponse(resp *azcore.Response) (LogAnalyticsOperationResultResponse, error) {
-	var val *LogAnalyticsOperationResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LogAnalyticsOperationResultResponse{}, err
-	}
-	return LogAnalyticsOperationResultResponse{RawResponse: resp.Response, LogAnalyticsOperationResult: val}, nil
-}
-
 // exportRequestRateByIntervalHandleError handles the ExportRequestRateByInterval error response.
 func (client *LogAnalyticsClient) exportRequestRateByIntervalHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -229,15 +220,6 @@ func (client *LogAnalyticsClient) exportThrottledRequestsCreateRequest(ctx conte
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// exportThrottledRequestsHandleResponse handles the ExportThrottledRequests response.
-func (client *LogAnalyticsClient) exportThrottledRequestsHandleResponse(resp *azcore.Response) (LogAnalyticsOperationResultResponse, error) {
-	var val *LogAnalyticsOperationResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LogAnalyticsOperationResultResponse{}, err
-	}
-	return LogAnalyticsOperationResultResponse{RawResponse: resp.Response, LogAnalyticsOperationResult: val}, nil
 }
 
 // exportThrottledRequestsHandleError handles the ExportThrottledRequests error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -124,15 +124,6 @@ func (client *SnapshotsClient) createOrUpdateCreateRequest(ctx context.Context, 
 	return req, req.MarshalAsJSON(snapshot)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *SnapshotsClient) createOrUpdateHandleResponse(resp *azcore.Response) (SnapshotResponse, error) {
-	var val *Snapshot
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SnapshotResponse{}, err
-	}
-	return SnapshotResponse{RawResponse: resp.Response, Snapshot: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SnapshotsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -407,15 +398,6 @@ func (client *SnapshotsClient) grantAccessCreateRequest(ctx context.Context, res
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(grantAccessData)
-}
-
-// grantAccessHandleResponse handles the GrantAccess response.
-func (client *SnapshotsClient) grantAccessHandleResponse(resp *azcore.Response) (AccessURIResponse, error) {
-	var val *AccessURI
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AccessURIResponse{}, err
-	}
-	return AccessURIResponse{RawResponse: resp.Response, AccessURI: val}, nil
 }
 
 // grantAccessHandleError handles the GrantAccess error response.
@@ -745,15 +727,6 @@ func (client *SnapshotsClient) updateCreateRequest(ctx context.Context, resource
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(snapshot)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *SnapshotsClient) updateHandleResponse(resp *azcore.Response) (SnapshotResponse, error) {
-	var val *Snapshot
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SnapshotResponse{}, err
-	}
-	return SnapshotResponse{RawResponse: resp.Response, Snapshot: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -128,15 +128,6 @@ func (client *VirtualMachineExtensionsClient) createOrUpdateCreateRequest(ctx co
 	return req, req.MarshalAsJSON(extensionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualMachineExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	var val *VirtualMachineExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualMachineExtensionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -494,15 +485,6 @@ func (client *VirtualMachineExtensionsClient) updateCreateRequest(ctx context.Co
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(extensionParameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachineExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	var val *VirtualMachineExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -126,15 +126,6 @@ func (client *VirtualMachinesClient) captureCreateRequest(ctx context.Context, r
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// captureHandleResponse handles the Capture response.
-func (client *VirtualMachinesClient) captureHandleResponse(resp *azcore.Response) (VirtualMachineCaptureResultResponse, error) {
-	var val *VirtualMachineCaptureResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineCaptureResultResponse{}, err
-	}
-	return VirtualMachineCaptureResultResponse{RawResponse: resp.Response, VirtualMachineCaptureResult: val}, nil
-}
-
 // captureHandleError handles the Capture error response.
 func (client *VirtualMachinesClient) captureHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -352,15 +343,6 @@ func (client *VirtualMachinesClient) createOrUpdateCreateRequest(ctx context.Con
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualMachinesClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineResponse, error) {
-	var val *VirtualMachine
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineResponse{}, err
-	}
-	return VirtualMachineResponse{RawResponse: resp.Response, VirtualMachine: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
@@ -1763,15 +1745,6 @@ func (client *VirtualMachinesClient) runCommandCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// runCommandHandleResponse handles the RunCommand response.
-func (client *VirtualMachinesClient) runCommandHandleResponse(resp *azcore.Response) (RunCommandResultResponse, error) {
-	var val *RunCommandResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RunCommandResultResponse{}, err
-	}
-	return RunCommandResultResponse{RawResponse: resp.Response, RunCommandResult: val}, nil
-}
-
 // runCommandHandleError handles the RunCommand error response.
 func (client *VirtualMachinesClient) runCommandHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2036,15 +2009,6 @@ func (client *VirtualMachinesClient) updateCreateRequest(ctx context.Context, re
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachinesClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineResponse, error) {
-	var val *VirtualMachine
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineResponse{}, err
-	}
-	return VirtualMachineResponse{RawResponse: resp.Response, VirtualMachine: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -128,15 +128,6 @@ func (client *VirtualMachineScaleSetExtensionsClient) createOrUpdateCreateReques
 	return req, req.MarshalAsJSON(extensionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualMachineScaleSetExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionResponse, error) {
-	var val *VirtualMachineScaleSetExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineScaleSetExtensionResponse{}, err
-	}
-	return VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtension: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualMachineScaleSetExtensionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -491,15 +482,6 @@ func (client *VirtualMachineScaleSetExtensionsClient) updateCreateRequest(ctx co
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(extensionParameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachineScaleSetExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetExtensionResponse, error) {
-	var val *VirtualMachineScaleSetExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineScaleSetExtensionResponse{}, err
-	}
-	return VirtualMachineScaleSetExtensionResponse{RawResponse: resp.Response, VirtualMachineScaleSetExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -180,15 +180,6 @@ func (client *VirtualMachineScaleSetsClient) createOrUpdateCreateRequest(ctx con
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualMachineScaleSetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetResponse, error) {
-	var val *VirtualMachineScaleSet
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineScaleSetResponse{}, err
-	}
-	return VirtualMachineScaleSetResponse{RawResponse: resp.Response, VirtualMachineScaleSet: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualMachineScaleSetsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1940,15 +1931,6 @@ func (client *VirtualMachineScaleSetsClient) updateCreateRequest(ctx context.Con
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachineScaleSetsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetResponse, error) {
-	var val *VirtualMachineScaleSet
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineScaleSetResponse{}, err
-	}
-	return VirtualMachineScaleSetResponse{RawResponse: resp.Response, VirtualMachineScaleSet: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -133,15 +133,6 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) createOrUpdateCreateRequ
 	return req, req.MarshalAsJSON(extensionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualMachineScaleSetVMExtensionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	var val *VirtualMachineExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualMachineScaleSetVMExtensionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -520,15 +511,6 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) updateCreateRequest(ctx 
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(extensionParameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachineScaleSetVMExtensionsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineExtensionResponse, error) {
-	var val *VirtualMachineExtension
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineExtensionResponse{}, err
-	}
-	return VirtualMachineExtensionResponse{RawResponse: resp.Response, VirtualMachineExtension: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -1234,15 +1234,6 @@ func (client *VirtualMachineScaleSetVMsClient) runCommandCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// runCommandHandleResponse handles the RunCommand response.
-func (client *VirtualMachineScaleSetVMsClient) runCommandHandleResponse(resp *azcore.Response) (RunCommandResultResponse, error) {
-	var val *RunCommandResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RunCommandResultResponse{}, err
-	}
-	return RunCommandResultResponse{RawResponse: resp.Response, RunCommandResult: val}, nil
-}
-
 // runCommandHandleError handles the RunCommand error response.
 func (client *VirtualMachineScaleSetVMsClient) runCommandHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1520,15 +1511,6 @@ func (client *VirtualMachineScaleSetVMsClient) updateCreateRequest(ctx context.C
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateHandleResponse handles the Update response.
-func (client *VirtualMachineScaleSetVMsClient) updateHandleResponse(resp *azcore.Response) (VirtualMachineScaleSetVMResponse, error) {
-	var val *VirtualMachineScaleSetVM
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualMachineScaleSetVMResponse{}, err
-	}
-	return VirtualMachineScaleSetVMResponse{RawResponse: resp.Response, VirtualMachineScaleSetVM: val}, nil
 }
 
 // updateHandleError handles the Update error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -128,15 +128,6 @@ func (client *ApplicationGatewaysClient) backendHealthCreateRequest(ctx context.
 	return req, nil
 }
 
-// backendHealthHandleResponse handles the BackendHealth response.
-func (client *ApplicationGatewaysClient) backendHealthHandleResponse(resp *azcore.Response) (ApplicationGatewayBackendHealthResponse, error) {
-	var val *ApplicationGatewayBackendHealth
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ApplicationGatewayBackendHealthResponse{}, err
-	}
-	return ApplicationGatewayBackendHealthResponse{RawResponse: resp.Response, ApplicationGatewayBackendHealth: val}, nil
-}
-
 // backendHealthHandleError handles the BackendHealth error response.
 func (client *ApplicationGatewaysClient) backendHealthHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -249,15 +240,6 @@ func (client *ApplicationGatewaysClient) backendHealthOnDemandCreateRequest(ctx 
 	return req, req.MarshalAsJSON(probeRequest)
 }
 
-// backendHealthOnDemandHandleResponse handles the BackendHealthOnDemand response.
-func (client *ApplicationGatewaysClient) backendHealthOnDemandHandleResponse(resp *azcore.Response) (ApplicationGatewayBackendHealthOnDemandResponse, error) {
-	var val *ApplicationGatewayBackendHealthOnDemand
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ApplicationGatewayBackendHealthOnDemandResponse{}, err
-	}
-	return ApplicationGatewayBackendHealthOnDemandResponse{RawResponse: resp.Response, ApplicationGatewayBackendHealthOnDemand: val}, nil
-}
-
 // backendHealthOnDemandHandleError handles the BackendHealthOnDemand error response.
 func (client *ApplicationGatewaysClient) backendHealthOnDemandHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -363,15 +345,6 @@ func (client *ApplicationGatewaysClient) createOrUpdateCreateRequest(ctx context
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApplicationGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (ApplicationGatewayResponse, error) {
-	var val *ApplicationGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ApplicationGatewayResponse{}, err
-	}
-	return ApplicationGatewayResponse{RawResponse: resp.Response, ApplicationGateway: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -125,15 +125,6 @@ func (client *ApplicationSecurityGroupsClient) createOrUpdateCreateRequest(ctx c
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApplicationSecurityGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ApplicationSecurityGroupResponse, error) {
-	var val *ApplicationSecurityGroup
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ApplicationSecurityGroupResponse{}, err
-	}
-	return ApplicationSecurityGroupResponse{RawResponse: resp.Response, ApplicationSecurityGroup: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ApplicationSecurityGroupsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -125,15 +125,6 @@ func (client *AzureFirewallsClient) createOrUpdateCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *AzureFirewallsClient) createOrUpdateHandleResponse(resp *azcore.Response) (AzureFirewallResponse, error) {
-	var val *AzureFirewall
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AzureFirewallResponse{}, err
-	}
-	return AzureFirewallResponse{RawResponse: resp.Response, AzureFirewall: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *AzureFirewallsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -532,15 +523,6 @@ func (client *AzureFirewallsClient) updateTagsCreateRequest(ctx context.Context,
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateTagsHandleResponse handles the UpdateTags response.
-func (client *AzureFirewallsClient) updateTagsHandleResponse(resp *azcore.Response) (AzureFirewallResponse, error) {
-	var val *AzureFirewall
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AzureFirewallResponse{}, err
-	}
-	return AzureFirewallResponse{RawResponse: resp.Response, AzureFirewall: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -125,15 +125,6 @@ func (client *BastionHostsClient) createOrUpdateCreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *BastionHostsClient) createOrUpdateHandleResponse(resp *azcore.Response) (BastionHostResponse, error) {
-	var val *BastionHost
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return BastionHostResponse{}, err
-	}
-	return BastionHostResponse{RawResponse: resp.Response, BastionHost: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *BastionHostsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -129,15 +129,6 @@ func (client *ConnectionMonitorsClient) createOrUpdateCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ConnectionMonitorsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ConnectionMonitorResultResponse, error) {
-	var val *ConnectionMonitorResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ConnectionMonitorResultResponse{}, err
-	}
-	return ConnectionMonitorResultResponse{RawResponse: resp.Response, ConnectionMonitorResult: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ConnectionMonitorsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -494,15 +485,6 @@ func (client *ConnectionMonitorsClient) queryCreateRequest(ctx context.Context, 
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// queryHandleResponse handles the Query response.
-func (client *ConnectionMonitorsClient) queryHandleResponse(resp *azcore.Response) (ConnectionMonitorQueryResultResponse, error) {
-	var val *ConnectionMonitorQueryResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ConnectionMonitorQueryResultResponse{}, err
-	}
-	return ConnectionMonitorQueryResultResponse{RawResponse: resp.Response, ConnectionMonitorQueryResult: val}, nil
 }
 
 // queryHandleError handles the Query error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -125,15 +125,6 @@ func (client *DdosCustomPoliciesClient) createOrUpdateCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *DdosCustomPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (DdosCustomPolicyResponse, error) {
-	var val *DdosCustomPolicy
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DdosCustomPolicyResponse{}, err
-	}
-	return DdosCustomPolicyResponse{RawResponse: resp.Response, DdosCustomPolicy: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosCustomPoliciesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -125,15 +125,6 @@ func (client *DdosProtectionPlansClient) createOrUpdateCreateRequest(ctx context
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *DdosProtectionPlansClient) createOrUpdateHandleResponse(resp *azcore.Response) (DdosProtectionPlanResponse, error) {
-	var val *DdosProtectionPlan
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DdosProtectionPlanResponse{}, err
-	}
-	return DdosProtectionPlanResponse{RawResponse: resp.Response, DdosProtectionPlan: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *DdosProtectionPlansClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -129,15 +129,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdateCreateReque
 	return req, req.MarshalAsJSON(authorizationParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitAuthorizationResponse, error) {
-	var val *ExpressRouteCircuitAuthorization
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitAuthorizationResponse{}, err
-	}
-	return ExpressRouteCircuitAuthorizationResponse{RawResponse: resp.Response, ExpressRouteCircuitAuthorization: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -133,15 +133,6 @@ func (client *ExpressRouteCircuitConnectionsClient) createOrUpdateCreateRequest(
 	return req, req.MarshalAsJSON(expressRouteCircuitConnectionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCircuitConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitConnectionResponse, error) {
-	var val *ExpressRouteCircuitConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitConnectionResponse{}, err
-	}
-	return ExpressRouteCircuitConnectionResponse{RawResponse: resp.Response, ExpressRouteCircuitConnection: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitConnectionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -129,15 +129,6 @@ func (client *ExpressRouteCircuitPeeringsClient) createOrUpdateCreateRequest(ctx
 	return req, req.MarshalAsJSON(peeringParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCircuitPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitPeeringResponse, error) {
-	var val *ExpressRouteCircuitPeering
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitPeeringResponse{}, err
-	}
-	return ExpressRouteCircuitPeeringResponse{RawResponse: resp.Response, ExpressRouteCircuitPeering: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitPeeringsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -125,15 +125,6 @@ func (client *ExpressRouteCircuitsClient) createOrUpdateCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCircuitsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCircuitResponse, error) {
-	var val *ExpressRouteCircuit
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitResponse{}, err
-	}
-	return ExpressRouteCircuitResponse{RawResponse: resp.Response, ExpressRouteCircuit: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCircuitsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -678,15 +669,6 @@ func (client *ExpressRouteCircuitsClient) listArpTableCreateRequest(ctx context.
 	return req, nil
 }
 
-// listArpTableHandleResponse handles the ListArpTable response.
-func (client *ExpressRouteCircuitsClient) listArpTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsArpTableListResultResponse, error) {
-	var val *ExpressRouteCircuitsArpTableListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitsArpTableListResultResponse{}, err
-	}
-	return ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsArpTableListResult: val}, nil
-}
-
 // listArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCircuitsClient) listArpTableHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -802,15 +784,6 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableCreateRequest(ctx conte
 	return req, nil
 }
 
-// listRoutesTableHandleResponse handles the ListRoutesTable response.
-func (client *ExpressRouteCircuitsClient) listRoutesTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
-	var val *ExpressRouteCircuitsRoutesTableListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitsRoutesTableListResultResponse{}, err
-	}
-	return ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableListResult: val}, nil
-}
-
 // listRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCircuitsClient) listRoutesTableHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -924,15 +897,6 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableSummaryCreateRequest(ct
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// listRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
-func (client *ExpressRouteCircuitsClient) listRoutesTableSummaryHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableSummaryListResultResponse, error) {
-	var val *ExpressRouteCircuitsRoutesTableSummaryListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitsRoutesTableSummaryListResultResponse{}, err
-	}
-	return ExpressRouteCircuitsRoutesTableSummaryListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableSummaryListResult: val}, nil
 }
 
 // listRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -129,15 +129,6 @@ func (client *ExpressRouteConnectionsClient) createOrUpdateCreateRequest(ctx con
 	return req, req.MarshalAsJSON(putExpressRouteConnectionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteConnectionResponse, error) {
-	var val *ExpressRouteConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteConnectionResponse{}, err
-	}
-	return ExpressRouteConnectionResponse{RawResponse: resp.Response, ExpressRouteConnection: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteConnectionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -129,15 +129,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdateCreateReq
 	return req, req.MarshalAsJSON(peeringParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionPeeringResponse, error) {
-	var val *ExpressRouteCrossConnectionPeering
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCrossConnectionPeeringResponse{}, err
-	}
-	return ExpressRouteCrossConnectionPeeringResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionPeering: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -125,15 +125,6 @@ func (client *ExpressRouteCrossConnectionsClient) createOrUpdateCreateRequest(ct
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteCrossConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionResponse, error) {
-	var val *ExpressRouteCrossConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCrossConnectionResponse{}, err
-	}
-	return ExpressRouteCrossConnectionResponse{RawResponse: resp.Response, ExpressRouteCrossConnection: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteCrossConnectionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -373,15 +364,6 @@ func (client *ExpressRouteCrossConnectionsClient) listArpTableCreateRequest(ctx 
 	return req, nil
 }
 
-// listArpTableHandleResponse handles the ListArpTable response.
-func (client *ExpressRouteCrossConnectionsClient) listArpTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsArpTableListResultResponse, error) {
-	var val *ExpressRouteCircuitsArpTableListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitsArpTableListResultResponse{}, err
-	}
-	return ExpressRouteCircuitsArpTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsArpTableListResult: val}, nil
-}
-
 // listArpTableHandleError handles the ListArpTable error response.
 func (client *ExpressRouteCrossConnectionsClient) listArpTableHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -559,15 +541,6 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableCreateRequest(c
 	return req, nil
 }
 
-// listRoutesTableHandleResponse handles the ListRoutesTable response.
-func (client *ExpressRouteCrossConnectionsClient) listRoutesTableHandleResponse(resp *azcore.Response) (ExpressRouteCircuitsRoutesTableListResultResponse, error) {
-	var val *ExpressRouteCircuitsRoutesTableListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCircuitsRoutesTableListResultResponse{}, err
-	}
-	return ExpressRouteCircuitsRoutesTableListResultResponse{RawResponse: resp.Response, ExpressRouteCircuitsRoutesTableListResult: val}, nil
-}
-
 // listRoutesTableHandleError handles the ListRoutesTable error response.
 func (client *ExpressRouteCrossConnectionsClient) listRoutesTableHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -681,15 +654,6 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableSummaryCreateRe
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// listRoutesTableSummaryHandleResponse handles the ListRoutesTableSummary response.
-func (client *ExpressRouteCrossConnectionsClient) listRoutesTableSummaryHandleResponse(resp *azcore.Response) (ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse, error) {
-	var val *ExpressRouteCrossConnectionsRoutesTableSummaryListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{}, err
-	}
-	return ExpressRouteCrossConnectionsRoutesTableSummaryListResultResponse{RawResponse: resp.Response, ExpressRouteCrossConnectionsRoutesTableSummaryListResult: val}, nil
 }
 
 // listRoutesTableSummaryHandleError handles the ListRoutesTableSummary error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -125,15 +125,6 @@ func (client *ExpressRouteGatewaysClient) createOrUpdateCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(putExpressRouteGatewayParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRouteGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRouteGatewayResponse, error) {
-	var val *ExpressRouteGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRouteGatewayResponse{}, err
-	}
-	return ExpressRouteGatewayResponse{RawResponse: resp.Response, ExpressRouteGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRouteGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -125,15 +125,6 @@ func (client *ExpressRoutePortsClient) createOrUpdateCreateRequest(ctx context.C
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ExpressRoutePortsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ExpressRoutePortResponse, error) {
-	var val *ExpressRoutePort
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ExpressRoutePortResponse{}, err
-	}
-	return ExpressRoutePortResponse{RawResponse: resp.Response, ExpressRoutePort: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ExpressRoutePortsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -125,15 +125,6 @@ func (client *FirewallPoliciesClient) createOrUpdateCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *FirewallPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (FirewallPolicyResponse, error) {
-	var val *FirewallPolicy
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return FirewallPolicyResponse{}, err
-	}
-	return FirewallPolicyResponse{RawResponse: resp.Response, FirewallPolicy: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPoliciesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -129,15 +129,6 @@ func (client *FirewallPolicyRuleGroupsClient) createOrUpdateCreateRequest(ctx co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *FirewallPolicyRuleGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (FirewallPolicyRuleGroupResponse, error) {
-	var val *FirewallPolicyRuleGroup
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return FirewallPolicyRuleGroupResponse{}, err
-	}
-	return FirewallPolicyRuleGroupResponse{RawResponse: resp.Response, FirewallPolicyRuleGroup: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FirewallPolicyRuleGroupsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -129,15 +129,6 @@ func (client *FlowLogsClient) createOrUpdateCreateRequest(ctx context.Context, r
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *FlowLogsClient) createOrUpdateHandleResponse(resp *azcore.Response) (FlowLogResponse, error) {
-	var val *FlowLog
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return FlowLogResponse{}, err
-	}
-	return FlowLogResponse{RawResponse: resp.Response, FlowLog: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *FlowLogsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -129,15 +129,6 @@ func (client *InboundNatRulesClient) createOrUpdateCreateRequest(ctx context.Con
 	return req, req.MarshalAsJSON(inboundNatRuleParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *InboundNatRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (InboundNatRuleResponse, error) {
-	var val *InboundNatRule
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return InboundNatRuleResponse{}, err
-	}
-	return InboundNatRuleResponse{RawResponse: resp.Response, InboundNatRule: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *InboundNatRulesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -125,15 +125,6 @@ func (client *IPAllocationsClient) createOrUpdateCreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *IPAllocationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (IPAllocationResponse, error) {
-	var val *IPAllocation
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return IPAllocationResponse{}, err
-	}
-	return IPAllocationResponse{RawResponse: resp.Response, IPAllocation: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPAllocationsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -125,15 +125,6 @@ func (client *IPGroupsClient) createOrUpdateCreateRequest(ctx context.Context, r
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *IPGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (IPGroupResponse, error) {
-	var val *IPGroup
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return IPGroupResponse{}, err
-	}
-	return IPGroupResponse{RawResponse: resp.Response, IPGroup: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *IPGroupsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -125,15 +125,6 @@ func (client *LoadBalancersClient) createOrUpdateCreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *LoadBalancersClient) createOrUpdateHandleResponse(resp *azcore.Response) (LoadBalancerResponse, error) {
-	var val *LoadBalancer
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LoadBalancerResponse{}, err
-	}
-	return LoadBalancerResponse{RawResponse: resp.Response, LoadBalancer: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LoadBalancersClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -125,15 +125,6 @@ func (client *LocalNetworkGatewaysClient) createOrUpdateCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *LocalNetworkGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (LocalNetworkGatewayResponse, error) {
-	var val *LocalNetworkGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LocalNetworkGatewayResponse{}, err
-	}
-	return LocalNetworkGatewayResponse{RawResponse: resp.Response, LocalNetworkGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *LocalNetworkGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -125,15 +125,6 @@ func (client *NatGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NatGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (NatGatewayResponse, error) {
-	var val *NatGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NatGatewayResponse{}, err
-	}
-	return NatGatewayResponse{RawResponse: resp.Response, NatGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NatGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
@@ -125,15 +125,6 @@ func (client *NetworkInterfacesClient) createOrUpdateCreateRequest(ctx context.C
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkInterfacesClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkInterfaceResponse, error) {
-	var val *NetworkInterface
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NetworkInterfaceResponse{}, err
-	}
-	return NetworkInterfaceResponse{RawResponse: resp.Response, NetworkInterface: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfacesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -415,15 +406,6 @@ func (client *NetworkInterfacesClient) getEffectiveRouteTableCreateRequest(ctx c
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getEffectiveRouteTableHandleResponse handles the GetEffectiveRouteTable response.
-func (client *NetworkInterfacesClient) getEffectiveRouteTableHandleResponse(resp *azcore.Response) (EffectiveRouteListResultResponse, error) {
-	var val *EffectiveRouteListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return EffectiveRouteListResultResponse{}, err
-	}
-	return EffectiveRouteListResultResponse{RawResponse: resp.Response, EffectiveRouteListResult: val}, nil
 }
 
 // getEffectiveRouteTableHandleError handles the GetEffectiveRouteTable error response.
@@ -809,15 +791,6 @@ func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsCreateR
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// listEffectiveNetworkSecurityGroupsHandleResponse handles the ListEffectiveNetworkSecurityGroups response.
-func (client *NetworkInterfacesClient) listEffectiveNetworkSecurityGroupsHandleResponse(resp *azcore.Response) (EffectiveNetworkSecurityGroupListResultResponse, error) {
-	var val *EffectiveNetworkSecurityGroupListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return EffectiveNetworkSecurityGroupListResultResponse{}, err
-	}
-	return EffectiveNetworkSecurityGroupListResultResponse{RawResponse: resp.Response, EffectiveNetworkSecurityGroupListResult: val}, nil
 }
 
 // listEffectiveNetworkSecurityGroupsHandleError handles the ListEffectiveNetworkSecurityGroups error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
@@ -129,15 +129,6 @@ func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateCreateReque
 	return req, req.MarshalAsJSON(tapConfigurationParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkInterfaceTapConfigurationResponse, error) {
-	var val *NetworkInterfaceTapConfiguration
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NetworkInterfaceTapConfigurationResponse{}, err
-	}
-	return NetworkInterfaceTapConfigurationResponse{RawResponse: resp.Response, NetworkInterfaceTapConfiguration: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkInterfaceTapConfigurationsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
@@ -363,15 +363,6 @@ func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationv
 	return req, req.MarshalAsJSON(vpnClientParams)
 }
 
-// generatevirtualwanvpnserverconfigurationvpnprofileHandleResponse handles the Generatevirtualwanvpnserverconfigurationvpnprofile response.
-func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileHandleResponse(resp *azcore.Response) (VPNProfileResponseResponse, error) {
-	var val *VPNProfileResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNProfileResponseResponse{}, err
-	}
-	return VPNProfileResponseResponse{RawResponse: resp.Response, VPNProfileResponse: val}, nil
-}
-
 // generatevirtualwanvpnserverconfigurationvpnprofileHandleError handles the Generatevirtualwanvpnserverconfigurationvpnprofile error response.
 func (client *NetworkManagementClient) generatevirtualwanvpnserverconfigurationvpnprofileHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -505,15 +496,6 @@ func (client *NetworkManagementClient) getActiveSessionsCreateRequest(ctx contex
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getActiveSessionsHandleResponse handles the GetActiveSessions response.
-func (client *NetworkManagementClient) getActiveSessionsHandleResponse(resp *azcore.Response) (BastionActiveSessionListResultResponse, error) {
-	var val *BastionActiveSessionListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return BastionActiveSessionListResultResponse{}, err
-	}
-	return BastionActiveSessionListResultResponse{RawResponse: resp.Response, BastionActiveSessionListResult: val}, nil
 }
 
 // getActiveSessionsHandleError handles the GetActiveSessions error response.
@@ -715,15 +697,6 @@ func (client *NetworkManagementClient) putBastionShareableLinkCreateRequest(ctx 
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(bslRequest)
-}
-
-// putBastionShareableLinkHandleResponse handles the PutBastionShareableLink response.
-func (client *NetworkManagementClient) putBastionShareableLinkHandleResponse(resp *azcore.Response) (BastionShareableLinkListResultResponse, error) {
-	var val *BastionShareableLinkListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return BastionShareableLinkListResultResponse{}, err
-	}
-	return BastionShareableLinkListResultResponse{RawResponse: resp.Response, BastionShareableLinkListResult: val}, nil
 }
 
 // putBastionShareableLinkHandleError handles the PutBastionShareableLink error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
@@ -125,15 +125,6 @@ func (client *NetworkSecurityGroupsClient) createOrUpdateCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkSecurityGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkSecurityGroupResponse, error) {
-	var val *NetworkSecurityGroup
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NetworkSecurityGroupResponse{}, err
-	}
-	return NetworkSecurityGroupResponse{RawResponse: resp.Response, NetworkSecurityGroup: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkSecurityGroupsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
@@ -125,15 +125,6 @@ func (client *NetworkVirtualAppliancesClient) createOrUpdateCreateRequest(ctx co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *NetworkVirtualAppliancesClient) createOrUpdateHandleResponse(resp *azcore.Response) (NetworkVirtualApplianceResponse, error) {
-	var val *NetworkVirtualAppliance
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NetworkVirtualApplianceResponse{}, err
-	}
-	return NetworkVirtualApplianceResponse{RawResponse: resp.Response, NetworkVirtualAppliance: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *NetworkVirtualAppliancesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
@@ -127,15 +127,6 @@ func (client *NetworkWatchersClient) checkConnectivityCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// checkConnectivityHandleResponse handles the CheckConnectivity response.
-func (client *NetworkWatchersClient) checkConnectivityHandleResponse(resp *azcore.Response) (ConnectivityInformationResponse, error) {
-	var val *ConnectivityInformation
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ConnectivityInformationResponse{}, err
-	}
-	return ConnectivityInformationResponse{RawResponse: resp.Response, ConnectivityInformation: val}, nil
-}
-
 // checkConnectivityHandleError handles the CheckConnectivity error response.
 func (client *NetworkWatchersClient) checkConnectivityHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -484,15 +475,6 @@ func (client *NetworkWatchersClient) getAzureReachabilityReportCreateRequest(ctx
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// getAzureReachabilityReportHandleResponse handles the GetAzureReachabilityReport response.
-func (client *NetworkWatchersClient) getAzureReachabilityReportHandleResponse(resp *azcore.Response) (AzureReachabilityReportResponse, error) {
-	var val *AzureReachabilityReport
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AzureReachabilityReportResponse{}, err
-	}
-	return AzureReachabilityReportResponse{RawResponse: resp.Response, AzureReachabilityReport: val}, nil
-}
-
 // getAzureReachabilityReportHandleError handles the GetAzureReachabilityReport error response.
 func (client *NetworkWatchersClient) getAzureReachabilityReportHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -598,15 +580,6 @@ func (client *NetworkWatchersClient) getFlowLogStatusCreateRequest(ctx context.C
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// getFlowLogStatusHandleResponse handles the GetFlowLogStatus response.
-func (client *NetworkWatchersClient) getFlowLogStatusHandleResponse(resp *azcore.Response) (FlowLogInformationResponse, error) {
-	var val *FlowLogInformation
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return FlowLogInformationResponse{}, err
-	}
-	return FlowLogInformationResponse{RawResponse: resp.Response, FlowLogInformation: val}, nil
 }
 
 // getFlowLogStatusHandleError handles the GetFlowLogStatus error response.
@@ -724,15 +697,6 @@ func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticCreateRequ
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// getNetworkConfigurationDiagnosticHandleResponse handles the GetNetworkConfigurationDiagnostic response.
-func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticHandleResponse(resp *azcore.Response) (NetworkConfigurationDiagnosticResponseResponse, error) {
-	var val *NetworkConfigurationDiagnosticResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NetworkConfigurationDiagnosticResponseResponse{}, err
-	}
-	return NetworkConfigurationDiagnosticResponseResponse{RawResponse: resp.Response, NetworkConfigurationDiagnosticResponse: val}, nil
-}
-
 // getNetworkConfigurationDiagnosticHandleError handles the GetNetworkConfigurationDiagnostic error response.
 func (client *NetworkWatchersClient) getNetworkConfigurationDiagnosticHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -838,15 +802,6 @@ func (client *NetworkWatchersClient) getNextHopCreateRequest(ctx context.Context
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// getNextHopHandleResponse handles the GetNextHop response.
-func (client *NetworkWatchersClient) getNextHopHandleResponse(resp *azcore.Response) (NextHopResultResponse, error) {
-	var val *NextHopResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NextHopResultResponse{}, err
-	}
-	return NextHopResultResponse{RawResponse: resp.Response, NextHopResult: val}, nil
 }
 
 // getNextHopHandleError handles the GetNextHop error response.
@@ -1022,15 +977,6 @@ func (client *NetworkWatchersClient) getTroubleshootingCreateRequest(ctx context
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// getTroubleshootingHandleResponse handles the GetTroubleshooting response.
-func (client *NetworkWatchersClient) getTroubleshootingHandleResponse(resp *azcore.Response) (TroubleshootingResultResponse, error) {
-	var val *TroubleshootingResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return TroubleshootingResultResponse{}, err
-	}
-	return TroubleshootingResultResponse{RawResponse: resp.Response, TroubleshootingResult: val}, nil
-}
-
 // getTroubleshootingHandleError handles the GetTroubleshooting error response.
 func (client *NetworkWatchersClient) getTroubleshootingHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1138,15 +1084,6 @@ func (client *NetworkWatchersClient) getTroubleshootingResultCreateRequest(ctx c
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// getTroubleshootingResultHandleResponse handles the GetTroubleshootingResult response.
-func (client *NetworkWatchersClient) getTroubleshootingResultHandleResponse(resp *azcore.Response) (TroubleshootingResultResponse, error) {
-	var val *TroubleshootingResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return TroubleshootingResultResponse{}, err
-	}
-	return TroubleshootingResultResponse{RawResponse: resp.Response, TroubleshootingResult: val}, nil
-}
-
 // getTroubleshootingResultHandleError handles the GetTroubleshootingResult error response.
 func (client *NetworkWatchersClient) getTroubleshootingResultHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1252,15 +1189,6 @@ func (client *NetworkWatchersClient) getVMSecurityRulesCreateRequest(ctx context
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// getVMSecurityRulesHandleResponse handles the GetVMSecurityRules response.
-func (client *NetworkWatchersClient) getVMSecurityRulesHandleResponse(resp *azcore.Response) (SecurityGroupViewResultResponse, error) {
-	var val *SecurityGroupViewResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SecurityGroupViewResultResponse{}, err
-	}
-	return SecurityGroupViewResultResponse{RawResponse: resp.Response, SecurityGroupViewResult: val}, nil
 }
 
 // getVMSecurityRulesHandleError handles the GetVMSecurityRules error response.
@@ -1492,15 +1420,6 @@ func (client *NetworkWatchersClient) listAvailableProvidersCreateRequest(ctx con
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// listAvailableProvidersHandleResponse handles the ListAvailableProviders response.
-func (client *NetworkWatchersClient) listAvailableProvidersHandleResponse(resp *azcore.Response) (AvailableProvidersListResponse, error) {
-	var val *AvailableProvidersList
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return AvailableProvidersListResponse{}, err
-	}
-	return AvailableProvidersListResponse{RawResponse: resp.Response, AvailableProvidersList: val}, nil
-}
-
 // listAvailableProvidersHandleError handles the ListAvailableProviders error response.
 func (client *NetworkWatchersClient) listAvailableProvidersHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1606,15 +1525,6 @@ func (client *NetworkWatchersClient) setFlowLogConfigurationCreateRequest(ctx co
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// setFlowLogConfigurationHandleResponse handles the SetFlowLogConfiguration response.
-func (client *NetworkWatchersClient) setFlowLogConfigurationHandleResponse(resp *azcore.Response) (FlowLogInformationResponse, error) {
-	var val *FlowLogInformation
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return FlowLogInformationResponse{}, err
-	}
-	return FlowLogInformationResponse{RawResponse: resp.Response, FlowLogInformation: val}, nil
 }
 
 // setFlowLogConfigurationHandleError handles the SetFlowLogConfiguration error response.
@@ -1788,15 +1698,6 @@ func (client *NetworkWatchersClient) verifyIPFlowCreateRequest(ctx context.Conte
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// verifyIPFlowHandleResponse handles the VerifyIPFlow response.
-func (client *NetworkWatchersClient) verifyIPFlowHandleResponse(resp *azcore.Response) (VerificationIPFlowResultResponse, error) {
-	var val *VerificationIPFlowResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VerificationIPFlowResultResponse{}, err
-	}
-	return VerificationIPFlowResultResponse{RawResponse: resp.Response, VerificationIPFlowResult: val}, nil
 }
 
 // verifyIPFlowHandleError handles the VerifyIPFlow error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -125,15 +125,6 @@ func (client *P2SVPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(p2SVPNGatewayParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *P2SVPNGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (P2SVPNGatewayResponse, error) {
-	var val *P2SVPNGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return P2SVPNGatewayResponse{}, err
-	}
-	return P2SVPNGatewayResponse{RawResponse: resp.Response, P2SVPNGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *P2SVPNGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -455,15 +446,6 @@ func (client *P2SVPNGatewaysClient) generateVPNProfileCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// generateVPNProfileHandleResponse handles the GenerateVPNProfile response.
-func (client *P2SVPNGatewaysClient) generateVPNProfileHandleResponse(resp *azcore.Response) (VPNProfileResponseResponse, error) {
-	var val *VPNProfileResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNProfileResponseResponse{}, err
-	}
-	return VPNProfileResponseResponse{RawResponse: resp.Response, VPNProfileResponse: val}, nil
-}
-
 // generateVPNProfileHandleError handles the GenerateVPNProfile error response.
 func (client *P2SVPNGatewaysClient) generateVPNProfileHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -637,15 +619,6 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthCreateRequest(ctx c
 	return req, nil
 }
 
-// getP2SVPNConnectionHealthHandleResponse handles the GetP2SVPNConnectionHealth response.
-func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthHandleResponse(resp *azcore.Response) (P2SVPNGatewayResponse, error) {
-	var val *P2SVPNGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return P2SVPNGatewayResponse{}, err
-	}
-	return P2SVPNGatewayResponse{RawResponse: resp.Response, P2SVPNGateway: val}, nil
-}
-
 // getP2SVPNConnectionHealthHandleError handles the GetP2SVPNConnectionHealth error response.
 func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -753,15 +726,6 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthDetailedCreateReque
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
-}
-
-// getP2SVPNConnectionHealthDetailedHandleResponse handles the GetP2SVPNConnectionHealthDetailed response.
-func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthDetailedHandleResponse(resp *azcore.Response) (P2SVPNConnectionHealthResponse, error) {
-	var val *P2SVPNConnectionHealth
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return P2SVPNConnectionHealthResponse{}, err
-	}
-	return P2SVPNConnectionHealthResponse{RawResponse: resp.Response, P2SVPNConnectionHealth: val}, nil
 }
 
 // getP2SVPNConnectionHealthDetailedHandleError handles the GetP2SVPNConnectionHealthDetailed error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -129,15 +129,6 @@ func (client *PacketCapturesClient) createCreateRequest(ctx context.Context, res
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createHandleResponse handles the Create response.
-func (client *PacketCapturesClient) createHandleResponse(resp *azcore.Response) (PacketCaptureResultResponse, error) {
-	var val *PacketCaptureResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PacketCaptureResultResponse{}, err
-	}
-	return PacketCaptureResultResponse{RawResponse: resp.Response, PacketCaptureResult: val}, nil
-}
-
 // createHandleError handles the Create error response.
 func (client *PacketCapturesClient) createHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -428,15 +419,6 @@ func (client *PacketCapturesClient) getStatusCreateRequest(ctx context.Context, 
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getStatusHandleResponse handles the GetStatus response.
-func (client *PacketCapturesClient) getStatusHandleResponse(resp *azcore.Response) (PacketCaptureQueryStatusResultResponse, error) {
-	var val *PacketCaptureQueryStatusResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PacketCaptureQueryStatusResultResponse{}, err
-	}
-	return PacketCaptureQueryStatusResultResponse{RawResponse: resp.Response, PacketCaptureQueryStatusResult: val}, nil
 }
 
 // getStatusHandleError handles the GetStatus error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -129,15 +129,6 @@ func (client *PrivateDNSZoneGroupsClient) createOrUpdateCreateRequest(ctx contex
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *PrivateDNSZoneGroupsClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateDNSZoneGroupResponse, error) {
-	var val *PrivateDNSZoneGroup
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PrivateDNSZoneGroupResponse{}, err
-	}
-	return PrivateDNSZoneGroupResponse{RawResponse: resp.Response, PrivateDNSZoneGroup: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateDNSZoneGroupsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -125,15 +125,6 @@ func (client *PrivateEndpointsClient) createOrUpdateCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *PrivateEndpointsClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateEndpointResponse, error) {
-	var val *PrivateEndpoint
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PrivateEndpointResponse{}, err
-	}
-	return PrivateEndpointResponse{RawResponse: resp.Response, PrivateEndpoint: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PrivateEndpointsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -121,15 +121,6 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityCreate
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// checkPrivateLinkServiceVisibilityHandleResponse handles the CheckPrivateLinkServiceVisibility response.
-func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityHandleResponse(resp *azcore.Response) (PrivateLinkServiceVisibilityResponse, error) {
-	var val *PrivateLinkServiceVisibility
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PrivateLinkServiceVisibilityResponse{}, err
-	}
-	return PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response, PrivateLinkServiceVisibility: val}, nil
-}
-
 // checkPrivateLinkServiceVisibilityHandleError handles the CheckPrivateLinkServiceVisibility error response.
 func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -238,15 +229,6 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByReso
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// checkPrivateLinkServiceVisibilityByResourceGroupHandleResponse handles the CheckPrivateLinkServiceVisibilityByResourceGroup response.
-func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByResourceGroupHandleResponse(resp *azcore.Response) (PrivateLinkServiceVisibilityResponse, error) {
-	var val *PrivateLinkServiceVisibility
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PrivateLinkServiceVisibilityResponse{}, err
-	}
-	return PrivateLinkServiceVisibilityResponse{RawResponse: resp.Response, PrivateLinkServiceVisibility: val}, nil
-}
-
 // checkPrivateLinkServiceVisibilityByResourceGroupHandleError handles the CheckPrivateLinkServiceVisibilityByResourceGroup error response.
 func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByResourceGroupHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -352,15 +334,6 @@ func (client *PrivateLinkServicesClient) createOrUpdateCreateRequest(ctx context
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *PrivateLinkServicesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PrivateLinkServiceResponse, error) {
-	var val *PrivateLinkService
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PrivateLinkServiceResponse{}, err
-	}
-	return PrivateLinkServiceResponse{RawResponse: resp.Response, PrivateLinkService: val}, nil
 }
 
 // createOrUpdateHandleError handles the CreateOrUpdate error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -125,15 +125,6 @@ func (client *PublicIPAddressesClient) createOrUpdateCreateRequest(ctx context.C
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *PublicIPAddressesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PublicIPAddressResponse, error) {
-	var val *PublicIPAddress
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PublicIPAddressResponse{}, err
-	}
-	return PublicIPAddressResponse{RawResponse: resp.Response, PublicIPAddress: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPAddressesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -125,15 +125,6 @@ func (client *PublicIPPrefixesClient) createOrUpdateCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *PublicIPPrefixesClient) createOrUpdateHandleResponse(resp *azcore.Response) (PublicIPPrefixResponse, error) {
-	var val *PublicIPPrefix
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PublicIPPrefixResponse{}, err
-	}
-	return PublicIPPrefixResponse{RawResponse: resp.Response, PublicIPPrefix: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *PublicIPPrefixesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -129,15 +129,6 @@ func (client *RouteFilterRulesClient) createOrUpdateCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(routeFilterRuleParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *RouteFilterRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteFilterRuleResponse, error) {
-	var val *RouteFilterRule
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RouteFilterRuleResponse{}, err
-	}
-	return RouteFilterRuleResponse{RawResponse: resp.Response, RouteFilterRule: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFilterRulesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -125,15 +125,6 @@ func (client *RouteFiltersClient) createOrUpdateCreateRequest(ctx context.Contex
 	return req, req.MarshalAsJSON(routeFilterParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *RouteFiltersClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteFilterResponse, error) {
-	var val *RouteFilter
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RouteFilterResponse{}, err
-	}
-	return RouteFilterResponse{RawResponse: resp.Response, RouteFilter: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteFiltersClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -129,15 +129,6 @@ func (client *RoutesClient) createOrUpdateCreateRequest(ctx context.Context, res
 	return req, req.MarshalAsJSON(routeParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *RoutesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteResponse, error) {
-	var val *Route
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RouteResponse{}, err
-	}
-	return RouteResponse{RawResponse: resp.Response, Route: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RoutesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -125,15 +125,6 @@ func (client *RouteTablesClient) createOrUpdateCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *RouteTablesClient) createOrUpdateHandleResponse(resp *azcore.Response) (RouteTableResponse, error) {
-	var val *RouteTable
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return RouteTableResponse{}, err
-	}
-	return RouteTableResponse{RawResponse: resp.Response, RouteTable: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *RouteTablesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -125,15 +125,6 @@ func (client *SecurityPartnerProvidersClient) createOrUpdateCreateRequest(ctx co
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *SecurityPartnerProvidersClient) createOrUpdateHandleResponse(resp *azcore.Response) (SecurityPartnerProviderResponse, error) {
-	var val *SecurityPartnerProvider
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SecurityPartnerProviderResponse{}, err
-	}
-	return SecurityPartnerProviderResponse{RawResponse: resp.Response, SecurityPartnerProvider: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityPartnerProvidersClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -129,15 +129,6 @@ func (client *SecurityRulesClient) createOrUpdateCreateRequest(ctx context.Conte
 	return req, req.MarshalAsJSON(securityRuleParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *SecurityRulesClient) createOrUpdateHandleResponse(resp *azcore.Response) (SecurityRuleResponse, error) {
-	var val *SecurityRule
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SecurityRuleResponse{}, err
-	}
-	return SecurityRuleResponse{RawResponse: resp.Response, SecurityRule: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SecurityRulesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -125,15 +125,6 @@ func (client *ServiceEndpointPoliciesClient) createOrUpdateCreateRequest(ctx con
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ServiceEndpointPoliciesClient) createOrUpdateHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyResponse, error) {
-	var val *ServiceEndpointPolicy
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ServiceEndpointPolicyResponse{}, err
-	}
-	return ServiceEndpointPolicyResponse{RawResponse: resp.Response, ServiceEndpointPolicy: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPoliciesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -129,15 +129,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdateCreateReques
 	return req, req.MarshalAsJSON(serviceEndpointPolicyDefinitions)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (ServiceEndpointPolicyDefinitionResponse, error) {
-	var val *ServiceEndpointPolicyDefinition
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ServiceEndpointPolicyDefinitionResponse{}, err
-	}
-	return ServiceEndpointPolicyDefinitionResponse{RawResponse: resp.Response, ServiceEndpointPolicyDefinition: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -129,15 +129,6 @@ func (client *SubnetsClient) createOrUpdateCreateRequest(ctx context.Context, re
 	return req, req.MarshalAsJSON(subnetParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *SubnetsClient) createOrUpdateHandleResponse(resp *azcore.Response) (SubnetResponse, error) {
-	var val *Subnet
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SubnetResponse{}, err
-	}
-	return SubnetResponse{RawResponse: resp.Response, Subnet: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *SubnetsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -129,15 +129,6 @@ func (client *VirtualHubRouteTableV2SClient) createOrUpdateCreateRequest(ctx con
 	return req, req.MarshalAsJSON(virtualHubRouteTableV2Parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualHubRouteTableV2SClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualHubRouteTableV2Response, error) {
-	var val *VirtualHubRouteTableV2
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualHubRouteTableV2Response{}, err
-	}
-	return VirtualHubRouteTableV2Response{RawResponse: resp.Response, VirtualHubRouteTableV2: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubRouteTableV2SClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -125,15 +125,6 @@ func (client *VirtualHubsClient) createOrUpdateCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(virtualHubParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualHubsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualHubResponse, error) {
-	var val *VirtualHub
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualHubResponse{}, err
-	}
-	return VirtualHubResponse{RawResponse: resp.Response, VirtualHub: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualHubsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -125,15 +125,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdateCreateReques
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionResponse, error) {
-	var val *VirtualNetworkGatewayConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkGatewayConnectionResponse{}, err
-	}
-	return VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnection: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -547,15 +538,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKeyCreateReques
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// resetSharedKeyHandleResponse handles the ResetSharedKey response.
-func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKeyHandleResponse(resp *azcore.Response) (ConnectionResetSharedKeyResponse, error) {
-	var val *ConnectionResetSharedKey
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ConnectionResetSharedKeyResponse{}, err
-	}
-	return ConnectionResetSharedKeyResponse{RawResponse: resp.Response, ConnectionResetSharedKey: val}, nil
-}
-
 // resetSharedKeyHandleError handles the ResetSharedKey error response.
 func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKeyHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -665,15 +647,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) setSharedKeyCreateRequest(
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// setSharedKeyHandleResponse handles the SetSharedKey response.
-func (client *VirtualNetworkGatewayConnectionsClient) setSharedKeyHandleResponse(resp *azcore.Response) (ConnectionSharedKeyResponse, error) {
-	var val *ConnectionSharedKey
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return ConnectionSharedKeyResponse{}, err
-	}
-	return ConnectionSharedKeyResponse{RawResponse: resp.Response, ConnectionSharedKey: val}, nil
 }
 
 // setSharedKeyHandleError handles the SetSharedKey error response.
@@ -786,15 +759,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureCreateRe
 	return req, nil
 }
 
-// startPacketCaptureHandleResponse handles the StartPacketCapture response.
-func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
-}
-
 // startPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -902,15 +866,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCaptureCreateReq
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// stopPacketCaptureHandleResponse handles the StopPacketCapture response.
-func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
-}
-
 // stopPacketCaptureHandleError handles the StopPacketCapture error response.
 func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCaptureHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1016,15 +971,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) updateTagsCreateRequest(ct
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateTagsHandleResponse handles the UpdateTags response.
-func (client *VirtualNetworkGatewayConnectionsClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayConnectionResponse, error) {
-	var val *VirtualNetworkGatewayConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkGatewayConnectionResponse{}, err
-	}
-	return VirtualNetworkGatewayConnectionResponse{RawResponse: resp.Response, VirtualNetworkGatewayConnection: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -125,15 +125,6 @@ func (client *VirtualNetworkGatewaysClient) createOrUpdateCreateRequest(ctx cont
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualNetworkGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	var val *VirtualNetworkGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkGatewayResponse{}, err
-	}
-	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -457,15 +448,6 @@ func (client *VirtualNetworkGatewaysClient) generateVPNProfileCreateRequest(ctx 
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// generateVPNProfileHandleResponse handles the GenerateVPNProfile response.
-func (client *VirtualNetworkGatewaysClient) generateVPNProfileHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
-}
-
 // generateVPNProfileHandleError handles the GenerateVPNProfile error response.
 func (client *VirtualNetworkGatewaysClient) generateVPNProfileHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -571,15 +553,6 @@ func (client *VirtualNetworkGatewaysClient) generatevpnclientpackageCreateReques
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// generatevpnclientpackageHandleResponse handles the Generatevpnclientpackage response.
-func (client *VirtualNetworkGatewaysClient) generatevpnclientpackageHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // generatevpnclientpackageHandleError handles the Generatevpnclientpackage error response.
@@ -756,15 +729,6 @@ func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutesCreateRequest(ctx
 	return req, nil
 }
 
-// getAdvertisedRoutesHandleResponse handles the GetAdvertisedRoutes response.
-func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutesHandleResponse(resp *azcore.Response) (GatewayRouteListResultResponse, error) {
-	var val *GatewayRouteListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GatewayRouteListResultResponse{}, err
-	}
-	return GatewayRouteListResultResponse{RawResponse: resp.Response, GatewayRouteListResult: val}, nil
-}
-
 // getAdvertisedRoutesHandleError handles the GetAdvertisedRoutes error response.
 func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutesHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -875,15 +839,6 @@ func (client *VirtualNetworkGatewaysClient) getBgpPeerStatusCreateRequest(ctx co
 	return req, nil
 }
 
-// getBgpPeerStatusHandleResponse handles the GetBgpPeerStatus response.
-func (client *VirtualNetworkGatewaysClient) getBgpPeerStatusHandleResponse(resp *azcore.Response) (BgpPeerStatusListResultResponse, error) {
-	var val *BgpPeerStatusListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return BgpPeerStatusListResultResponse{}, err
-	}
-	return BgpPeerStatusListResultResponse{RawResponse: resp.Response, BgpPeerStatusListResult: val}, nil
-}
-
 // getBgpPeerStatusHandleError handles the GetBgpPeerStatus error response.
 func (client *VirtualNetworkGatewaysClient) getBgpPeerStatusHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -989,15 +944,6 @@ func (client *VirtualNetworkGatewaysClient) getLearnedRoutesCreateRequest(ctx co
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getLearnedRoutesHandleResponse handles the GetLearnedRoutes response.
-func (client *VirtualNetworkGatewaysClient) getLearnedRoutesHandleResponse(resp *azcore.Response) (GatewayRouteListResultResponse, error) {
-	var val *GatewayRouteListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return GatewayRouteListResultResponse{}, err
-	}
-	return GatewayRouteListResultResponse{RawResponse: resp.Response, GatewayRouteListResult: val}, nil
 }
 
 // getLearnedRoutesHandleError handles the GetLearnedRoutes error response.
@@ -1109,15 +1055,6 @@ func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURLCreateRequest
 	return req, nil
 }
 
-// getVPNProfilePackageURLHandleResponse handles the GetVPNProfilePackageURL response.
-func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURLHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
-}
-
 // getVPNProfilePackageURLHandleError handles the GetVPNProfilePackageURL error response.
 func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURLHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1225,15 +1162,6 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientConnectionHealthCreateRe
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getVpnclientConnectionHealthHandleResponse handles the GetVpnclientConnectionHealth response.
-func (client *VirtualNetworkGatewaysClient) getVpnclientConnectionHealthHandleResponse(resp *azcore.Response) (VPNClientConnectionHealthDetailListResultResponse, error) {
-	var val *VPNClientConnectionHealthDetailListResult
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNClientConnectionHealthDetailListResultResponse{}, err
-	}
-	return VPNClientConnectionHealthDetailListResultResponse{RawResponse: resp.Response, VPNClientConnectionHealthDetailListResult: val}, nil
 }
 
 // getVpnclientConnectionHealthHandleError handles the GetVpnclientConnectionHealth error response.
@@ -1345,15 +1273,6 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientIPSecParametersCreateReq
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// getVpnclientIPSecParametersHandleResponse handles the GetVpnclientIPSecParameters response.
-func (client *VirtualNetworkGatewaysClient) getVpnclientIPSecParametersHandleResponse(resp *azcore.Response) (VPNClientIPsecParametersResponse, error) {
-	var val *VPNClientIPsecParameters
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNClientIPsecParametersResponse{}, err
-	}
-	return VPNClientIPsecParametersResponse{RawResponse: resp.Response, VPNClientIPsecParameters: val}, nil
 }
 
 // getVpnclientIPSecParametersHandleError handles the GetVpnclientIPSecParameters error response.
@@ -1594,15 +1513,6 @@ func (client *VirtualNetworkGatewaysClient) resetCreateRequest(ctx context.Conte
 	return req, nil
 }
 
-// resetHandleResponse handles the Reset response.
-func (client *VirtualNetworkGatewaysClient) resetHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	var val *VirtualNetworkGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkGatewayResponse{}, err
-	}
-	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
-}
-
 // resetHandleError handles the Reset error response.
 func (client *VirtualNetworkGatewaysClient) resetHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1819,15 +1729,6 @@ func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParametersCreateReq
 	return req, req.MarshalAsJSON(vpnclientIPSecParams)
 }
 
-// setVpnclientIPSecParametersHandleResponse handles the SetVpnclientIPSecParameters response.
-func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParametersHandleResponse(resp *azcore.Response) (VPNClientIPsecParametersResponse, error) {
-	var val *VPNClientIPsecParameters
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNClientIPsecParametersResponse{}, err
-	}
-	return VPNClientIPsecParametersResponse{RawResponse: resp.Response, VPNClientIPsecParameters: val}, nil
-}
-
 // setVpnclientIPSecParametersHandleError handles the SetVpnclientIPSecParameters error response.
 func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParametersHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -1938,15 +1839,6 @@ func (client *VirtualNetworkGatewaysClient) startPacketCaptureCreateRequest(ctx 
 	return req, nil
 }
 
-// startPacketCaptureHandleResponse handles the StartPacketCapture response.
-func (client *VirtualNetworkGatewaysClient) startPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
-}
-
 // startPacketCaptureHandleError handles the StartPacketCapture error response.
 func (client *VirtualNetworkGatewaysClient) startPacketCaptureHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -2052,15 +1944,6 @@ func (client *VirtualNetworkGatewaysClient) stopPacketCaptureCreateRequest(ctx c
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// stopPacketCaptureHandleResponse handles the StopPacketCapture response.
-func (client *VirtualNetworkGatewaysClient) stopPacketCaptureHandleResponse(resp *azcore.Response) (StringResponse, error) {
-	var val *string
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return StringResponse{}, err
-	}
-	return StringResponse{RawResponse: resp.Response, Value: val}, nil
 }
 
 // stopPacketCaptureHandleError handles the StopPacketCapture error response.
@@ -2234,15 +2117,6 @@ func (client *VirtualNetworkGatewaysClient) updateTagsCreateRequest(ctx context.
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(parameters)
-}
-
-// updateTagsHandleResponse handles the UpdateTags response.
-func (client *VirtualNetworkGatewaysClient) updateTagsHandleResponse(resp *azcore.Response) (VirtualNetworkGatewayResponse, error) {
-	var val *VirtualNetworkGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkGatewayResponse{}, err
-	}
-	return VirtualNetworkGatewayResponse{RawResponse: resp.Response, VirtualNetworkGateway: val}, nil
 }
 
 // updateTagsHandleError handles the UpdateTags error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -129,15 +129,6 @@ func (client *VirtualNetworkPeeringsClient) createOrUpdateCreateRequest(ctx cont
 	return req, req.MarshalAsJSON(virtualNetworkPeeringParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualNetworkPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkPeeringResponse, error) {
-	var val *VirtualNetworkPeering
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkPeeringResponse{}, err
-	}
-	return VirtualNetworkPeeringResponse{RawResponse: resp.Response, VirtualNetworkPeering: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkPeeringsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -192,15 +192,6 @@ func (client *VirtualNetworksClient) createOrUpdateCreateRequest(ctx context.Con
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualNetworksClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkResponse, error) {
-	var val *VirtualNetwork
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkResponse{}, err
-	}
-	return VirtualNetworkResponse{RawResponse: resp.Response, VirtualNetwork: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworksClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -125,15 +125,6 @@ func (client *VirtualNetworkTapsClient) createOrUpdateCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualNetworkTapsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualNetworkTapResponse, error) {
-	var val *VirtualNetworkTap
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualNetworkTapResponse{}, err
-	}
-	return VirtualNetworkTapResponse{RawResponse: resp.Response, VirtualNetworkTap: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualNetworkTapsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -129,15 +129,6 @@ func (client *VirtualRouterPeeringsClient) createOrUpdateCreateRequest(ctx conte
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualRouterPeeringsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualRouterPeeringResponse, error) {
-	var val *VirtualRouterPeering
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualRouterPeeringResponse{}, err
-	}
-	return VirtualRouterPeeringResponse{RawResponse: resp.Response, VirtualRouterPeering: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRouterPeeringsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -125,15 +125,6 @@ func (client *VirtualRoutersClient) createOrUpdateCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(parameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualRoutersClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualRouterResponse, error) {
-	var val *VirtualRouter
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualRouterResponse{}, err
-	}
-	return VirtualRouterResponse{RawResponse: resp.Response, VirtualRouter: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualRoutersClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -125,15 +125,6 @@ func (client *VirtualWansClient) createOrUpdateCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(wanParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VirtualWansClient) createOrUpdateHandleResponse(resp *azcore.Response) (VirtualWANResponse, error) {
-	var val *VirtualWAN
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VirtualWANResponse{}, err
-	}
-	return VirtualWANResponse{RawResponse: resp.Response, VirtualWAN: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VirtualWansClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -129,15 +129,6 @@ func (client *VPNConnectionsClient) createOrUpdateCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(vpnConnectionParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VPNConnectionsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VPNConnectionResponse, error) {
-	var val *VPNConnection
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNConnectionResponse{}, err
-	}
-	return VPNConnectionResponse{RawResponse: resp.Response, VPNConnection: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VPNConnectionsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -125,15 +125,6 @@ func (client *VPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 	return req, req.MarshalAsJSON(vpnGatewayParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VPNGatewaysClient) createOrUpdateHandleResponse(resp *azcore.Response) (VPNGatewayResponse, error) {
-	var val *VPNGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNGatewayResponse{}, err
-	}
-	return VPNGatewayResponse{RawResponse: resp.Response, VPNGateway: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VPNGatewaysClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -532,15 +523,6 @@ func (client *VPNGatewaysClient) resetCreateRequest(ctx context.Context, resourc
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// resetHandleResponse handles the Reset response.
-func (client *VPNGatewaysClient) resetHandleResponse(resp *azcore.Response) (VPNGatewayResponse, error) {
-	var val *VPNGateway
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNGatewayResponse{}, err
-	}
-	return VPNGatewayResponse{RawResponse: resp.Response, VPNGateway: val}, nil
 }
 
 // resetHandleError handles the Reset error response.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -125,15 +125,6 @@ func (client *VPNServerConfigurationsClient) createOrUpdateCreateRequest(ctx con
 	return req, req.MarshalAsJSON(vpnServerConfigurationParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VPNServerConfigurationsClient) createOrUpdateHandleResponse(resp *azcore.Response) (VPNServerConfigurationResponse, error) {
-	var val *VPNServerConfiguration
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNServerConfigurationResponse{}, err
-	}
-	return VPNServerConfigurationResponse{RawResponse: resp.Response, VPNServerConfiguration: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VPNServerConfigurationsClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -125,15 +125,6 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) listCreateR
 	return req, nil
 }
 
-// listHandleResponse handles the List response.
-func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) listHandleResponse(resp *azcore.Response) (VPNServerConfigurationsResponseResponse, error) {
-	var val *VPNServerConfigurationsResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNServerConfigurationsResponseResponse{}, err
-	}
-	return VPNServerConfigurationsResponseResponse{RawResponse: resp.Response, VPNServerConfigurationsResponse: val}, nil
-}
-
 // listHandleError handles the List error response.
 func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) listHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -125,15 +125,6 @@ func (client *VPNSitesClient) createOrUpdateCreateRequest(ctx context.Context, r
 	return req, req.MarshalAsJSON(vpnSiteParameters)
 }
 
-// createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *VPNSitesClient) createOrUpdateHandleResponse(resp *azcore.Response) (VPNSiteResponse, error) {
-	var val *VPNSite
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return VPNSiteResponse{}, err
-	}
-	return VPNSiteResponse{RawResponse: resp.Response, VPNSite: val}, nil
-}
-
 // createOrUpdateHandleError handles the CreateOrUpdate error response.
 func (client *VPNSitesClient) createOrUpdateHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -109,15 +109,6 @@ func (client *dataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(dataFlow)
 }
 
-// createOrUpdateDataFlowHandleResponse handles the CreateOrUpdateDataFlow response.
-func (client *dataFlowClient) createOrUpdateDataFlowHandleResponse(resp *azcore.Response) (DataFlowResourceResponse, error) {
-	var val *DataFlowResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DataFlowResourceResponse{}, err
-	}
-	return DataFlowResourceResponse{RawResponse: resp.Response, DataFlowResource: val}, nil
-}
-
 // createOrUpdateDataFlowHandleError handles the CreateOrUpdateDataFlow error response.
 func (client *dataFlowClient) createOrUpdateDataFlowHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -153,15 +153,6 @@ func (client *dataFlowDebugSessionClient) createDataFlowDebugSessionCreateReques
 	return req, req.MarshalAsJSON(request)
 }
 
-// createDataFlowDebugSessionHandleResponse handles the CreateDataFlowDebugSession response.
-func (client *dataFlowDebugSessionClient) createDataFlowDebugSessionHandleResponse(resp *azcore.Response) (CreateDataFlowDebugSessionResponseResponse, error) {
-	var val *CreateDataFlowDebugSessionResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return CreateDataFlowDebugSessionResponseResponse{}, err
-	}
-	return CreateDataFlowDebugSessionResponseResponse{RawResponse: resp.Response, CreateDataFlowDebugSessionResponse: val}, nil
-}
-
 // createDataFlowDebugSessionHandleError handles the CreateDataFlowDebugSession error response.
 func (client *dataFlowDebugSessionClient) createDataFlowDebugSessionHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -298,15 +289,6 @@ func (client *dataFlowDebugSessionClient) executeCommandCreateRequest(ctx contex
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(request)
-}
-
-// executeCommandHandleResponse handles the ExecuteCommand response.
-func (client *dataFlowDebugSessionClient) executeCommandHandleResponse(resp *azcore.Response) (DataFlowDebugCommandResponseResponse, error) {
-	var val *DataFlowDebugCommandResponse
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DataFlowDebugCommandResponseResponse{}, err
-	}
-	return DataFlowDebugCommandResponseResponse{RawResponse: resp.Response, DataFlowDebugCommandResponse: val}, nil
 }
 
 // executeCommandHandleError handles the ExecuteCommand error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -109,15 +109,6 @@ func (client *datasetClient) createOrUpdateDatasetCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(dataset)
 }
 
-// createOrUpdateDatasetHandleResponse handles the CreateOrUpdateDataset response.
-func (client *datasetClient) createOrUpdateDatasetHandleResponse(resp *azcore.Response) (DatasetResourceResponse, error) {
-	var val *DatasetResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return DatasetResourceResponse{}, err
-	}
-	return DatasetResourceResponse{RawResponse: resp.Response, DatasetResource: val}, nil
-}
-
 // createOrUpdateDatasetHandleError handles the CreateOrUpdateDataset error response.
 func (client *datasetClient) createOrUpdateDatasetHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -160,15 +160,6 @@ func (client *libraryClient) createCreateRequest(ctx context.Context, libraryNam
 	return req, nil
 }
 
-// createHandleResponse handles the Create response.
-func (client *libraryClient) createHandleResponse(resp *azcore.Response) (LibraryResourceInfoResponse, error) {
-	var val *LibraryResourceInfo
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LibraryResourceInfoResponse{}, err
-	}
-	return LibraryResourceInfoResponse{RawResponse: resp.Response, LibraryResourceInfo: val}, nil
-}
-
 // createHandleError handles the Create error response.
 func (client *libraryClient) createHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -266,15 +257,6 @@ func (client *libraryClient) deleteCreateRequest(ctx context.Context, libraryNam
 	return req, nil
 }
 
-// deleteHandleResponse handles the Delete response.
-func (client *libraryClient) deleteHandleResponse(resp *azcore.Response) (LibraryResourceInfoResponse, error) {
-	var val *LibraryResourceInfo
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LibraryResourceInfoResponse{}, err
-	}
-	return LibraryResourceInfoResponse{RawResponse: resp.Response, LibraryResourceInfo: val}, nil
-}
-
 // deleteHandleError handles the Delete error response.
 func (client *libraryClient) deleteHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -370,15 +352,6 @@ func (client *libraryClient) flushCreateRequest(ctx context.Context, libraryName
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// flushHandleResponse handles the Flush response.
-func (client *libraryClient) flushHandleResponse(resp *azcore.Response) (LibraryResourceInfoResponse, error) {
-	var val *LibraryResourceInfo
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LibraryResourceInfoResponse{}, err
-	}
-	return LibraryResourceInfoResponse{RawResponse: resp.Response, LibraryResourceInfo: val}, nil
 }
 
 // flushHandleError handles the Flush error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -109,15 +109,6 @@ func (client *linkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx 
 	return req, req.MarshalAsJSON(linkedService)
 }
 
-// createOrUpdateLinkedServiceHandleResponse handles the CreateOrUpdateLinkedService response.
-func (client *linkedServiceClient) createOrUpdateLinkedServiceHandleResponse(resp *azcore.Response) (LinkedServiceResourceResponse, error) {
-	var val *LinkedServiceResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return LinkedServiceResourceResponse{}, err
-	}
-	return LinkedServiceResourceResponse{RawResponse: resp.Response, LinkedServiceResource: val}, nil
-}
-
 // createOrUpdateLinkedServiceHandleError handles the CreateOrUpdateLinkedService error response.
 func (client *linkedServiceClient) createOrUpdateLinkedServiceHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -109,15 +109,6 @@ func (client *notebookClient) createOrUpdateNotebookCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(notebook)
 }
 
-// createOrUpdateNotebookHandleResponse handles the CreateOrUpdateNotebook response.
-func (client *notebookClient) createOrUpdateNotebookHandleResponse(resp *azcore.Response) (NotebookResourceResponse, error) {
-	var val *NotebookResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return NotebookResourceResponse{}, err
-	}
-	return NotebookResourceResponse{RawResponse: resp.Response, NotebookResource: val}, nil
-}
-
 // createOrUpdateNotebookHandleError handles the CreateOrUpdateNotebook error response.
 func (client *notebookClient) createOrUpdateNotebookHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -110,15 +110,6 @@ func (client *pipelineClient) createOrUpdatePipelineCreateRequest(ctx context.Co
 	return req, req.MarshalAsJSON(pipeline)
 }
 
-// createOrUpdatePipelineHandleResponse handles the CreateOrUpdatePipeline response.
-func (client *pipelineClient) createOrUpdatePipelineHandleResponse(resp *azcore.Response) (PipelineResourceResponse, error) {
-	var val *PipelineResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return PipelineResourceResponse{}, err
-	}
-	return PipelineResourceResponse{RawResponse: resp.Response, PipelineResource: val}, nil
-}
-
 // createOrUpdatePipelineHandleError handles the CreateOrUpdatePipeline error response.
 func (client *pipelineClient) createOrUpdatePipelineHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -109,15 +109,6 @@ func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateRe
 	return req, req.MarshalAsJSON(sparkJobDefinition)
 }
 
-// createOrUpdateSparkJobDefinitionHandleResponse handles the CreateOrUpdateSparkJobDefinition response.
-func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkJobDefinitionResourceResponse, error) {
-	var val *SparkJobDefinitionResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SparkJobDefinitionResourceResponse{}, err
-	}
-	return SparkJobDefinitionResourceResponse{RawResponse: resp.Response, SparkJobDefinitionResource: val}, nil
-}
-
 // createOrUpdateSparkJobDefinitionHandleError handles the CreateOrUpdateSparkJobDefinition error response.
 func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -209,15 +200,6 @@ func (client *sparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, req.MarshalAsJSON(sparkJobDefinitionAzureResource)
-}
-
-// debugSparkJobDefinitionHandleResponse handles the DebugSparkJobDefinition response.
-func (client *sparkJobDefinitionClient) debugSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	var val *SparkBatchJob
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SparkBatchJobResponse{}, err
-	}
-	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // debugSparkJobDefinitionHandleError handles the DebugSparkJobDefinition error response.
@@ -412,15 +394,6 @@ func (client *sparkJobDefinitionClient) executeSparkJobDefinitionCreateRequest(c
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// executeSparkJobDefinitionHandleResponse handles the ExecuteSparkJobDefinition response.
-func (client *sparkJobDefinitionClient) executeSparkJobDefinitionHandleResponse(resp *azcore.Response) (SparkBatchJobResponse, error) {
-	var val *SparkBatchJob
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SparkBatchJobResponse{}, err
-	}
-	return SparkBatchJobResponse{RawResponse: resp.Response, SparkBatchJob: val}, nil
 }
 
 // executeSparkJobDefinitionHandleError handles the ExecuteSparkJobDefinition error response.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -109,15 +109,6 @@ func (client *sqlScriptClient) createOrUpdateSQLScriptCreateRequest(ctx context.
 	return req, req.MarshalAsJSON(sqlScript)
 }
 
-// createOrUpdateSQLScriptHandleResponse handles the CreateOrUpdateSQLScript response.
-func (client *sqlScriptClient) createOrUpdateSQLScriptHandleResponse(resp *azcore.Response) (SQLScriptResourceResponse, error) {
-	var val *SQLScriptResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return SQLScriptResourceResponse{}, err
-	}
-	return SQLScriptResourceResponse{RawResponse: resp.Response, SQLScriptResource: val}, nil
-}
-
 // createOrUpdateSQLScriptHandleError handles the CreateOrUpdateSQLScript error response.
 func (client *sqlScriptClient) createOrUpdateSQLScriptHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -109,15 +109,6 @@ func (client *triggerClient) createOrUpdateTriggerCreateRequest(ctx context.Cont
 	return req, req.MarshalAsJSON(trigger)
 }
 
-// createOrUpdateTriggerHandleResponse handles the CreateOrUpdateTrigger response.
-func (client *triggerClient) createOrUpdateTriggerHandleResponse(resp *azcore.Response) (TriggerResourceResponse, error) {
-	var val *TriggerResource
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return TriggerResourceResponse{}, err
-	}
-	return TriggerResourceResponse{RawResponse: resp.Response, TriggerResource: val}, nil
-}
-
 // createOrUpdateTriggerHandleError handles the CreateOrUpdateTrigger error response.
 func (client *triggerClient) createOrUpdateTriggerHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -679,15 +670,6 @@ func (client *triggerClient) subscribeTriggerToEventsCreateRequest(ctx context.C
 	return req, nil
 }
 
-// subscribeTriggerToEventsHandleResponse handles the SubscribeTriggerToEvents response.
-func (client *triggerClient) subscribeTriggerToEventsHandleResponse(resp *azcore.Response) (TriggerSubscriptionOperationStatusResponse, error) {
-	var val *TriggerSubscriptionOperationStatus
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return TriggerSubscriptionOperationStatusResponse{}, err
-	}
-	return TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response, TriggerSubscriptionOperationStatus: val}, nil
-}
-
 // subscribeTriggerToEventsHandleError handles the SubscribeTriggerToEvents error response.
 func (client *triggerClient) subscribeTriggerToEventsHandleError(resp *azcore.Response) error {
 	body, err := resp.Payload()
@@ -783,15 +765,6 @@ func (client *triggerClient) unsubscribeTriggerFromEventsCreateRequest(ctx conte
 	req.URL.RawQuery = reqQP.Encode()
 	req.Header.Set("Accept", "application/json")
 	return req, nil
-}
-
-// unsubscribeTriggerFromEventsHandleResponse handles the UnsubscribeTriggerFromEvents response.
-func (client *triggerClient) unsubscribeTriggerFromEventsHandleResponse(resp *azcore.Response) (TriggerSubscriptionOperationStatusResponse, error) {
-	var val *TriggerSubscriptionOperationStatus
-	if err := resp.UnmarshalAsJSON(&val); err != nil {
-		return TriggerSubscriptionOperationStatusResponse{}, err
-	}
-	return TriggerSubscriptionOperationStatusResponse{RawResponse: resp.Response, TriggerSubscriptionOperationStatus: val}, nil
 }
 
 // unsubscribeTriggerFromEventsHandleError handles the UnsubscribeTriggerFromEvents error response.


### PR DESCRIPTION
LRO responses are unmarshalled by the pollers, so the handlers on the
clients weren't being used.