### PR TITLE
Extend --help with all current command line args

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -68,4 +68,19 @@ help-content:
       - key: export-clients
         type: boolean
         description: Indicates if generated clients are to be exported.  Default to true for ARM, false for data-plane.
+      - key: header-text
+        description: Text to include as a header comment in generated files (magic strings:MICROSOFT_MIT, MICROSOFT_APACHE, MICROSOFT_MIT_NO_VERSION, MICROSOFT_APACHE_NO_VERSION, MICROSOFT_MIT_NO_CODEGEN)
+        type: string
+      - key: output-folder
+        description: Target folder for generated artifacts.
+        type: string
+      - key: openapi-type
+        description: "Open API Type: 'arm' or 'data-plane'."
+        type: string
+      - key: azure-arm
+        description: Generate code in Azure flavor.
+        type: boolean
+      - key: head-as-boolean
+        description: With this flag, HEAD calls to non-existent resources (404) will not raise an error. Instead, if the resource exists, we return `true`, else `false`. Forced to be `true` if `--azure-arm` is set, otherwise defaults to `false`.
+        type: boolean
 ```


### PR DESCRIPTION
- Fixes https://github.com/Azure/autorest.go/issues/663

```
Go Generator (activated by --go)

  --module=<string>             The name of the Go module written to go.mod.  Omit to skip go.mod generation.
  --file-prefix=<string>        Optional prefix to file names. For example, if you set your file prefix to "zzz_", all generated code files will begin with "zzz_".
  --export-clients=<boolean>    Indicates if generated clients are to be exported.  Default to true for ARM, false for data-plane.
  --header-text=<string>        Text to include as a header comment in generated files (magic strings:MICROSOFT_MIT, MICROSOFT_APACHE, MICROSOFT_MIT_NO_VERSION, MICROSOFT_APACHE_NO_VERSION, MICROSOFT_MIT_NO_CODEGEN)
  --output-folder=<string>      Target folder for generated artifacts.
  --openapi-type=<string>       Open API Type: 'arm' or 'data-plane'.
  --azure-arm=<boolean>         Generate code in Azure flavor.
  --head-as-boolean=<boolean>   With this flag, HEAD calls to non-existent resources (404) will not raise an error. Instead, if the resource exists, we return true, else false. Forced to be true if --azure-arm is set, otherwise defaults to false.
```