### PR TITLE
Bump min node version from 12 to 14

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -9,7 +9,7 @@ pr:
     - track2
 
 variables:
-  NodeVersion: '12.x'
+  NodeVersion: '14.x'
   goTestPath: '$(system.defaultWorkingDirectory)/test'
   GOBIN: '$(system.defaultWorkingDirectory)/bin/go'
 

--- a/eng/pipelines/publish-dev-release.yml
+++ b/eng/pipelines/publish-dev-release.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 variables:
-  NodeVersion: '12.x'
+  NodeVersion: '14.x'
   goTestPath: '$(system.defaultWorkingDirectory)/test'
   GOBIN: '$(system.defaultWorkingDirectory)/bin/go'
 

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 variables:
-  NodeVersion: '12.x'
+  NodeVersion: '14.x'
   goTestPath: '$(system.defaultWorkingDirectory)/test'
   GOBIN: '$(system.defaultWorkingDirectory)/bin/go'
 

--- a/rush.json
+++ b/rush.json
@@ -49,7 +49,7 @@
    * Specify a SemVer range to ensure developers use a NodeJS version that is appropriate
    * for your repo.
    */
-  "nodeSupportedVersionRange": ">=12.12.0 <15.0.0",
+  "nodeSupportedVersionRange": ">=14.0.0 <15.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 2,


### PR DESCRIPTION
[Build failed](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1004024&view=logs&j=69981a2a-6be6-5d5d-38f7-b6a49aa026c7&t=6e8860b9-6da4-5222-da2f-47be71eaa278) starting Monday

Autorest core will be reverting the change that triggered this, but I see no reason why we shouldn't just bump. 