### PR TITLE
Return the future's HTTP response if available

### DIFF
--- a/src/Templates/MethodTemplate.cshtml
+++ b/src/Templates/MethodTemplate.cshtml
@@ -104,7 +104,7 @@ else
     <text>
         result, err = client.@(Model.SenderMethodName)(req)
         if err != nil {
-        err = @(Model.AutorestError("Failure sending request"))
+        err = @(Model.AutorestError("Failure sending request", "result.Response()"))
         return
         }
     </text>

--- a/test/src/tests/generated/lrogroup/lroretrys.go
+++ b/test/src/tests/generated/lrogroup/lroretrys.go
@@ -51,7 +51,7 @@ func (client LRORetrysClient) Delete202Retry200(ctx context.Context) (result LRO
 
 	result, err = client.Delete202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Delete202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Delete202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -115,7 +115,7 @@ func (client LRORetrysClient) DeleteAsyncRelativeRetrySucceeded(ctx context.Cont
 
 	result, err = client.DeleteAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteAsyncRelativeRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -180,7 +180,7 @@ func (client LRORetrysClient) DeleteProvisioning202Accepted200Succeeded(ctx cont
 
 	result, err = client.DeleteProvisioning202Accepted200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteProvisioning202Accepted200Succeeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "DeleteProvisioning202Accepted200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -247,7 +247,7 @@ func (client LRORetrysClient) Post202Retry200(ctx context.Context, product *Prod
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Post202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -319,7 +319,7 @@ func (client LRORetrysClient) PostAsyncRelativeRetrySucceeded(ctx context.Contex
 
 	result, err = client.PostAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PostAsyncRelativeRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PostAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -391,7 +391,7 @@ func (client LRORetrysClient) Put201CreatingSucceeded200(ctx context.Context, pr
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Put201CreatingSucceeded200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -464,7 +464,7 @@ func (client LRORetrysClient) PutAsyncRelativeRetrySucceeded(ctx context.Context
 
 	result, err = client.PutAsyncRelativeRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PutAsyncRelativeRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LRORetrysClient", "PutAsyncRelativeRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 

--- a/test/src/tests/generated/lrogroup/lros.go
+++ b/test/src/tests/generated/lrogroup/lros.go
@@ -51,7 +51,7 @@ func (client LROsClient) Delete202NoRetry204(ctx context.Context) (result LROsDe
 
 	result, err = client.Delete202NoRetry204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202NoRetry204", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202NoRetry204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -116,7 +116,7 @@ func (client LROsClient) Delete202Retry200(ctx context.Context) (result LROsDele
 
 	result, err = client.Delete202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -180,7 +180,7 @@ func (client LROsClient) Delete204Succeeded(ctx context.Context) (result LROsDel
 
 	result, err = client.Delete204SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete204Succeeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Delete204Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -244,7 +244,7 @@ func (client LROsClient) DeleteAsyncNoHeaderInRetry(ctx context.Context) (result
 
 	result, err = client.DeleteAsyncNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoHeaderInRetry", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -308,7 +308,7 @@ func (client LROsClient) DeleteAsyncNoRetrySucceeded(ctx context.Context) (resul
 
 	result, err = client.DeleteAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -372,7 +372,7 @@ func (client LROsClient) DeleteAsyncRetrycanceled(ctx context.Context) (result L
 
 	result, err = client.DeleteAsyncRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrycanceled", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -436,7 +436,7 @@ func (client LROsClient) DeleteAsyncRetryFailed(ctx context.Context) (result LRO
 
 	result, err = client.DeleteAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetryFailed", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -500,7 +500,7 @@ func (client LROsClient) DeleteAsyncRetrySucceeded(ctx context.Context) (result 
 
 	result, err = client.DeleteAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -564,7 +564,7 @@ func (client LROsClient) DeleteNoHeaderInRetry(ctx context.Context) (result LROs
 
 	result, err = client.DeleteNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteNoHeaderInRetry", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -629,7 +629,7 @@ func (client LROsClient) DeleteProvisioning202Accepted200Succeeded(ctx context.C
 
 	result, err = client.DeleteProvisioning202Accepted200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Accepted200Succeeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Accepted200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -695,7 +695,7 @@ func (client LROsClient) DeleteProvisioning202Deletingcanceled200(ctx context.Co
 
 	result, err = client.DeleteProvisioning202Deletingcanceled200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Deletingcanceled200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202Deletingcanceled200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -761,7 +761,7 @@ func (client LROsClient) DeleteProvisioning202DeletingFailed200(ctx context.Cont
 
 	result, err = client.DeleteProvisioning202DeletingFailed200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202DeletingFailed200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "DeleteProvisioning202DeletingFailed200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -826,7 +826,7 @@ func (client LROsClient) Post200WithPayload(ctx context.Context) (result LROsPos
 
 	result, err = client.Post200WithPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post200WithPayload", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post200WithPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -893,7 +893,7 @@ func (client LROsClient) Post202NoRetry204(ctx context.Context, product *Product
 
 	result, err = client.Post202NoRetry204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202NoRetry204", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202NoRetry204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -965,7 +965,7 @@ func (client LROsClient) Post202Retry200(ctx context.Context, product *Product) 
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1037,7 +1037,7 @@ func (client LROsClient) PostAsyncNoRetrySucceeded(ctx context.Context, product 
 
 	result, err = client.PostAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncNoRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1110,7 +1110,7 @@ func (client LROsClient) PostAsyncRetrycanceled(ctx context.Context, product *Pr
 
 	result, err = client.PostAsyncRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrycanceled", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1182,7 +1182,7 @@ func (client LROsClient) PostAsyncRetryFailed(ctx context.Context, product *Prod
 
 	result, err = client.PostAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetryFailed", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1254,7 +1254,7 @@ func (client LROsClient) PostAsyncRetrySucceeded(ctx context.Context, product *P
 
 	result, err = client.PostAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1325,7 +1325,7 @@ func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGet(ctx context.Contex
 
 	result, err = client.PostDoubleHeadersFinalAzureHeaderGetSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalAzureHeaderGet", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalAzureHeaderGet", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1391,7 +1391,7 @@ func (client LROsClient) PostDoubleHeadersFinalAzureHeaderGetDefault(ctx context
 
 	result, err = client.PostDoubleHeadersFinalAzureHeaderGetDefaultSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalAzureHeaderGetDefault", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalAzureHeaderGetDefault", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1456,7 +1456,7 @@ func (client LROsClient) PostDoubleHeadersFinalLocationGet(ctx context.Context) 
 
 	result, err = client.PostDoubleHeadersFinalLocationGetSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalLocationGet", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PostDoubleHeadersFinalLocationGet", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1524,7 +1524,7 @@ func (client LROsClient) Put200Acceptedcanceled200(ctx context.Context, product 
 
 	result, err = client.Put200Acceptedcanceled200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Acceptedcanceled200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Acceptedcanceled200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1596,7 +1596,7 @@ func (client LROsClient) Put200Succeeded(ctx context.Context, product *Product) 
 
 	result, err = client.Put200SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Succeeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1668,7 +1668,7 @@ func (client LROsClient) Put200SucceededNoState(ctx context.Context, product *Pr
 
 	result, err = client.Put200SucceededNoStateSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200SucceededNoState", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200SucceededNoState", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1741,7 +1741,7 @@ func (client LROsClient) Put200UpdatingSucceeded204(ctx context.Context, product
 
 	result, err = client.Put200UpdatingSucceeded204Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200UpdatingSucceeded204", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put200UpdatingSucceeded204", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1814,7 +1814,7 @@ func (client LROsClient) Put201CreatingFailed200(ctx context.Context, product *P
 
 	result, err = client.Put201CreatingFailed200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingFailed200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingFailed200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1887,7 +1887,7 @@ func (client LROsClient) Put201CreatingSucceeded200(ctx context.Context, product
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingSucceeded200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1959,7 +1959,7 @@ func (client LROsClient) Put202Retry200(ctx context.Context, product *Product) (
 
 	result, err = client.Put202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "Put202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2031,7 +2031,7 @@ func (client LROsClient) PutAsyncNoHeaderInRetry(ctx context.Context, product *P
 
 	result, err = client.PutAsyncNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoHeaderInRetry", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2102,7 +2102,7 @@ func (client LROsClient) PutAsyncNonResource(ctx context.Context, sku *Sku) (res
 
 	result, err = client.PutAsyncNonResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNonResource", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNonResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2175,7 +2175,7 @@ func (client LROsClient) PutAsyncNoRetrycanceled(ctx context.Context, product *P
 
 	result, err = client.PutAsyncNoRetrycanceledSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrycanceled", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrycanceled", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2248,7 +2248,7 @@ func (client LROsClient) PutAsyncNoRetrySucceeded(ctx context.Context, product *
 
 	result, err = client.PutAsyncNoRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncNoRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2321,7 +2321,7 @@ func (client LROsClient) PutAsyncRetryFailed(ctx context.Context, product *Produ
 
 	result, err = client.PutAsyncRetryFailedSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetryFailed", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetryFailed", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2394,7 +2394,7 @@ func (client LROsClient) PutAsyncRetrySucceeded(ctx context.Context, product *Pr
 
 	result, err = client.PutAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2465,7 +2465,7 @@ func (client LROsClient) PutAsyncSubResource(ctx context.Context, product *SubPr
 
 	result, err = client.PutAsyncSubResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncSubResource", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutAsyncSubResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2537,7 +2537,7 @@ func (client LROsClient) PutNoHeaderInRetry(ctx context.Context, product *Produc
 
 	result, err = client.PutNoHeaderInRetrySender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNoHeaderInRetry", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNoHeaderInRetry", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2608,7 +2608,7 @@ func (client LROsClient) PutNonResource(ctx context.Context, sku *Sku) (result L
 
 	result, err = client.PutNonResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNonResource", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutNonResource", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -2679,7 +2679,7 @@ func (client LROsClient) PutSubResource(ctx context.Context, product *SubProduct
 
 	result, err = client.PutSubResourceSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutSubResource", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsClient", "PutSubResource", result.Response(), "Failure sending request")
 		return
 	}
 

--- a/test/src/tests/generated/lrogroup/lrosads.go
+++ b/test/src/tests/generated/lrogroup/lrosads.go
@@ -50,7 +50,7 @@ func (client LROSADsClient) Delete202NonRetry400(ctx context.Context) (result LR
 
 	result, err = client.Delete202NonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202NonRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202NonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -114,7 +114,7 @@ func (client LROSADsClient) Delete202RetryInvalidHeader(ctx context.Context) (re
 
 	result, err = client.Delete202RetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202RetryInvalidHeader", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete202RetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -177,7 +177,7 @@ func (client LROSADsClient) Delete204Succeeded(ctx context.Context) (result LROS
 
 	result, err = client.Delete204SucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete204Succeeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Delete204Succeeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -241,7 +241,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetry400(ctx context.Context) (re
 
 	result, err = client.DeleteAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -305,7 +305,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidHeader(ctx context.Co
 
 	result, err = client.DeleteAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidHeader", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -369,7 +369,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryInvalidJSONPolling(ctx conte
 
 	result, err = client.DeleteAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -433,7 +433,7 @@ func (client LROSADsClient) DeleteAsyncRelativeRetryNoStatus(ctx context.Context
 
 	result, err = client.DeleteAsyncRelativeRetryNoStatusSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryNoStatus", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteAsyncRelativeRetryNoStatus", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -496,7 +496,7 @@ func (client LROSADsClient) DeleteNonRetry400(ctx context.Context) (result LROSA
 
 	result, err = client.DeleteNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteNonRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "DeleteNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -562,7 +562,7 @@ func (client LROSADsClient) Post202NoLocation(ctx context.Context, product *Prod
 
 	result, err = client.Post202NoLocationSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NoLocation", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NoLocation", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -632,7 +632,7 @@ func (client LROSADsClient) Post202NonRetry400(ctx context.Context, product *Pro
 
 	result, err = client.Post202NonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NonRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202NonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -703,7 +703,7 @@ func (client LROSADsClient) Post202RetryInvalidHeader(ctx context.Context, produ
 
 	result, err = client.Post202RetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202RetryInvalidHeader", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Post202RetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -774,7 +774,7 @@ func (client LROSADsClient) PostAsyncRelativeRetry400(ctx context.Context, produ
 
 	result, err = client.PostAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -846,7 +846,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidHeader(ctx context.Cont
 
 	result, err = client.PostAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidHeader", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -918,7 +918,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryInvalidJSONPolling(ctx context
 
 	result, err = client.PostAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -990,7 +990,7 @@ func (client LROSADsClient) PostAsyncRelativeRetryNoPayload(ctx context.Context,
 
 	result, err = client.PostAsyncRelativeRetryNoPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryNoPayload", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostAsyncRelativeRetryNoPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1060,7 +1060,7 @@ func (client LROSADsClient) PostNonRetry400(ctx context.Context, product *Produc
 
 	result, err = client.PostNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostNonRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PostNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1131,7 +1131,7 @@ func (client LROSADsClient) Put200InvalidJSON(ctx context.Context, product *Prod
 
 	result, err = client.Put200InvalidJSONSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Put200InvalidJSON", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "Put200InvalidJSON", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1203,7 +1203,7 @@ func (client LROSADsClient) PutAsyncRelativeRetry400(ctx context.Context, produc
 
 	result, err = client.PutAsyncRelativeRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetry400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1276,7 +1276,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidHeader(ctx context.Conte
 
 	result, err = client.PutAsyncRelativeRetryInvalidHeaderSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidHeader", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidHeader", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1349,7 +1349,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryInvalidJSONPolling(ctx context.
 
 	result, err = client.PutAsyncRelativeRetryInvalidJSONPollingSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidJSONPolling", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryInvalidJSONPolling", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1422,7 +1422,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatus(ctx context.Context, p
 
 	result, err = client.PutAsyncRelativeRetryNoStatusSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatus", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatus", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1495,7 +1495,7 @@ func (client LROSADsClient) PutAsyncRelativeRetryNoStatusPayload(ctx context.Con
 
 	result, err = client.PutAsyncRelativeRetryNoStatusPayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatusPayload", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutAsyncRelativeRetryNoStatusPayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1567,7 +1567,7 @@ func (client LROSADsClient) PutError201NoProvisioningStatePayload(ctx context.Co
 
 	result, err = client.PutError201NoProvisioningStatePayloadSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutError201NoProvisioningStatePayload", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutError201NoProvisioningStatePayload", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1639,7 +1639,7 @@ func (client LROSADsClient) PutNonRetry201Creating400(ctx context.Context, produ
 
 	result, err = client.PutNonRetry201Creating400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1711,7 +1711,7 @@ func (client LROSADsClient) PutNonRetry201Creating400InvalidJSON(ctx context.Con
 
 	result, err = client.PutNonRetry201Creating400InvalidJSONSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400InvalidJSON", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry201Creating400InvalidJSON", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -1782,7 +1782,7 @@ func (client LROSADsClient) PutNonRetry400(ctx context.Context, product *Product
 
 	result, err = client.PutNonRetry400Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry400", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROSADsClient", "PutNonRetry400", result.Response(), "Failure sending request")
 		return
 	}
 

--- a/test/src/tests/generated/lrogroup/lroscustomheader.go
+++ b/test/src/tests/generated/lrogroup/lroscustomheader.go
@@ -55,7 +55,7 @@ func (client LROsCustomHeaderClient) Post202Retry200(ctx context.Context, produc
 
 	result, err = client.Post202Retry200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Post202Retry200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Post202Retry200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -127,7 +127,7 @@ func (client LROsCustomHeaderClient) PostAsyncRetrySucceeded(ctx context.Context
 
 	result, err = client.PostAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PostAsyncRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PostAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -200,7 +200,7 @@ func (client LROsCustomHeaderClient) Put201CreatingSucceeded200(ctx context.Cont
 
 	result, err = client.Put201CreatingSucceeded200Sender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Put201CreatingSucceeded200", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "Put201CreatingSucceeded200", result.Response(), "Failure sending request")
 		return
 	}
 
@@ -273,7 +273,7 @@ func (client LROsCustomHeaderClient) PutAsyncRetrySucceeded(ctx context.Context,
 
 	result, err = client.PutAsyncRetrySucceededSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PutAsyncRetrySucceeded", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "lrogroup.LROsCustomHeaderClient", "PutAsyncRetrySucceeded", result.Response(), "Failure sending request")
 		return
 	}
 

--- a/test/src/tests/generated/paginggroup/paging.go
+++ b/test/src/tests/generated/paginggroup/paging.go
@@ -582,7 +582,7 @@ func (client PagingClient) GetMultiplePagesLRO(ctx context.Context, clientReques
 
 	result, err = client.GetMultiplePagesLROSender(req)
 	if err != nil {
-		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesLRO", nil, "Failure sending request")
+		err = autorest.NewErrorWithError(err, "paginggroup.PagingClient", "GetMultiplePagesLRO", result.Response(), "Failure sending request")
 		return
 	}
 


### PR DESCRIPTION
This ensures that the DetailedError is populated with the HTTP response
if the initial LRO response returns a failed status code.