### PR TITLE
Don't assume exported connection type in method generation

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -63,10 +63,10 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
     let text = await contentPreamble(session);
     let connection = 'Connection';
     let clientName = group.language.go!.clientName;
-    if (!isARM && !forceExports) {
-      connection = connection.uncapitalize();
-    } else if (<boolean>session.model.language.go!.azureARM) {
+    if (<boolean>session.model.language.go!.azureARM) {
       connection = 'armcore.Connection';
+    } else if (!forceExports) {
+      connection = connection.uncapitalize();
     }
     const clientCtor = group.language.go!.clientCtorName;
     text += imports.text();


### PR DESCRIPTION
Updated the condition to match that when generating the connection.
This fixes an issue where the connection wasn't exported but the method
group clients assumed it to be.