### PR TITLE
Fix publishing autorest test server coverage report

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -140,8 +140,6 @@ jobs:
 
       - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
         - pwsh: |
-            $currentVersion = node -p -e "require('./src/package.json').version";
-            $currentVersion="$currentVersion-$(Build.BuildNumber)";
-            cd src/node_modules/@microsoft.azure/autorest.testserver;
-            npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass) $currentVersion;
+            npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(github-token) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --coverageDirectory=./coverage
           displayName: 'Publish AutoRest Test Server Coverage Report'
+          workingDirectory: src/node_modules/@microsoft.azure/autorest.testserver


### PR DESCRIPTION
Updating publishing CI step after recent change to newer version of the
autorest.testserver package.