### PR TITLE
Handle non-string exploded query params

### DIFF
--- a/test/maps/azalias/zz_generated_alias_client.go
+++ b/test/maps/azalias/zz_generated_alias_client.go
@@ -11,6 +11,7 @@ package azalias
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -61,6 +62,11 @@ func (client *aliasClient) createCreateRequest(ctx context.Context, options *Ali
 	reqQP.Set("api-version", "2.0")
 	if options != nil && options.CreatorDataItemID != nil {
 		reqQP.Set("creatorDataItemId", *options.CreatorDataItemID)
+	}
+	if options != nil && options.GroupBy != nil {
+		for _, qv := range options.GroupBy {
+			reqQP.Add("groupBy", fmt.Sprintf("%d", qv))
+		}
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Accept", "application/json")
@@ -129,6 +135,11 @@ func (client *aliasClient) listCreateRequest(ctx context.Context, options *Alias
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("api-version", "2.0")
+	if options != nil && options.GroupBy != nil {
+		for _, qv := range options.GroupBy {
+			reqQP.Add("groupBy", string(qv))
+		}
+	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil

--- a/test/maps/azalias/zz_generated_constants.go
+++ b/test/maps/azalias/zz_generated_constants.go
@@ -55,3 +55,53 @@ func PossibleGeographyValues() []Geography {
 func (c Geography) ToPtr() *Geography {
 	return &c
 }
+
+type LogMetricsGroupBy string
+
+const (
+	LogMetricsGroupByCacheStatus    LogMetricsGroupBy = "cacheStatus"
+	LogMetricsGroupByCountry        LogMetricsGroupBy = "country"
+	LogMetricsGroupByCustomDomain   LogMetricsGroupBy = "customDomain"
+	LogMetricsGroupByHTTPStatusCode LogMetricsGroupBy = "httpStatusCode"
+	LogMetricsGroupByProtocol       LogMetricsGroupBy = "protocol"
+)
+
+// PossibleLogMetricsGroupByValues returns the possible values for the LogMetricsGroupBy const type.
+func PossibleLogMetricsGroupByValues() []LogMetricsGroupBy {
+	return []LogMetricsGroupBy{
+		LogMetricsGroupByCacheStatus,
+		LogMetricsGroupByCountry,
+		LogMetricsGroupByCustomDomain,
+		LogMetricsGroupByHTTPStatusCode,
+		LogMetricsGroupByProtocol,
+	}
+}
+
+// ToPtr returns a *LogMetricsGroupBy pointing to the current value.
+func (c LogMetricsGroupBy) ToPtr() *LogMetricsGroupBy {
+	return &c
+}
+
+type SomethingCount int32
+
+const (
+	SomethingCountTen    SomethingCount = 10
+	SomethingCountTwenty SomethingCount = 20
+	SomethingCountThirty SomethingCount = 30
+	SomethingCountForty  SomethingCount = 40
+)
+
+// PossibleSomethingCountValues returns the possible values for the SomethingCount const type.
+func PossibleSomethingCountValues() []SomethingCount {
+	return []SomethingCount{
+		SomethingCountTen,
+		SomethingCountTwenty,
+		SomethingCountThirty,
+		SomethingCountForty,
+	}
+}
+
+// ToPtr returns a *SomethingCount pointing to the current value.
+func (c SomethingCount) ToPtr() *SomethingCount {
+	return &c
+}

--- a/test/maps/azalias/zz_generated_models.go
+++ b/test/maps/azalias/zz_generated_models.go
@@ -18,6 +18,7 @@ import (
 type AliasCreateOptions struct {
 	// The unique id that references a creator data item to be aliased.
 	CreatorDataItemID *string
+	GroupBy           []SomethingCount
 }
 
 // AliasListItem - Detailed information for the alias.
@@ -37,7 +38,7 @@ type AliasListItem struct {
 
 // AliasListOptions contains the optional parameters for the Alias.List method.
 type AliasListOptions struct {
-	// placeholder for future optional parameters
+	GroupBy []LogMetricsGroupBy
 }
 
 // AliasListResponse - The response model for the List API. Returns a list of all the previously created aliases.

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -125,6 +125,25 @@
           },
           {
             "$ref": "#/parameters/CreateCreatorDataItemId"
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "type": "array",
+            "required": false,
+            "collectionFormat": "multi",
+            "items": {
+              "type": "integer",
+              "enum": [
+                "10",
+                "20",
+                "30",
+                "40"
+              ],
+              "x-ms-enum": {
+                "name": "SomethingCount"
+              }
+            }
           }
         ],
         "responses": {
@@ -156,6 +175,27 @@
         "parameters": [
           {
             "$ref": "#/parameters/AliasApiVersionV2"
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "type": "array",
+            "required": false,
+            "collectionFormat": "multi",
+            "items": {
+              "type": "string",
+              "enum": [
+                "httpStatusCode",
+                "protocol",
+                "cacheStatus",
+                "country",
+                "customDomain"
+              ],
+              "x-ms-enum": {
+                "name": "LogMetricsGroupBy",
+                "modelAsString": true
+              }
+            }
           }
         ],
         "x-ms-pageable": {


### PR DESCRIPTION
Exploded query params were assumed to be of type string which can lead
to bad codegen for cases where the query param element is either a const
or a non-string type.  Perform the necessary type conversion.