### PR TITLE
Rename HTTPClient to Transport

### DIFF
--- a/src/generator/connection.ts
+++ b/src/generator/connection.ts
@@ -54,8 +54,8 @@ function generateContent(session: Session<CodeModel>, imports: ImportManager): s
   text += `// ${connectionOptions} contains configuration settings for the connection's pipeline.\n`;
   text += '// All zero-value fields will be initialized with their default values.\n';
   text += `type ${connectionOptions} struct {\n`;
-  text += '\t// HTTPClient sets the transport for making HTTP requests.\n';
-  text += '\tHTTPClient policy.Transporter\n';
+  text += '\t// Transport sets the transport for making HTTP requests.\n';
+  text += '\tTransport policy.Transporter\n';
   text += '\t// Retry configures the built-in retry policy behavior.\n';
   text += '\tRetry policy.RetryOptions\n';
   text += '\t// Telemetry configures the built-in telemetry policy behavior.\n';
@@ -167,7 +167,7 @@ function generateContent(session: Session<CodeModel>, imports: ImportManager): s
     text += `\t\tpolicies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{${scopes}}}))\n`;
   }
   text += '\tpolicies = append(policies, runtime.NewLogPolicy(&options.Logging))\n';
-  const pipeline = 'runtime.NewPipeline(options.HTTPClient, policies...)';
+  const pipeline = 'runtime.NewPipeline(options.Transport, policies...)';
   if (!session.model.language.go!.complexHostParams) {
     // simple case, construct the full host here
     var hostURL: string;

--- a/test/autorest/additionalpropsgroup/zz_generated_connection.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/arraygroup/zz_generated_connection.go
+++ b/test/autorest/arraygroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/azurereportgroup/zz_generated_connection.go
+++ b/test/autorest/azurereportgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/azurespecialsgroup/zz_generated_connection.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/binarygroup/zz_generated_connection.go
+++ b/test/autorest/binarygroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/booleangroup/zz_generated_connection.go
+++ b/test/autorest/booleangroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/bytegroup/zz_generated_connection.go
+++ b/test/autorest/bytegroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/complexgroup/zz_generated_connection.go
+++ b/test/autorest/complexgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/complexmodelgroup/zz_generated_connection.go
+++ b/test/autorest/complexmodelgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/custombaseurlgroup/zz_generated_connection.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -53,7 +53,7 @@ func NewConnection(host *string, options *ConnectionOptions) *Connection {
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
 	client := &Connection{
-		p:    runtime.NewPipeline(options.HTTPClient, policies...),
+		p:    runtime.NewPipeline(options.Transport, policies...),
 		host: "host",
 	}
 	if host != nil {

--- a/test/autorest/dategroup/zz_generated_connection.go
+++ b/test/autorest/dategroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/datetimegroup/zz_generated_connection.go
+++ b/test/autorest/datetimegroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/datetimerfc1123group/zz_generated_connection.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/dictionarygroup/zz_generated_connection.go
+++ b/test/autorest/dictionarygroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/durationgroup/zz_generated_connection.go
+++ b/test/autorest/durationgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/errorsgroup/zz_generated_connection.go
+++ b/test/autorest/errorsgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/extenumsgroup/zz_generated_connection.go
+++ b/test/autorest/extenumsgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/filegroup/zz_generated_connection.go
+++ b/test/autorest/filegroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/formdatagroup/zz_generated_connection.go
+++ b/test/autorest/formdatagroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/headergroup/zz_generated_connection.go
+++ b/test/autorest/headergroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/headgroup/zz_generated_connection.go
+++ b/test/autorest/headgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -16,7 +16,7 @@ import (
 func newHTTPRetryClient() *HTTPRetryClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewHTTPRetryClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_connection.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/integergroup/zz_generated_connection.go
+++ b/test/autorest/integergroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -16,7 +16,7 @@ import (
 func newLRORetrysClient() *LRORetrysClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewLRORetrysClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -21,7 +21,7 @@ import (
 func newLROSClient() *LROsClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewLROsClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -13,7 +13,7 @@ import (
 func newLrosaDsClient() *LROSADsClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewLROSADsClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -17,7 +17,7 @@ import (
 func newLrOSCustomHeaderClient() *LROsCustomHeaderClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewLROsCustomHeaderClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/lrogroup/zz_generated_connection.go
+++ b/test/autorest/lrogroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/mediatypesgroup/zz_generated_connection.go
+++ b/test/autorest/mediatypesgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/migroup/zz_generated_connection.go
+++ b/test/autorest/migroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/morecustombaseurigroup/zz_generated_connection.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -53,7 +53,7 @@ func NewConnection(dnsSuffix *string, options *ConnectionOptions) *Connection {
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
 	client := &Connection{
-		p:         runtime.NewPipeline(options.HTTPClient, policies...),
+		p:         runtime.NewPipeline(options.Transport, policies...),
 		dnsSuffix: "host",
 	}
 	if dnsSuffix != nil {

--- a/test/autorest/nonstringenumgroup/zz_generated_connection.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/numbergroup/zz_generated_connection.go
+++ b/test/autorest/numbergroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/objectgroup/zz_generated_connection.go
+++ b/test/autorest/objectgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/optionalgroup/zz_generated_connection.go
+++ b/test/autorest/optionalgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -18,7 +18,7 @@ import (
 func newPagingClient() *PagingClient {
 	options := ConnectionOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
-	options.HTTPClient = httpClientWithCookieJar()
+	options.Transport = httpClientWithCookieJar()
 	return NewPagingClient(NewDefaultConnection(&options))
 }
 

--- a/test/autorest/paginggroup/zz_generated_connection.go
+++ b/test/autorest/paginggroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/paramgroupinggroup/zz_generated_connection.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/reportgroup/zz_generated_connection.go
+++ b/test/autorest/reportgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/stringgroup/zz_generated_connection.go
+++ b/test/autorest/stringgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/urlgroup/zz_generated_connection.go
+++ b/test/autorest/urlgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/urlmultigroup/zz_generated_connection.go
+++ b/test/autorest/urlmultigroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/validationgroup/zz_generated_connection.go
+++ b/test/autorest/validationgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/autorest/xmlgroup/zz_generated_connection.go
+++ b/test/autorest/xmlgroup/zz_generated_connection.go
@@ -16,8 +16,8 @@ import (
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func NewConnection(endpoint string, options *ConnectionOptions) *Connection {
 	policies = append(policies, runtime.NewRetryPolicy(&options.Retry))
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_connection.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_connection.go
@@ -17,8 +17,8 @@ import (
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -62,7 +62,7 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{}}))
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_connection.go
@@ -19,8 +19,8 @@ var scopes = []string{"https://vault.azure.net/.default"}
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -56,7 +56,7 @@ func NewConnection(cred azcore.Credential, options *ConnectionOptions) *Connecti
 	policies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{Scopes: scopes}}))
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
 	client := &Connection{
-		p: runtime.NewPipeline(options.HTTPClient, policies...),
+		p: runtime.NewPipeline(options.Transport, policies...),
 	}
 	return client
 }

--- a/test/maps/azalias/zz_generated_connection.go
+++ b/test/maps/azalias/zz_generated_connection.go
@@ -18,8 +18,8 @@ import (
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -61,7 +61,7 @@ func newConnection(geography *Geography, cred azcore.Credential, options *connec
 		geography = &defaultValue
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
-	return &connection{u: hostURL, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &connection{u: hostURL, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/storage/2020-06-12/azblob/zz_generated_connection.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_connection.go
@@ -17,8 +17,8 @@ import (
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -53,7 +53,7 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{}}))
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_connection.go
@@ -19,8 +19,8 @@ var scopes = []string{"https://dev.azuresynapse.net/.default"}
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -55,7 +55,7 @@ func newConnection(endpoint string, cred azcore.Credential, options *connectionO
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{Scopes: scopes}}))
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/synapse/2019-06-01/azspark/zz_generated_connection.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_connection.go
@@ -20,8 +20,8 @@ var scopes = []string{"https://dev.azuresynapse.net/.default"}
 // connectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type connectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -64,7 +64,7 @@ func newConnection(endpoint string, livyAPIVersion *string, sparkPoolName string
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{livyApiVersion}", *livyAPIVersion)
 	hostURL = strings.ReplaceAll(hostURL, "{sparkPoolName}", sparkPoolName)
-	return &connection{u: hostURL, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &connection{u: hostURL, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.

--- a/test/tables/2019-02-02/aztables/zz_generated_connection.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_connection.go
@@ -19,8 +19,8 @@ var scopes = []string{"https://tables.azure.com/.default"}
 // ConnectionOptions contains configuration settings for the connection's pipeline.
 // All zero-value fields will be initialized with their default values.
 type ConnectionOptions struct {
-	// HTTPClient sets the transport for making HTTP requests.
-	HTTPClient policy.Transporter
+	// Transport sets the transport for making HTTP requests.
+	Transport policy.Transporter
 	// Retry configures the built-in retry policy behavior.
 	Retry policy.RetryOptions
 	// Telemetry configures the built-in telemetry policy behavior.
@@ -55,7 +55,7 @@ func NewConnection(endpoint string, cred azcore.Credential, options *ConnectionO
 	policies = append(policies, options.PerRetryPolicies...)
 	policies = append(policies, cred.NewAuthenticationPolicy(runtime.AuthenticationOptions{TokenRequest: policy.TokenRequestOptions{Scopes: scopes}}))
 	policies = append(policies, runtime.NewLogPolicy(&options.Logging))
-	return &Connection{u: endpoint, p: runtime.NewPipeline(options.HTTPClient, policies...)}
+	return &Connection{u: endpoint, p: runtime.NewPipeline(options.Transport, policies...)}
 }
 
 // Endpoint returns the connection's endpoint.


### PR DESCRIPTION
Per feedback from a previous API review.