### PR TITLE
Fix handling of byte arrays

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -76,7 +76,7 @@ const tables = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228
 generateFromReadme(tables, 'package-2019-02', 'test/tables/2019-02-02/aztables', '--security=AADToken --security-scopes="https://tables.azure.com/.default" --module=aztables --openapi-type="data-plane" --export-clients --azure-validator=false');
 
 const keyvault = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/1e2c9f3ec93078da8078389941531359e274f32a/specification/keyvault/data-plane/readme.md';
-generateFromReadme(keyvault, 'package-7.2', 'test/keyvault/7.2/azkeyvault', '--security=AADToken --security-scopes="https://vault.azure.com/.default" --module=azkeyvault --openapi-type="data-plane" --export-clients');
+generateFromReadme(keyvault, 'package-7.2', 'test/keyvault/7.2/azkeyvault', '--security=AADToken --security-scopes="https://vault.azure.net/.default" --module=azkeyvault --openapi-type="data-plane" --export-clients');
 
 // helper to log the package being generated before invocation
 function generate(inputFile, outputDir, additionalArgs) {

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -16,7 +16,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
   text += 'go 1.13\n\n';
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
-  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0';
+  const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2';
   if (<boolean>session.model.language.go!.azureARM) {
     text += 'require (\n';
     text += '\tgithub.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0\n';

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -5,7 +5,7 @@
 
 import { Session } from '@autorest/extension-base';
 import { comment } from '@azure-tools/codegen';
-import { CodeModel, ComplexSchema, DictionarySchema, GroupProperty, ObjectSchema, Language, SchemaType, Parameter, Property } from '@autorest/codemodel';
+import { ByteArraySchema, CodeModel, ComplexSchema, DictionarySchema, GroupProperty, ObjectSchema, Language, SchemaType, Parameter, Property } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
 import { isArraySchema, isObjectSchema, hasAdditionalProperties, hasPolymorphicField, commentLength } from '../common/helpers';
 import { contentPreamble, sortAscending } from './helpers';
@@ -33,6 +33,7 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   // structs
   let needsJSONPopulate = false;
   let needsJSONUnpopulate = false;
+  let needsJSONPopulateByteArray = false;
   structs.sort((a: StructDef, b: StructDef) => { return sortAscending(a.Language.name, b.Language.name) });
   for (const struct of values(structs)) {
     text += struct.discriminator();
@@ -50,6 +51,9 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
     if (struct.HasJSONUnmarshaller) {
       needsJSONUnpopulate = true;
     }
+    if (struct.HasJSONByteArray) {
+      needsJSONPopulateByteArray = true;
+    }
   }
   if (needsJSONPopulate) {
     text += 'func populate(m map[string]interface{}, k string, v interface{}) {\n';
@@ -59,6 +63,17 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
     text += '\t\tm[k] = nil\n';
     text += '\t} else if !reflect.ValueOf(v).IsNil() {\n';
     text += '\t\tm[k] = v\n';
+    text += '\t}\n';
+    text += '}\n\n';
+  }
+  if (needsJSONPopulateByteArray) {
+    text += 'func populateByteArray(m map[string]interface{}, k string, b []byte, f azcore.Base64Encoding) {\n';
+    text += '\tif len(b) == 0 {\n';
+    text += '\t\treturn\n';
+    text += '\t} else if azcore.IsNullValue(b) {\n';
+    text += '\t\tm[k] = nil\n';
+    text += '\t} else if !reflect.ValueOf(b).IsNil() {\n';
+    text += '\t\tm[k] = azcore.EncodeByteArray(b, f)\n';
     text += '\t}\n';
     text += '}\n\n';
   }
@@ -126,6 +141,9 @@ function generateStructs(imports: ImportManager, objects?: ObjectSchema[]): Stru
       imports.add('reflect');
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
       structDef.HasJSONMarshaller = true;
+      if (obj.language.go!.byteArrayFormat) {
+        structDef.HasJSONByteArray = true;
+      }
       generateJSONMarshaller(imports, obj, structDef, parentType);
     }
     if (needs.U) {
@@ -175,6 +193,7 @@ function determineMarshallersForObj(obj: ObjectSchema): Marshallers {
   //   hasAdditionalProperties  M, U
   //   hasPolymorphicField      M, U
   //   discriminatorValue       M, U
+  //   byteArrayFormat          M, U
   //   hasArrayMap              M
   //   needsPatchMarshaller     M
 
@@ -184,7 +203,8 @@ function determineMarshallersForObj(obj: ObjectSchema): Marshallers {
     obj.language.go!.needsUnixTimeMarshalling ||
     hasAdditionalProperties(obj) ||
     hasPolymorphicField(obj) ||
-    obj.discriminatorValue) {
+    obj.discriminatorValue ||
+    obj.language.go!.byteArrayFormat) {
     needsM = needsU = true;
   } else if (obj.language.go!.hasArrayMap ||
     obj.language.go!.needsPatchMarshaller) {
@@ -331,28 +351,7 @@ function generateInternalMarshaller(obj: ObjectSchema, structDef: StructDef, par
   } else {
     marshalInteral += '\tobjectMap := make(map[string]interface{})\n';
   }
-  for (const prop of values(structDef.Properties)) {
-    if (prop.language.go!.isAdditionalProperties) {
-      continue;
-    }
-    if (prop.isDiscriminator) {
-      marshalInteral += `\t${receiver}.${prop.language.go!.name} = &${paramName}\n`;
-      marshalInteral += `\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
-    } else {
-      let source = `${receiver}.${prop.language.go!.name}`;
-      if (prop.schema.language.go!.internalTimeType) {
-        source = `(*${prop.schema.language.go!.internalTimeType})(${receiver}.${prop.language.go!.name})`;
-      }
-      marshalInteral += `\tpopulate(objectMap, "${prop.serializedName}", ${source})\n`;
-    }
-  }
-  if (hasAdditionalProperties(obj)) {
-    marshalInteral += `\tif ${receiver}.AdditionalProperties != nil {\n`;
-    marshalInteral += `\t\tfor key, val := range ${receiver}.AdditionalProperties {\n`;
-    marshalInteral += '\t\t\tobjectMap[key] = val\n';
-    marshalInteral += '\t\t}\n';;
-    marshalInteral += '\t}\n';
-  }
+  marshalInteral += generateJSONMarshallerBody(obj, structDef);
   marshalInteral += '\treturn objectMap\n';
   marshalInteral += '}\n\n';
   structDef.Methods.push({ name: 'marshalInternal', desc: '', text: marshalInteral });
@@ -395,27 +394,45 @@ function generateJSONMarshaller(imports: ImportManager, obj: ObjectSchema, struc
     } else {
       marshaller += '\tobjectMap := make(map[string]interface{})\n';
     }
-    for (const prop of values(structDef.Properties)) {
-      if (prop.language.go!.isAdditionalProperties) {
-        continue;
+    marshaller += generateJSONMarshallerBody(obj, structDef);
+  }
+  marshaller += '\treturn json.Marshal(objectMap)\n';
+  marshaller += '}\n\n';
+  structDef.Methods.push({ name: 'MarshalJSON', desc: `MarshalJSON implements the json.Marshaller interface for type ${typeName}.`, text: marshaller });
+}
+
+function generateJSONMarshallerBody(obj: ObjectSchema, structDef: StructDef): string {
+  const receiver = structDef.receiverName();
+  let marshaller = '';
+  for (const prop of values(structDef.Properties)) {
+    if (prop.language.go!.isAdditionalProperties) {
+      continue;
+    }
+    if (prop.isDiscriminator) {
+      marshaller += `\t${receiver}.${prop.language.go!.name} = &discValue\n`;
+      marshaller += `\tobjectMap["${prop.serializedName}"] = ${receiver}.${prop.language.go!.name}\n`;
+    } else if (prop.schema.type === SchemaType.ByteArray) {
+      let base64Format = 'Std';
+      if ((<ByteArraySchema>prop.schema).format === 'base64url') {
+        base64Format = 'URL';
       }
+      marshaller += `\tpopulateByteArray(objectMap, "${prop.serializedName}", ${receiver}.${prop.language.go!.name}, azcore.Base64${base64Format}Format)\n`;
+    } else {
       let source = `${receiver}.${prop.language.go!.name}`;
       if (prop.schema.language.go!.internalTimeType) {
         source = `(*${prop.schema.language.go!.internalTimeType})(${receiver}.${prop.language.go!.name})`;
       }
       marshaller += `\tpopulate(objectMap, "${prop.serializedName}", ${source})\n`;
     }
-    if (hasAdditionalProperties(obj)) {
-      marshaller += `\tif ${receiver}.AdditionalProperties != nil {\n`;
-      marshaller += `\t\tfor key, val := range ${receiver}.AdditionalProperties {\n`;
-      marshaller += '\t\t\tobjectMap[key] = val\n';
-      marshaller += '\t\t}\n';;
-      marshaller += '\t}\n';
-    }
   }
-  marshaller += '\treturn json.Marshal(objectMap)\n';
-  marshaller += '}\n\n';
-  structDef.Methods.push({ name: 'MarshalJSON', desc: `MarshalJSON implements the json.Marshaller interface for type ${typeName}.`, text: marshaller });
+  if (hasAdditionalProperties(obj)) {
+    marshaller += `\tif ${receiver}.AdditionalProperties != nil {\n`;
+    marshaller += `\t\tfor key, val := range ${receiver}.AdditionalProperties {\n`;
+    marshaller += '\t\t\tobjectMap[key] = val\n';
+    marshaller += '\t\t}\n';;
+    marshaller += '\t}\n';
+  }
+  return marshaller;
 }
 
 function generateJSONUnmarshaller(imports: ImportManager, obj: ObjectSchema, structDef: StructDef, parentType?: ObjectSchema) {
@@ -486,6 +503,12 @@ function generateJSONUnmarshallerBody(obj: ObjectSchema, structDef: StructDef, p
         unmarshalBody += `\t\t\t\tvar aux ${prop.schema.language.go!.internalTimeType}\n`;
         unmarshalBody += '\t\t\t\terr = unpopulate(val, &aux)\n';
         unmarshalBody += `\t\t\t\t${receiver}.${prop.language.go!.name} = (*time.Time)(&aux)\n`;
+      } else if (prop.schema.type === SchemaType.ByteArray) {
+        let base64Format = 'Std';
+        if ((<ByteArraySchema>prop.schema).format === 'base64url') {
+          base64Format = 'URL';
+        }
+        unmarshalBody += `\t\t\terr = azcore.DecodeByteArray(string(val), &${receiver}.${prop.language.go!.name}, azcore.Base64${base64Format}Format)\n`;
       } else {
         unmarshalBody += `\t\t\t\terr = unpopulate(val, &${receiver}.${prop.language.go!.name})\n`;
       }

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -68,11 +68,11 @@ export async function generateModels(session: Session<CodeModel>): Promise<strin
   }
   if (needsJSONPopulateByteArray) {
     text += 'func populateByteArray(m map[string]interface{}, k string, b []byte, f azcore.Base64Encoding) {\n';
-    text += '\tif len(b) == 0 {\n';
-    text += '\t\treturn\n';
-    text += '\t} else if azcore.IsNullValue(b) {\n';
+    text += '\tif azcore.IsNullValue(b) {\n';
     text += '\t\tm[k] = nil\n';
-    text += '\t} else if !reflect.ValueOf(b).IsNil() {\n';
+    text += '\t} else if len(b) == 0 {\n';
+    text += '\t\treturn\n';
+    text += '\t} else {\n';
     text += '\t\tm[k] = azcore.EncodeByteArray(b, f)\n';
     text += '\t}\n';
     text += '}\n\n';

--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -26,6 +26,7 @@ export class StructDef {
   readonly ComposedOf: ObjectSchema[];
   HasJSONMarshaller: boolean;
   HasJSONUnmarshaller: boolean;
+  HasJSONByteArray: boolean;
 
   constructor(language: Language, props?: Property[], params?: Parameter[]) {
     this.Language = language;
@@ -41,6 +42,7 @@ export class StructDef {
     this.ComposedOf = new Array<ObjectSchema>();
     this.HasJSONMarshaller = false;
     this.HasJSONUnmarshaller = false;
+    this.HasJSONByteArray = false;
   }
 
   text(): string {

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -5,7 +5,7 @@
 
 import { comment, KnownMediaType, serialize } from '@azure-tools/codegen';
 import { Host, startSession, Session } from '@autorest/extension-base';
-import { ObjectSchema, ArraySchema, ChoiceValue, codeModelSchema, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema, Request } from '@autorest/codemodel';
+import { ObjectSchema, ArraySchema, ByteArraySchema, ChoiceValue, codeModelSchema, CodeModel, DateTimeSchema, GroupProperty, HttpHeader, HttpResponse, ImplementationLocation, Language, OperationGroup, SchemaType, NumberSchema, Operation, SchemaResponse, Parameter, Property, Protocols, Response, Schema, DictionarySchema, Protocol, ChoiceSchema, SealedChoiceSchema, ConstantSchema, Request } from '@autorest/codemodel';
 import { clone, items, values } from '@azure-tools/linq';
 import { aggregateParameters, getResponse, hasAdditionalProperties, isPageableOperation, isObjectSchema, isSchemaResponse, isTypePassedByValue, PagerInfo, isLROOperation, PollerInfo } from '../common/helpers';
 import { namer, protocolMethods } from './namer';
@@ -112,6 +112,8 @@ async function process(session: Session<CodeModel>) {
         // mark that we need custom XML unmarshalling for a dictionary
         prop.language.go!.needsXMLDictionaryUnmarshalling = true;
         session.model.language.go!.needsXMLDictionaryUnmarshalling = true;
+      } else if (prop.schema.type === SchemaType.ByteArray) {
+        obj.language.go!.byteArrayFormat = (<ByteArraySchema>prop.schema).format;
       }
       if (prop.schema.type === SchemaType.Array || prop.schema.type === SchemaType.ByteArray || prop.schema.type === SchemaType.Dictionary) {
         obj.language.go!.hasArrayMap = true;

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -5,10 +5,12 @@ package complexgroup
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/to"
 	"github.com/google/go-cmp/cmp"
 )
@@ -152,6 +154,25 @@ func TestPrimitivePutBool(t *testing.T) {
 	}
 	if s := result.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
+	}
+}
+
+func TestByteWrapperJSONNull(t *testing.T) {
+	bw := ByteWrapper{}
+	b, err := json.Marshal(bw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "{}" {
+		t.Fatalf("unexpected value %s", string(b))
+	}
+	bw.Field = azcore.NullValue([]byte{}).([]byte)
+	b, err = json.Marshal(bw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `{"field":null}` {
+		t.Fatalf("unexpected value %s", string(b))
 	}
 }
 

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -1153,11 +1153,11 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 }
 
 func populateByteArray(m map[string]interface{}, k string, b []byte, f azcore.Base64Encoding) {
-	if len(b) == 0 {
-		return
-	} else if azcore.IsNullValue(b) {
+	if azcore.IsNullValue(b) {
 		m[k] = nil
-	} else if !reflect.ValueOf(b).IsNil() {
+	} else if len(b) == 0 {
+		return
+	} else {
 		m[k] = azcore.EncodeByteArray(b, f)
 	}
 }

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2
 )

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -1,8 +1,8 @@
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbtu9SoHYRmZPgLHjbSuOk=
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2
 	github.com/Azure/azure-sdk-for-go/sdk/to v0.1.4
 	github.com/google/go-cmp v0.5.4
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,8 +1,8 @@
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbtu9SoHYRmZPgLHjbSuOk=
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=

--- a/test/keyvault/7.2/azkeyvault/go.mod
+++ b/test/keyvault/7.2/azkeyvault/go.mod
@@ -2,4 +2,4 @@ module azkeyvault
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/keyvault/7.2/azkeyvault/go.sum
+++ b/test/keyvault/7.2/azkeyvault/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-var scopes = []string{"https://vault.azure.com/.default"}
+var scopes = []string{"https://vault.azure.net/.default"}
 
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_models.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_models.go
@@ -122,8 +122,28 @@ type BackupCertificateResult struct {
 // MarshalJSON implements the json.Marshaller interface for type BackupCertificateResult.
 func (b BackupCertificateResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", b.Value)
+	populateByteArray(objectMap, "value", b.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type BackupCertificateResult.
+func (b *BackupCertificateResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &b.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // BackupKeyResult - The backup key result, containing the backup blob.
@@ -135,8 +155,28 @@ type BackupKeyResult struct {
 // MarshalJSON implements the json.Marshaller interface for type BackupKeyResult.
 func (b BackupKeyResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", b.Value)
+	populateByteArray(objectMap, "value", b.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type BackupKeyResult.
+func (b *BackupKeyResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &b.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // BackupSecretResult - The backup secret result, containing the backup blob.
@@ -148,8 +188,28 @@ type BackupSecretResult struct {
 // MarshalJSON implements the json.Marshaller interface for type BackupSecretResult.
 func (b BackupSecretResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", b.Value)
+	populateByteArray(objectMap, "value", b.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type BackupSecretResult.
+func (b *BackupSecretResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &b.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // BackupStorageResult - The backup storage result, containing the backup blob.
@@ -161,8 +221,28 @@ type BackupStorageResult struct {
 // MarshalJSON implements the json.Marshaller interface for type BackupStorageResult.
 func (b BackupStorageResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", b.Value)
+	populateByteArray(objectMap, "value", b.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type BackupStorageResult.
+func (b *BackupStorageResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &b.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CertificateAttributes - The certificate management attributes.
@@ -256,14 +336,14 @@ func (c *CertificateBundle) UnmarshalJSON(data []byte) error {
 func (c CertificateBundle) marshalInternal() map[string]interface{} {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "attributes", c.Attributes)
-	populate(objectMap, "cer", c.Cer)
+	populateByteArray(objectMap, "cer", c.Cer, azcore.Base64StdFormat)
 	populate(objectMap, "contentType", c.ContentType)
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "kid", c.Kid)
 	populate(objectMap, "policy", c.Policy)
 	populate(objectMap, "sid", c.Sid)
 	populate(objectMap, "tags", c.Tags)
-	populate(objectMap, "x5t", c.X509Thumbprint)
+	populateByteArray(objectMap, "x5t", c.X509Thumbprint, azcore.Base64URLFormat)
 	return objectMap
 }
 
@@ -275,7 +355,7 @@ func (c *CertificateBundle) unmarshalInternal(rawMsg map[string]json.RawMessage)
 			err = unpopulate(val, &c.Attributes)
 			delete(rawMsg, key)
 		case "cer":
-			err = unpopulate(val, &c.Cer)
+			err = azcore.DecodeByteArray(string(val), &c.Cer, azcore.Base64StdFormat)
 			delete(rawMsg, key)
 		case "contentType":
 			err = unpopulate(val, &c.ContentType)
@@ -296,7 +376,7 @@ func (c *CertificateBundle) unmarshalInternal(rawMsg map[string]json.RawMessage)
 			err = unpopulate(val, &c.Tags)
 			delete(rawMsg, key)
 		case "x5t":
-			err = unpopulate(val, &c.X509Thumbprint)
+			err = azcore.DecodeByteArray(string(val), &c.X509Thumbprint, azcore.Base64URLFormat)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -473,7 +553,7 @@ func (c CertificateItem) marshalInternal() map[string]interface{} {
 	populate(objectMap, "attributes", c.Attributes)
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "tags", c.Tags)
-	populate(objectMap, "x5t", c.X509Thumbprint)
+	populateByteArray(objectMap, "x5t", c.X509Thumbprint, azcore.Base64URLFormat)
 	return objectMap
 }
 
@@ -491,7 +571,7 @@ func (c *CertificateItem) unmarshalInternal(rawMsg map[string]json.RawMessage) e
 			err = unpopulate(val, &c.Tags)
 			delete(rawMsg, key)
 		case "x5t":
-			err = unpopulate(val, &c.X509Thumbprint)
+			err = azcore.DecodeByteArray(string(val), &c.X509Thumbprint, azcore.Base64URLFormat)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -573,7 +653,7 @@ type CertificateOperation struct {
 func (c CertificateOperation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "cancellation_requested", c.CancellationRequested)
-	populate(objectMap, "csr", c.Csr)
+	populateByteArray(objectMap, "csr", c.Csr, azcore.Base64StdFormat)
 	populate(objectMap, "error", c.Error)
 	populate(objectMap, "id", c.ID)
 	populate(objectMap, "issuer", c.IssuerParameters)
@@ -582,6 +662,50 @@ func (c CertificateOperation) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "status_details", c.StatusDetails)
 	populate(objectMap, "target", c.Target)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type CertificateOperation.
+func (c *CertificateOperation) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "cancellation_requested":
+			err = unpopulate(val, &c.CancellationRequested)
+			delete(rawMsg, key)
+		case "csr":
+			err = azcore.DecodeByteArray(string(val), &c.Csr, azcore.Base64StdFormat)
+			delete(rawMsg, key)
+		case "error":
+			err = unpopulate(val, &c.Error)
+			delete(rawMsg, key)
+		case "id":
+			err = unpopulate(val, &c.ID)
+			delete(rawMsg, key)
+		case "issuer":
+			err = unpopulate(val, &c.IssuerParameters)
+			delete(rawMsg, key)
+		case "request_id":
+			err = unpopulate(val, &c.RequestID)
+			delete(rawMsg, key)
+		case "status":
+			err = unpopulate(val, &c.Status)
+			delete(rawMsg, key)
+		case "status_details":
+			err = unpopulate(val, &c.StatusDetails)
+			delete(rawMsg, key)
+		case "target":
+			err = unpopulate(val, &c.Target)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CertificateOperationUpdateParameter - The certificate operation update parameters.
@@ -643,8 +767,28 @@ type CertificateRestoreParameters struct {
 // MarshalJSON implements the json.Marshaller interface for type CertificateRestoreParameters.
 func (c CertificateRestoreParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", c.CertificateBundleBackup)
+	populateByteArray(objectMap, "value", c.CertificateBundleBackup, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type CertificateRestoreParameters.
+func (c *CertificateRestoreParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &c.CertificateBundleBackup, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // CertificateUpdateParameters - The certificate update parameters.
@@ -1563,22 +1707,87 @@ type JSONWebKey struct {
 func (j JSONWebKey) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "crv", j.Crv)
-	populate(objectMap, "d", j.D)
-	populate(objectMap, "dp", j.DP)
-	populate(objectMap, "dq", j.DQ)
-	populate(objectMap, "e", j.E)
-	populate(objectMap, "k", j.K)
+	populateByteArray(objectMap, "d", j.D, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "dp", j.DP, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "dq", j.DQ, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "e", j.E, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "k", j.K, azcore.Base64URLFormat)
 	populate(objectMap, "key_ops", j.KeyOps)
 	populate(objectMap, "kid", j.Kid)
 	populate(objectMap, "kty", j.Kty)
-	populate(objectMap, "n", j.N)
-	populate(objectMap, "p", j.P)
-	populate(objectMap, "q", j.Q)
-	populate(objectMap, "qi", j.QI)
-	populate(objectMap, "key_hsm", j.T)
-	populate(objectMap, "x", j.X)
-	populate(objectMap, "y", j.Y)
+	populateByteArray(objectMap, "n", j.N, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "p", j.P, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "q", j.Q, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "qi", j.QI, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "key_hsm", j.T, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "x", j.X, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "y", j.Y, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type JSONWebKey.
+func (j *JSONWebKey) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "crv":
+			err = unpopulate(val, &j.Crv)
+			delete(rawMsg, key)
+		case "d":
+			err = azcore.DecodeByteArray(string(val), &j.D, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "dp":
+			err = azcore.DecodeByteArray(string(val), &j.DP, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "dq":
+			err = azcore.DecodeByteArray(string(val), &j.DQ, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "e":
+			err = azcore.DecodeByteArray(string(val), &j.E, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "k":
+			err = azcore.DecodeByteArray(string(val), &j.K, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "key_ops":
+			err = unpopulate(val, &j.KeyOps)
+			delete(rawMsg, key)
+		case "kid":
+			err = unpopulate(val, &j.Kid)
+			delete(rawMsg, key)
+		case "kty":
+			err = unpopulate(val, &j.Kty)
+			delete(rawMsg, key)
+		case "n":
+			err = azcore.DecodeByteArray(string(val), &j.N, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "p":
+			err = azcore.DecodeByteArray(string(val), &j.P, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "q":
+			err = azcore.DecodeByteArray(string(val), &j.Q, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "qi":
+			err = azcore.DecodeByteArray(string(val), &j.QI, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "key_hsm":
+			err = azcore.DecodeByteArray(string(val), &j.T, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "x":
+			err = azcore.DecodeByteArray(string(val), &j.X, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "y":
+			err = azcore.DecodeByteArray(string(val), &j.Y, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeyAttributes - The attributes of a key managed by the key vault service.
@@ -1848,12 +2057,44 @@ type KeyOperationResult struct {
 // MarshalJSON implements the json.Marshaller interface for type KeyOperationResult.
 func (k KeyOperationResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "aad", k.AdditionalAuthenticatedData)
-	populate(objectMap, "tag", k.AuthenticationTag)
-	populate(objectMap, "iv", k.Iv)
+	populateByteArray(objectMap, "aad", k.AdditionalAuthenticatedData, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "tag", k.AuthenticationTag, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "iv", k.Iv, azcore.Base64URLFormat)
 	populate(objectMap, "kid", k.Kid)
-	populate(objectMap, "value", k.Result)
+	populateByteArray(objectMap, "value", k.Result, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyOperationResult.
+func (k *KeyOperationResult) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "aad":
+			err = azcore.DecodeByteArray(string(val), &k.AdditionalAuthenticatedData, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "tag":
+			err = azcore.DecodeByteArray(string(val), &k.AuthenticationTag, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "iv":
+			err = azcore.DecodeByteArray(string(val), &k.Iv, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "kid":
+			err = unpopulate(val, &k.Kid)
+			delete(rawMsg, key)
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &k.Result, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeyOperationsParameters - The key operations parameters.
@@ -1877,12 +2118,44 @@ type KeyOperationsParameters struct {
 // MarshalJSON implements the json.Marshaller interface for type KeyOperationsParameters.
 func (k KeyOperationsParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "aad", k.AAD)
+	populateByteArray(objectMap, "aad", k.AAD, azcore.Base64URLFormat)
 	populate(objectMap, "alg", k.Algorithm)
-	populate(objectMap, "iv", k.Iv)
-	populate(objectMap, "tag", k.Tag)
-	populate(objectMap, "value", k.Value)
+	populateByteArray(objectMap, "iv", k.Iv, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "tag", k.Tag, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "value", k.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyOperationsParameters.
+func (k *KeyOperationsParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "aad":
+			err = azcore.DecodeByteArray(string(val), &k.AAD, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "alg":
+			err = unpopulate(val, &k.Algorithm)
+			delete(rawMsg, key)
+		case "iv":
+			err = azcore.DecodeByteArray(string(val), &k.Iv, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "tag":
+			err = azcore.DecodeByteArray(string(val), &k.Tag, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &k.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeyProperties - Properties of the key pair backing a certificate.
@@ -1912,8 +2185,28 @@ type KeyRestoreParameters struct {
 // MarshalJSON implements the json.Marshaller interface for type KeyRestoreParameters.
 func (k KeyRestoreParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", k.KeyBundleBackup)
+	populateByteArray(objectMap, "value", k.KeyBundleBackup, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyRestoreParameters.
+func (k *KeyRestoreParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &k.KeyBundleBackup, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeySignParameters - The key operations parameters.
@@ -1929,8 +2222,31 @@ type KeySignParameters struct {
 func (k KeySignParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "alg", k.Algorithm)
-	populate(objectMap, "value", k.Value)
+	populateByteArray(objectMap, "value", k.Value, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeySignParameters.
+func (k *KeySignParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "alg":
+			err = unpopulate(val, &k.Algorithm)
+			delete(rawMsg, key)
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &k.Value, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeyUpdateParameters - The key update parameters.
@@ -2421,9 +2737,35 @@ type KeyVerifyParameters struct {
 func (k KeyVerifyParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
 	populate(objectMap, "alg", k.Algorithm)
-	populate(objectMap, "digest", k.Digest)
-	populate(objectMap, "value", k.Signature)
+	populateByteArray(objectMap, "digest", k.Digest, azcore.Base64URLFormat)
+	populateByteArray(objectMap, "value", k.Signature, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KeyVerifyParameters.
+func (k *KeyVerifyParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "alg":
+			err = unpopulate(val, &k.Algorithm)
+			delete(rawMsg, key)
+		case "digest":
+			err = azcore.DecodeByteArray(string(val), &k.Digest, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &k.Signature, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // KeyVerifyResult - The key verify result.
@@ -3279,8 +3621,28 @@ type SecretRestoreParameters struct {
 // MarshalJSON implements the json.Marshaller interface for type SecretRestoreParameters.
 func (s SecretRestoreParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", s.SecretBundleBackup)
+	populateByteArray(objectMap, "value", s.SecretBundleBackup, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SecretRestoreParameters.
+func (s *SecretRestoreParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &s.SecretBundleBackup, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SecretSetParameters - The secret set parameters.
@@ -3783,8 +4145,28 @@ type StorageRestoreParameters struct {
 // MarshalJSON implements the json.Marshaller interface for type StorageRestoreParameters.
 func (s StorageRestoreParameters) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]interface{})
-	populate(objectMap, "value", s.StorageBundleBackup)
+	populateByteArray(objectMap, "value", s.StorageBundleBackup, azcore.Base64URLFormat)
 	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type StorageRestoreParameters.
+func (s *StorageRestoreParameters) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return err
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "value":
+			err = azcore.DecodeByteArray(string(val), &s.StorageBundleBackup, azcore.Base64URLFormat)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // SubjectAlternativeNames - The subject alternate names of a X509 object.
@@ -3862,6 +4244,16 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
 		m[k] = v
+	}
+}
+
+func populateByteArray(m map[string]interface{}, k string, b []byte, f azcore.Base64Encoding) {
+	if len(b) == 0 {
+		return
+	} else if azcore.IsNullValue(b) {
+		m[k] = nil
+	} else if !reflect.ValueOf(b).IsNil() {
+		m[k] = azcore.EncodeByteArray(b, f)
 	}
 }
 

--- a/test/keyvault/7.2/azkeyvault/zz_generated_models.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_models.go
@@ -4248,11 +4248,11 @@ func populate(m map[string]interface{}, k string, v interface{}) {
 }
 
 func populateByteArray(m map[string]interface{}, k string, b []byte, f azcore.Base64Encoding) {
-	if len(b) == 0 {
-		return
-	} else if azcore.IsNullValue(b) {
+	if azcore.IsNullValue(b) {
 		m[k] = nil
-	} else if !reflect.ValueOf(b).IsNil() {
+	} else if len(b) == 0 {
+		return
+	} else {
 		m[k] = azcore.EncodeByteArray(b, f)
 	}
 }

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -4,5 +4,5 @@ go 1.13
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2
 )

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -1,8 +1,8 @@
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0 h1:+LyX2LaBmlKPsmTJV+U04wbtu9SoHYRmZPgLHjbSuOk=
 github.com/Azure/azure-sdk-for-go/sdk/armcore v0.7.0/go.mod h1:6yYd2qNvutd94jHTMUg9KrdbR39jNzI4d+15lm2gxkg=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v0.14.0/go.mod h1:pElNP+u99BvCZD+0jOlhI9OC/NB2IDTOTGZOZH0Qhq8=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.0/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=

--- a/test/storage/2020-06-12/azblob/go.mod
+++ b/test/storage/2020-06-12/azblob/go.mod
@@ -2,4 +2,4 @@ module azstorage
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/storage/2020-06-12/azblob/go.sum
+++ b/test/storage/2020-06-12/azblob/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -2,4 +2,4 @@ module azartifacts
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/synapse/2019-06-01/azartifacts/go.sum
+++ b/test/synapse/2019-06-01/azartifacts/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -2,4 +2,4 @@ module azspark
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/synapse/2019-06-01/azspark/go.sum
+++ b/test/synapse/2019-06-01/azspark/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/test/tables/2019-02-02/aztables/go.mod
+++ b/test/tables/2019-02-02/aztables/go.mod
@@ -2,4 +2,4 @@ module aztables
 
 go 1.13
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/tables/2019-02-02/aztables/go.sum
+++ b/test/tables/2019-02-02/aztables/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0 h1:ZsS7JltN+5D42mcU3Mb4lwVivlFL89v+FlXXMXE2YEM=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.0/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2 h1:UC4vfOhW2l0f2QOCQpOxJS4/K6oKFy2tQZE+uWU1MEo=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2/go.mod h1:MVdrcUC4Hup35qHym3VdzoW+NBgBxrta9Vei97jRtM8=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1 h1:vx8McI56N5oLSQu8xa+xdiE0fjQq8W8Zt49vHP8Rygw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v0.5.1/go.mod h1:k4KbFSunV/+0hOHL1vyFaPsiYQ1Vmvy1TBpmtvCDLZM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Byte arrays in URL format require special marshallers and unmarshallers.
Consolidate duplicate code for JSON marshaller and internal marshallers.
Fixed scope for azkeyvault.