### PR TITLE
Relax security schemes check

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -58,7 +58,7 @@ for (namespace in goMappings) {
 }
 
 const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/ee9bd6fe35eb7850ff0d1496c59259eb74f0d446/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json';
-generate(blobStorage, 'test/storage/2020-06-12/azblob', '--security=AADToken --security-scopes="https://storage.azure.com/.default" --module="azstorage" --openapi-type="data-plane"');
+generate(blobStorage, 'test/storage/2020-06-12/azblob', '--security=AzureKey --module="azstorage" --openapi-type="data-plane"');
 
 const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/network/resource-manager/readme.md';
 generateFromReadme(network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--module=armnetwork --azure-arm=true');

--- a/test/storage/2020-06-12/azblob/zz_generated_connection.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_connection.go
@@ -12,8 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-var scopes = []string{"https://storage.azure.com/.default"}
-
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
@@ -60,7 +58,7 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	policies = append(policies, options.PerCallPolicies...)
 	policies = append(policies, azcore.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
-	policies = append(policies, cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{Scopes: scopes}}))
+	policies = append(policies, cred.AuthenticationPolicy(azcore.AuthenticationPolicyOptions{Options: azcore.TokenRequestOptions{}}))
 	policies = append(policies, azcore.NewLogPolicy(&options.Logging))
 	return &connection{u: endpoint, p: azcore.NewPipeline(options.HTTPClient, policies...)}
 }


### PR DESCRIPTION
For schemes other than AADToken, just omit the scopes.
Updated regeneration script for azblob to test the changes.