### PR TITLE
Better fix for future-wrapped wrapper types

### DIFF
--- a/src/Model/CompositeTypeGo.cs
+++ b/src/Model/CompositeTypeGo.cs
@@ -117,7 +117,7 @@ namespace AutoRest.Go.Model
 
         public PropertyGo AdditionalPropertiesField => AllProperties.FirstOrDefault(p => p.ModelType is DictionaryTypeGo dictionaryType && dictionaryType.SupportsAdditionalProperties);
 
-        public virtual bool IsWrapperType { get; }
+        public bool IsWrapperType { get; }
 
         public IModelType BaseType { get; }
 

--- a/src/Model/FutureTypeGo.cs
+++ b/src/Model/FutureTypeGo.cs
@@ -74,6 +74,21 @@ namespace AutoRest.Go.Model
         public IModelType ResultType { get; }
 
         /// <summary>
+        /// Returns true if the result type is a wrapper type.
+        /// </summary>
+        public bool IsResultWrapperType
+        {
+            get
+            {
+                if (ResultType is CompositeTypeGo ctg)
+                {
+                    return ctg.IsWrapperType;
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Gets the type name of the object that's returned when the operation is complete.
         /// </summary>
         public string ResultTypeName
@@ -122,19 +137,6 @@ namespace AutoRest.Go.Model
         public override int GetHashCode()
         {
             return Name.GetHashCode();
-        }
-
-        public override bool IsWrapperType
-        {
-            get
-            {
-                if (ResultType is CompositeTypeGo ctg)
-                {
-                    // propagate the result's wrapper status
-                    return ctg.IsWrapperType;
-                }
-                return base.IsWrapperType;
-            }
         }
     }
 }

--- a/src/Model/MethodGo.cs
+++ b/src/Model/MethodGo.cs
@@ -536,7 +536,7 @@ namespace AutoRest.Go.Model
 
                 if (HasReturnValue() && !ReturnType.Body.IsStreamType() && !LroWrapsDefaultResp())
                 {
-                    if (((CompositeTypeGo)ReturnType.Body).IsWrapperType && !((CompositeTypeGo)ReturnType.Body).HasPolymorphicFields)
+                    if ((((CompositeTypeGo)ReturnType.Body).IsWrapperType || (ReturnType.Body is FutureTypeGo ftg && ftg.IsResultWrapperType)) && !((CompositeTypeGo)ReturnType.Body).HasPolymorphicFields)
                     {
                         decorators.Add("autorest.ByUnmarshallingJSON(&result.Value)");
                     }


### PR DESCRIPTION
The change in #674 introduced unwanted side-effects by treating future
types as direct wrapper types.
Added FutureTypeGo.IsResultWrapperType to check if the future holds a
wrapper type in cases where it's important.