### PR TITLE
Update to latest versions of Go

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -19,12 +19,12 @@ jobs:
 
     strategy:
       matrix:
-        Linux_Go115:
-          vm.image: 'ubuntu-18.04'
-          go.version: '1.15.11'
         Linux_Go116:
           vm.image: 'ubuntu-18.04'
-          go.version: '1.16.3'
+          go.version: '1.16.7'
+        Linux_Go117:
+          vm.image: 'ubuntu-18.04'
+          go.version: '1.17'
 
     pool:
       vmImage: '$(vm.image)'

--- a/eng/pipelines/publish-dev-release.yml
+++ b/eng/pipelines/publish-dev-release.yml
@@ -35,7 +35,7 @@ steps:
 
   - task: GoTool@0
     inputs:
-      version: '1.15.3'
+      version: '1.17'
     displayName: "Select Go Version"
 
   - script: |

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -35,7 +35,7 @@ steps:
 
   - task: GoTool@0
     inputs:
-      version: '1.15.3'
+      version: '1.17'
     displayName: "Select Go Version"
 
   - script: |

--- a/src/generator/constants.ts
+++ b/src/generator/constants.ts
@@ -13,7 +13,10 @@ import { commentLength } from '../common/helpers';
 // Creates the content in constants.go
 export async function generateConstants(session: Session<CodeModel>, version: string): Promise<string> {
   let text = await contentPreamble(session);
-  text += `const telemetryInfo = "azsdk-go-${session.model.language.go!.packageName}/v${version}"\n`;
+  text += `const (\n`;
+  text += `\ttelemetryInfo = "azsdk-go-${session.model.language.go!.packageName}/" + version\n`;
+  text += `\tversion = "v${version}"\n`;
+  text += ')\n\n';
   for (const enm of values(getEnums(session.model.schemas))) {
     if (enm.desc) {
       text += `${comment(`${enm.name} - ${enm.desc}`, '// ', undefined, commentLength)}\n`;

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -13,7 +13,7 @@ export async function generateGoModFile(session: Session<CodeModel>): Promise<st
     return '';
   }
   let text = `module ${modName}\n\n`;
-  text += 'go 1.13\n\n';
+  text += 'go 1.16\n\n';
   // here we specify the minimum version of armcore/azcore as required by the code generator
   // TODO: come up with a way to get the latest minor/patch versions.
   const azcore = 'github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2';

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -17,7 +17,8 @@ export const datetimeRFC1123Format = 'time.RFC1123';
 // returns the common source-file preamble (license comment, package name etc)
 export async function contentPreamble(session: Session<CodeModel>): Promise<string> {
   const headerText = comment(await session.getValue('header-text', 'MISSING LICENSE HEADER'), '// ');
-  let text = `// +build go1.13\n\n${headerText}\n\n`;
+  let text = `//go:build go1.16\n`;
+  text += `// +build go1.16\n\n${headerText}\n\n`;
   text += `package ${session.model.language.go!.packageName}\n\n`;
   return text;
 }

--- a/test/autorest/additionalpropsgroup/zz_generated_connection.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/additionalpropsgroup/zz_generated_constants.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/additionalpropsgroup/zz_generated_constants.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package additionalpropsgroup
 
-const telemetryInfo = "azsdk-go-additionalpropsgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-additionalpropsgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/additionalpropsgroup/zz_generated_models.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/additionalpropsgroup/zz_generated_response_types.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_array_client.go
+++ b/test/autorest/arraygroup/zz_generated_array_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_connection.go
+++ b/test/autorest/arraygroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_constants.go
+++ b/test/autorest/arraygroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_constants.go
+++ b/test/autorest/arraygroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package arraygroup
 
-const telemetryInfo = "azsdk-go-arraygroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-arraygroup/" + version
+	version       = "v0.1"
+)
 
 type Enum0 string
 

--- a/test/autorest/arraygroup/zz_generated_date_type.go
+++ b/test/autorest/arraygroup/zz_generated_date_type.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_models.go
+++ b/test/autorest/arraygroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_response_types.go
+++ b/test/autorest/arraygroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/arraygroup/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/arraygroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/arraygroup/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurereportgroup/zz_generated_connection.go
+++ b/test/autorest/azurereportgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurereportgroup/zz_generated_constants.go
+++ b/test/autorest/azurereportgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurereportgroup/zz_generated_constants.go
+++ b/test/autorest/azurereportgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package azurereportgroup
 
-const telemetryInfo = "azsdk-go-azurereportgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azurereportgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/azurereportgroup/zz_generated_models.go
+++ b/test/autorest/azurereportgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurereportgroup/zz_generated_response_types.go
+++ b/test/autorest/azurereportgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_connection.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_constants.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_constants.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package azurespecialsgroup
 
-const telemetryInfo = "azsdk-go-azurespecialsgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azurespecialsgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/azurespecialsgroup/zz_generated_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_models.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_response_types.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/booleangroup/zz_generated_bool_client.go
+++ b/test/autorest/booleangroup/zz_generated_bool_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/booleangroup/zz_generated_connection.go
+++ b/test/autorest/booleangroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/booleangroup/zz_generated_constants.go
+++ b/test/autorest/booleangroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/booleangroup/zz_generated_constants.go
+++ b/test/autorest/booleangroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package booleangroup
 
-const telemetryInfo = "azsdk-go-booleangroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-booleangroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/booleangroup/zz_generated_models.go
+++ b/test/autorest/booleangroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/booleangroup/zz_generated_response_types.go
+++ b/test/autorest/booleangroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/bytegroup/zz_generated_byte_client.go
+++ b/test/autorest/bytegroup/zz_generated_byte_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/bytegroup/zz_generated_connection.go
+++ b/test/autorest/bytegroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/bytegroup/zz_generated_constants.go
+++ b/test/autorest/bytegroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/bytegroup/zz_generated_constants.go
+++ b/test/autorest/bytegroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package bytegroup
 
-const telemetryInfo = "azsdk-go-bytegroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-bytegroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/bytegroup/zz_generated_models.go
+++ b/test/autorest/bytegroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/bytegroup/zz_generated_response_types.go
+++ b/test/autorest/bytegroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_array_client.go
+++ b/test/autorest/complexgroup/zz_generated_array_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_basic_client.go
+++ b/test/autorest/complexgroup/zz_generated_basic_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_connection.go
+++ b/test/autorest/complexgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_constants.go
+++ b/test/autorest/complexgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_constants.go
+++ b/test/autorest/complexgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package complexgroup
 
-const telemetryInfo = "azsdk-go-complexgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-complexgroup/" + version
+	version       = "v0.1"
+)
 
 type CMYKColors string
 

--- a/test/autorest/complexgroup/zz_generated_date_type.go
+++ b/test/autorest/complexgroup/zz_generated_date_type.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_dictionary_client.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_inheritance_client.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_models.go
+++ b/test/autorest/complexgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphic_helpers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_polymorphism_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_primitive_client.go
+++ b/test/autorest/complexgroup/zz_generated_primitive_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_response_types.go
+++ b/test/autorest/complexgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/complexgroup/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexgroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/complexgroup/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient_client.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexmodelgroup/zz_generated_connection.go
+++ b/test/autorest/complexmodelgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexmodelgroup/zz_generated_constants.go
+++ b/test/autorest/complexmodelgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexmodelgroup/zz_generated_constants.go
+++ b/test/autorest/complexmodelgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package complexmodelgroup
 
-const telemetryInfo = "azsdk-go-complexmodelgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-complexmodelgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/complexmodelgroup/zz_generated_models.go
+++ b/test/autorest/complexmodelgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/complexmodelgroup/zz_generated_response_types.go
+++ b/test/autorest/complexmodelgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/custombaseurlgroup/zz_generated_connection.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/custombaseurlgroup/zz_generated_constants.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/custombaseurlgroup/zz_generated_constants.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package custombaseurlgroup
 
-const telemetryInfo = "azsdk-go-custombaseurlgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-custombaseurlgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/custombaseurlgroup/zz_generated_models.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/custombaseurlgroup/zz_generated_response_types.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_connection.go
+++ b/test/autorest/dategroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_constants.go
+++ b/test/autorest/dategroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_constants.go
+++ b/test/autorest/dategroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package dategroup
 
-const telemetryInfo = "azsdk-go-dategroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-dategroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/dategroup/zz_generated_date_client.go
+++ b/test/autorest/dategroup/zz_generated_date_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_date_type.go
+++ b/test/autorest/dategroup/zz_generated_date_type.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_models.go
+++ b/test/autorest/dategroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dategroup/zz_generated_response_types.go
+++ b/test/autorest/dategroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_connection.go
+++ b/test/autorest/datetimegroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_constants.go
+++ b/test/autorest/datetimegroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_constants.go
+++ b/test/autorest/datetimegroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package datetimegroup
 
-const telemetryInfo = "azsdk-go-datetimegroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-datetimegroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/datetimegroup/zz_generated_datetime_client.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_models.go
+++ b/test/autorest/datetimegroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_response_types.go
+++ b/test/autorest/datetimegroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimegroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/datetimegroup/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_connection.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_constants.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_constants.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package datetimerfc1123group
 
-const telemetryInfo = "azsdk-go-datetimerfc1123group/v0.1"
+const (
+	telemetryInfo = "azsdk-go-datetimerfc1123group/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_models.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_response_types.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/datetimerfc1123group/zz_generated_time_rfc1123.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_connection.go
+++ b/test/autorest/dictionarygroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_constants.go
+++ b/test/autorest/dictionarygroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_constants.go
+++ b/test/autorest/dictionarygroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package dictionarygroup
 
-const telemetryInfo = "azsdk-go-dictionarygroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-dictionarygroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/dictionarygroup/zz_generated_date_type.go
+++ b/test/autorest/dictionarygroup/zz_generated_date_type.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_models.go
+++ b/test/autorest/dictionarygroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_response_types.go
+++ b/test/autorest/dictionarygroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/dictionarygroup/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/dictionarygroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/dictionarygroup/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/durationgroup/zz_generated_connection.go
+++ b/test/autorest/durationgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/durationgroup/zz_generated_constants.go
+++ b/test/autorest/durationgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/durationgroup/zz_generated_constants.go
+++ b/test/autorest/durationgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package durationgroup
 
-const telemetryInfo = "azsdk-go-durationgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-durationgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/durationgroup/zz_generated_duration_client.go
+++ b/test/autorest/durationgroup/zz_generated_duration_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/durationgroup/zz_generated_models.go
+++ b/test/autorest/durationgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/durationgroup/zz_generated_response_types.go
+++ b/test/autorest/durationgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_connection.go
+++ b/test/autorest/errorsgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_constants.go
+++ b/test/autorest/errorsgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_constants.go
+++ b/test/autorest/errorsgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package errorsgroup
 
-const telemetryInfo = "azsdk-go-errorsgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-errorsgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/errorsgroup/zz_generated_models.go
+++ b/test/autorest/errorsgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_pet_client.go
+++ b/test/autorest/errorsgroup/zz_generated_pet_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_polymorphic_helpers.go
+++ b/test/autorest/errorsgroup/zz_generated_polymorphic_helpers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/errorsgroup/zz_generated_response_types.go
+++ b/test/autorest/errorsgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/extenumsgroup/zz_generated_connection.go
+++ b/test/autorest/extenumsgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/extenumsgroup/zz_generated_constants.go
+++ b/test/autorest/extenumsgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/extenumsgroup/zz_generated_constants.go
+++ b/test/autorest/extenumsgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package extenumsgroup
 
-const telemetryInfo = "azsdk-go-extenumsgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-extenumsgroup/" + version
+	version       = "v0.1"
+)
 
 // DaysOfWeekExtensibleEnum - Type of Pet
 type DaysOfWeekExtensibleEnum string

--- a/test/autorest/extenumsgroup/zz_generated_models.go
+++ b/test/autorest/extenumsgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/extenumsgroup/zz_generated_pet_client.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/extenumsgroup/zz_generated_response_types.go
+++ b/test/autorest/extenumsgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/filegroup/zz_generated_connection.go
+++ b/test/autorest/filegroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/filegroup/zz_generated_constants.go
+++ b/test/autorest/filegroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/filegroup/zz_generated_constants.go
+++ b/test/autorest/filegroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package filegroup
 
-const telemetryInfo = "azsdk-go-filegroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-filegroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/filegroup/zz_generated_files_client.go
+++ b/test/autorest/filegroup/zz_generated_files_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/filegroup/zz_generated_models.go
+++ b/test/autorest/filegroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/filegroup/zz_generated_response_types.go
+++ b/test/autorest/filegroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/formdatagroup/zz_generated_connection.go
+++ b/test/autorest/formdatagroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/formdatagroup/zz_generated_constants.go
+++ b/test/autorest/formdatagroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/formdatagroup/zz_generated_constants.go
+++ b/test/autorest/formdatagroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package formdatagroup
 
-const telemetryInfo = "azsdk-go-formdatagroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-formdatagroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/formdatagroup/zz_generated_formdata_client.go
+++ b/test/autorest/formdatagroup/zz_generated_formdata_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/formdatagroup/zz_generated_models.go
+++ b/test/autorest/formdatagroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/formdatagroup/zz_generated_response_types.go
+++ b/test/autorest/formdatagroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headergroup/zz_generated_connection.go
+++ b/test/autorest/headergroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headergroup/zz_generated_constants.go
+++ b/test/autorest/headergroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headergroup/zz_generated_constants.go
+++ b/test/autorest/headergroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package headergroup
 
-const telemetryInfo = "azsdk-go-headergroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-headergroup/" + version
+	version       = "v0.1"
+)
 
 type GreyscaleColors string
 

--- a/test/autorest/headergroup/zz_generated_header_client.go
+++ b/test/autorest/headergroup/zz_generated_header_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headergroup/zz_generated_models.go
+++ b/test/autorest/headergroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headergroup/zz_generated_response_types.go
+++ b/test/autorest/headergroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headgroup/zz_generated_connection.go
+++ b/test/autorest/headgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headgroup/zz_generated_constants.go
+++ b/test/autorest/headgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headgroup/zz_generated_constants.go
+++ b/test/autorest/headgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package headgroup
 
-const telemetryInfo = "azsdk-go-headgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-headgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/headgroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/headgroup/zz_generated_httpsuccess_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headgroup/zz_generated_models.go
+++ b/test/autorest/headgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/headgroup/zz_generated_response_types.go
+++ b/test/autorest/headgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_connection.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package httpinfrastructuregroup
 
-const telemetryInfo = "azsdk-go-httpinfrastructuregroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-httpinfrastructuregroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_models.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_connection.go
+++ b/test/autorest/integergroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_constants.go
+++ b/test/autorest/integergroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_constants.go
+++ b/test/autorest/integergroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package integergroup
 
-const telemetryInfo = "azsdk-go-integergroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-integergroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/integergroup/zz_generated_int_client.go
+++ b/test/autorest/integergroup/zz_generated_int_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_models.go
+++ b/test/autorest/integergroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_response_types.go
+++ b/test/autorest/integergroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/integergroup/zz_generated_time_unix.go
+++ b/test/autorest/integergroup/zz_generated_time_unix.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_connection.go
+++ b/test/autorest/lrogroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_constants.go
+++ b/test/autorest/lrogroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_constants.go
+++ b/test/autorest/lrogroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package lrogroup
 
-const telemetryInfo = "azsdk-go-lrogroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-lrogroup/" + version
+	version       = "v0.1"
+)
 
 // OperationResultStatus - The status of the request
 type OperationResultStatus string

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_models.go
+++ b/test/autorest/lrogroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_pollers.go
+++ b/test/autorest/lrogroup/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/lrogroup/zz_generated_response_types.go
+++ b/test/autorest/lrogroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/mediatypesgroup/zz_generated_connection.go
+++ b/test/autorest/mediatypesgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/mediatypesgroup/zz_generated_constants.go
+++ b/test/autorest/mediatypesgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/mediatypesgroup/zz_generated_constants.go
+++ b/test/autorest/mediatypesgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package mediatypesgroup
 
-const telemetryInfo = "azsdk-go-mediatypesgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-mediatypesgroup/" + version
+	version       = "v0.1"
+)
 
 // ContentType - Content type for upload
 type ContentType string

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/mediatypesgroup/zz_generated_models.go
+++ b/test/autorest/mediatypesgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/mediatypesgroup/zz_generated_response_types.go
+++ b/test/autorest/mediatypesgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/migroup/zz_generated_connection.go
+++ b/test/autorest/migroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/migroup/zz_generated_constants.go
+++ b/test/autorest/migroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/migroup/zz_generated_constants.go
+++ b/test/autorest/migroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package migroup
 
-const telemetryInfo = "azsdk-go-migroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-migroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/migroup/zz_generated_models.go
+++ b/test/autorest/migroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient_client.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/migroup/zz_generated_response_types.go
+++ b/test/autorest/migroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/morecustombaseurigroup/zz_generated_connection.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/morecustombaseurigroup/zz_generated_constants.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/morecustombaseurigroup/zz_generated_constants.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package morecustombaseurigroup
 
-const telemetryInfo = "azsdk-go-morecustombaseurigroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-morecustombaseurigroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/morecustombaseurigroup/zz_generated_models.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/morecustombaseurigroup/zz_generated_response_types.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_connection.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_constants.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_constants.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package nonstringenumgroup
 
-const telemetryInfo = "azsdk-go-nonstringenumgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-nonstringenumgroup/" + version
+	version       = "v0.1"
+)
 
 // FloatEnum - List of float enums
 type FloatEnum float32

--- a/test/autorest/nonstringenumgroup/zz_generated_float_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_int_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_models.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/nonstringenumgroup/zz_generated_response_types.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/numbergroup/zz_generated_connection.go
+++ b/test/autorest/numbergroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/numbergroup/zz_generated_constants.go
+++ b/test/autorest/numbergroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/numbergroup/zz_generated_constants.go
+++ b/test/autorest/numbergroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package numbergroup
 
-const telemetryInfo = "azsdk-go-numbergroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-numbergroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/numbergroup/zz_generated_models.go
+++ b/test/autorest/numbergroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/numbergroup/zz_generated_number_client.go
+++ b/test/autorest/numbergroup/zz_generated_number_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/numbergroup/zz_generated_response_types.go
+++ b/test/autorest/numbergroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/objectgroup/zz_generated_connection.go
+++ b/test/autorest/objectgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/objectgroup/zz_generated_constants.go
+++ b/test/autorest/objectgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/objectgroup/zz_generated_constants.go
+++ b/test/autorest/objectgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package objectgroup
 
-const telemetryInfo = "azsdk-go-objectgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-objectgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/objectgroup/zz_generated_models.go
+++ b/test/autorest/objectgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/objectgroup/zz_generated_objecttypeclient_client.go
+++ b/test/autorest/objectgroup/zz_generated_objecttypeclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/objectgroup/zz_generated_response_types.go
+++ b/test/autorest/objectgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_connection.go
+++ b/test/autorest/optionalgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_constants.go
+++ b/test/autorest/optionalgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_constants.go
+++ b/test/autorest/optionalgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package optionalgroup
 
-const telemetryInfo = "azsdk-go-optionalgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-optionalgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/optionalgroup/zz_generated_explicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_implicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_models.go
+++ b/test/autorest/optionalgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/optionalgroup/zz_generated_response_types.go
+++ b/test/autorest/optionalgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_connection.go
+++ b/test/autorest/paginggroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_constants.go
+++ b/test/autorest/paginggroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_constants.go
+++ b/test/autorest/paginggroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package paginggroup
 
-const telemetryInfo = "azsdk-go-paginggroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-paginggroup/" + version
+	version       = "v0.1"
+)
 
 // OperationResultStatus - The status of the request
 type OperationResultStatus string

--- a/test/autorest/paginggroup/zz_generated_models.go
+++ b/test/autorest/paginggroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_pagers.go
+++ b/test/autorest/paginggroup/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_pollers.go
+++ b/test/autorest/paginggroup/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paginggroup/zz_generated_response_types.go
+++ b/test/autorest/paginggroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paramgroupinggroup/zz_generated_connection.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paramgroupinggroup/zz_generated_constants.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paramgroupinggroup/zz_generated_constants.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package paramgroupinggroup
 
-const telemetryInfo = "azsdk-go-paramgroupinggroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-paramgroupinggroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/paramgroupinggroup/zz_generated_models.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/paramgroupinggroup/zz_generated_response_types.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/reportgroup/zz_generated_connection.go
+++ b/test/autorest/reportgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/reportgroup/zz_generated_constants.go
+++ b/test/autorest/reportgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/reportgroup/zz_generated_constants.go
+++ b/test/autorest/reportgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package reportgroup
 
-const telemetryInfo = "azsdk-go-reportgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-reportgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/reportgroup/zz_generated_models.go
+++ b/test/autorest/reportgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/reportgroup/zz_generated_response_types.go
+++ b/test/autorest/reportgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_connection.go
+++ b/test/autorest/stringgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_constants.go
+++ b/test/autorest/stringgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_constants.go
+++ b/test/autorest/stringgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package stringgroup
 
-const telemetryInfo = "azsdk-go-stringgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-stringgroup/" + version
+	version       = "v0.1"
+)
 
 // Colors - Referenced Color Enum Description.
 type Colors string

--- a/test/autorest/stringgroup/zz_generated_enum_client.go
+++ b/test/autorest/stringgroup/zz_generated_enum_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_models.go
+++ b/test/autorest/stringgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_response_types.go
+++ b/test/autorest/stringgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/stringgroup/zz_generated_string_client.go
+++ b/test/autorest/stringgroup/zz_generated_string_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_connection.go
+++ b/test/autorest/urlgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_constants.go
+++ b/test/autorest/urlgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_constants.go
+++ b/test/autorest/urlgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package urlgroup
 
-const telemetryInfo = "azsdk-go-urlgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-urlgroup/" + version
+	version       = "v0.1"
+)
 
 type URIColor string
 

--- a/test/autorest/urlgroup/zz_generated_models.go
+++ b/test/autorest/urlgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_pathitems_client.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_paths_client.go
+++ b/test/autorest/urlgroup/zz_generated_paths_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_queries_client.go
+++ b/test/autorest/urlgroup/zz_generated_queries_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_response_types.go
+++ b/test/autorest/urlgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlgroup/zz_generated_time_unix.go
+++ b/test/autorest/urlgroup/zz_generated_time_unix.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlmultigroup/zz_generated_connection.go
+++ b/test/autorest/urlmultigroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlmultigroup/zz_generated_constants.go
+++ b/test/autorest/urlmultigroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlmultigroup/zz_generated_constants.go
+++ b/test/autorest/urlmultigroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package urlmultigroup
 
-const telemetryInfo = "azsdk-go-urlmultigroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-urlmultigroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/urlmultigroup/zz_generated_models.go
+++ b/test/autorest/urlmultigroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlmultigroup/zz_generated_queries_client.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/urlmultigroup/zz_generated_response_types.go
+++ b/test/autorest/urlmultigroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/validationgroup/zz_generated_connection.go
+++ b/test/autorest/validationgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/validationgroup/zz_generated_constants.go
+++ b/test/autorest/validationgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/validationgroup/zz_generated_constants.go
+++ b/test/autorest/validationgroup/zz_generated_constants.go
@@ -8,4 +8,7 @@
 
 package validationgroup
 
-const telemetryInfo = "azsdk-go-validationgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-validationgroup/" + version
+	version       = "v0.1"
+)

--- a/test/autorest/validationgroup/zz_generated_models.go
+++ b/test/autorest/validationgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/validationgroup/zz_generated_response_types.go
+++ b/test/autorest/validationgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_connection.go
+++ b/test/autorest/xmlgroup/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_constants.go
+++ b/test/autorest/xmlgroup/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_constants.go
+++ b/test/autorest/xmlgroup/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package xmlgroup
 
-const telemetryInfo = "azsdk-go-xmlgroup/v0.1"
+const (
+	telemetryInfo = "azsdk-go-xmlgroup/" + version
+	version       = "v0.1"
+)
 
 type AccessTier string
 

--- a/test/autorest/xmlgroup/zz_generated_models.go
+++ b/test/autorest/xmlgroup/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_response_types.go
+++ b/test/autorest/xmlgroup/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_time_rfc1123.go
+++ b/test/autorest/xmlgroup/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_time_rfc3339.go
+++ b/test/autorest/xmlgroup/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_xml_client.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/autorest/xmlgroup/zz_generated_xml_helper.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_helper.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -1,6 +1,6 @@
 module armcompute
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.8.0

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_constants.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_constants.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package armcompute
 
-const telemetryInfo = "azsdk-go-armcompute/v0.1"
+const (
+	telemetryInfo = "azsdk-go-armcompute/" + version
+	version       = "v0.1"
+)
 
 type AccessLevel string
 

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_loganalytics_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_time_rfc3339.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/go.mod
+++ b/test/keyvault/7.2/azkeyvault/go.mod
@@ -1,5 +1,5 @@
 module azkeyvault
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package azkeyvault
 
-const telemetryInfo = "azsdk-go-azkeyvault/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azkeyvault/" + version
+	version       = "v0.1"
+)
 
 // ActionType - The type of the action.
 type ActionType string

--- a/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_keyvaultclient_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_keyvaultclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_models.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_time_unix.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_time_unix.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/go.mod
+++ b/test/maps/azalias/go.mod
@@ -1,5 +1,5 @@
 module azalias
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/maps/azalias/zz_generated_alias_client.go
+++ b/test/maps/azalias/zz_generated_alias_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/zz_generated_connection.go
+++ b/test/maps/azalias/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/zz_generated_constants.go
+++ b/test/maps/azalias/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/zz_generated_constants.go
+++ b/test/maps/azalias/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package azalias
 
-const telemetryInfo = "azsdk-go-azalias/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azalias/" + version
+	version       = "v0.1"
+)
 
 type GeographicResourceLocation string
 

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/zz_generated_pagers.go
+++ b/test/maps/azalias/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/maps/azalias/zz_generated_response_types.go
+++ b/test/maps/azalias/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -1,6 +1,6 @@
 module armnetwork
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/armcore v0.8.0

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_constants.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_constants.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package armnetwork
 
-const telemetryInfo = "azsdk-go-armnetwork/v0.1"
+const (
+	telemetryInfo = "azsdk-go-armnetwork/" + version
+	version       = "v0.1"
+)
 
 // Access - Access to be allowed or denied.
 type Access string

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_polymorphic_helpers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_time_rfc3339.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitesconfiguration_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/go.mod
+++ b/test/storage/2020-06-12/azblob/go.mod
@@ -1,5 +1,5 @@
 module azstorage
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_blob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blob_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_connection.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_constants.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_constants.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package azblob
 
-const telemetryInfo = "azsdk-go-azblob/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azblob/" + version
+	version       = "v0.1"
+)
 
 type AccessTier string
 

--- a/test/storage/2020-06-12/azblob/zz_generated_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_container_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_models.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_pagers.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_response_types.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_service_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_service_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_time_rfc1123.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_time_rfc3339.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/storage/2020-06-12/azblob/zz_generated_xml_helper.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_xml_helper.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -1,5 +1,5 @@
 module azartifacts
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package azartifacts
 
-const telemetryInfo = "azsdk-go-azartifacts/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azartifacts/" + version
+	version       = "v0.1"
+)
 
 type AvroCompressionCodec string
 

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pagers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pollers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_polymorphic_helpers.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_time_rfc3339.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -1,5 +1,5 @@
 module azspark
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/synapse/2019-06-01/azspark/zz_generated_connection.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package azspark
 
-const telemetryInfo = "azsdk-go-azspark/v0.1"
+const (
+	telemetryInfo = "azsdk-go-azspark/" + version
+	version       = "v0.1"
+)
 
 type PluginCurrentState string
 

--- a/test/synapse/2019-06-01/azspark/zz_generated_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparksession_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparksession_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/synapse/2019-06-01/azspark/zz_generated_time_rfc3339.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/go.mod
+++ b/test/tables/2019-02-02/aztables/go.mod
@@ -1,5 +1,5 @@
 module aztables
 
-go 1.13
+go 1.16
 
 require github.com/Azure/azure-sdk-for-go/sdk/azcore v0.16.2

--- a/test/tables/2019-02-02/aztables/zz_generated_connection.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_connection.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_constants.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_constants.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_constants.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_constants.go
@@ -8,7 +8,10 @@
 
 package aztables
 
-const telemetryInfo = "azsdk-go-aztables/v0.1"
+const (
+	telemetryInfo = "azsdk-go-aztables/" + version
+	version       = "v0.1"
+)
 
 // GeoReplicationStatusType - The status of the secondary location.
 type GeoReplicationStatusType string

--- a/test/tables/2019-02-02/aztables/zz_generated_models.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_models.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_response_types.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_response_types.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_service_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_service_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_table_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_table_client.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_time_rfc1123.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_time_rfc1123.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.

--- a/test/tables/2019-02-02/aztables/zz_generated_time_rfc3339.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_time_rfc3339.go
@@ -1,4 +1,5 @@
-// +build go1.13
+//go:build go1.16
+// +build go1.16
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
Added build constraint format introduced in Go 1.17.
Updated go.mod Go version to 1.16.
Updated CI and publishing pipelines.