### PR TITLE
Propagate wrapper status for future types

### DIFF
--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -117,7 +117,7 @@ namespace AutoRest.Go.Model
 
         public PropertyGo AdditionalPropertiesField => AllProperties.FirstOrDefault(p => p.ModelType is DictionaryTypeGo dictionaryType && dictionaryType.SupportsAdditionalProperties);
 
-        public bool IsWrapperType { get; }
+        public virtual bool IsWrapperType { get; }
 
         public IModelType BaseType { get; }
 

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -123,5 +123,18 @@ namespace AutoRest.Go.Model
         {
             return Name.GetHashCode();
         }
+
+        public override bool IsWrapperType
+        {
+            get
+            {
+                if (ResultType is CompositeTypeGo ctg)
+                {
+                    // propagate the result's wrapper status
+                    return ctg.IsWrapperType;
+                }
+                return base.IsWrapperType;
+            }
+        }
     }
 }


### PR DESCRIPTION
For FutureTypeGo, propagate the wrapper status from the result type.
This makes the replacement of the concrete response type with the future
type transparent to IsWrapperType checks.