### PR TITLE
Use default value for coverage report dir

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -140,6 +140,6 @@ jobs:
 
       - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
         - pwsh: |
-            npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(github-token) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --coverageDirectory=./coverage
+            npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(github-token) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass)
           displayName: 'Publish AutoRest Test Server Coverage Report'
           workingDirectory: src/node_modules/@microsoft.azure/autorest.testserver


### PR DESCRIPTION
Didn't realize it had a smart default value, so just remove my incorrect one.

https://dev.azure.com/azure-sdk/public/_build/results?buildId=1150007&view=logs&j=d7bbc280-3804-57e4-46fd-e07df910bb61&t=8d54847b-697a-55ce-c3e4-0f712f7222ae