### PR TITLE
Don't tie head as boolean codegen to OpenAPI type

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -9,45 +9,45 @@ const sem = require('./semaphore')(8);
 const swaggerDir = 'src/node_modules/@microsoft.azure/autorest.testserver/swagger/';
 
 const goMappings = {
-    'additionalpropsgroup': 'additionalProperties.json',
-    'arraygroup': 'body-array.json',
-    'azurereportgroup': 'azure-report.json',
-    'azurespecialsgroup': 'azure-special-properties.json',
-    'booleangroup': 'body-boolean.json',
-    'bytegroup': 'body-byte.json',
-    'complexgroup': 'body-complex.json',
-    'complexmodelgroup': 'complex-model.json',
-    'custombaseurlgroup': 'custom-baseUrl.json',
-    'dategroup': 'body-date.json',
-    'datetimegroup': 'body-datetime.json',
-    'datetimerfc1123group': 'body-datetime-rfc1123.json',
-    'dictionarygroup': 'body-dictionary.json',
-    'durationgroup': 'body-duration.json',
-    'errorsgroup': 'xms-error-responses.json',
-    'extenumsgroup': 'extensible-enums-swagger.json',
-    'filegroup': 'body-file.json',
-    'formdatagroup': 'body-formdata.json',
-    'headergroup': 'header.json',
-    'headgroup': 'head.json',
-    'httpinfrastructuregroup': 'httpInfrastructure.json',
-    'integergroup': 'body-integer.json',
-    'lrogroup': 'lro.json',
-    'mediatypesgroup': 'media_types.json',
-    'migroup': 'multiple-inheritance.json',
-    //'modelflatteninggroup': 'model-flattening.json',
-    'morecustombaseurigroup': 'custom-baseUrl-more-options.json',
-    'nonstringenumgroup': 'non-string-enum.json',
-    'numbergroup': 'body-number.json',
-    'objectgroup': 'object-type.json',
-    'optionalgroup': 'required-optional.json',
-    'paginggroup': 'paging.json',
-    'paramgroupinggroup': 'azure-parameter-grouping.json',
-    'reportgroup': 'report.json',
-    'stringgroup': 'body-string.json',
-    'urlgroup': 'url.json',
-    'urlmultigroup': 'url-multi-collectionFormat.json',
-    'validationgroup': 'validation.json',
-    'xmlgroup': 'xml-service.json',
+    'additionalpropsgroup': ['additionalProperties.json'],
+    'arraygroup': ['body-array.json'],
+    'azurereportgroup': ['azure-report.json'],
+    'azurespecialsgroup': ['azure-special-properties.json', '--head-as-boolean'],
+    'booleangroup': ['body-boolean.json'],
+    'bytegroup': ['body-byte.json'],
+    'complexgroup': ['body-complex.json'],
+    'complexmodelgroup': ['complex-model.json'],
+    'custombaseurlgroup': ['custom-baseUrl.json'],
+    'dategroup': ['body-date.json'],
+    'datetimegroup': ['body-datetime.json'],
+    'datetimerfc1123group': ['body-datetime-rfc1123.json'],
+    'dictionarygroup': ['body-dictionary.json'],
+    'durationgroup': ['body-duration.json'],
+    'errorsgroup': ['xms-error-responses.json'],
+    'extenumsgroup': ['extensible-enums-swagger.json'],
+    'filegroup': ['body-file.json'],
+    'formdatagroup': ['body-formdata.json'],
+    'headergroup': ['header.json'],
+    'headgroup': ['head.json', '--head-as-boolean'],
+    'httpinfrastructuregroup': ['httpInfrastructure.json', '--head-as-boolean'],
+    'integergroup': ['body-integer.json'],
+    'lrogroup': ['lro.json'],
+    'mediatypesgroup': ['media_types.json'],
+    'migroup': ['multiple-inheritance.json'],
+    //'modelflatteninggroup': ['model-flattening.json'],
+    'morecustombaseurigroup': ['custom-baseUrl-more-options.json'],
+    'nonstringenumgroup': ['non-string-enum.json'],
+    'numbergroup': ['body-number.json'],
+    'objectgroup': ['object-type.json'],
+    'optionalgroup': ['required-optional.json'],
+    'paginggroup': ['paging.json'],
+    'paramgroupinggroup': ['azure-parameter-grouping.json'],
+    'reportgroup': ['report.json'],
+    'stringgroup': ['body-string.json'],
+    'urlgroup': ['url.json'],
+    'urlmultigroup': ['url-multi-collectionFormat.json'],
+    'validationgroup': ['validation.json'],
+    'xmlgroup': ['xml-service.json'],
 };
 
 const args = process.argv.slice(2);
@@ -80,8 +80,13 @@ if (filter !== undefined) {
 // loop through all of the namespaces in goMappings
 for (namespace in goMappings) {
     // for each swagger run the autorest command to generate code based on the swagger for the relevant namespace and output to the /generated directory
-    const inputFile = swaggerDir + goMappings[namespace];
-    generate(namespace, inputFile, 'test/autorest/' + namespace, '--export-clients');
+    const entry = goMappings[namespace];
+    const inputFile = swaggerDir + entry[0];
+    let extraParams = ['--export-clients'];
+    if (entry.length > 1) {
+        extraParams = extraParams.concat(entry.slice());
+    }
+    generate(namespace, inputFile, 'test/autorest/' + namespace, extraParams.join(' '));
 }
 
 const blobStorage = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/ee9bd6fe35eb7850ff0d1496c59259eb74f0d446/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-06-12/blob.json';

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -74,6 +74,8 @@ export async function namer(session: Session<CodeModel>) {
   model.language.go!.azureARM = azureARM;
   const exportClients = await session.getValue('export-clients', false);
   model.language.go!.exportClients = exportClients;
+  const headAsBoolean = await session.getValue('head-as-boolean', false);
+  model.language.go!.headAsBoolean = headAsBoolean;
 
   // pascal-case and capitzalize acronym names of objects and their fields
   for (const obj of values(model.schemas.objects)) {
@@ -122,8 +124,8 @@ export async function namer(session: Session<CodeModel>) {
     for (const op of values(group.operations)) {
       const details = <OperationNaming>op.language.go;
       // propagate these settings to each operation for ease of access
-      details.azureARM = model.language.go!.azureARM
-      details.openApiType = model.language.go!.openApiType
+      details.azureARM = model.language.go!.azureARM;
+      details.openApiType = model.language.go!.openApiType;
       details.name = ensureNameCase(details.name);
       // add the client name to the operation as it's needed all over the place
       details.clientName = groupDetails.clientName;

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -697,7 +697,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
   // if this is an ARM spec and this is a HEAD method then return a BooleanResponse
   // response envelope instead of http.Response.  only do this if the operation doesn't model any
   // header values (HAB will be enabled for that response envelope).
-  if (op.language.go!.openApiType === 'arm' && op.requests![0].protocol.http!.method === 'head' && headers.size === 0) {
+  if (codeModel.language.go!.headAsBoolean && op.requests![0].protocol.http!.method === 'head' && headers.size === 0) {
     // enable treating HEAD requests as boolean responses.
     op.language.go!.headAsBoolean = true;
     const name = 'BooleanResponse';
@@ -742,7 +742,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
           prop.language.go!.fromHeader = item.value.header;
           (<Array<Property>>respEnv.language.go!.properties).push(prop);
         }
-        if (op.language.go!.openApiType === 'arm' && op.requests![0].protocol.http!.method === 'head') {
+        if (codeModel.language.go!.headAsBoolean && op.requests![0].protocol.http!.method === 'head') {
           // this is the intersection of head-as-boolean with modeled header responses
           op.language.go!.headAsBoolean = true;
           (<Array<Property>>respEnv.language.go!.properties).push(createSuccessProp());


### PR DESCRIPTION
Use the head-as-boolean flag which is implicity set to true when
azure-arm is true.
Tweak regeneration script to allow additional properties to be set to
enable head-as-boolean for some of the test server swaggers.