### PR TITLE
Make *http.Response available if unmarshalling fails

### DIFF
--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -711,7 +711,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
     // use the designated time type for unmarshalling
     unmarshallerText += `\tvar aux *${response.schema.language.go!.internalTimeType}\n`;
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaType(response.protocol)}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+    unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
     unmarshallerText += '\t}\n';
     unmarshallerText += `\tresult.${getResultFieldName(op)} = (*time.Time)(aux)\n`;
     return unmarshallerText;
@@ -719,7 +719,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
     // unmarshalling arrays of date/time is a little more involved
     unmarshallerText += `\tvar aux []*${(<ArraySchema>response.schema).elementType.language.go!.internalTimeType}\n`;
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaType(response.protocol)}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+    unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
     unmarshallerText += '\t}\n';
     unmarshallerText += '\tcp := make([]*time.Time, len(aux), len(aux))\n';
     unmarshallerText += '\tfor i := 0; i < len(aux); i++ {\n';
@@ -730,7 +730,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
   } else if (isMapOfDateTime(response.schema) || isMapOfDate(response.schema)) {
     unmarshallerText += `\taux := map[string]*${(<DictionarySchema>response.schema).elementType.language.go!.internalTimeType}{}\n`;
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaType(response.protocol)}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+    unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
     unmarshallerText += '\t}\n';
     unmarshallerText += `\tcp := map[string]*time.Time{}\n`;
     unmarshallerText += `\tfor k, v := range aux {\n`;
@@ -742,7 +742,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
   const mediaType = getMediaType(response.protocol);
   if (mediaType === 'JSON' || mediaType === 'XML') {
     unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaFormat(response.schema, mediaType, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
-    unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+    unmarshallerText += `\t\treturn ${zeroValue}, runtime.NewResponseError(err, resp)\n`;
     unmarshallerText += '\t}\n';
   }
   return unmarshallerText;

--- a/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
@@ -59,7 +59,7 @@ func (client *PetsClient) createAPInPropertiesCreateRequest(ctx context.Context,
 func (client *PetsClient) createAPInPropertiesHandleResponse(resp *http.Response) (PetsCreateAPInPropertiesResponse, error) {
 	result := PetsCreateAPInPropertiesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPInProperties); err != nil {
-		return PetsCreateAPInPropertiesResponse{}, err
+		return PetsCreateAPInPropertiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *PetsClient) createAPInPropertiesWithAPStringCreateRequest(ctx cont
 func (client *PetsClient) createAPInPropertiesWithAPStringHandleResponse(resp *http.Response) (PetsCreateAPInPropertiesWithAPStringResponse, error) {
 	result := PetsCreateAPInPropertiesWithAPStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPInPropertiesWithAPString); err != nil {
-		return PetsCreateAPInPropertiesWithAPStringResponse{}, err
+		return PetsCreateAPInPropertiesWithAPStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *PetsClient) createAPObjectCreateRequest(ctx context.Context, creat
 func (client *PetsClient) createAPObjectHandleResponse(resp *http.Response) (PetsCreateAPObjectResponse, error) {
 	result := PetsCreateAPObjectResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPObject); err != nil {
-		return PetsCreateAPObjectResponse{}, err
+		return PetsCreateAPObjectResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *PetsClient) createAPStringCreateRequest(ctx context.Context, creat
 func (client *PetsClient) createAPStringHandleResponse(resp *http.Response) (PetsCreateAPStringResponse, error) {
 	result := PetsCreateAPStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPString); err != nil {
-		return PetsCreateAPStringResponse{}, err
+		return PetsCreateAPStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -259,7 +259,7 @@ func (client *PetsClient) createAPTrueCreateRequest(ctx context.Context, createP
 func (client *PetsClient) createAPTrueHandleResponse(resp *http.Response) (PetsCreateAPTrueResponse, error) {
 	result := PetsCreateAPTrueResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAPTrue); err != nil {
-		return PetsCreateAPTrueResponse{}, err
+		return PetsCreateAPTrueResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -309,7 +309,7 @@ func (client *PetsClient) createCatAPTrueCreateRequest(ctx context.Context, crea
 func (client *PetsClient) createCatAPTrueHandleResponse(resp *http.Response) (PetsCreateCatAPTrueResponse, error) {
 	result := PetsCreateCatAPTrueResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatAPTrue); err != nil {
-		return PetsCreateCatAPTrueResponse{}, err
+		return PetsCreateCatAPTrueResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/arraygroup/zz_generated_array_client.go
+++ b/test/autorest/arraygroup/zz_generated_array_client.go
@@ -60,7 +60,7 @@ func (client *ArrayClient) getArrayEmptyCreateRequest(ctx context.Context, optio
 func (client *ArrayClient) getArrayEmptyHandleResponse(resp *http.Response) (ArrayGetArrayEmptyResponse, error) {
 	result := ArrayGetArrayEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
-		return ArrayGetArrayEmptyResponse{}, err
+		return ArrayGetArrayEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -110,7 +110,7 @@ func (client *ArrayClient) getArrayItemEmptyCreateRequest(ctx context.Context, o
 func (client *ArrayClient) getArrayItemEmptyHandleResponse(resp *http.Response) (ArrayGetArrayItemEmptyResponse, error) {
 	result := ArrayGetArrayItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
-		return ArrayGetArrayItemEmptyResponse{}, err
+		return ArrayGetArrayItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -160,7 +160,7 @@ func (client *ArrayClient) getArrayItemNullCreateRequest(ctx context.Context, op
 func (client *ArrayClient) getArrayItemNullHandleResponse(resp *http.Response) (ArrayGetArrayItemNullResponse, error) {
 	result := ArrayGetArrayItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
-		return ArrayGetArrayItemNullResponse{}, err
+		return ArrayGetArrayItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -210,7 +210,7 @@ func (client *ArrayClient) getArrayNullCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getArrayNullHandleResponse(resp *http.Response) (ArrayGetArrayNullResponse, error) {
 	result := ArrayGetArrayNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
-		return ArrayGetArrayNullResponse{}, err
+		return ArrayGetArrayNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -260,7 +260,7 @@ func (client *ArrayClient) getArrayValidCreateRequest(ctx context.Context, optio
 func (client *ArrayClient) getArrayValidHandleResponse(resp *http.Response) (ArrayGetArrayValidResponse, error) {
 	result := ArrayGetArrayValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArrayArray); err != nil {
-		return ArrayGetArrayValidResponse{}, err
+		return ArrayGetArrayValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -310,7 +310,7 @@ func (client *ArrayClient) getBase64URLCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getBase64URLHandleResponse(resp *http.Response) (ArrayGetBase64URLResponse, error) {
 	result := ArrayGetBase64URLResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
-		return ArrayGetBase64URLResponse{}, err
+		return ArrayGetBase64URLResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -360,7 +360,7 @@ func (client *ArrayClient) getBooleanInvalidNullCreateRequest(ctx context.Contex
 func (client *ArrayClient) getBooleanInvalidNullHandleResponse(resp *http.Response) (ArrayGetBooleanInvalidNullResponse, error) {
 	result := ArrayGetBooleanInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
-		return ArrayGetBooleanInvalidNullResponse{}, err
+		return ArrayGetBooleanInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -410,7 +410,7 @@ func (client *ArrayClient) getBooleanInvalidStringCreateRequest(ctx context.Cont
 func (client *ArrayClient) getBooleanInvalidStringHandleResponse(resp *http.Response) (ArrayGetBooleanInvalidStringResponse, error) {
 	result := ArrayGetBooleanInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
-		return ArrayGetBooleanInvalidStringResponse{}, err
+		return ArrayGetBooleanInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -460,7 +460,7 @@ func (client *ArrayClient) getBooleanTfftCreateRequest(ctx context.Context, opti
 func (client *ArrayClient) getBooleanTfftHandleResponse(resp *http.Response) (ArrayGetBooleanTfftResponse, error) {
 	result := ArrayGetBooleanTfftResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BoolArray); err != nil {
-		return ArrayGetBooleanTfftResponse{}, err
+		return ArrayGetBooleanTfftResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -510,7 +510,7 @@ func (client *ArrayClient) getByteInvalidNullCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getByteInvalidNullHandleResponse(resp *http.Response) (ArrayGetByteInvalidNullResponse, error) {
 	result := ArrayGetByteInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
-		return ArrayGetByteInvalidNullResponse{}, err
+		return ArrayGetByteInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -560,7 +560,7 @@ func (client *ArrayClient) getByteValidCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getByteValidHandleResponse(resp *http.Response) (ArrayGetByteValidResponse, error) {
 	result := ArrayGetByteValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteArrayArray); err != nil {
-		return ArrayGetByteValidResponse{}, err
+		return ArrayGetByteValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -610,7 +610,7 @@ func (client *ArrayClient) getComplexEmptyCreateRequest(ctx context.Context, opt
 func (client *ArrayClient) getComplexEmptyHandleResponse(resp *http.Response) (ArrayGetComplexEmptyResponse, error) {
 	result := ArrayGetComplexEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
-		return ArrayGetComplexEmptyResponse{}, err
+		return ArrayGetComplexEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -660,7 +660,7 @@ func (client *ArrayClient) getComplexItemEmptyCreateRequest(ctx context.Context,
 func (client *ArrayClient) getComplexItemEmptyHandleResponse(resp *http.Response) (ArrayGetComplexItemEmptyResponse, error) {
 	result := ArrayGetComplexItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
-		return ArrayGetComplexItemEmptyResponse{}, err
+		return ArrayGetComplexItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -710,7 +710,7 @@ func (client *ArrayClient) getComplexItemNullCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getComplexItemNullHandleResponse(resp *http.Response) (ArrayGetComplexItemNullResponse, error) {
 	result := ArrayGetComplexItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
-		return ArrayGetComplexItemNullResponse{}, err
+		return ArrayGetComplexItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -760,7 +760,7 @@ func (client *ArrayClient) getComplexNullCreateRequest(ctx context.Context, opti
 func (client *ArrayClient) getComplexNullHandleResponse(resp *http.Response) (ArrayGetComplexNullResponse, error) {
 	result := ArrayGetComplexNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
-		return ArrayGetComplexNullResponse{}, err
+		return ArrayGetComplexNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -810,7 +810,7 @@ func (client *ArrayClient) getComplexValidCreateRequest(ctx context.Context, opt
 func (client *ArrayClient) getComplexValidHandleResponse(resp *http.Response) (ArrayGetComplexValidResponse, error) {
 	result := ArrayGetComplexValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductArray); err != nil {
-		return ArrayGetComplexValidResponse{}, err
+		return ArrayGetComplexValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -861,7 +861,7 @@ func (client *ArrayClient) getDateInvalidCharsHandleResponse(resp *http.Response
 	result := ArrayGetDateInvalidCharsResponse{RawResponse: resp}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateInvalidCharsResponse{}, err
+		return ArrayGetDateInvalidCharsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -917,7 +917,7 @@ func (client *ArrayClient) getDateInvalidNullHandleResponse(resp *http.Response)
 	result := ArrayGetDateInvalidNullResponse{RawResponse: resp}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateInvalidNullResponse{}, err
+		return ArrayGetDateInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -973,7 +973,7 @@ func (client *ArrayClient) getDateTimeInvalidCharsHandleResponse(resp *http.Resp
 	result := ArrayGetDateTimeInvalidCharsResponse{RawResponse: resp}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateTimeInvalidCharsResponse{}, err
+		return ArrayGetDateTimeInvalidCharsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -1029,7 +1029,7 @@ func (client *ArrayClient) getDateTimeInvalidNullHandleResponse(resp *http.Respo
 	result := ArrayGetDateTimeInvalidNullResponse{RawResponse: resp}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateTimeInvalidNullResponse{}, err
+		return ArrayGetDateTimeInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -1085,7 +1085,7 @@ func (client *ArrayClient) getDateTimeRFC1123ValidHandleResponse(resp *http.Resp
 	result := ArrayGetDateTimeRFC1123ValidResponse{RawResponse: resp}
 	var aux []*timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateTimeRFC1123ValidResponse{}, err
+		return ArrayGetDateTimeRFC1123ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -1141,7 +1141,7 @@ func (client *ArrayClient) getDateTimeValidHandleResponse(resp *http.Response) (
 	result := ArrayGetDateTimeValidResponse{RawResponse: resp}
 	var aux []*timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateTimeValidResponse{}, err
+		return ArrayGetDateTimeValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -1197,7 +1197,7 @@ func (client *ArrayClient) getDateValidHandleResponse(resp *http.Response) (Arra
 	result := ArrayGetDateValidResponse{RawResponse: resp}
 	var aux []*dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return ArrayGetDateValidResponse{}, err
+		return ArrayGetDateValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := make([]*time.Time, len(aux), len(aux))
 	for i := 0; i < len(aux); i++ {
@@ -1252,7 +1252,7 @@ func (client *ArrayClient) getDictionaryEmptyCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getDictionaryEmptyHandleResponse(resp *http.Response) (ArrayGetDictionaryEmptyResponse, error) {
 	result := ArrayGetDictionaryEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
-		return ArrayGetDictionaryEmptyResponse{}, err
+		return ArrayGetDictionaryEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1303,7 +1303,7 @@ func (client *ArrayClient) getDictionaryItemEmptyCreateRequest(ctx context.Conte
 func (client *ArrayClient) getDictionaryItemEmptyHandleResponse(resp *http.Response) (ArrayGetDictionaryItemEmptyResponse, error) {
 	result := ArrayGetDictionaryItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
-		return ArrayGetDictionaryItemEmptyResponse{}, err
+		return ArrayGetDictionaryItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1354,7 +1354,7 @@ func (client *ArrayClient) getDictionaryItemNullCreateRequest(ctx context.Contex
 func (client *ArrayClient) getDictionaryItemNullHandleResponse(resp *http.Response) (ArrayGetDictionaryItemNullResponse, error) {
 	result := ArrayGetDictionaryItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
-		return ArrayGetDictionaryItemNullResponse{}, err
+		return ArrayGetDictionaryItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1404,7 +1404,7 @@ func (client *ArrayClient) getDictionaryNullCreateRequest(ctx context.Context, o
 func (client *ArrayClient) getDictionaryNullHandleResponse(resp *http.Response) (ArrayGetDictionaryNullResponse, error) {
 	result := ArrayGetDictionaryNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
-		return ArrayGetDictionaryNullResponse{}, err
+		return ArrayGetDictionaryNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1455,7 +1455,7 @@ func (client *ArrayClient) getDictionaryValidCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getDictionaryValidHandleResponse(resp *http.Response) (ArrayGetDictionaryValidResponse, error) {
 	result := ArrayGetDictionaryValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MapOfStringArray); err != nil {
-		return ArrayGetDictionaryValidResponse{}, err
+		return ArrayGetDictionaryValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1505,7 +1505,7 @@ func (client *ArrayClient) getDoubleInvalidNullCreateRequest(ctx context.Context
 func (client *ArrayClient) getDoubleInvalidNullHandleResponse(resp *http.Response) (ArrayGetDoubleInvalidNullResponse, error) {
 	result := ArrayGetDoubleInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
-		return ArrayGetDoubleInvalidNullResponse{}, err
+		return ArrayGetDoubleInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1555,7 +1555,7 @@ func (client *ArrayClient) getDoubleInvalidStringCreateRequest(ctx context.Conte
 func (client *ArrayClient) getDoubleInvalidStringHandleResponse(resp *http.Response) (ArrayGetDoubleInvalidStringResponse, error) {
 	result := ArrayGetDoubleInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
-		return ArrayGetDoubleInvalidStringResponse{}, err
+		return ArrayGetDoubleInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1605,7 +1605,7 @@ func (client *ArrayClient) getDoubleValidCreateRequest(ctx context.Context, opti
 func (client *ArrayClient) getDoubleValidHandleResponse(resp *http.Response) (ArrayGetDoubleValidResponse, error) {
 	result := ArrayGetDoubleValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float64Array); err != nil {
-		return ArrayGetDoubleValidResponse{}, err
+		return ArrayGetDoubleValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1655,7 +1655,7 @@ func (client *ArrayClient) getDurationValidCreateRequest(ctx context.Context, op
 func (client *ArrayClient) getDurationValidHandleResponse(resp *http.Response) (ArrayGetDurationValidResponse, error) {
 	result := ArrayGetDurationValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetDurationValidResponse{}, err
+		return ArrayGetDurationValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1705,7 +1705,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 func (client *ArrayClient) getEmptyHandleResponse(resp *http.Response) (ArrayGetEmptyResponse, error) {
 	result := ArrayGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetEmptyResponse{}, err
+		return ArrayGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1755,7 +1755,7 @@ func (client *ArrayClient) getEnumValidCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getEnumValidHandleResponse(resp *http.Response) (ArrayGetEnumValidResponse, error) {
 	result := ArrayGetEnumValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FooEnumArray); err != nil {
-		return ArrayGetEnumValidResponse{}, err
+		return ArrayGetEnumValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1805,7 +1805,7 @@ func (client *ArrayClient) getFloatInvalidNullCreateRequest(ctx context.Context,
 func (client *ArrayClient) getFloatInvalidNullHandleResponse(resp *http.Response) (ArrayGetFloatInvalidNullResponse, error) {
 	result := ArrayGetFloatInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
-		return ArrayGetFloatInvalidNullResponse{}, err
+		return ArrayGetFloatInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1855,7 +1855,7 @@ func (client *ArrayClient) getFloatInvalidStringCreateRequest(ctx context.Contex
 func (client *ArrayClient) getFloatInvalidStringHandleResponse(resp *http.Response) (ArrayGetFloatInvalidStringResponse, error) {
 	result := ArrayGetFloatInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
-		return ArrayGetFloatInvalidStringResponse{}, err
+		return ArrayGetFloatInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1905,7 +1905,7 @@ func (client *ArrayClient) getFloatValidCreateRequest(ctx context.Context, optio
 func (client *ArrayClient) getFloatValidHandleResponse(resp *http.Response) (ArrayGetFloatValidResponse, error) {
 	result := ArrayGetFloatValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Float32Array); err != nil {
-		return ArrayGetFloatValidResponse{}, err
+		return ArrayGetFloatValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1955,7 +1955,7 @@ func (client *ArrayClient) getIntInvalidNullCreateRequest(ctx context.Context, o
 func (client *ArrayClient) getIntInvalidNullHandleResponse(resp *http.Response) (ArrayGetIntInvalidNullResponse, error) {
 	result := ArrayGetIntInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetIntInvalidNullResponse{}, err
+		return ArrayGetIntInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2005,7 +2005,7 @@ func (client *ArrayClient) getIntInvalidStringCreateRequest(ctx context.Context,
 func (client *ArrayClient) getIntInvalidStringHandleResponse(resp *http.Response) (ArrayGetIntInvalidStringResponse, error) {
 	result := ArrayGetIntInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetIntInvalidStringResponse{}, err
+		return ArrayGetIntInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2055,7 +2055,7 @@ func (client *ArrayClient) getIntegerValidCreateRequest(ctx context.Context, opt
 func (client *ArrayClient) getIntegerValidHandleResponse(resp *http.Response) (ArrayGetIntegerValidResponse, error) {
 	result := ArrayGetIntegerValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetIntegerValidResponse{}, err
+		return ArrayGetIntegerValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2105,7 +2105,7 @@ func (client *ArrayClient) getInvalidCreateRequest(ctx context.Context, options 
 func (client *ArrayClient) getInvalidHandleResponse(resp *http.Response) (ArrayGetInvalidResponse, error) {
 	result := ArrayGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetInvalidResponse{}, err
+		return ArrayGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2155,7 +2155,7 @@ func (client *ArrayClient) getLongInvalidNullCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getLongInvalidNullHandleResponse(resp *http.Response) (ArrayGetLongInvalidNullResponse, error) {
 	result := ArrayGetLongInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
-		return ArrayGetLongInvalidNullResponse{}, err
+		return ArrayGetLongInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2205,7 +2205,7 @@ func (client *ArrayClient) getLongInvalidStringCreateRequest(ctx context.Context
 func (client *ArrayClient) getLongInvalidStringHandleResponse(resp *http.Response) (ArrayGetLongInvalidStringResponse, error) {
 	result := ArrayGetLongInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
-		return ArrayGetLongInvalidStringResponse{}, err
+		return ArrayGetLongInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2255,7 +2255,7 @@ func (client *ArrayClient) getLongValidCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getLongValidHandleResponse(resp *http.Response) (ArrayGetLongValidResponse, error) {
 	result := ArrayGetLongValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int64Array); err != nil {
-		return ArrayGetLongValidResponse{}, err
+		return ArrayGetLongValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2305,7 +2305,7 @@ func (client *ArrayClient) getNullCreateRequest(ctx context.Context, options *Ar
 func (client *ArrayClient) getNullHandleResponse(resp *http.Response) (ArrayGetNullResponse, error) {
 	result := ArrayGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Int32Array); err != nil {
-		return ArrayGetNullResponse{}, err
+		return ArrayGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2355,7 +2355,7 @@ func (client *ArrayClient) getStringEnumValidCreateRequest(ctx context.Context, 
 func (client *ArrayClient) getStringEnumValidHandleResponse(resp *http.Response) (ArrayGetStringEnumValidResponse, error) {
 	result := ArrayGetStringEnumValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Enum0Array); err != nil {
-		return ArrayGetStringEnumValidResponse{}, err
+		return ArrayGetStringEnumValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2405,7 +2405,7 @@ func (client *ArrayClient) getStringValidCreateRequest(ctx context.Context, opti
 func (client *ArrayClient) getStringValidHandleResponse(resp *http.Response) (ArrayGetStringValidResponse, error) {
 	result := ArrayGetStringValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetStringValidResponse{}, err
+		return ArrayGetStringValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2455,7 +2455,7 @@ func (client *ArrayClient) getStringWithInvalidCreateRequest(ctx context.Context
 func (client *ArrayClient) getStringWithInvalidHandleResponse(resp *http.Response) (ArrayGetStringWithInvalidResponse, error) {
 	result := ArrayGetStringWithInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetStringWithInvalidResponse{}, err
+		return ArrayGetStringWithInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2505,7 +2505,7 @@ func (client *ArrayClient) getStringWithNullCreateRequest(ctx context.Context, o
 func (client *ArrayClient) getStringWithNullHandleResponse(resp *http.Response) (ArrayGetStringWithNullResponse, error) {
 	result := ArrayGetStringWithNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetStringWithNullResponse{}, err
+		return ArrayGetStringWithNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2555,7 +2555,7 @@ func (client *ArrayClient) getUUIDInvalidCharsCreateRequest(ctx context.Context,
 func (client *ArrayClient) getUUIDInvalidCharsHandleResponse(resp *http.Response) (ArrayGetUUIDInvalidCharsResponse, error) {
 	result := ArrayGetUUIDInvalidCharsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetUUIDInvalidCharsResponse{}, err
+		return ArrayGetUUIDInvalidCharsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2605,7 +2605,7 @@ func (client *ArrayClient) getUUIDValidCreateRequest(ctx context.Context, option
 func (client *ArrayClient) getUUIDValidHandleResponse(resp *http.Response) (ArrayGetUUIDValidResponse, error) {
 	result := ArrayGetUUIDValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ArrayGetUUIDValidResponse{}, err
+		return ArrayGetUUIDValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
@@ -64,7 +64,7 @@ func (client *AutoRestReportServiceForAzureClient) getReportCreateRequest(ctx co
 func (client *AutoRestReportServiceForAzureClient) getReportHandleResponse(resp *http.Response) (AutoRestReportServiceForAzureGetReportResponse, error) {
 	result := AutoRestReportServiceForAzureGetReportResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return AutoRestReportServiceForAzureGetReportResponse{}, err
+		return AutoRestReportServiceForAzureGetReportResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/booleangroup/zz_generated_bool_client.go
+++ b/test/autorest/booleangroup/zz_generated_bool_client.go
@@ -59,7 +59,7 @@ func (client *BoolClient) getFalseCreateRequest(ctx context.Context, options *Bo
 func (client *BoolClient) getFalseHandleResponse(resp *http.Response) (BoolGetFalseResponse, error) {
 	result := BoolGetFalseResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return BoolGetFalseResponse{}, err
+		return BoolGetFalseResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *BoolClient) getInvalidCreateRequest(ctx context.Context, options *
 func (client *BoolClient) getInvalidHandleResponse(resp *http.Response) (BoolGetInvalidResponse, error) {
 	result := BoolGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return BoolGetInvalidResponse{}, err
+		return BoolGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *BoolClient) getNullCreateRequest(ctx context.Context, options *Boo
 func (client *BoolClient) getNullHandleResponse(resp *http.Response) (BoolGetNullResponse, error) {
 	result := BoolGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return BoolGetNullResponse{}, err
+		return BoolGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *BoolClient) getTrueCreateRequest(ctx context.Context, options *Boo
 func (client *BoolClient) getTrueHandleResponse(resp *http.Response) (BoolGetTrueResponse, error) {
 	result := BoolGetTrueResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return BoolGetTrueResponse{}, err
+		return BoolGetTrueResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/bytegroup/zz_generated_byte_client.go
+++ b/test/autorest/bytegroup/zz_generated_byte_client.go
@@ -59,7 +59,7 @@ func (client *ByteClient) getEmptyCreateRequest(ctx context.Context, options *By
 func (client *ByteClient) getEmptyHandleResponse(resp *http.Response) (ByteGetEmptyResponse, error) {
 	result := ByteGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ByteGetEmptyResponse{}, err
+		return ByteGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *ByteClient) getInvalidCreateRequest(ctx context.Context, options *
 func (client *ByteClient) getInvalidHandleResponse(resp *http.Response) (ByteGetInvalidResponse, error) {
 	result := ByteGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ByteGetInvalidResponse{}, err
+		return ByteGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *ByteClient) getNonASCIICreateRequest(ctx context.Context, options 
 func (client *ByteClient) getNonASCIIHandleResponse(resp *http.Response) (ByteGetNonASCIIResponse, error) {
 	result := ByteGetNonASCIIResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ByteGetNonASCIIResponse{}, err
+		return ByteGetNonASCIIResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *ByteClient) getNullCreateRequest(ctx context.Context, options *Byt
 func (client *ByteClient) getNullHandleResponse(resp *http.Response) (ByteGetNullResponse, error) {
 	result := ByteGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ByteGetNullResponse{}, err
+		return ByteGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_array_client.go
+++ b/test/autorest/complexgroup/zz_generated_array_client.go
@@ -59,7 +59,7 @@ func (client *ArrayClient) getEmptyCreateRequest(ctx context.Context, options *A
 func (client *ArrayClient) getEmptyHandleResponse(resp *http.Response) (ArrayGetEmptyResponse, error) {
 	result := ArrayGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
-		return ArrayGetEmptyResponse{}, err
+		return ArrayGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *ArrayClient) getNotProvidedCreateRequest(ctx context.Context, opti
 func (client *ArrayClient) getNotProvidedHandleResponse(resp *http.Response) (ArrayGetNotProvidedResponse, error) {
 	result := ArrayGetNotProvidedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
-		return ArrayGetNotProvidedResponse{}, err
+		return ArrayGetNotProvidedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *ArrayClient) getValidCreateRequest(ctx context.Context, options *A
 func (client *ArrayClient) getValidHandleResponse(resp *http.Response) (ArrayGetValidResponse, error) {
 	result := ArrayGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArrayWrapper); err != nil {
-		return ArrayGetValidResponse{}, err
+		return ArrayGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_basic_client.go
+++ b/test/autorest/complexgroup/zz_generated_basic_client.go
@@ -59,7 +59,7 @@ func (client *BasicClient) getEmptyCreateRequest(ctx context.Context, options *B
 func (client *BasicClient) getEmptyHandleResponse(resp *http.Response) (BasicGetEmptyResponse, error) {
 	result := BasicGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
-		return BasicGetEmptyResponse{}, err
+		return BasicGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *BasicClient) getInvalidCreateRequest(ctx context.Context, options 
 func (client *BasicClient) getInvalidHandleResponse(resp *http.Response) (BasicGetInvalidResponse, error) {
 	result := BasicGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
-		return BasicGetInvalidResponse{}, err
+		return BasicGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *BasicClient) getNotProvidedCreateRequest(ctx context.Context, opti
 func (client *BasicClient) getNotProvidedHandleResponse(resp *http.Response) (BasicGetNotProvidedResponse, error) {
 	result := BasicGetNotProvidedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
-		return BasicGetNotProvidedResponse{}, err
+		return BasicGetNotProvidedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *BasicClient) getNullCreateRequest(ctx context.Context, options *Ba
 func (client *BasicClient) getNullHandleResponse(resp *http.Response) (BasicGetNullResponse, error) {
 	result := BasicGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
-		return BasicGetNullResponse{}, err
+		return BasicGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -259,7 +259,7 @@ func (client *BasicClient) getValidCreateRequest(ctx context.Context, options *B
 func (client *BasicClient) getValidHandleResponse(resp *http.Response) (BasicGetValidResponse, error) {
 	result := BasicGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Basic); err != nil {
-		return BasicGetValidResponse{}, err
+		return BasicGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_dictionary_client.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary_client.go
@@ -59,7 +59,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 func (client *DictionaryClient) getEmptyHandleResponse(resp *http.Response) (DictionaryGetEmptyResponse, error) {
 	result := DictionaryGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
-		return DictionaryGetEmptyResponse{}, err
+		return DictionaryGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *DictionaryClient) getNotProvidedCreateRequest(ctx context.Context,
 func (client *DictionaryClient) getNotProvidedHandleResponse(resp *http.Response) (DictionaryGetNotProvidedResponse, error) {
 	result := DictionaryGetNotProvidedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
-		return DictionaryGetNotProvidedResponse{}, err
+		return DictionaryGetNotProvidedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 func (client *DictionaryClient) getNullHandleResponse(resp *http.Response) (DictionaryGetNullResponse, error) {
 	result := DictionaryGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
-		return DictionaryGetNullResponse{}, err
+		return DictionaryGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *DictionaryClient) getValidCreateRequest(ctx context.Context, optio
 func (client *DictionaryClient) getValidHandleResponse(resp *http.Response) (DictionaryGetValidResponse, error) {
 	result := DictionaryGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DictionaryWrapper); err != nil {
-		return DictionaryGetValidResponse{}, err
+		return DictionaryGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
@@ -59,7 +59,7 @@ func (client *FlattencomplexClient) getValidCreateRequest(ctx context.Context, o
 func (client *FlattencomplexClient) getValidHandleResponse(resp *http.Response) (FlattencomplexGetValidResponse, error) {
 	result := FlattencomplexGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return FlattencomplexGetValidResponse{}, err
+		return FlattencomplexGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_inheritance_client.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance_client.go
@@ -59,7 +59,7 @@ func (client *InheritanceClient) getValidCreateRequest(ctx context.Context, opti
 func (client *InheritanceClient) getValidHandleResponse(resp *http.Response) (InheritanceGetValidResponse, error) {
 	result := InheritanceGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Siamese); err != nil {
-		return InheritanceGetValidResponse{}, err
+		return InheritanceGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
@@ -59,7 +59,7 @@ func (client *PolymorphicrecursiveClient) getValidCreateRequest(ctx context.Cont
 func (client *PolymorphicrecursiveClient) getValidHandleResponse(resp *http.Response) (PolymorphicrecursiveGetValidResponse, error) {
 	result := PolymorphicrecursiveGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return PolymorphicrecursiveGetValidResponse{}, err
+		return PolymorphicrecursiveGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphism_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism_client.go
@@ -59,7 +59,7 @@ func (client *PolymorphismClient) getComplicatedCreateRequest(ctx context.Contex
 func (client *PolymorphismClient) getComplicatedHandleResponse(resp *http.Response) (PolymorphismGetComplicatedResponse, error) {
 	result := PolymorphismGetComplicatedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return PolymorphismGetComplicatedResponse{}, err
+		return PolymorphismGetComplicatedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -111,7 +111,7 @@ func (client *PolymorphismClient) getComposedWithDiscriminatorCreateRequest(ctx 
 func (client *PolymorphismClient) getComposedWithDiscriminatorHandleResponse(resp *http.Response) (PolymorphismGetComposedWithDiscriminatorResponse, error) {
 	result := PolymorphismGetComposedWithDiscriminatorResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DotFishMarket); err != nil {
-		return PolymorphismGetComposedWithDiscriminatorResponse{}, err
+		return PolymorphismGetComposedWithDiscriminatorResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -163,7 +163,7 @@ func (client *PolymorphismClient) getComposedWithoutDiscriminatorCreateRequest(c
 func (client *PolymorphismClient) getComposedWithoutDiscriminatorHandleResponse(resp *http.Response) (PolymorphismGetComposedWithoutDiscriminatorResponse, error) {
 	result := PolymorphismGetComposedWithoutDiscriminatorResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DotFishMarket); err != nil {
-		return PolymorphismGetComposedWithoutDiscriminatorResponse{}, err
+		return PolymorphismGetComposedWithoutDiscriminatorResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -213,7 +213,7 @@ func (client *PolymorphismClient) getDotSyntaxCreateRequest(ctx context.Context,
 func (client *PolymorphismClient) getDotSyntaxHandleResponse(resp *http.Response) (PolymorphismGetDotSyntaxResponse, error) {
 	result := PolymorphismGetDotSyntaxResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return PolymorphismGetDotSyntaxResponse{}, err
+		return PolymorphismGetDotSyntaxResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -263,7 +263,7 @@ func (client *PolymorphismClient) getValidCreateRequest(ctx context.Context, opt
 func (client *PolymorphismClient) getValidHandleResponse(resp *http.Response) (PolymorphismGetValidResponse, error) {
 	result := PolymorphismGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return PolymorphismGetValidResponse{}, err
+		return PolymorphismGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -354,7 +354,7 @@ func (client *PolymorphismClient) putMissingDiscriminatorCreateRequest(ctx conte
 func (client *PolymorphismClient) putMissingDiscriminatorHandleResponse(resp *http.Response) (PolymorphismPutMissingDiscriminatorResponse, error) {
 	result := PolymorphismPutMissingDiscriminatorResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return PolymorphismPutMissingDiscriminatorResponse{}, err
+		return PolymorphismPutMissingDiscriminatorResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_primitive_client.go
+++ b/test/autorest/complexgroup/zz_generated_primitive_client.go
@@ -59,7 +59,7 @@ func (client *PrimitiveClient) getBoolCreateRequest(ctx context.Context, options
 func (client *PrimitiveClient) getBoolHandleResponse(resp *http.Response) (PrimitiveGetBoolResponse, error) {
 	result := PrimitiveGetBoolResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BooleanWrapper); err != nil {
-		return PrimitiveGetBoolResponse{}, err
+		return PrimitiveGetBoolResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *PrimitiveClient) getByteCreateRequest(ctx context.Context, options
 func (client *PrimitiveClient) getByteHandleResponse(resp *http.Response) (PrimitiveGetByteResponse, error) {
 	result := PrimitiveGetByteResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ByteWrapper); err != nil {
-		return PrimitiveGetByteResponse{}, err
+		return PrimitiveGetByteResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *PrimitiveClient) getDateCreateRequest(ctx context.Context, options
 func (client *PrimitiveClient) getDateHandleResponse(resp *http.Response) (PrimitiveGetDateResponse, error) {
 	result := PrimitiveGetDateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DateWrapper); err != nil {
-		return PrimitiveGetDateResponse{}, err
+		return PrimitiveGetDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *PrimitiveClient) getDateTimeCreateRequest(ctx context.Context, opt
 func (client *PrimitiveClient) getDateTimeHandleResponse(resp *http.Response) (PrimitiveGetDateTimeResponse, error) {
 	result := PrimitiveGetDateTimeResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatetimeWrapper); err != nil {
-		return PrimitiveGetDateTimeResponse{}, err
+		return PrimitiveGetDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -259,7 +259,7 @@ func (client *PrimitiveClient) getDateTimeRFC1123CreateRequest(ctx context.Conte
 func (client *PrimitiveClient) getDateTimeRFC1123HandleResponse(resp *http.Response) (PrimitiveGetDateTimeRFC1123Response, error) {
 	result := PrimitiveGetDateTimeRFC1123Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Datetimerfc1123Wrapper); err != nil {
-		return PrimitiveGetDateTimeRFC1123Response{}, err
+		return PrimitiveGetDateTimeRFC1123Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -309,7 +309,7 @@ func (client *PrimitiveClient) getDoubleCreateRequest(ctx context.Context, optio
 func (client *PrimitiveClient) getDoubleHandleResponse(resp *http.Response) (PrimitiveGetDoubleResponse, error) {
 	result := PrimitiveGetDoubleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DoubleWrapper); err != nil {
-		return PrimitiveGetDoubleResponse{}, err
+		return PrimitiveGetDoubleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -359,7 +359,7 @@ func (client *PrimitiveClient) getDurationCreateRequest(ctx context.Context, opt
 func (client *PrimitiveClient) getDurationHandleResponse(resp *http.Response) (PrimitiveGetDurationResponse, error) {
 	result := PrimitiveGetDurationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DurationWrapper); err != nil {
-		return PrimitiveGetDurationResponse{}, err
+		return PrimitiveGetDurationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -409,7 +409,7 @@ func (client *PrimitiveClient) getFloatCreateRequest(ctx context.Context, option
 func (client *PrimitiveClient) getFloatHandleResponse(resp *http.Response) (PrimitiveGetFloatResponse, error) {
 	result := PrimitiveGetFloatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FloatWrapper); err != nil {
-		return PrimitiveGetFloatResponse{}, err
+		return PrimitiveGetFloatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -459,7 +459,7 @@ func (client *PrimitiveClient) getIntCreateRequest(ctx context.Context, options 
 func (client *PrimitiveClient) getIntHandleResponse(resp *http.Response) (PrimitiveGetIntResponse, error) {
 	result := PrimitiveGetIntResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntWrapper); err != nil {
-		return PrimitiveGetIntResponse{}, err
+		return PrimitiveGetIntResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -509,7 +509,7 @@ func (client *PrimitiveClient) getLongCreateRequest(ctx context.Context, options
 func (client *PrimitiveClient) getLongHandleResponse(resp *http.Response) (PrimitiveGetLongResponse, error) {
 	result := PrimitiveGetLongResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LongWrapper); err != nil {
-		return PrimitiveGetLongResponse{}, err
+		return PrimitiveGetLongResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -559,7 +559,7 @@ func (client *PrimitiveClient) getStringCreateRequest(ctx context.Context, optio
 func (client *PrimitiveClient) getStringHandleResponse(resp *http.Response) (PrimitiveGetStringResponse, error) {
 	result := PrimitiveGetStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringWrapper); err != nil {
-		return PrimitiveGetStringResponse{}, err
+		return PrimitiveGetStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
@@ -59,7 +59,7 @@ func (client *ReadonlypropertyClient) getValidCreateRequest(ctx context.Context,
 func (client *ReadonlypropertyClient) getValidHandleResponse(resp *http.Response) (ReadonlypropertyGetValidResponse, error) {
 	result := ReadonlypropertyGetValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReadonlyObj); err != nil {
-		return ReadonlypropertyGetValidResponse{}, err
+		return ReadonlypropertyGetValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodelclient_client.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodelclient_client.go
@@ -73,7 +73,7 @@ func (client *ComplexModelClient) createCreateRequest(ctx context.Context, subsc
 func (client *ComplexModelClient) createHandleResponse(resp *http.Response) (ComplexModelClientCreateResponse, error) {
 	result := ComplexModelClientCreateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogDictionary); err != nil {
-		return ComplexModelClientCreateResponse{}, err
+		return ComplexModelClientCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -133,7 +133,7 @@ func (client *ComplexModelClient) listCreateRequest(ctx context.Context, resourc
 func (client *ComplexModelClient) listHandleResponse(resp *http.Response) (ComplexModelClientListResponse, error) {
 	result := ComplexModelClientListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogArray); err != nil {
-		return ComplexModelClientListResponse{}, err
+		return ComplexModelClientListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -194,7 +194,7 @@ func (client *ComplexModelClient) updateCreateRequest(ctx context.Context, subsc
 func (client *ComplexModelClient) updateHandleResponse(resp *http.Response) (ComplexModelClientUpdateResponse, error) {
 	result := ComplexModelClientUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CatalogArray); err != nil {
-		return ComplexModelClientUpdateResponse{}, err
+		return ComplexModelClientUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/dategroup/zz_generated_date_client.go
+++ b/test/autorest/dategroup/zz_generated_date_client.go
@@ -61,7 +61,7 @@ func (client *DateClient) getInvalidDateHandleResponse(resp *http.Response) (Dat
 	result := DateGetInvalidDateResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetInvalidDateResponse{}, err
+		return DateGetInvalidDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -113,7 +113,7 @@ func (client *DateClient) getMaxDateHandleResponse(resp *http.Response) (DateGet
 	result := DateGetMaxDateResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetMaxDateResponse{}, err
+		return DateGetMaxDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -165,7 +165,7 @@ func (client *DateClient) getMinDateHandleResponse(resp *http.Response) (DateGet
 	result := DateGetMinDateResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetMinDateResponse{}, err
+		return DateGetMinDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -217,7 +217,7 @@ func (client *DateClient) getNullHandleResponse(resp *http.Response) (DateGetNul
 	result := DateGetNullResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetNullResponse{}, err
+		return DateGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -269,7 +269,7 @@ func (client *DateClient) getOverflowDateHandleResponse(resp *http.Response) (Da
 	result := DateGetOverflowDateResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetOverflowDateResponse{}, err
+		return DateGetOverflowDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -321,7 +321,7 @@ func (client *DateClient) getUnderflowDateHandleResponse(resp *http.Response) (D
 	result := DateGetUnderflowDateResponse{RawResponse: resp}
 	var aux *dateType
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DateGetUnderflowDateResponse{}, err
+		return DateGetUnderflowDateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil

--- a/test/autorest/datetimegroup/zz_generated_datetime_client.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime_client.go
@@ -61,7 +61,7 @@ func (client *DatetimeClient) getInvalidHandleResponse(resp *http.Response) (Dat
 	result := DatetimeGetInvalidResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetInvalidResponse{}, err
+		return DatetimeGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -113,7 +113,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetLowercaseMaxDateTimeHandleRe
 	result := DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}, err
+		return DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -165,7 +165,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetMinDateTimeHandleResponse(re
 	result := DatetimeGetLocalNegativeOffsetMinDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalNegativeOffsetMinDateTimeResponse{}, err
+		return DatetimeGetLocalNegativeOffsetMinDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -217,7 +217,7 @@ func (client *DatetimeClient) getLocalNegativeOffsetUppercaseMaxDateTimeHandleRe
 	result := DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}, err
+		return DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -269,7 +269,7 @@ func (client *DatetimeClient) getLocalNoOffsetMinDateTimeHandleResponse(resp *ht
 	result := DatetimeGetLocalNoOffsetMinDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalNoOffsetMinDateTimeResponse{}, err
+		return DatetimeGetLocalNoOffsetMinDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -321,7 +321,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetLowercaseMaxDateTimeHandleRe
 	result := DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}, err
+		return DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -373,7 +373,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetMinDateTimeHandleResponse(re
 	result := DatetimeGetLocalPositiveOffsetMinDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalPositiveOffsetMinDateTimeResponse{}, err
+		return DatetimeGetLocalPositiveOffsetMinDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -425,7 +425,7 @@ func (client *DatetimeClient) getLocalPositiveOffsetUppercaseMaxDateTimeHandleRe
 	result := DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}, err
+		return DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -477,7 +477,7 @@ func (client *DatetimeClient) getNullHandleResponse(resp *http.Response) (Dateti
 	result := DatetimeGetNullResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetNullResponse{}, err
+		return DatetimeGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -529,7 +529,7 @@ func (client *DatetimeClient) getOverflowHandleResponse(resp *http.Response) (Da
 	result := DatetimeGetOverflowResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetOverflowResponse{}, err
+		return DatetimeGetOverflowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -581,7 +581,7 @@ func (client *DatetimeClient) getUTCLowercaseMaxDateTimeHandleResponse(resp *htt
 	result := DatetimeGetUTCLowercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetUTCLowercaseMaxDateTimeResponse{}, err
+		return DatetimeGetUTCLowercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -633,7 +633,7 @@ func (client *DatetimeClient) getUTCMinDateTimeHandleResponse(resp *http.Respons
 	result := DatetimeGetUTCMinDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetUTCMinDateTimeResponse{}, err
+		return DatetimeGetUTCMinDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -685,7 +685,7 @@ func (client *DatetimeClient) getUTCUppercaseMaxDateTimeHandleResponse(resp *htt
 	result := DatetimeGetUTCUppercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetUTCUppercaseMaxDateTimeResponse{}, err
+		return DatetimeGetUTCUppercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -737,7 +737,7 @@ func (client *DatetimeClient) getUTCUppercaseMaxDateTime7DigitsHandleResponse(re
 	result := DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse{}, err
+		return DatetimeGetUTCUppercaseMaxDateTime7DigitsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -789,7 +789,7 @@ func (client *DatetimeClient) getUnderflowHandleResponse(resp *http.Response) (D
 	result := DatetimeGetUnderflowResponse{RawResponse: resp}
 	var aux *timeRFC3339
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DatetimeGetUnderflowResponse{}, err
+		return DatetimeGetUnderflowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
@@ -61,7 +61,7 @@ func (client *Datetimerfc1123Client) getInvalidHandleResponse(resp *http.Respons
 	result := Datetimerfc1123GetInvalidResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetInvalidResponse{}, err
+		return Datetimerfc1123GetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -113,7 +113,7 @@ func (client *Datetimerfc1123Client) getNullHandleResponse(resp *http.Response) 
 	result := Datetimerfc1123GetNullResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetNullResponse{}, err
+		return Datetimerfc1123GetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -165,7 +165,7 @@ func (client *Datetimerfc1123Client) getOverflowHandleResponse(resp *http.Respon
 	result := Datetimerfc1123GetOverflowResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetOverflowResponse{}, err
+		return Datetimerfc1123GetOverflowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -217,7 +217,7 @@ func (client *Datetimerfc1123Client) getUTCLowercaseMaxDateTimeHandleResponse(re
 	result := Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse{}, err
+		return Datetimerfc1123GetUTCLowercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -269,7 +269,7 @@ func (client *Datetimerfc1123Client) getUTCMinDateTimeHandleResponse(resp *http.
 	result := Datetimerfc1123GetUTCMinDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetUTCMinDateTimeResponse{}, err
+		return Datetimerfc1123GetUTCMinDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -321,7 +321,7 @@ func (client *Datetimerfc1123Client) getUTCUppercaseMaxDateTimeHandleResponse(re
 	result := Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse{}, err
+		return Datetimerfc1123GetUTCUppercaseMaxDateTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -373,7 +373,7 @@ func (client *Datetimerfc1123Client) getUnderflowHandleResponse(resp *http.Respo
 	result := Datetimerfc1123GetUnderflowResponse{RawResponse: resp}
 	var aux *timeRFC1123
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return Datetimerfc1123GetUnderflowResponse{}, err
+		return Datetimerfc1123GetUnderflowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil

--- a/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
@@ -60,7 +60,7 @@ func (client *DictionaryClient) getArrayEmptyCreateRequest(ctx context.Context, 
 func (client *DictionaryClient) getArrayEmptyHandleResponse(resp *http.Response) (DictionaryGetArrayEmptyResponse, error) {
 	result := DictionaryGetArrayEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetArrayEmptyResponse{}, err
+		return DictionaryGetArrayEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -110,7 +110,7 @@ func (client *DictionaryClient) getArrayItemEmptyCreateRequest(ctx context.Conte
 func (client *DictionaryClient) getArrayItemEmptyHandleResponse(resp *http.Response) (DictionaryGetArrayItemEmptyResponse, error) {
 	result := DictionaryGetArrayItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetArrayItemEmptyResponse{}, err
+		return DictionaryGetArrayItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -160,7 +160,7 @@ func (client *DictionaryClient) getArrayItemNullCreateRequest(ctx context.Contex
 func (client *DictionaryClient) getArrayItemNullHandleResponse(resp *http.Response) (DictionaryGetArrayItemNullResponse, error) {
 	result := DictionaryGetArrayItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetArrayItemNullResponse{}, err
+		return DictionaryGetArrayItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -210,7 +210,7 @@ func (client *DictionaryClient) getArrayNullCreateRequest(ctx context.Context, o
 func (client *DictionaryClient) getArrayNullHandleResponse(resp *http.Response) (DictionaryGetArrayNullResponse, error) {
 	result := DictionaryGetArrayNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetArrayNullResponse{}, err
+		return DictionaryGetArrayNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -260,7 +260,7 @@ func (client *DictionaryClient) getArrayValidCreateRequest(ctx context.Context, 
 func (client *DictionaryClient) getArrayValidHandleResponse(resp *http.Response) (DictionaryGetArrayValidResponse, error) {
 	result := DictionaryGetArrayValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetArrayValidResponse{}, err
+		return DictionaryGetArrayValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -310,7 +310,7 @@ func (client *DictionaryClient) getBase64URLCreateRequest(ctx context.Context, o
 func (client *DictionaryClient) getBase64URLHandleResponse(resp *http.Response) (DictionaryGetBase64URLResponse, error) {
 	result := DictionaryGetBase64URLResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetBase64URLResponse{}, err
+		return DictionaryGetBase64URLResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -360,7 +360,7 @@ func (client *DictionaryClient) getBooleanInvalidNullCreateRequest(ctx context.C
 func (client *DictionaryClient) getBooleanInvalidNullHandleResponse(resp *http.Response) (DictionaryGetBooleanInvalidNullResponse, error) {
 	result := DictionaryGetBooleanInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetBooleanInvalidNullResponse{}, err
+		return DictionaryGetBooleanInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -410,7 +410,7 @@ func (client *DictionaryClient) getBooleanInvalidStringCreateRequest(ctx context
 func (client *DictionaryClient) getBooleanInvalidStringHandleResponse(resp *http.Response) (DictionaryGetBooleanInvalidStringResponse, error) {
 	result := DictionaryGetBooleanInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetBooleanInvalidStringResponse{}, err
+		return DictionaryGetBooleanInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -460,7 +460,7 @@ func (client *DictionaryClient) getBooleanTfftCreateRequest(ctx context.Context,
 func (client *DictionaryClient) getBooleanTfftHandleResponse(resp *http.Response) (DictionaryGetBooleanTfftResponse, error) {
 	result := DictionaryGetBooleanTfftResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetBooleanTfftResponse{}, err
+		return DictionaryGetBooleanTfftResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -510,7 +510,7 @@ func (client *DictionaryClient) getByteInvalidNullCreateRequest(ctx context.Cont
 func (client *DictionaryClient) getByteInvalidNullHandleResponse(resp *http.Response) (DictionaryGetByteInvalidNullResponse, error) {
 	result := DictionaryGetByteInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetByteInvalidNullResponse{}, err
+		return DictionaryGetByteInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -560,7 +560,7 @@ func (client *DictionaryClient) getByteValidCreateRequest(ctx context.Context, o
 func (client *DictionaryClient) getByteValidHandleResponse(resp *http.Response) (DictionaryGetByteValidResponse, error) {
 	result := DictionaryGetByteValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetByteValidResponse{}, err
+		return DictionaryGetByteValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -610,7 +610,7 @@ func (client *DictionaryClient) getComplexEmptyCreateRequest(ctx context.Context
 func (client *DictionaryClient) getComplexEmptyHandleResponse(resp *http.Response) (DictionaryGetComplexEmptyResponse, error) {
 	result := DictionaryGetComplexEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetComplexEmptyResponse{}, err
+		return DictionaryGetComplexEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -660,7 +660,7 @@ func (client *DictionaryClient) getComplexItemEmptyCreateRequest(ctx context.Con
 func (client *DictionaryClient) getComplexItemEmptyHandleResponse(resp *http.Response) (DictionaryGetComplexItemEmptyResponse, error) {
 	result := DictionaryGetComplexItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetComplexItemEmptyResponse{}, err
+		return DictionaryGetComplexItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -710,7 +710,7 @@ func (client *DictionaryClient) getComplexItemNullCreateRequest(ctx context.Cont
 func (client *DictionaryClient) getComplexItemNullHandleResponse(resp *http.Response) (DictionaryGetComplexItemNullResponse, error) {
 	result := DictionaryGetComplexItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetComplexItemNullResponse{}, err
+		return DictionaryGetComplexItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -760,7 +760,7 @@ func (client *DictionaryClient) getComplexNullCreateRequest(ctx context.Context,
 func (client *DictionaryClient) getComplexNullHandleResponse(resp *http.Response) (DictionaryGetComplexNullResponse, error) {
 	result := DictionaryGetComplexNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetComplexNullResponse{}, err
+		return DictionaryGetComplexNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -811,7 +811,7 @@ func (client *DictionaryClient) getComplexValidCreateRequest(ctx context.Context
 func (client *DictionaryClient) getComplexValidHandleResponse(resp *http.Response) (DictionaryGetComplexValidResponse, error) {
 	result := DictionaryGetComplexValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetComplexValidResponse{}, err
+		return DictionaryGetComplexValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -862,7 +862,7 @@ func (client *DictionaryClient) getDateInvalidCharsHandleResponse(resp *http.Res
 	result := DictionaryGetDateInvalidCharsResponse{RawResponse: resp}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateInvalidCharsResponse{}, err
+		return DictionaryGetDateInvalidCharsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -918,7 +918,7 @@ func (client *DictionaryClient) getDateInvalidNullHandleResponse(resp *http.Resp
 	result := DictionaryGetDateInvalidNullResponse{RawResponse: resp}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateInvalidNullResponse{}, err
+		return DictionaryGetDateInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -974,7 +974,7 @@ func (client *DictionaryClient) getDateTimeInvalidCharsHandleResponse(resp *http
 	result := DictionaryGetDateTimeInvalidCharsResponse{RawResponse: resp}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateTimeInvalidCharsResponse{}, err
+		return DictionaryGetDateTimeInvalidCharsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -1030,7 +1030,7 @@ func (client *DictionaryClient) getDateTimeInvalidNullHandleResponse(resp *http.
 	result := DictionaryGetDateTimeInvalidNullResponse{RawResponse: resp}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateTimeInvalidNullResponse{}, err
+		return DictionaryGetDateTimeInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -1087,7 +1087,7 @@ func (client *DictionaryClient) getDateTimeRFC1123ValidHandleResponse(resp *http
 	result := DictionaryGetDateTimeRFC1123ValidResponse{RawResponse: resp}
 	aux := map[string]*timeRFC1123{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateTimeRFC1123ValidResponse{}, err
+		return DictionaryGetDateTimeRFC1123ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -1143,7 +1143,7 @@ func (client *DictionaryClient) getDateTimeValidHandleResponse(resp *http.Respon
 	result := DictionaryGetDateTimeValidResponse{RawResponse: resp}
 	aux := map[string]*timeRFC3339{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateTimeValidResponse{}, err
+		return DictionaryGetDateTimeValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -1199,7 +1199,7 @@ func (client *DictionaryClient) getDateValidHandleResponse(resp *http.Response) 
 	result := DictionaryGetDateValidResponse{RawResponse: resp}
 	aux := map[string]*dateType{}
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return DictionaryGetDateValidResponse{}, err
+		return DictionaryGetDateValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	cp := map[string]*time.Time{}
 	for k, v := range aux {
@@ -1254,7 +1254,7 @@ func (client *DictionaryClient) getDictionaryEmptyCreateRequest(ctx context.Cont
 func (client *DictionaryClient) getDictionaryEmptyHandleResponse(resp *http.Response) (DictionaryGetDictionaryEmptyResponse, error) {
 	result := DictionaryGetDictionaryEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDictionaryEmptyResponse{}, err
+		return DictionaryGetDictionaryEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1305,7 +1305,7 @@ func (client *DictionaryClient) getDictionaryItemEmptyCreateRequest(ctx context.
 func (client *DictionaryClient) getDictionaryItemEmptyHandleResponse(resp *http.Response) (DictionaryGetDictionaryItemEmptyResponse, error) {
 	result := DictionaryGetDictionaryItemEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDictionaryItemEmptyResponse{}, err
+		return DictionaryGetDictionaryItemEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1356,7 +1356,7 @@ func (client *DictionaryClient) getDictionaryItemNullCreateRequest(ctx context.C
 func (client *DictionaryClient) getDictionaryItemNullHandleResponse(resp *http.Response) (DictionaryGetDictionaryItemNullResponse, error) {
 	result := DictionaryGetDictionaryItemNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDictionaryItemNullResponse{}, err
+		return DictionaryGetDictionaryItemNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1406,7 +1406,7 @@ func (client *DictionaryClient) getDictionaryNullCreateRequest(ctx context.Conte
 func (client *DictionaryClient) getDictionaryNullHandleResponse(resp *http.Response) (DictionaryGetDictionaryNullResponse, error) {
 	result := DictionaryGetDictionaryNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDictionaryNullResponse{}, err
+		return DictionaryGetDictionaryNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1457,7 +1457,7 @@ func (client *DictionaryClient) getDictionaryValidCreateRequest(ctx context.Cont
 func (client *DictionaryClient) getDictionaryValidHandleResponse(resp *http.Response) (DictionaryGetDictionaryValidResponse, error) {
 	result := DictionaryGetDictionaryValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDictionaryValidResponse{}, err
+		return DictionaryGetDictionaryValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1507,7 +1507,7 @@ func (client *DictionaryClient) getDoubleInvalidNullCreateRequest(ctx context.Co
 func (client *DictionaryClient) getDoubleInvalidNullHandleResponse(resp *http.Response) (DictionaryGetDoubleInvalidNullResponse, error) {
 	result := DictionaryGetDoubleInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDoubleInvalidNullResponse{}, err
+		return DictionaryGetDoubleInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1557,7 +1557,7 @@ func (client *DictionaryClient) getDoubleInvalidStringCreateRequest(ctx context.
 func (client *DictionaryClient) getDoubleInvalidStringHandleResponse(resp *http.Response) (DictionaryGetDoubleInvalidStringResponse, error) {
 	result := DictionaryGetDoubleInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDoubleInvalidStringResponse{}, err
+		return DictionaryGetDoubleInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1607,7 +1607,7 @@ func (client *DictionaryClient) getDoubleValidCreateRequest(ctx context.Context,
 func (client *DictionaryClient) getDoubleValidHandleResponse(resp *http.Response) (DictionaryGetDoubleValidResponse, error) {
 	result := DictionaryGetDoubleValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDoubleValidResponse{}, err
+		return DictionaryGetDoubleValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1657,7 +1657,7 @@ func (client *DictionaryClient) getDurationValidCreateRequest(ctx context.Contex
 func (client *DictionaryClient) getDurationValidHandleResponse(resp *http.Response) (DictionaryGetDurationValidResponse, error) {
 	result := DictionaryGetDurationValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetDurationValidResponse{}, err
+		return DictionaryGetDurationValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1707,7 +1707,7 @@ func (client *DictionaryClient) getEmptyCreateRequest(ctx context.Context, optio
 func (client *DictionaryClient) getEmptyHandleResponse(resp *http.Response) (DictionaryGetEmptyResponse, error) {
 	result := DictionaryGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetEmptyResponse{}, err
+		return DictionaryGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1757,7 +1757,7 @@ func (client *DictionaryClient) getEmptyStringKeyCreateRequest(ctx context.Conte
 func (client *DictionaryClient) getEmptyStringKeyHandleResponse(resp *http.Response) (DictionaryGetEmptyStringKeyResponse, error) {
 	result := DictionaryGetEmptyStringKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetEmptyStringKeyResponse{}, err
+		return DictionaryGetEmptyStringKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1807,7 +1807,7 @@ func (client *DictionaryClient) getFloatInvalidNullCreateRequest(ctx context.Con
 func (client *DictionaryClient) getFloatInvalidNullHandleResponse(resp *http.Response) (DictionaryGetFloatInvalidNullResponse, error) {
 	result := DictionaryGetFloatInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetFloatInvalidNullResponse{}, err
+		return DictionaryGetFloatInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1857,7 +1857,7 @@ func (client *DictionaryClient) getFloatInvalidStringCreateRequest(ctx context.C
 func (client *DictionaryClient) getFloatInvalidStringHandleResponse(resp *http.Response) (DictionaryGetFloatInvalidStringResponse, error) {
 	result := DictionaryGetFloatInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetFloatInvalidStringResponse{}, err
+		return DictionaryGetFloatInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1907,7 +1907,7 @@ func (client *DictionaryClient) getFloatValidCreateRequest(ctx context.Context, 
 func (client *DictionaryClient) getFloatValidHandleResponse(resp *http.Response) (DictionaryGetFloatValidResponse, error) {
 	result := DictionaryGetFloatValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetFloatValidResponse{}, err
+		return DictionaryGetFloatValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1957,7 +1957,7 @@ func (client *DictionaryClient) getIntInvalidNullCreateRequest(ctx context.Conte
 func (client *DictionaryClient) getIntInvalidNullHandleResponse(resp *http.Response) (DictionaryGetIntInvalidNullResponse, error) {
 	result := DictionaryGetIntInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetIntInvalidNullResponse{}, err
+		return DictionaryGetIntInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2007,7 +2007,7 @@ func (client *DictionaryClient) getIntInvalidStringCreateRequest(ctx context.Con
 func (client *DictionaryClient) getIntInvalidStringHandleResponse(resp *http.Response) (DictionaryGetIntInvalidStringResponse, error) {
 	result := DictionaryGetIntInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetIntInvalidStringResponse{}, err
+		return DictionaryGetIntInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2057,7 +2057,7 @@ func (client *DictionaryClient) getIntegerValidCreateRequest(ctx context.Context
 func (client *DictionaryClient) getIntegerValidHandleResponse(resp *http.Response) (DictionaryGetIntegerValidResponse, error) {
 	result := DictionaryGetIntegerValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetIntegerValidResponse{}, err
+		return DictionaryGetIntegerValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2107,7 +2107,7 @@ func (client *DictionaryClient) getInvalidCreateRequest(ctx context.Context, opt
 func (client *DictionaryClient) getInvalidHandleResponse(resp *http.Response) (DictionaryGetInvalidResponse, error) {
 	result := DictionaryGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetInvalidResponse{}, err
+		return DictionaryGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2157,7 +2157,7 @@ func (client *DictionaryClient) getLongInvalidNullCreateRequest(ctx context.Cont
 func (client *DictionaryClient) getLongInvalidNullHandleResponse(resp *http.Response) (DictionaryGetLongInvalidNullResponse, error) {
 	result := DictionaryGetLongInvalidNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetLongInvalidNullResponse{}, err
+		return DictionaryGetLongInvalidNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2207,7 +2207,7 @@ func (client *DictionaryClient) getLongInvalidStringCreateRequest(ctx context.Co
 func (client *DictionaryClient) getLongInvalidStringHandleResponse(resp *http.Response) (DictionaryGetLongInvalidStringResponse, error) {
 	result := DictionaryGetLongInvalidStringResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetLongInvalidStringResponse{}, err
+		return DictionaryGetLongInvalidStringResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2257,7 +2257,7 @@ func (client *DictionaryClient) getLongValidCreateRequest(ctx context.Context, o
 func (client *DictionaryClient) getLongValidHandleResponse(resp *http.Response) (DictionaryGetLongValidResponse, error) {
 	result := DictionaryGetLongValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetLongValidResponse{}, err
+		return DictionaryGetLongValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2307,7 +2307,7 @@ func (client *DictionaryClient) getNullCreateRequest(ctx context.Context, option
 func (client *DictionaryClient) getNullHandleResponse(resp *http.Response) (DictionaryGetNullResponse, error) {
 	result := DictionaryGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetNullResponse{}, err
+		return DictionaryGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2357,7 +2357,7 @@ func (client *DictionaryClient) getNullKeyCreateRequest(ctx context.Context, opt
 func (client *DictionaryClient) getNullKeyHandleResponse(resp *http.Response) (DictionaryGetNullKeyResponse, error) {
 	result := DictionaryGetNullKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetNullKeyResponse{}, err
+		return DictionaryGetNullKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2407,7 +2407,7 @@ func (client *DictionaryClient) getNullValueCreateRequest(ctx context.Context, o
 func (client *DictionaryClient) getNullValueHandleResponse(resp *http.Response) (DictionaryGetNullValueResponse, error) {
 	result := DictionaryGetNullValueResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetNullValueResponse{}, err
+		return DictionaryGetNullValueResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2457,7 +2457,7 @@ func (client *DictionaryClient) getStringValidCreateRequest(ctx context.Context,
 func (client *DictionaryClient) getStringValidHandleResponse(resp *http.Response) (DictionaryGetStringValidResponse, error) {
 	result := DictionaryGetStringValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetStringValidResponse{}, err
+		return DictionaryGetStringValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2507,7 +2507,7 @@ func (client *DictionaryClient) getStringWithInvalidCreateRequest(ctx context.Co
 func (client *DictionaryClient) getStringWithInvalidHandleResponse(resp *http.Response) (DictionaryGetStringWithInvalidResponse, error) {
 	result := DictionaryGetStringWithInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetStringWithInvalidResponse{}, err
+		return DictionaryGetStringWithInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2557,7 +2557,7 @@ func (client *DictionaryClient) getStringWithNullCreateRequest(ctx context.Conte
 func (client *DictionaryClient) getStringWithNullHandleResponse(resp *http.Response) (DictionaryGetStringWithNullResponse, error) {
 	result := DictionaryGetStringWithNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DictionaryGetStringWithNullResponse{}, err
+		return DictionaryGetStringWithNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/durationgroup/zz_generated_duration_client.go
+++ b/test/autorest/durationgroup/zz_generated_duration_client.go
@@ -59,7 +59,7 @@ func (client *DurationClient) getInvalidCreateRequest(ctx context.Context, optio
 func (client *DurationClient) getInvalidHandleResponse(resp *http.Response) (DurationGetInvalidResponse, error) {
 	result := DurationGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DurationGetInvalidResponse{}, err
+		return DurationGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *DurationClient) getNullCreateRequest(ctx context.Context, options 
 func (client *DurationClient) getNullHandleResponse(resp *http.Response) (DurationGetNullResponse, error) {
 	result := DurationGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DurationGetNullResponse{}, err
+		return DurationGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *DurationClient) getPositiveDurationCreateRequest(ctx context.Conte
 func (client *DurationClient) getPositiveDurationHandleResponse(resp *http.Response) (DurationGetPositiveDurationResponse, error) {
 	result := DurationGetPositiveDurationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return DurationGetPositiveDurationResponse{}, err
+		return DurationGetPositiveDurationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/errorsgroup/zz_generated_pet_client.go
+++ b/test/autorest/errorsgroup/zz_generated_pet_client.go
@@ -67,7 +67,7 @@ func (client *PetClient) doSomethingCreateRequest(ctx context.Context, whatActio
 func (client *PetClient) doSomethingHandleResponse(resp *http.Response) (PetDoSomethingResponse, error) {
 	result := PetDoSomethingResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PetAction); err != nil {
-		return PetDoSomethingResponse{}, err
+		return PetDoSomethingResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -122,7 +122,7 @@ func (client *PetClient) getPetByIDCreateRequest(ctx context.Context, petID stri
 func (client *PetClient) getPetByIDHandleResponse(resp *http.Response) (PetGetPetByIDResponse, error) {
 	result := PetGetPetByIDResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
-		return PetGetPetByIDResponse{}, err
+		return PetGetPetByIDResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/extenumsgroup/zz_generated_pet_client.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet_client.go
@@ -64,7 +64,7 @@ func (client *PetClient) addPetCreateRequest(ctx context.Context, options *PetAd
 func (client *PetClient) addPetHandleResponse(resp *http.Response) (PetAddPetResponse, error) {
 	result := PetAddPetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
-		return PetAddPetResponse{}, err
+		return PetAddPetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -117,7 +117,7 @@ func (client *PetClient) getByPetIDCreateRequest(ctx context.Context, petID stri
 func (client *PetClient) getByPetIDHandleResponse(resp *http.Response) (PetGetByPetIDResponse, error) {
 	result := PetGetByPetIDResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
-		return PetGetByPetIDResponse{}, err
+		return PetGetByPetIDResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
@@ -60,7 +60,7 @@ func (client *HTTPFailureClient) getEmptyErrorCreateRequest(ctx context.Context,
 func (client *HTTPFailureClient) getEmptyErrorHandleResponse(resp *http.Response) (HTTPFailureGetEmptyErrorResponse, error) {
 	result := HTTPFailureGetEmptyErrorResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPFailureGetEmptyErrorResponse{}, err
+		return HTTPFailureGetEmptyErrorResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -110,7 +110,7 @@ func (client *HTTPFailureClient) getNoModelEmptyCreateRequest(ctx context.Contex
 func (client *HTTPFailureClient) getNoModelEmptyHandleResponse(resp *http.Response) (HTTPFailureGetNoModelEmptyResponse, error) {
 	result := HTTPFailureGetNoModelEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPFailureGetNoModelEmptyResponse{}, err
+		return HTTPFailureGetNoModelEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *HTTPFailureClient) getNoModelErrorCreateRequest(ctx context.Contex
 func (client *HTTPFailureClient) getNoModelErrorHandleResponse(resp *http.Response) (HTTPFailureGetNoModelErrorResponse, error) {
 	result := HTTPFailureGetNoModelErrorResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPFailureGetNoModelErrorResponse{}, err
+		return HTTPFailureGetNoModelErrorResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
@@ -103,7 +103,7 @@ func (client *HTTPRedirectsClient) get300HandleResponse(resp *http.Response) (HT
 		result.Location = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return HTTPRedirectsGet300Response{}, err
+		return HTTPRedirectsGet300Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
@@ -170,7 +170,7 @@ func (client *HTTPRetryClient) options502CreateRequest(ctx context.Context, opti
 func (client *HTTPRetryClient) options502HandleResponse(resp *http.Response) (HTTPRetryOptions502Response, error) {
 	result := HTTPRetryOptions502Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPRetryOptions502Response{}, err
+		return HTTPRetryOptions502Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
@@ -182,7 +182,7 @@ func (client *HTTPSuccessClient) get200CreateRequest(ctx context.Context, option
 func (client *HTTPSuccessClient) get200HandleResponse(resp *http.Response) (HTTPSuccessGet200Response, error) {
 	result := HTTPSuccessGet200Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPSuccessGet200Response{}, err
+		return HTTPSuccessGet200Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -319,7 +319,7 @@ func (client *HTTPSuccessClient) options200CreateRequest(ctx context.Context, op
 func (client *HTTPSuccessClient) options200HandleResponse(resp *http.Response) (HTTPSuccessOptions200Response, error) {
 	result := HTTPSuccessOptions200Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return HTTPSuccessOptions200Response{}, err
+		return HTTPSuccessOptions200Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
@@ -63,13 +63,13 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError200ValidHa
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError200ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val B
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError200ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -126,13 +126,13 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError201ValidHa
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError201ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError201ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val B
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError201ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError201ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -189,13 +189,13 @@ func (client *MultipleResponsesClient) get200Model201ModelDefaultError400ValidHa
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError400ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val B
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200Model201ModelDefaultError400ValidResponse{}, err
+			return MultipleResponsesGet200Model201ModelDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -249,7 +249,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError200Valid
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError200ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse, error) {
 	result := MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse{}, err
+		return MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -299,7 +299,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError201Inval
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError201InvalidHandleResponse(resp *http.Response) (MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse, error) {
 	result := MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse{}, err
+		return MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -349,7 +349,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError202NoneC
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError202NoneHandleResponse(resp *http.Response) (MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse, error) {
 	result := MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse{}, err
+		return MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -399,7 +399,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError204Valid
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError204ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse, error) {
 	result := MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse{}, err
+		return MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -449,7 +449,7 @@ func (client *MultipleResponsesClient) get200Model204NoModelDefaultError400Valid
 func (client *MultipleResponsesClient) get200Model204NoModelDefaultError400ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse, error) {
 	result := MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse{}, err
+		return MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -499,7 +499,7 @@ func (client *MultipleResponsesClient) get200ModelA200InvalidCreateRequest(ctx c
 func (client *MultipleResponsesClient) get200ModelA200InvalidHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA200InvalidResponse, error) {
 	result := MultipleResponsesGet200ModelA200InvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA200InvalidResponse{}, err
+		return MultipleResponsesGet200ModelA200InvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -548,7 +548,7 @@ func (client *MultipleResponsesClient) get200ModelA200NoneCreateRequest(ctx cont
 func (client *MultipleResponsesClient) get200ModelA200NoneHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA200NoneResponse, error) {
 	result := MultipleResponsesGet200ModelA200NoneResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA200NoneResponse{}, err
+		return MultipleResponsesGet200ModelA200NoneResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -597,7 +597,7 @@ func (client *MultipleResponsesClient) get200ModelA200ValidCreateRequest(ctx con
 func (client *MultipleResponsesClient) get200ModelA200ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA200ValidResponse, error) {
 	result := MultipleResponsesGet200ModelA200ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA200ValidResponse{}, err
+		return MultipleResponsesGet200ModelA200ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -649,19 +649,19 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val C
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusNotFound:
 		var val D
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -718,19 +718,19 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val C
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusNotFound:
 		var val D
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -787,19 +787,19 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val C
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusNotFound:
 		var val D
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -856,19 +856,19 @@ func (client *MultipleResponsesClient) get200ModelA201ModelC404ModelDDefaultErro
 	case http.StatusOK:
 		var val MyException
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusCreated:
 		var val C
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusNotFound:
 		var val D
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, err
+			return MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -922,7 +922,7 @@ func (client *MultipleResponsesClient) get200ModelA202ValidCreateRequest(ctx con
 func (client *MultipleResponsesClient) get200ModelA202ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA202ValidResponse, error) {
 	result := MultipleResponsesGet200ModelA202ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA202ValidResponse{}, err
+		return MultipleResponsesGet200ModelA202ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -971,7 +971,7 @@ func (client *MultipleResponsesClient) get200ModelA400InvalidCreateRequest(ctx c
 func (client *MultipleResponsesClient) get200ModelA400InvalidHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA400InvalidResponse, error) {
 	result := MultipleResponsesGet200ModelA400InvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA400InvalidResponse{}, err
+		return MultipleResponsesGet200ModelA400InvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1020,7 +1020,7 @@ func (client *MultipleResponsesClient) get200ModelA400NoneCreateRequest(ctx cont
 func (client *MultipleResponsesClient) get200ModelA400NoneHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA400NoneResponse, error) {
 	result := MultipleResponsesGet200ModelA400NoneResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA400NoneResponse{}, err
+		return MultipleResponsesGet200ModelA400NoneResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1069,7 +1069,7 @@ func (client *MultipleResponsesClient) get200ModelA400ValidCreateRequest(ctx con
 func (client *MultipleResponsesClient) get200ModelA400ValidHandleResponse(resp *http.Response) (MultipleResponsesGet200ModelA400ValidResponse, error) {
 	result := MultipleResponsesGet200ModelA400ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGet200ModelA400ValidResponse{}, err
+		return MultipleResponsesGet200ModelA400ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1397,7 +1397,7 @@ func (client *MultipleResponsesClient) getDefaultModelA200NoneCreateRequest(ctx 
 func (client *MultipleResponsesClient) getDefaultModelA200NoneHandleResponse(resp *http.Response) (MultipleResponsesGetDefaultModelA200NoneResponse, error) {
 	result := MultipleResponsesGetDefaultModelA200NoneResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGetDefaultModelA200NoneResponse{}, err
+		return MultipleResponsesGetDefaultModelA200NoneResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1446,7 +1446,7 @@ func (client *MultipleResponsesClient) getDefaultModelA200ValidCreateRequest(ctx
 func (client *MultipleResponsesClient) getDefaultModelA200ValidHandleResponse(resp *http.Response) (MultipleResponsesGetDefaultModelA200ValidResponse, error) {
 	result := MultipleResponsesGetDefaultModelA200ValidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MyException); err != nil {
-		return MultipleResponsesGetDefaultModelA200ValidResponse{}, err
+		return MultipleResponsesGetDefaultModelA200ValidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/integergroup/zz_generated_int_client.go
+++ b/test/autorest/integergroup/zz_generated_int_client.go
@@ -60,7 +60,7 @@ func (client *IntClient) getInvalidCreateRequest(ctx context.Context, options *I
 func (client *IntClient) getInvalidHandleResponse(resp *http.Response) (IntGetInvalidResponse, error) {
 	result := IntGetInvalidResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetInvalidResponse{}, err
+		return IntGetInvalidResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -111,7 +111,7 @@ func (client *IntClient) getInvalidUnixTimeHandleResponse(resp *http.Response) (
 	result := IntGetInvalidUnixTimeResponse{RawResponse: resp}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return IntGetInvalidUnixTimeResponse{}, err
+		return IntGetInvalidUnixTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -162,7 +162,7 @@ func (client *IntClient) getNullCreateRequest(ctx context.Context, options *IntG
 func (client *IntClient) getNullHandleResponse(resp *http.Response) (IntGetNullResponse, error) {
 	result := IntGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetNullResponse{}, err
+		return IntGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -213,7 +213,7 @@ func (client *IntClient) getNullUnixTimeHandleResponse(resp *http.Response) (Int
 	result := IntGetNullUnixTimeResponse{RawResponse: resp}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return IntGetNullUnixTimeResponse{}, err
+		return IntGetNullUnixTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil
@@ -264,7 +264,7 @@ func (client *IntClient) getOverflowInt32CreateRequest(ctx context.Context, opti
 func (client *IntClient) getOverflowInt32HandleResponse(resp *http.Response) (IntGetOverflowInt32Response, error) {
 	result := IntGetOverflowInt32Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetOverflowInt32Response{}, err
+		return IntGetOverflowInt32Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -314,7 +314,7 @@ func (client *IntClient) getOverflowInt64CreateRequest(ctx context.Context, opti
 func (client *IntClient) getOverflowInt64HandleResponse(resp *http.Response) (IntGetOverflowInt64Response, error) {
 	result := IntGetOverflowInt64Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetOverflowInt64Response{}, err
+		return IntGetOverflowInt64Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -364,7 +364,7 @@ func (client *IntClient) getUnderflowInt32CreateRequest(ctx context.Context, opt
 func (client *IntClient) getUnderflowInt32HandleResponse(resp *http.Response) (IntGetUnderflowInt32Response, error) {
 	result := IntGetUnderflowInt32Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetUnderflowInt32Response{}, err
+		return IntGetUnderflowInt32Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -414,7 +414,7 @@ func (client *IntClient) getUnderflowInt64CreateRequest(ctx context.Context, opt
 func (client *IntClient) getUnderflowInt64HandleResponse(resp *http.Response) (IntGetUnderflowInt64Response, error) {
 	result := IntGetUnderflowInt64Response{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetUnderflowInt64Response{}, err
+		return IntGetUnderflowInt64Response{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -465,7 +465,7 @@ func (client *IntClient) getUnixTimeHandleResponse(resp *http.Response) (IntGetU
 	result := IntGetUnixTimeResponse{RawResponse: resp}
 	var aux *timeUnix
 	if err := runtime.UnmarshalAsJSON(resp, &aux); err != nil {
-		return IntGetUnixTimeResponse{}, err
+		return IntGetUnixTimeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	result.Value = (*time.Time)(aux)
 	return result, nil

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
@@ -65,7 +65,7 @@ func (client *MediaTypesClient) analyzeBodyCreateRequest(ctx context.Context, co
 func (client *MediaTypesClient) analyzeBodyHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyResponse, error) {
 	result := MediaTypesClientAnalyzeBodyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MediaTypesClientAnalyzeBodyResponse{}, err
+		return MediaTypesClientAnalyzeBodyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -202,7 +202,7 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathCreateRequest(ctx conte
 func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyWithSourcePathResponse, error) {
 	result := MediaTypesClientAnalyzeBodyWithSourcePathResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, err
+		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -255,7 +255,7 @@ func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context
 func (client *MediaTypesClient) contentTypeWithEncodingHandleResponse(resp *http.Response) (MediaTypesClientContentTypeWithEncodingResponse, error) {
 	result := MediaTypesClientContentTypeWithEncodingResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MediaTypesClientContentTypeWithEncodingResponse{}, err
+		return MediaTypesClientContentTypeWithEncodingResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient_client.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceserviceclient_client.go
@@ -60,7 +60,7 @@ func (client *MultipleInheritanceServiceClient) getCatCreateRequest(ctx context.
 func (client *MultipleInheritanceServiceClient) getCatHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetCatResponse, error) {
 	result := MultipleInheritanceServiceClientGetCatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Cat); err != nil {
-		return MultipleInheritanceServiceClientGetCatResponse{}, err
+		return MultipleInheritanceServiceClientGetCatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -110,7 +110,7 @@ func (client *MultipleInheritanceServiceClient) getFelineCreateRequest(ctx conte
 func (client *MultipleInheritanceServiceClient) getFelineHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetFelineResponse, error) {
 	result := MultipleInheritanceServiceClientGetFelineResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Feline); err != nil {
-		return MultipleInheritanceServiceClientGetFelineResponse{}, err
+		return MultipleInheritanceServiceClientGetFelineResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -160,7 +160,7 @@ func (client *MultipleInheritanceServiceClient) getHorseCreateRequest(ctx contex
 func (client *MultipleInheritanceServiceClient) getHorseHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetHorseResponse, error) {
 	result := MultipleInheritanceServiceClientGetHorseResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Horse); err != nil {
-		return MultipleInheritanceServiceClientGetHorseResponse{}, err
+		return MultipleInheritanceServiceClientGetHorseResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -210,7 +210,7 @@ func (client *MultipleInheritanceServiceClient) getKittenCreateRequest(ctx conte
 func (client *MultipleInheritanceServiceClient) getKittenHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetKittenResponse, error) {
 	result := MultipleInheritanceServiceClientGetKittenResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Kitten); err != nil {
-		return MultipleInheritanceServiceClientGetKittenResponse{}, err
+		return MultipleInheritanceServiceClientGetKittenResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -260,7 +260,7 @@ func (client *MultipleInheritanceServiceClient) getPetCreateRequest(ctx context.
 func (client *MultipleInheritanceServiceClient) getPetHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientGetPetResponse, error) {
 	result := MultipleInheritanceServiceClientGetPetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Pet); err != nil {
-		return MultipleInheritanceServiceClientGetPetResponse{}, err
+		return MultipleInheritanceServiceClientGetPetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -310,7 +310,7 @@ func (client *MultipleInheritanceServiceClient) putCatCreateRequest(ctx context.
 func (client *MultipleInheritanceServiceClient) putCatHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutCatResponse, error) {
 	result := MultipleInheritanceServiceClientPutCatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MultipleInheritanceServiceClientPutCatResponse{}, err
+		return MultipleInheritanceServiceClientPutCatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -359,7 +359,7 @@ func (client *MultipleInheritanceServiceClient) putFelineCreateRequest(ctx conte
 func (client *MultipleInheritanceServiceClient) putFelineHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutFelineResponse, error) {
 	result := MultipleInheritanceServiceClientPutFelineResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MultipleInheritanceServiceClientPutFelineResponse{}, err
+		return MultipleInheritanceServiceClientPutFelineResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -408,7 +408,7 @@ func (client *MultipleInheritanceServiceClient) putHorseCreateRequest(ctx contex
 func (client *MultipleInheritanceServiceClient) putHorseHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutHorseResponse, error) {
 	result := MultipleInheritanceServiceClientPutHorseResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MultipleInheritanceServiceClientPutHorseResponse{}, err
+		return MultipleInheritanceServiceClientPutHorseResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -457,7 +457,7 @@ func (client *MultipleInheritanceServiceClient) putKittenCreateRequest(ctx conte
 func (client *MultipleInheritanceServiceClient) putKittenHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutKittenResponse, error) {
 	result := MultipleInheritanceServiceClientPutKittenResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MultipleInheritanceServiceClientPutKittenResponse{}, err
+		return MultipleInheritanceServiceClientPutKittenResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -506,7 +506,7 @@ func (client *MultipleInheritanceServiceClient) putPetCreateRequest(ctx context.
 func (client *MultipleInheritanceServiceClient) putPetHandleResponse(resp *http.Response) (MultipleInheritanceServiceClientPutPetResponse, error) {
 	result := MultipleInheritanceServiceClientPutPetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MultipleInheritanceServiceClientPutPetResponse{}, err
+		return MultipleInheritanceServiceClientPutPetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_float_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float_client.go
@@ -59,7 +59,7 @@ func (client *FloatClient) getCreateRequest(ctx context.Context, options *FloatG
 func (client *FloatClient) getHandleResponse(resp *http.Response) (FloatGetResponse, error) {
 	result := FloatGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return FloatGetResponse{}, err
+		return FloatGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -111,7 +111,7 @@ func (client *FloatClient) putCreateRequest(ctx context.Context, options *FloatP
 func (client *FloatClient) putHandleResponse(resp *http.Response) (FloatPutResponse, error) {
 	result := FloatPutResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return FloatPutResponse{}, err
+		return FloatPutResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_int_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int_client.go
@@ -59,7 +59,7 @@ func (client *IntClient) getCreateRequest(ctx context.Context, options *IntGetOp
 func (client *IntClient) getHandleResponse(resp *http.Response) (IntGetResponse, error) {
 	result := IntGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntGetResponse{}, err
+		return IntGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -111,7 +111,7 @@ func (client *IntClient) putCreateRequest(ctx context.Context, options *IntPutOp
 func (client *IntClient) putHandleResponse(resp *http.Response) (IntPutResponse, error) {
 	result := IntPutResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return IntPutResponse{}, err
+		return IntPutResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/numbergroup/zz_generated_number_client.go
+++ b/test/autorest/numbergroup/zz_generated_number_client.go
@@ -59,7 +59,7 @@ func (client *NumberClient) getBigDecimalCreateRequest(ctx context.Context, opti
 func (client *NumberClient) getBigDecimalHandleResponse(resp *http.Response) (NumberGetBigDecimalResponse, error) {
 	result := NumberGetBigDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDecimalResponse{}, err
+		return NumberGetBigDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *NumberClient) getBigDecimalNegativeDecimalCreateRequest(ctx contex
 func (client *NumberClient) getBigDecimalNegativeDecimalHandleResponse(resp *http.Response) (NumberGetBigDecimalNegativeDecimalResponse, error) {
 	result := NumberGetBigDecimalNegativeDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDecimalNegativeDecimalResponse{}, err
+		return NumberGetBigDecimalNegativeDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *NumberClient) getBigDecimalPositiveDecimalCreateRequest(ctx contex
 func (client *NumberClient) getBigDecimalPositiveDecimalHandleResponse(resp *http.Response) (NumberGetBigDecimalPositiveDecimalResponse, error) {
 	result := NumberGetBigDecimalPositiveDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDecimalPositiveDecimalResponse{}, err
+		return NumberGetBigDecimalPositiveDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *NumberClient) getBigDoubleCreateRequest(ctx context.Context, optio
 func (client *NumberClient) getBigDoubleHandleResponse(resp *http.Response) (NumberGetBigDoubleResponse, error) {
 	result := NumberGetBigDoubleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDoubleResponse{}, err
+		return NumberGetBigDoubleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -259,7 +259,7 @@ func (client *NumberClient) getBigDoubleNegativeDecimalCreateRequest(ctx context
 func (client *NumberClient) getBigDoubleNegativeDecimalHandleResponse(resp *http.Response) (NumberGetBigDoubleNegativeDecimalResponse, error) {
 	result := NumberGetBigDoubleNegativeDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDoubleNegativeDecimalResponse{}, err
+		return NumberGetBigDoubleNegativeDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -309,7 +309,7 @@ func (client *NumberClient) getBigDoublePositiveDecimalCreateRequest(ctx context
 func (client *NumberClient) getBigDoublePositiveDecimalHandleResponse(resp *http.Response) (NumberGetBigDoublePositiveDecimalResponse, error) {
 	result := NumberGetBigDoublePositiveDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigDoublePositiveDecimalResponse{}, err
+		return NumberGetBigDoublePositiveDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -359,7 +359,7 @@ func (client *NumberClient) getBigFloatCreateRequest(ctx context.Context, option
 func (client *NumberClient) getBigFloatHandleResponse(resp *http.Response) (NumberGetBigFloatResponse, error) {
 	result := NumberGetBigFloatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetBigFloatResponse{}, err
+		return NumberGetBigFloatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -409,7 +409,7 @@ func (client *NumberClient) getInvalidDecimalCreateRequest(ctx context.Context, 
 func (client *NumberClient) getInvalidDecimalHandleResponse(resp *http.Response) (NumberGetInvalidDecimalResponse, error) {
 	result := NumberGetInvalidDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetInvalidDecimalResponse{}, err
+		return NumberGetInvalidDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -459,7 +459,7 @@ func (client *NumberClient) getInvalidDoubleCreateRequest(ctx context.Context, o
 func (client *NumberClient) getInvalidDoubleHandleResponse(resp *http.Response) (NumberGetInvalidDoubleResponse, error) {
 	result := NumberGetInvalidDoubleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetInvalidDoubleResponse{}, err
+		return NumberGetInvalidDoubleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -509,7 +509,7 @@ func (client *NumberClient) getInvalidFloatCreateRequest(ctx context.Context, op
 func (client *NumberClient) getInvalidFloatHandleResponse(resp *http.Response) (NumberGetInvalidFloatResponse, error) {
 	result := NumberGetInvalidFloatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetInvalidFloatResponse{}, err
+		return NumberGetInvalidFloatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -559,7 +559,7 @@ func (client *NumberClient) getNullCreateRequest(ctx context.Context, options *N
 func (client *NumberClient) getNullHandleResponse(resp *http.Response) (NumberGetNullResponse, error) {
 	result := NumberGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetNullResponse{}, err
+		return NumberGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -609,7 +609,7 @@ func (client *NumberClient) getSmallDecimalCreateRequest(ctx context.Context, op
 func (client *NumberClient) getSmallDecimalHandleResponse(resp *http.Response) (NumberGetSmallDecimalResponse, error) {
 	result := NumberGetSmallDecimalResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetSmallDecimalResponse{}, err
+		return NumberGetSmallDecimalResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -659,7 +659,7 @@ func (client *NumberClient) getSmallDoubleCreateRequest(ctx context.Context, opt
 func (client *NumberClient) getSmallDoubleHandleResponse(resp *http.Response) (NumberGetSmallDoubleResponse, error) {
 	result := NumberGetSmallDoubleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetSmallDoubleResponse{}, err
+		return NumberGetSmallDoubleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -709,7 +709,7 @@ func (client *NumberClient) getSmallFloatCreateRequest(ctx context.Context, opti
 func (client *NumberClient) getSmallFloatHandleResponse(resp *http.Response) (NumberGetSmallFloatResponse, error) {
 	result := NumberGetSmallFloatResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return NumberGetSmallFloatResponse{}, err
+		return NumberGetSmallFloatResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/objectgroup/zz_generated_objecttypeclient_client.go
+++ b/test/autorest/objectgroup/zz_generated_objecttypeclient_client.go
@@ -59,7 +59,7 @@ func (client *ObjectTypeClient) getCreateRequest(ctx context.Context, options *O
 func (client *ObjectTypeClient) getHandleResponse(resp *http.Response) (ObjectTypeClientGetResponse, error) {
 	result := ObjectTypeClientGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Object); err != nil {
-		return ObjectTypeClientGetResponse{}, err
+		return ObjectTypeClientGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -61,7 +61,7 @@ func (client *PagingClient) firstResponseEmptyCreateRequest(ctx context.Context,
 func (client *PagingClient) firstResponseEmptyHandleResponse(resp *http.Response) (PagingFirstResponseEmptyResponse, error) {
 	result := PagingFirstResponseEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValue); err != nil {
-		return PagingFirstResponseEmptyResponse{}, err
+		return PagingFirstResponseEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -116,7 +116,7 @@ func (client *PagingClient) getMultiplePagesCreateRequest(ctx context.Context, o
 func (client *PagingClient) getMultiplePagesHandleResponse(resp *http.Response) (PagingGetMultiplePagesResponse, error) {
 	result := PagingGetMultiplePagesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesResponse{}, err
+		return PagingGetMultiplePagesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -162,7 +162,7 @@ func (client *PagingClient) getMultiplePagesFailureCreateRequest(ctx context.Con
 func (client *PagingClient) getMultiplePagesFailureHandleResponse(resp *http.Response) (PagingGetMultiplePagesFailureResponse, error) {
 	result := PagingGetMultiplePagesFailureResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesFailureResponse{}, err
+		return PagingGetMultiplePagesFailureResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -208,7 +208,7 @@ func (client *PagingClient) getMultiplePagesFailureURICreateRequest(ctx context.
 func (client *PagingClient) getMultiplePagesFailureURIHandleResponse(resp *http.Response) (PagingGetMultiplePagesFailureURIResponse, error) {
 	result := PagingGetMultiplePagesFailureURIResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesFailureURIResponse{}, err
+		return PagingGetMultiplePagesFailureURIResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -261,7 +261,7 @@ func (client *PagingClient) getMultiplePagesFragmentNextLinkCreateRequest(ctx co
 func (client *PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp *http.Response) (PagingGetMultiplePagesFragmentNextLinkResponse, error) {
 	result := PagingGetMultiplePagesFragmentNextLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
-		return PagingGetMultiplePagesFragmentNextLinkResponse{}, err
+		return PagingGetMultiplePagesFragmentNextLinkResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -314,7 +314,7 @@ func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkCreateRe
 func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkHandleResponse(resp *http.Response) (PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse, error) {
 	result := PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
-		return PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
+		return PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -393,7 +393,7 @@ func (client *PagingClient) getMultiplePagesLROCreateRequest(ctx context.Context
 func (client *PagingClient) getMultiplePagesLROHandleResponse(resp *http.Response) (PagingGetMultiplePagesLROResponse, error) {
 	result := PagingGetMultiplePagesLROResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesLROResponse{}, err
+		return PagingGetMultiplePagesLROResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -440,7 +440,7 @@ func (client *PagingClient) getMultiplePagesRetryFirstCreateRequest(ctx context.
 func (client *PagingClient) getMultiplePagesRetryFirstHandleResponse(resp *http.Response) (PagingGetMultiplePagesRetryFirstResponse, error) {
 	result := PagingGetMultiplePagesRetryFirstResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesRetryFirstResponse{}, err
+		return PagingGetMultiplePagesRetryFirstResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -487,7 +487,7 @@ func (client *PagingClient) getMultiplePagesRetrySecondCreateRequest(ctx context
 func (client *PagingClient) getMultiplePagesRetrySecondHandleResponse(resp *http.Response) (PagingGetMultiplePagesRetrySecondResponse, error) {
 	result := PagingGetMultiplePagesRetrySecondResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesRetrySecondResponse{}, err
+		return PagingGetMultiplePagesRetrySecondResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -543,7 +543,7 @@ func (client *PagingClient) getMultiplePagesWithOffsetCreateRequest(ctx context.
 func (client *PagingClient) getMultiplePagesWithOffsetHandleResponse(resp *http.Response) (PagingGetMultiplePagesWithOffsetResponse, error) {
 	result := PagingGetMultiplePagesWithOffsetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetMultiplePagesWithOffsetResponse{}, err
+		return PagingGetMultiplePagesWithOffsetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -589,7 +589,7 @@ func (client *PagingClient) getNoItemNamePagesCreateRequest(ctx context.Context,
 func (client *PagingClient) getNoItemNamePagesHandleResponse(resp *http.Response) (PagingGetNoItemNamePagesResponse, error) {
 	result := PagingGetNoItemNamePagesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValue); err != nil {
-		return PagingGetNoItemNamePagesResponse{}, err
+		return PagingGetNoItemNamePagesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -638,7 +638,7 @@ func (client *PagingClient) getNullNextLinkNamePagesCreateRequest(ctx context.Co
 func (client *PagingClient) getNullNextLinkNamePagesHandleResponse(resp *http.Response) (PagingGetNullNextLinkNamePagesResponse, error) {
 	result := PagingGetNullNextLinkNamePagesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetNullNextLinkNamePagesResponse{}, err
+		return PagingGetNullNextLinkNamePagesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -693,7 +693,7 @@ func (client *PagingClient) getODataMultiplePagesCreateRequest(ctx context.Conte
 func (client *PagingClient) getODataMultiplePagesHandleResponse(resp *http.Response) (PagingGetODataMultiplePagesResponse, error) {
 	result := PagingGetODataMultiplePagesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
-		return PagingGetODataMultiplePagesResponse{}, err
+		return PagingGetODataMultiplePagesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -739,7 +739,7 @@ func (client *PagingClient) getPagingModelWithItemNameWithXMSClientNameCreateReq
 func (client *PagingClient) getPagingModelWithItemNameWithXMSClientNameHandleResponse(resp *http.Response) (PagingGetPagingModelWithItemNameWithXMSClientNameResponse, error) {
 	result := PagingGetPagingModelWithItemNameWithXMSClientNameResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResultValueWithXMSClientName); err != nil {
-		return PagingGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
+		return PagingGetPagingModelWithItemNameWithXMSClientNameResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -785,7 +785,7 @@ func (client *PagingClient) getSinglePagesCreateRequest(ctx context.Context, opt
 func (client *PagingClient) getSinglePagesHandleResponse(resp *http.Response) (PagingGetSinglePagesResponse, error) {
 	result := PagingGetSinglePagesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetSinglePagesResponse{}, err
+		return PagingGetSinglePagesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -831,7 +831,7 @@ func (client *PagingClient) getSinglePagesFailureCreateRequest(ctx context.Conte
 func (client *PagingClient) getSinglePagesFailureHandleResponse(resp *http.Response) (PagingGetSinglePagesFailureResponse, error) {
 	result := PagingGetSinglePagesFailureResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetSinglePagesFailureResponse{}, err
+		return PagingGetSinglePagesFailureResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -882,7 +882,7 @@ func (client *PagingClient) getWithQueryParamsCreateRequest(ctx context.Context,
 func (client *PagingClient) getWithQueryParamsHandleResponse(resp *http.Response) (PagingGetWithQueryParamsResponse, error) {
 	result := PagingGetWithQueryParamsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingGetWithQueryParamsResponse{}, err
+		return PagingGetWithQueryParamsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -922,7 +922,7 @@ func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVe
 func (client *PagingClient) nextFragmentHandleResponse(resp *http.Response) (PagingNextFragmentResponse, error) {
 	result := PagingNextFragmentResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
-		return PagingNextFragmentResponse{}, err
+		return PagingNextFragmentResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -962,7 +962,7 @@ func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Co
 func (client *PagingClient) nextFragmentWithGroupingHandleResponse(resp *http.Response) (PagingNextFragmentWithGroupingResponse, error) {
 	result := PagingNextFragmentWithGroupingResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ODataProductResult); err != nil {
-		return PagingNextFragmentWithGroupingResponse{}, err
+		return PagingNextFragmentWithGroupingResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -997,7 +997,7 @@ func (client *PagingClient) nextOperationWithQueryParamsCreateRequest(ctx contex
 func (client *PagingClient) nextOperationWithQueryParamsHandleResponse(resp *http.Response) (PagingNextOperationWithQueryParamsResponse, error) {
 	result := PagingNextOperationWithQueryParamsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProductResult); err != nil {
-		return PagingNextOperationWithQueryParamsResponse{}, err
+		return PagingNextOperationWithQueryParamsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
@@ -64,7 +64,7 @@ func (client *AutoRestReportServiceClient) getOptionalReportCreateRequest(ctx co
 func (client *AutoRestReportServiceClient) getOptionalReportHandleResponse(resp *http.Response) (AutoRestReportServiceGetOptionalReportResponse, error) {
 	result := AutoRestReportServiceGetOptionalReportResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return AutoRestReportServiceGetOptionalReportResponse{}, err
+		return AutoRestReportServiceGetOptionalReportResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -119,7 +119,7 @@ func (client *AutoRestReportServiceClient) getReportCreateRequest(ctx context.Co
 func (client *AutoRestReportServiceClient) getReportHandleResponse(resp *http.Response) (AutoRestReportServiceGetReportResponse, error) {
 	result := AutoRestReportServiceGetReportResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return AutoRestReportServiceGetReportResponse{}, err
+		return AutoRestReportServiceGetReportResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/stringgroup/zz_generated_enum_client.go
+++ b/test/autorest/stringgroup/zz_generated_enum_client.go
@@ -59,7 +59,7 @@ func (client *EnumClient) getNotExpandableCreateRequest(ctx context.Context, opt
 func (client *EnumClient) getNotExpandableHandleResponse(resp *http.Response) (EnumGetNotExpandableResponse, error) {
 	result := EnumGetNotExpandableResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return EnumGetNotExpandableResponse{}, err
+		return EnumGetNotExpandableResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *EnumClient) getReferencedCreateRequest(ctx context.Context, option
 func (client *EnumClient) getReferencedHandleResponse(resp *http.Response) (EnumGetReferencedResponse, error) {
 	result := EnumGetReferencedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return EnumGetReferencedResponse{}, err
+		return EnumGetReferencedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *EnumClient) getReferencedConstantCreateRequest(ctx context.Context
 func (client *EnumClient) getReferencedConstantHandleResponse(resp *http.Response) (EnumGetReferencedConstantResponse, error) {
 	result := EnumGetReferencedConstantResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RefColorConstant); err != nil {
-		return EnumGetReferencedConstantResponse{}, err
+		return EnumGetReferencedConstantResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/stringgroup/zz_generated_string_client.go
+++ b/test/autorest/stringgroup/zz_generated_string_client.go
@@ -59,7 +59,7 @@ func (client *StringClient) getBase64EncodedCreateRequest(ctx context.Context, o
 func (client *StringClient) getBase64EncodedHandleResponse(resp *http.Response) (StringGetBase64EncodedResponse, error) {
 	result := StringGetBase64EncodedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return StringGetBase64EncodedResponse{}, err
+		return StringGetBase64EncodedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -109,7 +109,7 @@ func (client *StringClient) getBase64URLEncodedCreateRequest(ctx context.Context
 func (client *StringClient) getBase64URLEncodedHandleResponse(resp *http.Response) (StringGetBase64URLEncodedResponse, error) {
 	result := StringGetBase64URLEncodedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64URLFormat); err != nil {
-		return StringGetBase64URLEncodedResponse{}, err
+		return StringGetBase64URLEncodedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -159,7 +159,7 @@ func (client *StringClient) getEmptyCreateRequest(ctx context.Context, options *
 func (client *StringClient) getEmptyHandleResponse(resp *http.Response) (StringGetEmptyResponse, error) {
 	result := StringGetEmptyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return StringGetEmptyResponse{}, err
+		return StringGetEmptyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *StringClient) getMBCSCreateRequest(ctx context.Context, options *S
 func (client *StringClient) getMBCSHandleResponse(resp *http.Response) (StringGetMBCSResponse, error) {
 	result := StringGetMBCSResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return StringGetMBCSResponse{}, err
+		return StringGetMBCSResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -259,7 +259,7 @@ func (client *StringClient) getNotProvidedCreateRequest(ctx context.Context, opt
 func (client *StringClient) getNotProvidedHandleResponse(resp *http.Response) (StringGetNotProvidedResponse, error) {
 	result := StringGetNotProvidedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return StringGetNotProvidedResponse{}, err
+		return StringGetNotProvidedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -309,7 +309,7 @@ func (client *StringClient) getNullCreateRequest(ctx context.Context, options *S
 func (client *StringClient) getNullHandleResponse(resp *http.Response) (StringGetNullResponse, error) {
 	result := StringGetNullResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return StringGetNullResponse{}, err
+		return StringGetNullResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -359,7 +359,7 @@ func (client *StringClient) getNullBase64URLEncodedCreateRequest(ctx context.Con
 func (client *StringClient) getNullBase64URLEncodedHandleResponse(resp *http.Response) (StringGetNullBase64URLEncodedResponse, error) {
 	result := StringGetNullBase64URLEncodedResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64URLFormat); err != nil {
-		return StringGetNullBase64URLEncodedResponse{}, err
+		return StringGetNullBase64URLEncodedResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -409,7 +409,7 @@ func (client *StringClient) getWhitespaceCreateRequest(ctx context.Context, opti
 func (client *StringClient) getWhitespaceHandleResponse(resp *http.Response) (StringGetWhitespaceResponse, error) {
 	result := StringGetWhitespaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return StringGetWhitespaceResponse{}, err
+		return StringGetWhitespaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
@@ -108,7 +108,7 @@ func (client *AutoRestValidationTestClient) postWithConstantInBodyCreateRequest(
 func (client *AutoRestValidationTestClient) postWithConstantInBodyHandleResponse(resp *http.Response) (AutoRestValidationTestPostWithConstantInBodyResponse, error) {
 	result := AutoRestValidationTestPostWithConstantInBodyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
-		return AutoRestValidationTestPostWithConstantInBodyResponse{}, err
+		return AutoRestValidationTestPostWithConstantInBodyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -172,7 +172,7 @@ func (client *AutoRestValidationTestClient) validationOfBodyCreateRequest(ctx co
 func (client *AutoRestValidationTestClient) validationOfBodyHandleResponse(resp *http.Response) (AutoRestValidationTestValidationOfBodyResponse, error) {
 	result := AutoRestValidationTestValidationOfBodyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
-		return AutoRestValidationTestValidationOfBodyResponse{}, err
+		return AutoRestValidationTestValidationOfBodyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -234,7 +234,7 @@ func (client *AutoRestValidationTestClient) validationOfMethodParametersCreateRe
 func (client *AutoRestValidationTestClient) validationOfMethodParametersHandleResponse(resp *http.Response) (AutoRestValidationTestValidationOfMethodParametersResponse, error) {
 	result := AutoRestValidationTestValidationOfMethodParametersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Product); err != nil {
-		return AutoRestValidationTestValidationOfMethodParametersResponse{}, err
+		return AutoRestValidationTestValidationOfMethodParametersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/autorest/xmlgroup/zz_generated_xml_client.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_client.go
@@ -65,7 +65,7 @@ func (client *XMLClient) getACLsCreateRequest(ctx context.Context, options *XMLG
 func (client *XMLClient) getACLsHandleResponse(resp *http.Response) (XMLGetACLsResponse, error) {
 	result := XMLGetACLsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return XMLGetACLsResponse{}, err
+		return XMLGetACLsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -114,7 +114,7 @@ func (client *XMLClient) getBytesCreateRequest(ctx context.Context, options *XML
 func (client *XMLClient) getBytesHandleResponse(resp *http.Response) (XMLGetBytesResponse, error) {
 	result := XMLGetBytesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.ModelWithByteProperty); err != nil {
-		return XMLGetBytesResponse{}, err
+		return XMLGetBytesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -164,7 +164,7 @@ func (client *XMLClient) getComplexTypeRefNoMetaCreateRequest(ctx context.Contex
 func (client *XMLClient) getComplexTypeRefNoMetaHandleResponse(resp *http.Response) (XMLGetComplexTypeRefNoMetaResponse, error) {
 	result := XMLGetComplexTypeRefNoMetaResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.RootWithRefAndNoMeta); err != nil {
-		return XMLGetComplexTypeRefNoMetaResponse{}, err
+		return XMLGetComplexTypeRefNoMetaResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -213,7 +213,7 @@ func (client *XMLClient) getComplexTypeRefWithMetaCreateRequest(ctx context.Cont
 func (client *XMLClient) getComplexTypeRefWithMetaHandleResponse(resp *http.Response) (XMLGetComplexTypeRefWithMetaResponse, error) {
 	result := XMLGetComplexTypeRefWithMetaResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.RootWithRefAndMeta); err != nil {
-		return XMLGetComplexTypeRefWithMetaResponse{}, err
+		return XMLGetComplexTypeRefWithMetaResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -262,7 +262,7 @@ func (client *XMLClient) getEmptyChildElementCreateRequest(ctx context.Context, 
 func (client *XMLClient) getEmptyChildElementHandleResponse(resp *http.Response) (XMLGetEmptyChildElementResponse, error) {
 	result := XMLGetEmptyChildElementResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.Banana); err != nil {
-		return XMLGetEmptyChildElementResponse{}, err
+		return XMLGetEmptyChildElementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -311,7 +311,7 @@ func (client *XMLClient) getEmptyListCreateRequest(ctx context.Context, options 
 func (client *XMLClient) getEmptyListHandleResponse(resp *http.Response) (XMLGetEmptyListResponse, error) {
 	result := XMLGetEmptyListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.Slideshow); err != nil {
-		return XMLGetEmptyListResponse{}, err
+		return XMLGetEmptyListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -360,7 +360,7 @@ func (client *XMLClient) getEmptyRootListCreateRequest(ctx context.Context, opti
 func (client *XMLClient) getEmptyRootListHandleResponse(resp *http.Response) (XMLGetEmptyRootListResponse, error) {
 	result := XMLGetEmptyRootListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return XMLGetEmptyRootListResponse{}, err
+		return XMLGetEmptyRootListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -409,7 +409,7 @@ func (client *XMLClient) getEmptyWrappedListsCreateRequest(ctx context.Context, 
 func (client *XMLClient) getEmptyWrappedListsHandleResponse(resp *http.Response) (XMLGetEmptyWrappedListsResponse, error) {
 	result := XMLGetEmptyWrappedListsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.AppleBarrel); err != nil {
-		return XMLGetEmptyWrappedListsResponse{}, err
+		return XMLGetEmptyWrappedListsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -506,7 +506,7 @@ func (client *XMLClient) getRootListCreateRequest(ctx context.Context, options *
 func (client *XMLClient) getRootListHandleResponse(resp *http.Response) (XMLGetRootListResponse, error) {
 	result := XMLGetRootListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return XMLGetRootListResponse{}, err
+		return XMLGetRootListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -555,7 +555,7 @@ func (client *XMLClient) getRootListSingleItemCreateRequest(ctx context.Context,
 func (client *XMLClient) getRootListSingleItemHandleResponse(resp *http.Response) (XMLGetRootListSingleItemResponse, error) {
 	result := XMLGetRootListSingleItemResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return XMLGetRootListSingleItemResponse{}, err
+		return XMLGetRootListSingleItemResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -608,7 +608,7 @@ func (client *XMLClient) getServicePropertiesCreateRequest(ctx context.Context, 
 func (client *XMLClient) getServicePropertiesHandleResponse(resp *http.Response) (XMLGetServicePropertiesResponse, error) {
 	result := XMLGetServicePropertiesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.StorageServiceProperties); err != nil {
-		return XMLGetServicePropertiesResponse{}, err
+		return XMLGetServicePropertiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -657,7 +657,7 @@ func (client *XMLClient) getSimpleCreateRequest(ctx context.Context, options *XM
 func (client *XMLClient) getSimpleHandleResponse(resp *http.Response) (XMLGetSimpleResponse, error) {
 	result := XMLGetSimpleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.Slideshow); err != nil {
-		return XMLGetSimpleResponse{}, err
+		return XMLGetSimpleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -707,7 +707,7 @@ func (client *XMLClient) getURICreateRequest(ctx context.Context, options *XMLGe
 func (client *XMLClient) getURIHandleResponse(resp *http.Response) (XMLGetURIResponse, error) {
 	result := XMLGetURIResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.ModelWithURLProperty); err != nil {
-		return XMLGetURIResponse{}, err
+		return XMLGetURIResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -757,7 +757,7 @@ func (client *XMLClient) getWrappedListsCreateRequest(ctx context.Context, optio
 func (client *XMLClient) getWrappedListsHandleResponse(resp *http.Response) (XMLGetWrappedListsResponse, error) {
 	result := XMLGetWrappedListsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.AppleBarrel); err != nil {
-		return XMLGetWrappedListsResponse{}, err
+		return XMLGetWrappedListsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -807,7 +807,7 @@ func (client *XMLClient) getXMsTextCreateRequest(ctx context.Context, options *X
 func (client *XMLClient) getXMsTextHandleResponse(resp *http.Response) (XMLGetXMsTextResponse, error) {
 	result := XMLGetXMsTextResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.ObjectWithXMsTextProperty); err != nil {
-		return XMLGetXMsTextResponse{}, err
+		return XMLGetXMsTextResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -895,7 +895,7 @@ func (client *XMLClient) jsonOutputCreateRequest(ctx context.Context, options *X
 func (client *XMLClient) jsonOutputHandleResponse(resp *http.Response) (XMLJSONOutputResponse, error) {
 	result := XMLJSONOutputResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.JSONOutput); err != nil {
-		return XMLJSONOutputResponse{}, err
+		return XMLJSONOutputResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -948,7 +948,7 @@ func (client *XMLClient) listBlobsCreateRequest(ctx context.Context, options *XM
 func (client *XMLClient) listBlobsHandleResponse(resp *http.Response) (XMLListBlobsResponse, error) {
 	result := XMLListBlobsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListBlobsResponse); err != nil {
-		return XMLListBlobsResponse{}, err
+		return XMLListBlobsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1000,7 +1000,7 @@ func (client *XMLClient) listContainersCreateRequest(ctx context.Context, option
 func (client *XMLClient) listContainersHandleResponse(resp *http.Response) (XMLListContainersResponse, error) {
 	result := XMLListContainersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListContainersResponse); err != nil {
-		return XMLListContainersResponse{}, err
+		return XMLListContainersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
@@ -88,7 +88,7 @@ func (client *AvailabilitySetsClient) createOrUpdateCreateRequest(ctx context.Co
 func (client *AvailabilitySetsClient) createOrUpdateHandleResponse(resp *http.Response) (AvailabilitySetsCreateOrUpdateResponse, error) {
 	result := AvailabilitySetsCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
-		return AvailabilitySetsCreateOrUpdateResponse{}, err
+		return AvailabilitySetsCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -206,7 +206,7 @@ func (client *AvailabilitySetsClient) getCreateRequest(ctx context.Context, reso
 func (client *AvailabilitySetsClient) getHandleResponse(resp *http.Response) (AvailabilitySetsGetResponse, error) {
 	result := AvailabilitySetsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
-		return AvailabilitySetsGetResponse{}, err
+		return AvailabilitySetsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -263,7 +263,7 @@ func (client *AvailabilitySetsClient) listCreateRequest(ctx context.Context, res
 func (client *AvailabilitySetsClient) listHandleResponse(resp *http.Response) (AvailabilitySetsListResponse, error) {
 	result := AvailabilitySetsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySetListResult); err != nil {
-		return AvailabilitySetsListResponse{}, err
+		return AvailabilitySetsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -327,7 +327,7 @@ func (client *AvailabilitySetsClient) listAvailableSizesCreateRequest(ctx contex
 func (client *AvailabilitySetsClient) listAvailableSizesHandleResponse(resp *http.Response) (AvailabilitySetsListAvailableSizesResponse, error) {
 	result := AvailabilitySetsListAvailableSizesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
-		return AvailabilitySetsListAvailableSizesResponse{}, err
+		return AvailabilitySetsListAvailableSizesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -383,7 +383,7 @@ func (client *AvailabilitySetsClient) listBySubscriptionCreateRequest(ctx contex
 func (client *AvailabilitySetsClient) listBySubscriptionHandleResponse(resp *http.Response) (AvailabilitySetsListBySubscriptionResponse, error) {
 	result := AvailabilitySetsListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySetListResult); err != nil {
-		return AvailabilitySetsListBySubscriptionResponse{}, err
+		return AvailabilitySetsListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -447,7 +447,7 @@ func (client *AvailabilitySetsClient) updateCreateRequest(ctx context.Context, r
 func (client *AvailabilitySetsClient) updateHandleResponse(resp *http.Response) (AvailabilitySetsUpdateResponse, error) {
 	result := AvailabilitySetsUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailabilitySet); err != nil {
-		return AvailabilitySetsUpdateResponse{}, err
+		return AvailabilitySetsUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -245,7 +245,7 @@ func (client *ContainerServicesClient) getCreateRequest(ctx context.Context, res
 func (client *ContainerServicesClient) getHandleResponse(resp *http.Response) (ContainerServicesGetResponse, error) {
 	result := ContainerServicesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerService); err != nil {
-		return ContainerServicesGetResponse{}, err
+		return ContainerServicesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -300,7 +300,7 @@ func (client *ContainerServicesClient) listCreateRequest(ctx context.Context, op
 func (client *ContainerServicesClient) listHandleResponse(resp *http.Response) (ContainerServicesListResponse, error) {
 	result := ContainerServicesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerServiceListResult); err != nil {
-		return ContainerServicesListResponse{}, err
+		return ContainerServicesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -359,7 +359,7 @@ func (client *ContainerServicesClient) listByResourceGroupCreateRequest(ctx cont
 func (client *ContainerServicesClient) listByResourceGroupHandleResponse(resp *http.Response) (ContainerServicesListByResourceGroupResponse, error) {
 	result := ContainerServicesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerServiceListResult); err != nil {
-		return ContainerServicesListByResourceGroupResponse{}, err
+		return ContainerServicesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
@@ -89,7 +89,7 @@ func (client *DedicatedHostGroupsClient) createOrUpdateCreateRequest(ctx context
 func (client *DedicatedHostGroupsClient) createOrUpdateHandleResponse(resp *http.Response) (DedicatedHostGroupsCreateOrUpdateResponse, error) {
 	result := DedicatedHostGroupsCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
-		return DedicatedHostGroupsCreateOrUpdateResponse{}, err
+		return DedicatedHostGroupsCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -207,7 +207,7 @@ func (client *DedicatedHostGroupsClient) getCreateRequest(ctx context.Context, r
 func (client *DedicatedHostGroupsClient) getHandleResponse(resp *http.Response) (DedicatedHostGroupsGetResponse, error) {
 	result := DedicatedHostGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
-		return DedicatedHostGroupsGetResponse{}, err
+		return DedicatedHostGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -265,7 +265,7 @@ func (client *DedicatedHostGroupsClient) listByResourceGroupCreateRequest(ctx co
 func (client *DedicatedHostGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (DedicatedHostGroupsListByResourceGroupResponse, error) {
 	result := DedicatedHostGroupsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroupListResult); err != nil {
-		return DedicatedHostGroupsListByResourceGroupResponse{}, err
+		return DedicatedHostGroupsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -319,7 +319,7 @@ func (client *DedicatedHostGroupsClient) listBySubscriptionCreateRequest(ctx con
 func (client *DedicatedHostGroupsClient) listBySubscriptionHandleResponse(resp *http.Response) (DedicatedHostGroupsListBySubscriptionResponse, error) {
 	result := DedicatedHostGroupsListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroupListResult); err != nil {
-		return DedicatedHostGroupsListBySubscriptionResponse{}, err
+		return DedicatedHostGroupsListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -383,7 +383,7 @@ func (client *DedicatedHostGroupsClient) updateCreateRequest(ctx context.Context
 func (client *DedicatedHostGroupsClient) updateHandleResponse(resp *http.Response) (DedicatedHostGroupsUpdateResponse, error) {
 	result := DedicatedHostGroupsUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostGroup); err != nil {
-		return DedicatedHostGroupsUpdateResponse{}, err
+		return DedicatedHostGroupsUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -252,7 +252,7 @@ func (client *DedicatedHostsClient) getCreateRequest(ctx context.Context, resour
 func (client *DedicatedHostsClient) getHandleResponse(resp *http.Response) (DedicatedHostsGetResponse, error) {
 	result := DedicatedHostsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHost); err != nil {
-		return DedicatedHostsGetResponse{}, err
+		return DedicatedHostsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -314,7 +314,7 @@ func (client *DedicatedHostsClient) listByHostGroupCreateRequest(ctx context.Con
 func (client *DedicatedHostsClient) listByHostGroupHandleResponse(resp *http.Response) (DedicatedHostsListByHostGroupResponse, error) {
 	result := DedicatedHostsListByHostGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DedicatedHostListResult); err != nil {
-		return DedicatedHostsListByHostGroupResponse{}, err
+		return DedicatedHostsListByHostGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -241,7 +241,7 @@ func (client *DiskEncryptionSetsClient) getCreateRequest(ctx context.Context, re
 func (client *DiskEncryptionSetsClient) getHandleResponse(resp *http.Response) (DiskEncryptionSetsGetResponse, error) {
 	result := DiskEncryptionSetsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSet); err != nil {
-		return DiskEncryptionSetsGetResponse{}, err
+		return DiskEncryptionSetsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *DiskEncryptionSetsClient) listCreateRequest(ctx context.Context, o
 func (client *DiskEncryptionSetsClient) listHandleResponse(resp *http.Response) (DiskEncryptionSetsListResponse, error) {
 	result := DiskEncryptionSetsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSetList); err != nil {
-		return DiskEncryptionSetsListResponse{}, err
+		return DiskEncryptionSetsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *DiskEncryptionSetsClient) listByResourceGroupCreateRequest(ctx con
 func (client *DiskEncryptionSetsClient) listByResourceGroupHandleResponse(resp *http.Response) (DiskEncryptionSetsListByResourceGroupResponse, error) {
 	result := DiskEncryptionSetsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskEncryptionSetList); err != nil {
-		return DiskEncryptionSetsListByResourceGroupResponse{}, err
+		return DiskEncryptionSetsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -237,7 +237,7 @@ func (client *DisksClient) getCreateRequest(ctx context.Context, resourceGroupNa
 func (client *DisksClient) getHandleResponse(resp *http.Response) (DisksGetResponse, error) {
 	result := DisksGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Disk); err != nil {
-		return DisksGetResponse{}, err
+		return DisksGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -365,7 +365,7 @@ func (client *DisksClient) listCreateRequest(ctx context.Context, options *Disks
 func (client *DisksClient) listHandleResponse(resp *http.Response) (DisksListResponse, error) {
 	result := DisksListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskList); err != nil {
-		return DisksListResponse{}, err
+		return DisksListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -422,7 +422,7 @@ func (client *DisksClient) listByResourceGroupCreateRequest(ctx context.Context,
 func (client *DisksClient) listByResourceGroupHandleResponse(resp *http.Response) (DisksListByResourceGroupResponse, error) {
 	result := DisksListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiskList); err != nil {
-		return DisksListByResourceGroupResponse{}, err
+		return DisksListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -241,7 +241,7 @@ func (client *GalleriesClient) getCreateRequest(ctx context.Context, resourceGro
 func (client *GalleriesClient) getHandleResponse(resp *http.Response) (GalleriesGetResponse, error) {
 	result := GalleriesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Gallery); err != nil {
-		return GalleriesGetResponse{}, err
+		return GalleriesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *GalleriesClient) listCreateRequest(ctx context.Context, options *G
 func (client *GalleriesClient) listHandleResponse(resp *http.Response) (GalleriesListResponse, error) {
 	result := GalleriesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryList); err != nil {
-		return GalleriesListResponse{}, err
+		return GalleriesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *GalleriesClient) listByResourceGroupCreateRequest(ctx context.Cont
 func (client *GalleriesClient) listByResourceGroupHandleResponse(resp *http.Response) (GalleriesListByResourceGroupResponse, error) {
 	result := GalleriesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryList); err != nil {
-		return GalleriesListByResourceGroupResponse{}, err
+		return GalleriesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -253,7 +253,7 @@ func (client *GalleryApplicationsClient) getCreateRequest(ctx context.Context, r
 func (client *GalleryApplicationsClient) getHandleResponse(resp *http.Response) (GalleryApplicationsGetResponse, error) {
 	result := GalleryApplicationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplication); err != nil {
-		return GalleryApplicationsGetResponse{}, err
+		return GalleryApplicationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *GalleryApplicationsClient) listByGalleryCreateRequest(ctx context.
 func (client *GalleryApplicationsClient) listByGalleryHandleResponse(resp *http.Response) (GalleryApplicationsListByGalleryResponse, error) {
 	result := GalleryApplicationsListByGalleryResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationList); err != nil {
-		return GalleryApplicationsListByGalleryResponse{}, err
+		return GalleryApplicationsListByGalleryResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -268,7 +268,7 @@ func (client *GalleryApplicationVersionsClient) getCreateRequest(ctx context.Con
 func (client *GalleryApplicationVersionsClient) getHandleResponse(resp *http.Response) (GalleryApplicationVersionsGetResponse, error) {
 	result := GalleryApplicationVersionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationVersion); err != nil {
-		return GalleryApplicationVersionsGetResponse{}, err
+		return GalleryApplicationVersionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -334,7 +334,7 @@ func (client *GalleryApplicationVersionsClient) listByGalleryApplicationCreateRe
 func (client *GalleryApplicationVersionsClient) listByGalleryApplicationHandleResponse(resp *http.Response) (GalleryApplicationVersionsListByGalleryApplicationResponse, error) {
 	result := GalleryApplicationVersionsListByGalleryApplicationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryApplicationVersionList); err != nil {
-		return GalleryApplicationVersionsListByGalleryApplicationResponse{}, err
+		return GalleryApplicationVersionsListByGalleryApplicationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -253,7 +253,7 @@ func (client *GalleryImagesClient) getCreateRequest(ctx context.Context, resourc
 func (client *GalleryImagesClient) getHandleResponse(resp *http.Response) (GalleryImagesGetResponse, error) {
 	result := GalleryImagesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImage); err != nil {
-		return GalleryImagesGetResponse{}, err
+		return GalleryImagesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *GalleryImagesClient) listByGalleryCreateRequest(ctx context.Contex
 func (client *GalleryImagesClient) listByGalleryHandleResponse(resp *http.Response) (GalleryImagesListByGalleryResponse, error) {
 	result := GalleryImagesListByGalleryResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageList); err != nil {
-		return GalleryImagesListByGalleryResponse{}, err
+		return GalleryImagesListByGalleryResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -268,7 +268,7 @@ func (client *GalleryImageVersionsClient) getCreateRequest(ctx context.Context, 
 func (client *GalleryImageVersionsClient) getHandleResponse(resp *http.Response) (GalleryImageVersionsGetResponse, error) {
 	result := GalleryImageVersionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageVersion); err != nil {
-		return GalleryImageVersionsGetResponse{}, err
+		return GalleryImageVersionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -334,7 +334,7 @@ func (client *GalleryImageVersionsClient) listByGalleryImageCreateRequest(ctx co
 func (client *GalleryImageVersionsClient) listByGalleryImageHandleResponse(resp *http.Response) (GalleryImageVersionsListByGalleryImageResponse, error) {
 	result := GalleryImageVersionsListByGalleryImageResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GalleryImageVersionList); err != nil {
-		return GalleryImageVersionsListByGalleryImageResponse{}, err
+		return GalleryImageVersionsListByGalleryImageResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -240,7 +240,7 @@ func (client *ImagesClient) getCreateRequest(ctx context.Context, resourceGroupN
 func (client *ImagesClient) getHandleResponse(resp *http.Response) (ImagesGetResponse, error) {
 	result := ImagesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Image); err != nil {
-		return ImagesGetResponse{}, err
+		return ImagesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -294,7 +294,7 @@ func (client *ImagesClient) listCreateRequest(ctx context.Context, options *Imag
 func (client *ImagesClient) listHandleResponse(resp *http.Response) (ImagesListResponse, error) {
 	result := ImagesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ImageListResult); err != nil {
-		return ImagesListResponse{}, err
+		return ImagesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -351,7 +351,7 @@ func (client *ImagesClient) listByResourceGroupCreateRequest(ctx context.Context
 func (client *ImagesClient) listByResourceGroupHandleResponse(resp *http.Response) (ImagesListByResourceGroupResponse, error) {
 	result := ImagesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ImageListResult); err != nil {
-		return ImagesListByResourceGroupResponse{}, err
+		return ImagesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -73,7 +73,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsListResponse, error) {
 	result := OperationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ComputeOperationListResult); err != nil {
-		return OperationsListResponse{}, err
+		return OperationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
@@ -88,7 +88,7 @@ func (client *ProximityPlacementGroupsClient) createOrUpdateCreateRequest(ctx co
 func (client *ProximityPlacementGroupsClient) createOrUpdateHandleResponse(resp *http.Response) (ProximityPlacementGroupsCreateOrUpdateResponse, error) {
 	result := ProximityPlacementGroupsCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
-		return ProximityPlacementGroupsCreateOrUpdateResponse{}, err
+		return ProximityPlacementGroupsCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -209,7 +209,7 @@ func (client *ProximityPlacementGroupsClient) getCreateRequest(ctx context.Conte
 func (client *ProximityPlacementGroupsClient) getHandleResponse(resp *http.Response) (ProximityPlacementGroupsGetResponse, error) {
 	result := ProximityPlacementGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
-		return ProximityPlacementGroupsGetResponse{}, err
+		return ProximityPlacementGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -266,7 +266,7 @@ func (client *ProximityPlacementGroupsClient) listByResourceGroupCreateRequest(c
 func (client *ProximityPlacementGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (ProximityPlacementGroupsListByResourceGroupResponse, error) {
 	result := ProximityPlacementGroupsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroupListResult); err != nil {
-		return ProximityPlacementGroupsListByResourceGroupResponse{}, err
+		return ProximityPlacementGroupsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -319,7 +319,7 @@ func (client *ProximityPlacementGroupsClient) listBySubscriptionCreateRequest(ct
 func (client *ProximityPlacementGroupsClient) listBySubscriptionHandleResponse(resp *http.Response) (ProximityPlacementGroupsListBySubscriptionResponse, error) {
 	result := ProximityPlacementGroupsListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroupListResult); err != nil {
-		return ProximityPlacementGroupsListBySubscriptionResponse{}, err
+		return ProximityPlacementGroupsListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -383,7 +383,7 @@ func (client *ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Co
 func (client *ProximityPlacementGroupsClient) updateHandleResponse(resp *http.Response) (ProximityPlacementGroupsUpdateResponse, error) {
 	result := ProximityPlacementGroupsUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ProximityPlacementGroup); err != nil {
-		return ProximityPlacementGroupsUpdateResponse{}, err
+		return ProximityPlacementGroupsUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
@@ -80,7 +80,7 @@ func (client *ResourceSKUsClient) listCreateRequest(ctx context.Context, options
 func (client *ResourceSKUsClient) listHandleResponse(resp *http.Response) (ResourceSKUsListResponse, error) {
 	result := ResourceSKUsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceSKUsResult); err != nil {
-		return ResourceSKUsListResponse{}, err
+		return ResourceSKUsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -237,7 +237,7 @@ func (client *SnapshotsClient) getCreateRequest(ctx context.Context, resourceGro
 func (client *SnapshotsClient) getHandleResponse(resp *http.Response) (SnapshotsGetResponse, error) {
 	result := SnapshotsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Snapshot); err != nil {
-		return SnapshotsGetResponse{}, err
+		return SnapshotsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -365,7 +365,7 @@ func (client *SnapshotsClient) listCreateRequest(ctx context.Context, options *S
 func (client *SnapshotsClient) listHandleResponse(resp *http.Response) (SnapshotsListResponse, error) {
 	result := SnapshotsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SnapshotList); err != nil {
-		return SnapshotsListResponse{}, err
+		return SnapshotsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -422,7 +422,7 @@ func (client *SnapshotsClient) listByResourceGroupCreateRequest(ctx context.Cont
 func (client *SnapshotsClient) listByResourceGroupHandleResponse(resp *http.Response) (SnapshotsListByResourceGroupResponse, error) {
 	result := SnapshotsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SnapshotList); err != nil {
-		return SnapshotsListByResourceGroupResponse{}, err
+		return SnapshotsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
@@ -88,7 +88,7 @@ func (client *SSHPublicKeysClient) createCreateRequest(ctx context.Context, reso
 func (client *SSHPublicKeysClient) createHandleResponse(resp *http.Response) (SSHPublicKeysCreateResponse, error) {
 	result := SSHPublicKeysCreateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
-		return SSHPublicKeysCreateResponse{}, err
+		return SSHPublicKeysCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -208,7 +208,7 @@ func (client *SSHPublicKeysClient) generateKeyPairCreateRequest(ctx context.Cont
 func (client *SSHPublicKeysClient) generateKeyPairHandleResponse(resp *http.Response) (SSHPublicKeysGenerateKeyPairResponse, error) {
 	result := SSHPublicKeysGenerateKeyPairResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyGenerateKeyPairResult); err != nil {
-		return SSHPublicKeysGenerateKeyPairResponse{}, err
+		return SSHPublicKeysGenerateKeyPairResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -272,7 +272,7 @@ func (client *SSHPublicKeysClient) getCreateRequest(ctx context.Context, resourc
 func (client *SSHPublicKeysClient) getHandleResponse(resp *http.Response) (SSHPublicKeysGetResponse, error) {
 	result := SSHPublicKeysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
-		return SSHPublicKeysGetResponse{}, err
+		return SSHPublicKeysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -330,7 +330,7 @@ func (client *SSHPublicKeysClient) listByResourceGroupCreateRequest(ctx context.
 func (client *SSHPublicKeysClient) listByResourceGroupHandleResponse(resp *http.Response) (SSHPublicKeysListByResourceGroupResponse, error) {
 	result := SSHPublicKeysListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeysGroupListResult); err != nil {
-		return SSHPublicKeysListByResourceGroupResponse{}, err
+		return SSHPublicKeysListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -384,7 +384,7 @@ func (client *SSHPublicKeysClient) listBySubscriptionCreateRequest(ctx context.C
 func (client *SSHPublicKeysClient) listBySubscriptionHandleResponse(resp *http.Response) (SSHPublicKeysListBySubscriptionResponse, error) {
 	result := SSHPublicKeysListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeysGroupListResult); err != nil {
-		return SSHPublicKeysListBySubscriptionResponse{}, err
+		return SSHPublicKeysListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -448,7 +448,7 @@ func (client *SSHPublicKeysClient) updateCreateRequest(ctx context.Context, reso
 func (client *SSHPublicKeysClient) updateHandleResponse(resp *http.Response) (SSHPublicKeysUpdateResponse, error) {
 	result := SSHPublicKeysUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SSHPublicKeyResource); err != nil {
-		return SSHPublicKeysUpdateResponse{}, err
+		return SSHPublicKeysUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
@@ -81,7 +81,7 @@ func (client *UsageClient) listCreateRequest(ctx context.Context, location strin
 func (client *UsageClient) listHandleResponse(resp *http.Response) (UsageListResponse, error) {
 	result := UsageListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListUsagesResult); err != nil {
-		return UsageListResponse{}, err
+		return UsageListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensionimages_client.go
@@ -97,7 +97,7 @@ func (client *VirtualMachineExtensionImagesClient) getCreateRequest(ctx context.
 func (client *VirtualMachineExtensionImagesClient) getHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesGetResponse, error) {
 	result := VirtualMachineExtensionImagesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImage); err != nil {
-		return VirtualMachineExtensionImagesGetResponse{}, err
+		return VirtualMachineExtensionImagesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -161,7 +161,7 @@ func (client *VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx co
 func (client *VirtualMachineExtensionImagesClient) listTypesHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesListTypesResponse, error) {
 	result := VirtualMachineExtensionImagesListTypesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImageArray); err != nil {
-		return VirtualMachineExtensionImagesListTypesResponse{}, err
+		return VirtualMachineExtensionImagesListTypesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -238,7 +238,7 @@ func (client *VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx
 func (client *VirtualMachineExtensionImagesClient) listVersionsHandleResponse(resp *http.Response) (VirtualMachineExtensionImagesListVersionsResponse, error) {
 	result := VirtualMachineExtensionImagesListVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionImageArray); err != nil {
-		return VirtualMachineExtensionImagesListVersionsResponse{}, err
+		return VirtualMachineExtensionImagesListVersionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineextensions_client.go
@@ -252,7 +252,7 @@ func (client *VirtualMachineExtensionsClient) getCreateRequest(ctx context.Conte
 func (client *VirtualMachineExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineExtensionsGetResponse, error) {
 	result := VirtualMachineExtensionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtension); err != nil {
-		return VirtualMachineExtensionsGetResponse{}, err
+		return VirtualMachineExtensionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -319,7 +319,7 @@ func (client *VirtualMachineExtensionsClient) listCreateRequest(ctx context.Cont
 func (client *VirtualMachineExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineExtensionsListResponse, error) {
 	result := VirtualMachineExtensionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionsListResult); err != nil {
-		return VirtualMachineExtensionsListResponse{}, err
+		return VirtualMachineExtensionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineimages_client.go
@@ -101,7 +101,7 @@ func (client *VirtualMachineImagesClient) getCreateRequest(ctx context.Context, 
 func (client *VirtualMachineImagesClient) getHandleResponse(resp *http.Response) (VirtualMachineImagesGetResponse, error) {
 	result := VirtualMachineImagesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImage); err != nil {
-		return VirtualMachineImagesGetResponse{}, err
+		return VirtualMachineImagesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -182,7 +182,7 @@ func (client *VirtualMachineImagesClient) listCreateRequest(ctx context.Context,
 func (client *VirtualMachineImagesClient) listHandleResponse(resp *http.Response) (VirtualMachineImagesListResponse, error) {
 	result := VirtualMachineImagesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
-		return VirtualMachineImagesListResponse{}, err
+		return VirtualMachineImagesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -246,7 +246,7 @@ func (client *VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Co
 func (client *VirtualMachineImagesClient) listOffersHandleResponse(resp *http.Response) (VirtualMachineImagesListOffersResponse, error) {
 	result := VirtualMachineImagesListOffersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
-		return VirtualMachineImagesListOffersResponse{}, err
+		return VirtualMachineImagesListOffersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -306,7 +306,7 @@ func (client *VirtualMachineImagesClient) listPublishersCreateRequest(ctx contex
 func (client *VirtualMachineImagesClient) listPublishersHandleResponse(resp *http.Response) (VirtualMachineImagesListPublishersResponse, error) {
 	result := VirtualMachineImagesListPublishersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
-		return VirtualMachineImagesListPublishersResponse{}, err
+		return VirtualMachineImagesListPublishersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -374,7 +374,7 @@ func (client *VirtualMachineImagesClient) listSKUsCreateRequest(ctx context.Cont
 func (client *VirtualMachineImagesClient) listSKUsHandleResponse(resp *http.Response) (VirtualMachineImagesListSKUsResponse, error) {
 	result := VirtualMachineImagesListSKUsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineImageResourceArray); err != nil {
-		return VirtualMachineImagesListSKUsResponse{}, err
+		return VirtualMachineImagesListSKUsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
@@ -88,7 +88,7 @@ func (client *VirtualMachineRunCommandsClient) getCreateRequest(ctx context.Cont
 func (client *VirtualMachineRunCommandsClient) getHandleResponse(resp *http.Response) (VirtualMachineRunCommandsGetResponse, error) {
 	result := VirtualMachineRunCommandsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RunCommandDocument); err != nil {
-		return VirtualMachineRunCommandsGetResponse{}, err
+		return VirtualMachineRunCommandsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -145,7 +145,7 @@ func (client *VirtualMachineRunCommandsClient) listCreateRequest(ctx context.Con
 func (client *VirtualMachineRunCommandsClient) listHandleResponse(resp *http.Response) (VirtualMachineRunCommandsListResponse, error) {
 	result := VirtualMachineRunCommandsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RunCommandListResult); err != nil {
-		return VirtualMachineRunCommandsListResponse{}, err
+		return VirtualMachineRunCommandsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -533,7 +533,7 @@ func (client *VirtualMachinesClient) getCreateRequest(ctx context.Context, resou
 func (client *VirtualMachinesClient) getHandleResponse(resp *http.Response) (VirtualMachinesGetResponse, error) {
 	result := VirtualMachinesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachine); err != nil {
-		return VirtualMachinesGetResponse{}, err
+		return VirtualMachinesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -597,7 +597,7 @@ func (client *VirtualMachinesClient) instanceViewCreateRequest(ctx context.Conte
 func (client *VirtualMachinesClient) instanceViewHandleResponse(resp *http.Response) (VirtualMachinesInstanceViewResponse, error) {
 	result := VirtualMachinesInstanceViewResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineInstanceView); err != nil {
-		return VirtualMachinesInstanceViewResponse{}, err
+		return VirtualMachinesInstanceViewResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -654,7 +654,7 @@ func (client *VirtualMachinesClient) listCreateRequest(ctx context.Context, reso
 func (client *VirtualMachinesClient) listHandleResponse(resp *http.Response) (VirtualMachinesListResponse, error) {
 	result := VirtualMachinesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
-		return VirtualMachinesListResponse{}, err
+		return VirtualMachinesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -711,7 +711,7 @@ func (client *VirtualMachinesClient) listAllCreateRequest(ctx context.Context, o
 func (client *VirtualMachinesClient) listAllHandleResponse(resp *http.Response) (VirtualMachinesListAllResponse, error) {
 	result := VirtualMachinesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
-		return VirtualMachinesListAllResponse{}, err
+		return VirtualMachinesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -775,7 +775,7 @@ func (client *VirtualMachinesClient) listAvailableSizesCreateRequest(ctx context
 func (client *VirtualMachinesClient) listAvailableSizesHandleResponse(resp *http.Response) (VirtualMachinesListAvailableSizesResponse, error) {
 	result := VirtualMachinesListAvailableSizesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
-		return VirtualMachinesListAvailableSizesResponse{}, err
+		return VirtualMachinesListAvailableSizesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -832,7 +832,7 @@ func (client *VirtualMachinesClient) listByLocationCreateRequest(ctx context.Con
 func (client *VirtualMachinesClient) listByLocationHandleResponse(resp *http.Response) (VirtualMachinesListByLocationResponse, error) {
 	result := VirtualMachinesListByLocationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineListResult); err != nil {
-		return VirtualMachinesListByLocationResponse{}, err
+		return VirtualMachinesListByLocationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -252,7 +252,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) getCreateRequest(ctx conte
 func (client *VirtualMachineScaleSetExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetExtensionsGetResponse, error) {
 	result := VirtualMachineScaleSetExtensionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetExtension); err != nil {
-		return VirtualMachineScaleSetExtensionsGetResponse{}, err
+		return VirtualMachineScaleSetExtensionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -313,7 +313,7 @@ func (client *VirtualMachineScaleSetExtensionsClient) listCreateRequest(ctx cont
 func (client *VirtualMachineScaleSetExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetExtensionsListResponse, error) {
 	result := VirtualMachineScaleSetExtensionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetExtensionListResult); err != nil {
-		return VirtualMachineScaleSetExtensionsListResponse{}, err
+		return VirtualMachineScaleSetExtensionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetrollingupgrades_client.go
@@ -162,7 +162,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestCreateReques
 func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestHandleResponse(resp *http.Response) (VirtualMachineScaleSetRollingUpgradesGetLatestResponse, error) {
 	result := VirtualMachineScaleSetRollingUpgradesGetLatestResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RollingUpgradeStatusInfo); err != nil {
-		return VirtualMachineScaleSetRollingUpgradesGetLatestResponse{}, err
+		return VirtualMachineScaleSetRollingUpgradesGetLatestResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -449,7 +449,7 @@ func (client *VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformU
 func (client *VirtualMachineScaleSetsClient) forceRecoveryServiceFabricPlatformUpdateDomainWalkHandleResponse(resp *http.Response) (VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse, error) {
 	result := VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RecoveryWalkResponse); err != nil {
-		return VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{}, err
+		return VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -513,7 +513,7 @@ func (client *VirtualMachineScaleSetsClient) getCreateRequest(ctx context.Contex
 func (client *VirtualMachineScaleSetsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetsGetResponse, error) {
 	result := VirtualMachineScaleSetsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSet); err != nil {
-		return VirtualMachineScaleSetsGetResponse{}, err
+		return VirtualMachineScaleSetsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -577,7 +577,7 @@ func (client *VirtualMachineScaleSetsClient) getInstanceViewCreateRequest(ctx co
 func (client *VirtualMachineScaleSetsClient) getInstanceViewHandleResponse(resp *http.Response) (VirtualMachineScaleSetsGetInstanceViewResponse, error) {
 	result := VirtualMachineScaleSetsGetInstanceViewResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetInstanceView); err != nil {
-		return VirtualMachineScaleSetsGetInstanceViewResponse{}, err
+		return VirtualMachineScaleSetsGetInstanceViewResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -638,7 +638,7 @@ func (client *VirtualMachineScaleSetsClient) getOSUpgradeHistoryCreateRequest(ct
 func (client *VirtualMachineScaleSetsClient) getOSUpgradeHistoryHandleResponse(resp *http.Response) (VirtualMachineScaleSetsGetOSUpgradeHistoryResponse, error) {
 	result := VirtualMachineScaleSetsGetOSUpgradeHistoryResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListOSUpgradeHistory); err != nil {
-		return VirtualMachineScaleSetsGetOSUpgradeHistoryResponse{}, err
+		return VirtualMachineScaleSetsGetOSUpgradeHistoryResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -695,7 +695,7 @@ func (client *VirtualMachineScaleSetsClient) listCreateRequest(ctx context.Conte
 func (client *VirtualMachineScaleSetsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetsListResponse, error) {
 	result := VirtualMachineScaleSetsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListResult); err != nil {
-		return VirtualMachineScaleSetsListResponse{}, err
+		return VirtualMachineScaleSetsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -750,7 +750,7 @@ func (client *VirtualMachineScaleSetsClient) listAllCreateRequest(ctx context.Co
 func (client *VirtualMachineScaleSetsClient) listAllHandleResponse(resp *http.Response) (VirtualMachineScaleSetsListAllResponse, error) {
 	result := VirtualMachineScaleSetsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListWithLinkResult); err != nil {
-		return VirtualMachineScaleSetsListAllResponse{}, err
+		return VirtualMachineScaleSetsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -811,7 +811,7 @@ func (client *VirtualMachineScaleSetsClient) listSKUsCreateRequest(ctx context.C
 func (client *VirtualMachineScaleSetsClient) listSKUsHandleResponse(resp *http.Response) (VirtualMachineScaleSetsListSKUsResponse, error) {
 	result := VirtualMachineScaleSetsListSKUsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetListSKUsResult); err != nil {
-		return VirtualMachineScaleSetsListSKUsResponse{}, err
+		return VirtualMachineScaleSetsListSKUsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvmextensions_client.go
@@ -268,7 +268,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) getCreateRequest(ctx con
 func (client *VirtualMachineScaleSetVMExtensionsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMExtensionsGetResponse, error) {
 	result := VirtualMachineScaleSetVMExtensionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtension); err != nil {
-		return VirtualMachineScaleSetVMExtensionsGetResponse{}, err
+		return VirtualMachineScaleSetVMExtensionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -340,7 +340,7 @@ func (client *VirtualMachineScaleSetVMExtensionsClient) listCreateRequest(ctx co
 func (client *VirtualMachineScaleSetVMExtensionsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMExtensionsListResponse, error) {
 	result := VirtualMachineScaleSetVMExtensionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineExtensionsListResult); err != nil {
-		return VirtualMachineScaleSetVMExtensionsListResponse{}, err
+		return VirtualMachineScaleSetVMExtensionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -256,7 +256,7 @@ func (client *VirtualMachineScaleSetVMsClient) getCreateRequest(ctx context.Cont
 func (client *VirtualMachineScaleSetVMsClient) getHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsGetResponse, error) {
 	result := VirtualMachineScaleSetVMsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVM); err != nil {
-		return VirtualMachineScaleSetVMsGetResponse{}, err
+		return VirtualMachineScaleSetVMsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -324,7 +324,7 @@ func (client *VirtualMachineScaleSetVMsClient) getInstanceViewCreateRequest(ctx 
 func (client *VirtualMachineScaleSetVMsClient) getInstanceViewHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsGetInstanceViewResponse, error) {
 	result := VirtualMachineScaleSetVMsGetInstanceViewResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVMInstanceView); err != nil {
-		return VirtualMachineScaleSetVMsGetInstanceViewResponse{}, err
+		return VirtualMachineScaleSetVMsGetInstanceViewResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -394,7 +394,7 @@ func (client *VirtualMachineScaleSetVMsClient) listCreateRequest(ctx context.Con
 func (client *VirtualMachineScaleSetVMsClient) listHandleResponse(resp *http.Response) (VirtualMachineScaleSetVMsListResponse, error) {
 	result := VirtualMachineScaleSetVMsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineScaleSetVMListResult); err != nil {
-		return VirtualMachineScaleSetVMsListResponse{}, err
+		return VirtualMachineScaleSetVMsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
@@ -84,7 +84,7 @@ func (client *VirtualMachineSizesClient) listCreateRequest(ctx context.Context, 
 func (client *VirtualMachineSizesClient) listHandleResponse(resp *http.Response) (VirtualMachineSizesListResponse, error) {
 	result := VirtualMachineSizesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualMachineSizeListResult); err != nil {
-		return VirtualMachineSizesListResponse{}, err
+		return VirtualMachineSizesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_aggregatedcost_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_aggregatedcost_client.go
@@ -83,7 +83,7 @@ func (client *AggregatedCostClient) getByManagementGroupCreateRequest(ctx contex
 func (client *AggregatedCostClient) getByManagementGroupHandleResponse(resp *http.Response) (AggregatedCostGetByManagementGroupResponse, error) {
 	result := AggregatedCostGetByManagementGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ManagementGroupAggregatedCostResult); err != nil {
-		return AggregatedCostGetByManagementGroupResponse{}, err
+		return AggregatedCostGetByManagementGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *AggregatedCostClient) getForBillingPeriodByManagementGroupCreateRe
 func (client *AggregatedCostClient) getForBillingPeriodByManagementGroupHandleResponse(resp *http.Response) (AggregatedCostGetForBillingPeriodByManagementGroupResponse, error) {
 	result := AggregatedCostGetForBillingPeriodByManagementGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ManagementGroupAggregatedCostResult); err != nil {
-		return AggregatedCostGetForBillingPeriodByManagementGroupResponse{}, err
+		return AggregatedCostGetForBillingPeriodByManagementGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_balances_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_balances_client.go
@@ -80,7 +80,7 @@ func (client *BalancesClient) getByBillingAccountCreateRequest(ctx context.Conte
 func (client *BalancesClient) getByBillingAccountHandleResponse(resp *http.Response) (BalancesGetByBillingAccountResponse, error) {
 	result := BalancesGetByBillingAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Balance); err != nil {
-		return BalancesGetByBillingAccountResponse{}, err
+		return BalancesGetByBillingAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -142,7 +142,7 @@ func (client *BalancesClient) getForBillingPeriodByBillingAccountCreateRequest(c
 func (client *BalancesClient) getForBillingPeriodByBillingAccountHandleResponse(resp *http.Response) (BalancesGetForBillingPeriodByBillingAccountResponse, error) {
 	result := BalancesGetForBillingPeriodByBillingAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Balance); err != nil {
-		return BalancesGetForBillingPeriodByBillingAccountResponse{}, err
+		return BalancesGetForBillingPeriodByBillingAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
@@ -83,7 +83,7 @@ func (client *BudgetsClient) createOrUpdateCreateRequest(ctx context.Context, sc
 func (client *BudgetsClient) createOrUpdateHandleResponse(resp *http.Response) (BudgetsCreateOrUpdateResponse, error) {
 	result := BudgetsCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Budget); err != nil {
-		return BudgetsCreateOrUpdateResponse{}, err
+		return BudgetsCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -190,7 +190,7 @@ func (client *BudgetsClient) getCreateRequest(ctx context.Context, scope string,
 func (client *BudgetsClient) getHandleResponse(resp *http.Response) (BudgetsGetResponse, error) {
 	result := BudgetsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Budget); err != nil {
-		return BudgetsGetResponse{}, err
+		return BudgetsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -241,7 +241,7 @@ func (client *BudgetsClient) listCreateRequest(ctx context.Context, scope string
 func (client *BudgetsClient) listHandleResponse(resp *http.Response) (BudgetsListResponse, error) {
 	result := BudgetsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BudgetsListResult); err != nil {
-		return BudgetsListResponse{}, err
+		return BudgetsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_charges_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_charges_client.go
@@ -87,7 +87,7 @@ func (client *ChargesClient) listCreateRequest(ctx context.Context, scope string
 func (client *ChargesClient) listHandleResponse(resp *http.Response) (ChargesListResponse, error) {
 	result := ChargesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ChargesListResult); err != nil {
-		return ChargesListResponse{}, err
+		return ChargesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_credits_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_credits_client.go
@@ -75,7 +75,7 @@ func (client *CreditsClient) getCreateRequest(ctx context.Context, scope string,
 func (client *CreditsClient) getHandleResponse(resp *http.Response) (CreditsGetResponse, error) {
 	result := CreditsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CreditSummary); err != nil {
-		return CreditsGetResponse{}, err
+		return CreditsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
@@ -74,7 +74,7 @@ func (client *EventsClient) listCreateRequest(ctx context.Context, startDate str
 func (client *EventsClient) listHandleResponse(resp *http.Response) (EventsListResponse, error) {
 	result := EventsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Events); err != nil {
-		return EventsListResponse{}, err
+		return EventsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
@@ -86,7 +86,7 @@ func (client *ForecastsClient) listCreateRequest(ctx context.Context, options *F
 func (client *ForecastsClient) listHandleResponse(resp *http.Response) (ForecastsListResponse, error) {
 	result := ForecastsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ForecastsListResult); err != nil {
-		return ForecastsListResponse{}, err
+		return ForecastsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
@@ -72,7 +72,7 @@ func (client *LotsClient) listCreateRequest(ctx context.Context, scope string, o
 func (client *LotsClient) listHandleResponse(resp *http.Response) (LotsListResponse, error) {
 	result := LotsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Lots); err != nil {
-		return LotsListResponse{}, err
+		return LotsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
@@ -82,7 +82,7 @@ func (client *MarketplacesClient) listCreateRequest(ctx context.Context, scope s
 func (client *MarketplacesClient) listHandleResponse(resp *http.Response) (MarketplacesListResponse, error) {
 	result := MarketplacesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MarketplacesListResult); err != nil {
-		return MarketplacesListResponse{}, err
+		return MarketplacesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
@@ -70,7 +70,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsListResponse, error) {
 	result := OperationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
-		return OperationsListResponse{}, err
+		return OperationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_pricesheet_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_pricesheet_client.go
@@ -91,7 +91,7 @@ func (client *PriceSheetClient) getCreateRequest(ctx context.Context, options *P
 func (client *PriceSheetClient) getHandleResponse(resp *http.Response) (PriceSheetGetResponse, error) {
 	result := PriceSheetGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PriceSheetResult); err != nil {
-		return PriceSheetGetResponse{}, err
+		return PriceSheetGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -162,7 +162,7 @@ func (client *PriceSheetClient) getByBillingPeriodCreateRequest(ctx context.Cont
 func (client *PriceSheetClient) getByBillingPeriodHandleResponse(resp *http.Response) (PriceSheetGetByBillingPeriodResponse, error) {
 	result := PriceSheetGetByBillingPeriodResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PriceSheetResult); err != nil {
-		return PriceSheetGetByBillingPeriodResponse{}, err
+		return PriceSheetGetByBillingPeriodResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendationdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendationdetails_client.go
@@ -80,7 +80,7 @@ func (client *ReservationRecommendationDetailsClient) getCreateRequest(ctx conte
 func (client *ReservationRecommendationDetailsClient) getHandleResponse(resp *http.Response) (ReservationRecommendationDetailsGetResponse, error) {
 	result := ReservationRecommendationDetailsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationRecommendationDetailsModel); err != nil {
-		return ReservationRecommendationDetailsGetResponse{}, err
+		return ReservationRecommendationDetailsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
@@ -75,7 +75,7 @@ func (client *ReservationRecommendationsClient) listCreateRequest(ctx context.Co
 func (client *ReservationRecommendationsClient) listHandleResponse(resp *http.Response) (ReservationRecommendationsListResponse, error) {
 	result := ReservationRecommendationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationRecommendationsListResult); err != nil {
-		return ReservationRecommendationsListResponse{}, err
+		return ReservationRecommendationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
@@ -89,7 +89,7 @@ func (client *ReservationsDetailsClient) listCreateRequest(ctx context.Context, 
 func (client *ReservationsDetailsClient) listHandleResponse(resp *http.Response) (ReservationsDetailsListResponse, error) {
 	result := ReservationsDetailsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
-		return ReservationsDetailsListResponse{}, err
+		return ReservationsDetailsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderCreateRequest(ctx
 func (client *ReservationsDetailsClient) listByReservationOrderHandleResponse(resp *http.Response) (ReservationsDetailsListByReservationOrderResponse, error) {
 	result := ReservationsDetailsListByReservationOrderResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
-		return ReservationsDetailsListByReservationOrderResponse{}, err
+		return ReservationsDetailsListByReservationOrderResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -203,7 +203,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderAndReservationCre
 func (client *ReservationsDetailsClient) listByReservationOrderAndReservationHandleResponse(resp *http.Response) (ReservationsDetailsListByReservationOrderAndReservationResponse, error) {
 	result := ReservationsDetailsListByReservationOrderAndReservationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationDetailsListResult); err != nil {
-		return ReservationsDetailsListByReservationOrderAndReservationResponse{}, err
+		return ReservationsDetailsListByReservationOrderAndReservationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
@@ -90,7 +90,7 @@ func (client *ReservationsSummariesClient) listCreateRequest(ctx context.Context
 func (client *ReservationsSummariesClient) listHandleResponse(resp *http.Response) (ReservationsSummariesListResponse, error) {
 	result := ReservationsSummariesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
-		return ReservationsSummariesListResponse{}, err
+		return ReservationsSummariesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -148,7 +148,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderCreateRequest(c
 func (client *ReservationsSummariesClient) listByReservationOrderHandleResponse(resp *http.Response) (ReservationsSummariesListByReservationOrderResponse, error) {
 	result := ReservationsSummariesListByReservationOrderResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
-		return ReservationsSummariesListByReservationOrderResponse{}, err
+		return ReservationsSummariesListByReservationOrderResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -210,7 +210,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderAndReservationC
 func (client *ReservationsSummariesClient) listByReservationOrderAndReservationHandleResponse(resp *http.Response) (ReservationsSummariesListByReservationOrderAndReservationResponse, error) {
 	result := ReservationsSummariesListByReservationOrderAndReservationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationSummariesListResult); err != nil {
-		return ReservationsSummariesListByReservationOrderAndReservationResponse{}, err
+		return ReservationsSummariesListByReservationOrderAndReservationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
@@ -80,7 +80,7 @@ func (client *ReservationTransactionsClient) listCreateRequest(ctx context.Conte
 func (client *ReservationTransactionsClient) listHandleResponse(resp *http.Response) (ReservationTransactionsListResponse, error) {
 	result := ReservationTransactionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ReservationTransactionsListResult); err != nil {
-		return ReservationTransactionsListResponse{}, err
+		return ReservationTransactionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -141,7 +141,7 @@ func (client *ReservationTransactionsClient) listByBillingProfileCreateRequest(c
 func (client *ReservationTransactionsClient) listByBillingProfileHandleResponse(resp *http.Response) (ReservationTransactionsListByBillingProfileResponse, error) {
 	result := ReservationTransactionsListByBillingProfileResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ModernReservationTransactionsListResult); err != nil {
-		return ReservationTransactionsListByBillingProfileResponse{}, err
+		return ReservationTransactionsListByBillingProfileResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_tags_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_tags_client.go
@@ -75,7 +75,7 @@ func (client *TagsClient) getCreateRequest(ctx context.Context, scope string, op
 func (client *TagsClient) getHandleResponse(resp *http.Response) (TagsGetResponse, error) {
 	result := TagsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TagsResult); err != nil {
-		return TagsGetResponse{}, err
+		return TagsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
@@ -90,7 +90,7 @@ func (client *UsageDetailsClient) listCreateRequest(ctx context.Context, scope s
 func (client *UsageDetailsClient) listHandleResponse(resp *http.Response) (UsageDetailsListResponse, error) {
 	result := UsageDetailsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UsageDetailsListResult); err != nil {
-		return UsageDetailsListResponse{}, err
+		return UsageDetailsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
@@ -255,7 +255,7 @@ func (client *AddonsClient) getCreateRequest(ctx context.Context, deviceName str
 func (client *AddonsClient) getHandleResponse(resp *http.Response) (AddonsGetResponse, error) {
 	result := AddonsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return AddonsGetResponse{}, err
+		return AddonsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -321,7 +321,7 @@ func (client *AddonsClient) listByRoleCreateRequest(ctx context.Context, deviceN
 func (client *AddonsClient) listByRoleHandleResponse(resp *http.Response) (AddonsListByRoleResponse, error) {
 	result := AddonsListByRoleResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AddonList); err != nil {
-		return AddonsListByRoleResponse{}, err
+		return AddonsListByRoleResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
@@ -82,7 +82,7 @@ func (client *AlertsClient) getCreateRequest(ctx context.Context, deviceName str
 func (client *AlertsClient) getHandleResponse(resp *http.Response) (AlertsGetResponse, error) {
 	result := AlertsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Alert); err != nil {
-		return AlertsGetResponse{}, err
+		return AlertsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *AlertsClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 func (client *AlertsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (AlertsListByDataBoxEdgeDeviceResponse, error) {
 	result := AlertsListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AlertList); err != nil {
-		return AlertsListByDataBoxEdgeDeviceResponse{}, err
+		return AlertsListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
@@ -67,7 +67,7 @@ func (client *AvailableSKUsClient) listCreateRequest(ctx context.Context, option
 func (client *AvailableSKUsClient) listHandleResponse(resp *http.Response) (AvailableSKUsListResponse, error) {
 	result := AvailableSKUsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeSKUList); err != nil {
-		return AvailableSKUsListResponse{}, err
+		return AvailableSKUsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
@@ -243,7 +243,7 @@ func (client *BandwidthSchedulesClient) getCreateRequest(ctx context.Context, de
 func (client *BandwidthSchedulesClient) getHandleResponse(resp *http.Response) (BandwidthSchedulesGetResponse, error) {
 	result := BandwidthSchedulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BandwidthSchedule); err != nil {
-		return BandwidthSchedulesGetResponse{}, err
+		return BandwidthSchedulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -305,7 +305,7 @@ func (client *BandwidthSchedulesClient) listByDataBoxEdgeDeviceCreateRequest(ctx
 func (client *BandwidthSchedulesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (BandwidthSchedulesListByDataBoxEdgeDeviceResponse, error) {
 	result := BandwidthSchedulesListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BandwidthSchedulesList); err != nil {
-		return BandwidthSchedulesListByDataBoxEdgeDeviceResponse{}, err
+		return BandwidthSchedulesListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
@@ -255,7 +255,7 @@ func (client *ContainersClient) getCreateRequest(ctx context.Context, deviceName
 func (client *ContainersClient) getHandleResponse(resp *http.Response) (ContainersGetResponse, error) {
 	result := ContainersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Container); err != nil {
-		return ContainersGetResponse{}, err
+		return ContainersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -321,7 +321,7 @@ func (client *ContainersClient) listByStorageAccountCreateRequest(ctx context.Co
 func (client *ContainersClient) listByStorageAccountHandleResponse(resp *http.Response) (ContainersListByStorageAccountResponse, error) {
 	result := ContainersListByStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerList); err != nil {
-		return ContainersListByStorageAccountResponse{}, err
+		return ContainersListByStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
@@ -79,7 +79,7 @@ func (client *DevicesClient) createOrUpdateCreateRequest(ctx context.Context, de
 func (client *DevicesClient) createOrUpdateHandleResponse(resp *http.Response) (DevicesCreateOrUpdateResponse, error) {
 	result := DevicesCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDevice); err != nil {
-		return DevicesCreateOrUpdateResponse{}, err
+		return DevicesCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -372,7 +372,7 @@ func (client *DevicesClient) generateCertificateCreateRequest(ctx context.Contex
 func (client *DevicesClient) generateCertificateHandleResponse(resp *http.Response) (DevicesGenerateCertificateResponse, error) {
 	result := DevicesGenerateCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GenerateCertResponse); err != nil {
-		return DevicesGenerateCertificateResponse{}, err
+		return DevicesGenerateCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -437,7 +437,7 @@ func (client *DevicesClient) getCreateRequest(ctx context.Context, deviceName st
 func (client *DevicesClient) getHandleResponse(resp *http.Response) (DevicesGetResponse, error) {
 	result := DevicesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDevice); err != nil {
-		return DevicesGetResponse{}, err
+		return DevicesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -502,7 +502,7 @@ func (client *DevicesClient) getExtendedInformationCreateRequest(ctx context.Con
 func (client *DevicesClient) getExtendedInformationHandleResponse(resp *http.Response) (DevicesGetExtendedInformationResponse, error) {
 	result := DevicesGetExtendedInformationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDeviceExtendedInfo); err != nil {
-		return DevicesGetExtendedInformationResponse{}, err
+		return DevicesGetExtendedInformationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -567,7 +567,7 @@ func (client *DevicesClient) getNetworkSettingsCreateRequest(ctx context.Context
 func (client *DevicesClient) getNetworkSettingsHandleResponse(resp *http.Response) (DevicesGetNetworkSettingsResponse, error) {
 	result := DevicesGetNetworkSettingsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSettings); err != nil {
-		return DevicesGetNetworkSettingsResponse{}, err
+		return DevicesGetNetworkSettingsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -633,7 +633,7 @@ func (client *DevicesClient) getUpdateSummaryCreateRequest(ctx context.Context, 
 func (client *DevicesClient) getUpdateSummaryHandleResponse(resp *http.Response) (DevicesGetUpdateSummaryResponse, error) {
 	result := DevicesGetUpdateSummaryResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UpdateSummary); err != nil {
-		return DevicesGetUpdateSummaryResponse{}, err
+		return DevicesGetUpdateSummaryResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -770,7 +770,7 @@ func (client *DevicesClient) listByResourceGroupCreateRequest(ctx context.Contex
 func (client *DevicesClient) listByResourceGroupHandleResponse(resp *http.Response) (DevicesListByResourceGroupResponse, error) {
 	result := DevicesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDeviceList); err != nil {
-		return DevicesListByResourceGroupResponse{}, err
+		return DevicesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -827,7 +827,7 @@ func (client *DevicesClient) listBySubscriptionCreateRequest(ctx context.Context
 func (client *DevicesClient) listBySubscriptionHandleResponse(resp *http.Response) (DevicesListBySubscriptionResponse, error) {
 	result := DevicesListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDeviceList); err != nil {
-		return DevicesListBySubscriptionResponse{}, err
+		return DevicesListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -968,7 +968,7 @@ func (client *DevicesClient) updateCreateRequest(ctx context.Context, deviceName
 func (client *DevicesClient) updateHandleResponse(resp *http.Response) (DevicesUpdateResponse, error) {
 	result := DevicesUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDevice); err != nil {
-		return DevicesUpdateResponse{}, err
+		return DevicesUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1033,7 +1033,7 @@ func (client *DevicesClient) updateExtendedInformationCreateRequest(ctx context.
 func (client *DevicesClient) updateExtendedInformationHandleResponse(resp *http.Response) (DevicesUpdateExtendedInformationResponse, error) {
 	result := DevicesUpdateExtendedInformationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataBoxEdgeDeviceExtendedInfo); err != nil {
-		return DevicesUpdateExtendedInformationResponse{}, err
+		return DevicesUpdateExtendedInformationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1098,7 +1098,7 @@ func (client *DevicesClient) uploadCertificateCreateRequest(ctx context.Context,
 func (client *DevicesClient) uploadCertificateHandleResponse(resp *http.Response) (DevicesUploadCertificateResponse, error) {
 	result := DevicesUploadCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UploadCertificateResponse); err != nil {
-		return DevicesUploadCertificateResponse{}, err
+		return DevicesUploadCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_diagnosticsettings_client.go
@@ -79,7 +79,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSetti
 func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSettingsHandleResponse(resp *http.Response) (DiagnosticSettingsGetDiagnosticProactiveLogCollectionSettingsResponse, error) {
 	result := DiagnosticSettingsGetDiagnosticProactiveLogCollectionSettingsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiagnosticProactiveLogCollectionSettings); err != nil {
-		return DiagnosticSettingsGetDiagnosticProactiveLogCollectionSettingsResponse{}, err
+		return DiagnosticSettingsGetDiagnosticProactiveLogCollectionSettingsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsCreate
 func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsHandleResponse(resp *http.Response) (DiagnosticSettingsGetDiagnosticRemoteSupportSettingsResponse, error) {
 	result := DiagnosticSettingsGetDiagnosticRemoteSupportSettingsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DiagnosticRemoteSupportSettings); err != nil {
-		return DiagnosticSettingsGetDiagnosticRemoteSupportSettingsResponse{}, err
+		return DiagnosticSettingsGetDiagnosticRemoteSupportSettingsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_jobs_client.go
@@ -82,7 +82,7 @@ func (client *JobsClient) getCreateRequest(ctx context.Context, deviceName strin
 func (client *JobsClient) getHandleResponse(resp *http.Response) (JobsGetResponse, error) {
 	result := JobsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Job); err != nil {
-		return JobsGetResponse{}, err
+		return JobsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
@@ -243,7 +243,7 @@ func (client *MonitoringConfigClient) getCreateRequest(ctx context.Context, devi
 func (client *MonitoringConfigClient) getHandleResponse(resp *http.Response) (MonitoringConfigGetResponse, error) {
 	result := MonitoringConfigGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MonitoringMetricConfiguration); err != nil {
-		return MonitoringConfigGetResponse{}, err
+		return MonitoringConfigGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -309,7 +309,7 @@ func (client *MonitoringConfigClient) listCreateRequest(ctx context.Context, dev
 func (client *MonitoringConfigClient) listHandleResponse(resp *http.Response) (MonitoringConfigListResponse, error) {
 	result := MonitoringConfigListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.MonitoringMetricConfigurationList); err != nil {
-		return MonitoringConfigListResponse{}, err
+		return MonitoringConfigListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
@@ -75,7 +75,7 @@ func (client *NodesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 func (client *NodesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (NodesListByDataBoxEdgeDeviceResponse, error) {
 	result := NodesListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NodeList); err != nil {
-		return NodesListByDataBoxEdgeDeviceResponse{}, err
+		return NodesListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
@@ -59,7 +59,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsListResponse, error) {
 	result := OperationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationsList); err != nil {
-		return OperationsListResponse{}, err
+		return OperationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operationsstatus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operationsstatus_client.go
@@ -82,7 +82,7 @@ func (client *OperationsStatusClient) getCreateRequest(ctx context.Context, devi
 func (client *OperationsStatusClient) getHandleResponse(resp *http.Response) (OperationsStatusGetResponse, error) {
 	result := OperationsStatusGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Job); err != nil {
-		return OperationsStatusGetResponse{}, err
+		return OperationsStatusGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
@@ -231,7 +231,7 @@ func (client *OrdersClient) getCreateRequest(ctx context.Context, deviceName str
 func (client *OrdersClient) getHandleResponse(resp *http.Response) (OrdersGetResponse, error) {
 	result := OrdersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Order); err != nil {
-		return OrdersGetResponse{}, err
+		return OrdersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -293,7 +293,7 @@ func (client *OrdersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 func (client *OrdersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (OrdersListByDataBoxEdgeDeviceResponse, error) {
 	result := OrdersListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OrderList); err != nil {
-		return OrdersListByDataBoxEdgeDeviceResponse{}, err
+		return OrdersListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -358,7 +358,7 @@ func (client *OrdersClient) listDCAccessCodeCreateRequest(ctx context.Context, d
 func (client *OrdersClient) listDCAccessCodeHandleResponse(resp *http.Response) (OrdersListDCAccessCodeResponse, error) {
 	result := OrdersListDCAccessCodeResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DCAccessCode); err != nil {
-		return OrdersListDCAccessCodeResponse{}, err
+		return OrdersListDCAccessCodeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
@@ -243,7 +243,7 @@ func (client *RolesClient) getCreateRequest(ctx context.Context, deviceName stri
 func (client *RolesClient) getHandleResponse(resp *http.Response) (RolesGetResponse, error) {
 	result := RolesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return RolesGetResponse{}, err
+		return RolesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -305,7 +305,7 @@ func (client *RolesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 func (client *RolesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (RolesListByDataBoxEdgeDeviceResponse, error) {
 	result := RolesListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleList); err != nil {
-		return RolesListByDataBoxEdgeDeviceResponse{}, err
+		return RolesListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
@@ -243,7 +243,7 @@ func (client *SharesClient) getCreateRequest(ctx context.Context, deviceName str
 func (client *SharesClient) getHandleResponse(resp *http.Response) (SharesGetResponse, error) {
 	result := SharesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Share); err != nil {
-		return SharesGetResponse{}, err
+		return SharesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -305,7 +305,7 @@ func (client *SharesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Con
 func (client *SharesClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (SharesListByDataBoxEdgeDeviceResponse, error) {
 	result := SharesListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ShareList); err != nil {
-		return SharesListByDataBoxEdgeDeviceResponse{}, err
+		return SharesListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
@@ -243,7 +243,7 @@ func (client *StorageAccountCredentialsClient) getCreateRequest(ctx context.Cont
 func (client *StorageAccountCredentialsClient) getHandleResponse(resp *http.Response) (StorageAccountCredentialsGetResponse, error) {
 	result := StorageAccountCredentialsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountCredential); err != nil {
-		return StorageAccountCredentialsGetResponse{}, err
+		return StorageAccountCredentialsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -305,7 +305,7 @@ func (client *StorageAccountCredentialsClient) listByDataBoxEdgeDeviceCreateRequ
 func (client *StorageAccountCredentialsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (StorageAccountCredentialsListByDataBoxEdgeDeviceResponse, error) {
 	result := StorageAccountCredentialsListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountCredentialList); err != nil {
-		return StorageAccountCredentialsListByDataBoxEdgeDeviceResponse{}, err
+		return StorageAccountCredentialsListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
@@ -243,7 +243,7 @@ func (client *StorageAccountsClient) getCreateRequest(ctx context.Context, devic
 func (client *StorageAccountsClient) getHandleResponse(resp *http.Response) (StorageAccountsGetResponse, error) {
 	result := StorageAccountsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccount); err != nil {
-		return StorageAccountsGetResponse{}, err
+		return StorageAccountsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -305,7 +305,7 @@ func (client *StorageAccountsClient) listByDataBoxEdgeDeviceCreateRequest(ctx co
 func (client *StorageAccountsClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (StorageAccountsListByDataBoxEdgeDeviceResponse, error) {
 	result := StorageAccountsListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageAccountList); err != nil {
-		return StorageAccountsListByDataBoxEdgeDeviceResponse{}, err
+		return StorageAccountsListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
@@ -243,7 +243,7 @@ func (client *TriggersClient) getCreateRequest(ctx context.Context, deviceName s
 func (client *TriggersClient) getHandleResponse(resp *http.Response) (TriggersGetResponse, error) {
 	result := TriggersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
-		return TriggersGetResponse{}, err
+		return TriggersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -308,7 +308,7 @@ func (client *TriggersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.C
 func (client *TriggersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (TriggersListByDataBoxEdgeDeviceResponse, error) {
 	result := TriggersListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerList); err != nil {
-		return TriggersListByDataBoxEdgeDeviceResponse{}, err
+		return TriggersListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
@@ -243,7 +243,7 @@ func (client *UsersClient) getCreateRequest(ctx context.Context, deviceName stri
 func (client *UsersClient) getHandleResponse(resp *http.Response) (UsersGetResponse, error) {
 	result := UsersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.User); err != nil {
-		return UsersGetResponse{}, err
+		return UsersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -308,7 +308,7 @@ func (client *UsersClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 func (client *UsersClient) listByDataBoxEdgeDeviceHandleResponse(resp *http.Response) (UsersListByDataBoxEdgeDeviceResponse, error) {
 	result := UsersListByDataBoxEdgeDeviceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UserList); err != nil {
-		return UsersListByDataBoxEdgeDeviceResponse{}, err
+		return UsersListByDataBoxEdgeDeviceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_hsmsecuritydomain_client.go
@@ -128,7 +128,7 @@ func (client *HSMSecurityDomainClient) downloadPendingCreateRequest(ctx context.
 func (client *HSMSecurityDomainClient) downloadPendingHandleResponse(resp *http.Response) (HSMSecurityDomainDownloadPendingResponse, error) {
 	result := HSMSecurityDomainDownloadPendingResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityDomainOperationStatus); err != nil {
-		return HSMSecurityDomainDownloadPendingResponse{}, err
+		return HSMSecurityDomainDownloadPendingResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -183,7 +183,7 @@ func (client *HSMSecurityDomainClient) transferKeyCreateRequest(ctx context.Cont
 func (client *HSMSecurityDomainClient) transferKeyHandleResponse(resp *http.Response) (HSMSecurityDomainTransferKeyResponse, error) {
 	result := HSMSecurityDomainTransferKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TransferKey); err != nil {
-		return HSMSecurityDomainTransferKeyResponse{}, err
+		return HSMSecurityDomainTransferKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *HSMSecurityDomainClient) uploadPendingCreateRequest(ctx context.Co
 func (client *HSMSecurityDomainClient) uploadPendingHandleResponse(resp *http.Response) (HSMSecurityDomainUploadPendingResponse, error) {
 	result := HSMSecurityDomainUploadPendingResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityDomainOperationStatus); err != nil {
-		return HSMSecurityDomainUploadPendingResponse{}, err
+		return HSMSecurityDomainUploadPendingResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_keyvaultclient_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_keyvaultclient_client.go
@@ -73,7 +73,7 @@ func (client *KeyVaultClient) backupCertificateCreateRequest(ctx context.Context
 func (client *KeyVaultClient) backupCertificateHandleResponse(resp *http.Response) (KeyVaultClientBackupCertificateResponse, error) {
 	result := KeyVaultClientBackupCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupCertificateResult); err != nil {
-		return KeyVaultClientBackupCertificateResponse{}, err
+		return KeyVaultClientBackupCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -141,7 +141,7 @@ func (client *KeyVaultClient) backupKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) backupKeyHandleResponse(resp *http.Response) (KeyVaultClientBackupKeyResponse, error) {
 	result := KeyVaultClientBackupKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupKeyResult); err != nil {
-		return KeyVaultClientBackupKeyResponse{}, err
+		return KeyVaultClientBackupKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -201,7 +201,7 @@ func (client *KeyVaultClient) backupSecretCreateRequest(ctx context.Context, vau
 func (client *KeyVaultClient) backupSecretHandleResponse(resp *http.Response) (KeyVaultClientBackupSecretResponse, error) {
 	result := KeyVaultClientBackupSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupSecretResult); err != nil {
-		return KeyVaultClientBackupSecretResponse{}, err
+		return KeyVaultClientBackupSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -261,7 +261,7 @@ func (client *KeyVaultClient) backupStorageAccountCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) backupStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientBackupStorageAccountResponse, error) {
 	result := KeyVaultClientBackupStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackupStorageResult); err != nil {
-		return KeyVaultClientBackupStorageAccountResponse{}, err
+		return KeyVaultClientBackupStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -320,7 +320,7 @@ func (client *KeyVaultClient) createCertificateCreateRequest(ctx context.Context
 func (client *KeyVaultClient) createCertificateHandleResponse(resp *http.Response) (KeyVaultClientCreateCertificateResponse, error) {
 	result := KeyVaultClientCreateCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
-		return KeyVaultClientCreateCertificateResponse{}, err
+		return KeyVaultClientCreateCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -381,7 +381,7 @@ func (client *KeyVaultClient) createKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) createKeyHandleResponse(resp *http.Response) (KeyVaultClientCreateKeyResponse, error) {
 	result := KeyVaultClientCreateKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientCreateKeyResponse{}, err
+		return KeyVaultClientCreateKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -448,7 +448,7 @@ func (client *KeyVaultClient) decryptCreateRequest(ctx context.Context, vaultBas
 func (client *KeyVaultClient) decryptHandleResponse(resp *http.Response) (KeyVaultClientDecryptResponse, error) {
 	result := KeyVaultClientDecryptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientDecryptResponse{}, err
+		return KeyVaultClientDecryptResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -509,7 +509,7 @@ func (client *KeyVaultClient) deleteCertificateCreateRequest(ctx context.Context
 func (client *KeyVaultClient) deleteCertificateHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateResponse, error) {
 	result := KeyVaultClientDeleteCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
-		return KeyVaultClientDeleteCertificateResponse{}, err
+		return KeyVaultClientDeleteCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -565,7 +565,7 @@ func (client *KeyVaultClient) deleteCertificateContactsCreateRequest(ctx context
 func (client *KeyVaultClient) deleteCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateContactsResponse, error) {
 	result := KeyVaultClientDeleteCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
-		return KeyVaultClientDeleteCertificateContactsResponse{}, err
+		return KeyVaultClientDeleteCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -625,7 +625,7 @@ func (client *KeyVaultClient) deleteCertificateIssuerCreateRequest(ctx context.C
 func (client *KeyVaultClient) deleteCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateIssuerResponse, error) {
 	result := KeyVaultClientDeleteCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
-		return KeyVaultClientDeleteCertificateIssuerResponse{}, err
+		return KeyVaultClientDeleteCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -685,7 +685,7 @@ func (client *KeyVaultClient) deleteCertificateOperationCreateRequest(ctx contex
 func (client *KeyVaultClient) deleteCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientDeleteCertificateOperationResponse, error) {
 	result := KeyVaultClientDeleteCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
-		return KeyVaultClientDeleteCertificateOperationResponse{}, err
+		return KeyVaultClientDeleteCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -746,7 +746,7 @@ func (client *KeyVaultClient) deleteKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) deleteKeyHandleResponse(resp *http.Response) (KeyVaultClientDeleteKeyResponse, error) {
 	result := KeyVaultClientDeleteKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
-		return KeyVaultClientDeleteKeyResponse{}, err
+		return KeyVaultClientDeleteKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -809,7 +809,7 @@ func (client *KeyVaultClient) deleteSasDefinitionCreateRequest(ctx context.Conte
 func (client *KeyVaultClient) deleteSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientDeleteSasDefinitionResponse, error) {
 	result := KeyVaultClientDeleteSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
-		return KeyVaultClientDeleteSasDefinitionResponse{}, err
+		return KeyVaultClientDeleteSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -869,7 +869,7 @@ func (client *KeyVaultClient) deleteSecretCreateRequest(ctx context.Context, vau
 func (client *KeyVaultClient) deleteSecretHandleResponse(resp *http.Response) (KeyVaultClientDeleteSecretResponse, error) {
 	result := KeyVaultClientDeleteSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
-		return KeyVaultClientDeleteSecretResponse{}, err
+		return KeyVaultClientDeleteSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -928,7 +928,7 @@ func (client *KeyVaultClient) deleteStorageAccountCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) deleteStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientDeleteStorageAccountResponse, error) {
 	result := KeyVaultClientDeleteStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
-		return KeyVaultClientDeleteStorageAccountResponse{}, err
+		return KeyVaultClientDeleteStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -997,7 +997,7 @@ func (client *KeyVaultClient) encryptCreateRequest(ctx context.Context, vaultBas
 func (client *KeyVaultClient) encryptHandleResponse(resp *http.Response) (KeyVaultClientEncryptResponse, error) {
 	result := KeyVaultClientEncryptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientEncryptResponse{}, err
+		return KeyVaultClientEncryptResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1125,7 +1125,7 @@ func (client *KeyVaultClient) fullBackupStatusCreateRequest(ctx context.Context,
 func (client *KeyVaultClient) fullBackupStatusHandleResponse(resp *http.Response) (KeyVaultClientFullBackupStatusResponse, error) {
 	result := KeyVaultClientFullBackupStatusResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FullBackupOperation); err != nil {
-		return KeyVaultClientFullBackupStatusResponse{}, err
+		return KeyVaultClientFullBackupStatusResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1257,7 +1257,7 @@ func (client *KeyVaultClient) getCertificateCreateRequest(ctx context.Context, v
 func (client *KeyVaultClient) getCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateResponse, error) {
 	result := KeyVaultClientGetCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientGetCertificateResponse{}, err
+		return KeyVaultClientGetCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1313,7 +1313,7 @@ func (client *KeyVaultClient) getCertificateContactsCreateRequest(ctx context.Co
 func (client *KeyVaultClient) getCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateContactsResponse, error) {
 	result := KeyVaultClientGetCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
-		return KeyVaultClientGetCertificateContactsResponse{}, err
+		return KeyVaultClientGetCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1373,7 +1373,7 @@ func (client *KeyVaultClient) getCertificateIssuerCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) getCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuerResponse, error) {
 	result := KeyVaultClientGetCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
-		return KeyVaultClientGetCertificateIssuerResponse{}, err
+		return KeyVaultClientGetCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1429,7 +1429,7 @@ func (client *KeyVaultClient) getCertificateIssuersCreateRequest(ctx context.Con
 func (client *KeyVaultClient) getCertificateIssuersHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateIssuersResponse, error) {
 	result := KeyVaultClientGetCertificateIssuersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateIssuerListResult); err != nil {
-		return KeyVaultClientGetCertificateIssuersResponse{}, err
+		return KeyVaultClientGetCertificateIssuersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1488,7 +1488,7 @@ func (client *KeyVaultClient) getCertificateOperationCreateRequest(ctx context.C
 func (client *KeyVaultClient) getCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateOperationResponse, error) {
 	result := KeyVaultClientGetCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
-		return KeyVaultClientGetCertificateOperationResponse{}, err
+		return KeyVaultClientGetCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1548,7 +1548,7 @@ func (client *KeyVaultClient) getCertificatePolicyCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) getCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatePolicyResponse, error) {
 	result := KeyVaultClientGetCertificatePolicyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
-		return KeyVaultClientGetCertificatePolicyResponse{}, err
+		return KeyVaultClientGetCertificatePolicyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1608,7 +1608,7 @@ func (client *KeyVaultClient) getCertificateVersionsCreateRequest(ctx context.Co
 func (client *KeyVaultClient) getCertificateVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetCertificateVersionsResponse, error) {
 	result := KeyVaultClientGetCertificateVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
-		return KeyVaultClientGetCertificateVersionsResponse{}, err
+		return KeyVaultClientGetCertificateVersionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1667,7 +1667,7 @@ func (client *KeyVaultClient) getCertificatesCreateRequest(ctx context.Context, 
 func (client *KeyVaultClient) getCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetCertificatesResponse, error) {
 	result := KeyVaultClientGetCertificatesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateListResult); err != nil {
-		return KeyVaultClientGetCertificatesResponse{}, err
+		return KeyVaultClientGetCertificatesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1728,7 +1728,7 @@ func (client *KeyVaultClient) getDeletedCertificateCreateRequest(ctx context.Con
 func (client *KeyVaultClient) getDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificateResponse, error) {
 	result := KeyVaultClientGetDeletedCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateBundle); err != nil {
-		return KeyVaultClientGetDeletedCertificateResponse{}, err
+		return KeyVaultClientGetDeletedCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1788,7 +1788,7 @@ func (client *KeyVaultClient) getDeletedCertificatesCreateRequest(ctx context.Co
 func (client *KeyVaultClient) getDeletedCertificatesHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedCertificatesResponse, error) {
 	result := KeyVaultClientGetDeletedCertificatesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedCertificateListResult); err != nil {
-		return KeyVaultClientGetDeletedCertificatesResponse{}, err
+		return KeyVaultClientGetDeletedCertificatesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1849,7 +1849,7 @@ func (client *KeyVaultClient) getDeletedKeyCreateRequest(ctx context.Context, va
 func (client *KeyVaultClient) getDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeyResponse, error) {
 	result := KeyVaultClientGetDeletedKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyBundle); err != nil {
-		return KeyVaultClientGetDeletedKeyResponse{}, err
+		return KeyVaultClientGetDeletedKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1908,7 +1908,7 @@ func (client *KeyVaultClient) getDeletedKeysCreateRequest(ctx context.Context, v
 func (client *KeyVaultClient) getDeletedKeysHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedKeysResponse, error) {
 	result := KeyVaultClientGetDeletedKeysResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedKeyListResult); err != nil {
-		return KeyVaultClientGetDeletedKeysResponse{}, err
+		return KeyVaultClientGetDeletedKeysResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1972,7 +1972,7 @@ func (client *KeyVaultClient) getDeletedSasDefinitionCreateRequest(ctx context.C
 func (client *KeyVaultClient) getDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionResponse, error) {
 	result := KeyVaultClientGetDeletedSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionBundle); err != nil {
-		return KeyVaultClientGetDeletedSasDefinitionResponse{}, err
+		return KeyVaultClientGetDeletedSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2032,7 +2032,7 @@ func (client *KeyVaultClient) getDeletedSasDefinitionsCreateRequest(ctx context.
 func (client *KeyVaultClient) getDeletedSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSasDefinitionsResponse, error) {
 	result := KeyVaultClientGetDeletedSasDefinitionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSasDefinitionListResult); err != nil {
-		return KeyVaultClientGetDeletedSasDefinitionsResponse{}, err
+		return KeyVaultClientGetDeletedSasDefinitionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2092,7 +2092,7 @@ func (client *KeyVaultClient) getDeletedSecretCreateRequest(ctx context.Context,
 func (client *KeyVaultClient) getDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretResponse, error) {
 	result := KeyVaultClientGetDeletedSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretBundle); err != nil {
-		return KeyVaultClientGetDeletedSecretResponse{}, err
+		return KeyVaultClientGetDeletedSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2148,7 +2148,7 @@ func (client *KeyVaultClient) getDeletedSecretsCreateRequest(ctx context.Context
 func (client *KeyVaultClient) getDeletedSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedSecretsResponse, error) {
 	result := KeyVaultClientGetDeletedSecretsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedSecretListResult); err != nil {
-		return KeyVaultClientGetDeletedSecretsResponse{}, err
+		return KeyVaultClientGetDeletedSecretsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2208,7 +2208,7 @@ func (client *KeyVaultClient) getDeletedStorageAccountCreateRequest(ctx context.
 func (client *KeyVaultClient) getDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountResponse, error) {
 	result := KeyVaultClientGetDeletedStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageBundle); err != nil {
-		return KeyVaultClientGetDeletedStorageAccountResponse{}, err
+		return KeyVaultClientGetDeletedStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2264,7 +2264,7 @@ func (client *KeyVaultClient) getDeletedStorageAccountsCreateRequest(ctx context
 func (client *KeyVaultClient) getDeletedStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetDeletedStorageAccountsResponse, error) {
 	result := KeyVaultClientGetDeletedStorageAccountsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeletedStorageListResult); err != nil {
-		return KeyVaultClientGetDeletedStorageAccountsResponse{}, err
+		return KeyVaultClientGetDeletedStorageAccountsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2328,7 +2328,7 @@ func (client *KeyVaultClient) getKeyCreateRequest(ctx context.Context, vaultBase
 func (client *KeyVaultClient) getKeyHandleResponse(resp *http.Response) (KeyVaultClientGetKeyResponse, error) {
 	result := KeyVaultClientGetKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientGetKeyResponse{}, err
+		return KeyVaultClientGetKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2387,7 +2387,7 @@ func (client *KeyVaultClient) getKeyVersionsCreateRequest(ctx context.Context, v
 func (client *KeyVaultClient) getKeyVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetKeyVersionsResponse, error) {
 	result := KeyVaultClientGetKeyVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
-		return KeyVaultClientGetKeyVersionsResponse{}, err
+		return KeyVaultClientGetKeyVersionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2445,7 +2445,7 @@ func (client *KeyVaultClient) getKeysCreateRequest(ctx context.Context, vaultBas
 func (client *KeyVaultClient) getKeysHandleResponse(resp *http.Response) (KeyVaultClientGetKeysResponse, error) {
 	result := KeyVaultClientGetKeysResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyListResult); err != nil {
-		return KeyVaultClientGetKeysResponse{}, err
+		return KeyVaultClientGetKeysResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2508,7 +2508,7 @@ func (client *KeyVaultClient) getSasDefinitionCreateRequest(ctx context.Context,
 func (client *KeyVaultClient) getSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionResponse, error) {
 	result := KeyVaultClientGetSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
-		return KeyVaultClientGetSasDefinitionResponse{}, err
+		return KeyVaultClientGetSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2567,7 +2567,7 @@ func (client *KeyVaultClient) getSasDefinitionsCreateRequest(ctx context.Context
 func (client *KeyVaultClient) getSasDefinitionsHandleResponse(resp *http.Response) (KeyVaultClientGetSasDefinitionsResponse, error) {
 	result := KeyVaultClientGetSasDefinitionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionListResult); err != nil {
-		return KeyVaultClientGetSasDefinitionsResponse{}, err
+		return KeyVaultClientGetSasDefinitionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2630,7 +2630,7 @@ func (client *KeyVaultClient) getSecretCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) getSecretHandleResponse(resp *http.Response) (KeyVaultClientGetSecretResponse, error) {
 	result := KeyVaultClientGetSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
-		return KeyVaultClientGetSecretResponse{}, err
+		return KeyVaultClientGetSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2690,7 +2690,7 @@ func (client *KeyVaultClient) getSecretVersionsCreateRequest(ctx context.Context
 func (client *KeyVaultClient) getSecretVersionsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretVersionsResponse, error) {
 	result := KeyVaultClientGetSecretVersionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
-		return KeyVaultClientGetSecretVersionsResponse{}, err
+		return KeyVaultClientGetSecretVersionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2747,7 +2747,7 @@ func (client *KeyVaultClient) getSecretsCreateRequest(ctx context.Context, vault
 func (client *KeyVaultClient) getSecretsHandleResponse(resp *http.Response) (KeyVaultClientGetSecretsResponse, error) {
 	result := KeyVaultClientGetSecretsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretListResult); err != nil {
-		return KeyVaultClientGetSecretsResponse{}, err
+		return KeyVaultClientGetSecretsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2806,7 +2806,7 @@ func (client *KeyVaultClient) getStorageAccountCreateRequest(ctx context.Context
 func (client *KeyVaultClient) getStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountResponse, error) {
 	result := KeyVaultClientGetStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientGetStorageAccountResponse{}, err
+		return KeyVaultClientGetStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2861,7 +2861,7 @@ func (client *KeyVaultClient) getStorageAccountsCreateRequest(ctx context.Contex
 func (client *KeyVaultClient) getStorageAccountsHandleResponse(resp *http.Response) (KeyVaultClientGetStorageAccountsResponse, error) {
 	result := KeyVaultClientGetStorageAccountsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageListResult); err != nil {
-		return KeyVaultClientGetStorageAccountsResponse{}, err
+		return KeyVaultClientGetStorageAccountsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2922,7 +2922,7 @@ func (client *KeyVaultClient) importCertificateCreateRequest(ctx context.Context
 func (client *KeyVaultClient) importCertificateHandleResponse(resp *http.Response) (KeyVaultClientImportCertificateResponse, error) {
 	result := KeyVaultClientImportCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientImportCertificateResponse{}, err
+		return KeyVaultClientImportCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -2983,7 +2983,7 @@ func (client *KeyVaultClient) importKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) importKeyHandleResponse(resp *http.Response) (KeyVaultClientImportKeyResponse, error) {
 	result := KeyVaultClientImportKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientImportKeyResponse{}, err
+		return KeyVaultClientImportKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3044,7 +3044,7 @@ func (client *KeyVaultClient) mergeCertificateCreateRequest(ctx context.Context,
 func (client *KeyVaultClient) mergeCertificateHandleResponse(resp *http.Response) (KeyVaultClientMergeCertificateResponse, error) {
 	result := KeyVaultClientMergeCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientMergeCertificateResponse{}, err
+		return KeyVaultClientMergeCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3313,7 +3313,7 @@ func (client *KeyVaultClient) recoverDeletedCertificateCreateRequest(ctx context
 func (client *KeyVaultClient) recoverDeletedCertificateHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedCertificateResponse, error) {
 	result := KeyVaultClientRecoverDeletedCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientRecoverDeletedCertificateResponse{}, err
+		return KeyVaultClientRecoverDeletedCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3374,7 +3374,7 @@ func (client *KeyVaultClient) recoverDeletedKeyCreateRequest(ctx context.Context
 func (client *KeyVaultClient) recoverDeletedKeyHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedKeyResponse, error) {
 	result := KeyVaultClientRecoverDeletedKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientRecoverDeletedKeyResponse{}, err
+		return KeyVaultClientRecoverDeletedKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3438,7 +3438,7 @@ func (client *KeyVaultClient) recoverDeletedSasDefinitionCreateRequest(ctx conte
 func (client *KeyVaultClient) recoverDeletedSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSasDefinitionResponse, error) {
 	result := KeyVaultClientRecoverDeletedSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
-		return KeyVaultClientRecoverDeletedSasDefinitionResponse{}, err
+		return KeyVaultClientRecoverDeletedSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3498,7 +3498,7 @@ func (client *KeyVaultClient) recoverDeletedSecretCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) recoverDeletedSecretHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedSecretResponse, error) {
 	result := KeyVaultClientRecoverDeletedSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
-		return KeyVaultClientRecoverDeletedSecretResponse{}, err
+		return KeyVaultClientRecoverDeletedSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3558,7 +3558,7 @@ func (client *KeyVaultClient) recoverDeletedStorageAccountCreateRequest(ctx cont
 func (client *KeyVaultClient) recoverDeletedStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRecoverDeletedStorageAccountResponse, error) {
 	result := KeyVaultClientRecoverDeletedStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientRecoverDeletedStorageAccountResponse{}, err
+		return KeyVaultClientRecoverDeletedStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3617,7 +3617,7 @@ func (client *KeyVaultClient) regenerateStorageAccountKeyCreateRequest(ctx conte
 func (client *KeyVaultClient) regenerateStorageAccountKeyHandleResponse(resp *http.Response) (KeyVaultClientRegenerateStorageAccountKeyResponse, error) {
 	result := KeyVaultClientRegenerateStorageAccountKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientRegenerateStorageAccountKeyResponse{}, err
+		return KeyVaultClientRegenerateStorageAccountKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3672,7 +3672,7 @@ func (client *KeyVaultClient) restoreCertificateCreateRequest(ctx context.Contex
 func (client *KeyVaultClient) restoreCertificateHandleResponse(resp *http.Response) (KeyVaultClientRestoreCertificateResponse, error) {
 	result := KeyVaultClientRestoreCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientRestoreCertificateResponse{}, err
+		return KeyVaultClientRestoreCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3735,7 +3735,7 @@ func (client *KeyVaultClient) restoreKeyCreateRequest(ctx context.Context, vault
 func (client *KeyVaultClient) restoreKeyHandleResponse(resp *http.Response) (KeyVaultClientRestoreKeyResponse, error) {
 	result := KeyVaultClientRestoreKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientRestoreKeyResponse{}, err
+		return KeyVaultClientRestoreKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3790,7 +3790,7 @@ func (client *KeyVaultClient) restoreSecretCreateRequest(ctx context.Context, va
 func (client *KeyVaultClient) restoreSecretHandleResponse(resp *http.Response) (KeyVaultClientRestoreSecretResponse, error) {
 	result := KeyVaultClientRestoreSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
-		return KeyVaultClientRestoreSecretResponse{}, err
+		return KeyVaultClientRestoreSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3849,7 +3849,7 @@ func (client *KeyVaultClient) restoreStatusCreateRequest(ctx context.Context, va
 func (client *KeyVaultClient) restoreStatusHandleResponse(resp *http.Response) (KeyVaultClientRestoreStatusResponse, error) {
 	result := KeyVaultClientRestoreStatusResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RestoreOperation); err != nil {
-		return KeyVaultClientRestoreStatusResponse{}, err
+		return KeyVaultClientRestoreStatusResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -3904,7 +3904,7 @@ func (client *KeyVaultClient) restoreStorageAccountCreateRequest(ctx context.Con
 func (client *KeyVaultClient) restoreStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientRestoreStorageAccountResponse, error) {
 	result := KeyVaultClientRestoreStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientRestoreStorageAccountResponse{}, err
+		return KeyVaultClientRestoreStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4034,7 +4034,7 @@ func (client *KeyVaultClient) setCertificateContactsCreateRequest(ctx context.Co
 func (client *KeyVaultClient) setCertificateContactsHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateContactsResponse, error) {
 	result := KeyVaultClientSetCertificateContactsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Contacts); err != nil {
-		return KeyVaultClientSetCertificateContactsResponse{}, err
+		return KeyVaultClientSetCertificateContactsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4094,7 +4094,7 @@ func (client *KeyVaultClient) setCertificateIssuerCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) setCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientSetCertificateIssuerResponse, error) {
 	result := KeyVaultClientSetCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
-		return KeyVaultClientSetCertificateIssuerResponse{}, err
+		return KeyVaultClientSetCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4157,7 +4157,7 @@ func (client *KeyVaultClient) setSasDefinitionCreateRequest(ctx context.Context,
 func (client *KeyVaultClient) setSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientSetSasDefinitionResponse, error) {
 	result := KeyVaultClientSetSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
-		return KeyVaultClientSetSasDefinitionResponse{}, err
+		return KeyVaultClientSetSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4217,7 +4217,7 @@ func (client *KeyVaultClient) setSecretCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) setSecretHandleResponse(resp *http.Response) (KeyVaultClientSetSecretResponse, error) {
 	result := KeyVaultClientSetSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
-		return KeyVaultClientSetSecretResponse{}, err
+		return KeyVaultClientSetSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4276,7 +4276,7 @@ func (client *KeyVaultClient) setStorageAccountCreateRequest(ctx context.Context
 func (client *KeyVaultClient) setStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientSetStorageAccountResponse, error) {
 	result := KeyVaultClientSetStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientSetStorageAccountResponse{}, err
+		return KeyVaultClientSetStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4340,7 +4340,7 @@ func (client *KeyVaultClient) signCreateRequest(ctx context.Context, vaultBaseUR
 func (client *KeyVaultClient) signHandleResponse(resp *http.Response) (KeyVaultClientSignResponse, error) {
 	result := KeyVaultClientSignResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientSignResponse{}, err
+		return KeyVaultClientSignResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4405,7 +4405,7 @@ func (client *KeyVaultClient) unwrapKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) unwrapKeyHandleResponse(resp *http.Response) (KeyVaultClientUnwrapKeyResponse, error) {
 	result := KeyVaultClientUnwrapKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientUnwrapKeyResponse{}, err
+		return KeyVaultClientUnwrapKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4470,7 +4470,7 @@ func (client *KeyVaultClient) updateCertificateCreateRequest(ctx context.Context
 func (client *KeyVaultClient) updateCertificateHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateResponse, error) {
 	result := KeyVaultClientUpdateCertificateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateBundle); err != nil {
-		return KeyVaultClientUpdateCertificateResponse{}, err
+		return KeyVaultClientUpdateCertificateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4530,7 +4530,7 @@ func (client *KeyVaultClient) updateCertificateIssuerCreateRequest(ctx context.C
 func (client *KeyVaultClient) updateCertificateIssuerHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateIssuerResponse, error) {
 	result := KeyVaultClientUpdateCertificateIssuerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IssuerBundle); err != nil {
-		return KeyVaultClientUpdateCertificateIssuerResponse{}, err
+		return KeyVaultClientUpdateCertificateIssuerResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4589,7 +4589,7 @@ func (client *KeyVaultClient) updateCertificateOperationCreateRequest(ctx contex
 func (client *KeyVaultClient) updateCertificateOperationHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificateOperationResponse, error) {
 	result := KeyVaultClientUpdateCertificateOperationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificateOperation); err != nil {
-		return KeyVaultClientUpdateCertificateOperationResponse{}, err
+		return KeyVaultClientUpdateCertificateOperationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4648,7 +4648,7 @@ func (client *KeyVaultClient) updateCertificatePolicyCreateRequest(ctx context.C
 func (client *KeyVaultClient) updateCertificatePolicyHandleResponse(resp *http.Response) (KeyVaultClientUpdateCertificatePolicyResponse, error) {
 	result := KeyVaultClientUpdateCertificatePolicyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CertificatePolicy); err != nil {
-		return KeyVaultClientUpdateCertificatePolicyResponse{}, err
+		return KeyVaultClientUpdateCertificatePolicyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4712,7 +4712,7 @@ func (client *KeyVaultClient) updateKeyCreateRequest(ctx context.Context, vaultB
 func (client *KeyVaultClient) updateKeyHandleResponse(resp *http.Response) (KeyVaultClientUpdateKeyResponse, error) {
 	result := KeyVaultClientUpdateKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyBundle); err != nil {
-		return KeyVaultClientUpdateKeyResponse{}, err
+		return KeyVaultClientUpdateKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4775,7 +4775,7 @@ func (client *KeyVaultClient) updateSasDefinitionCreateRequest(ctx context.Conte
 func (client *KeyVaultClient) updateSasDefinitionHandleResponse(resp *http.Response) (KeyVaultClientUpdateSasDefinitionResponse, error) {
 	result := KeyVaultClientUpdateSasDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SasDefinitionBundle); err != nil {
-		return KeyVaultClientUpdateSasDefinitionResponse{}, err
+		return KeyVaultClientUpdateSasDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4840,7 +4840,7 @@ func (client *KeyVaultClient) updateSecretCreateRequest(ctx context.Context, vau
 func (client *KeyVaultClient) updateSecretHandleResponse(resp *http.Response) (KeyVaultClientUpdateSecretResponse, error) {
 	result := KeyVaultClientUpdateSecretResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecretBundle); err != nil {
-		return KeyVaultClientUpdateSecretResponse{}, err
+		return KeyVaultClientUpdateSecretResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4899,7 +4899,7 @@ func (client *KeyVaultClient) updateStorageAccountCreateRequest(ctx context.Cont
 func (client *KeyVaultClient) updateStorageAccountHandleResponse(resp *http.Response) (KeyVaultClientUpdateStorageAccountResponse, error) {
 	result := KeyVaultClientUpdateStorageAccountResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StorageBundle); err != nil {
-		return KeyVaultClientUpdateStorageAccountResponse{}, err
+		return KeyVaultClientUpdateStorageAccountResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -4966,7 +4966,7 @@ func (client *KeyVaultClient) verifyCreateRequest(ctx context.Context, vaultBase
 func (client *KeyVaultClient) verifyHandleResponse(resp *http.Response) (KeyVaultClientVerifyResponse, error) {
 	result := KeyVaultClientVerifyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyVerifyResult); err != nil {
-		return KeyVaultClientVerifyResponse{}, err
+		return KeyVaultClientVerifyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -5033,7 +5033,7 @@ func (client *KeyVaultClient) wrapKeyCreateRequest(ctx context.Context, vaultBas
 func (client *KeyVaultClient) wrapKeyHandleResponse(resp *http.Response) (KeyVaultClientWrapKeyResponse, error) {
 	result := KeyVaultClientWrapKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.KeyOperationResult); err != nil {
-		return KeyVaultClientWrapKeyResponse{}, err
+		return KeyVaultClientWrapKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
@@ -72,7 +72,7 @@ func (client *RoleAssignmentsClient) createCreateRequest(ctx context.Context, va
 func (client *RoleAssignmentsClient) createHandleResponse(resp *http.Response) (RoleAssignmentsCreateResponse, error) {
 	result := RoleAssignmentsCreateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
-		return RoleAssignmentsCreateResponse{}, err
+		return RoleAssignmentsCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -132,7 +132,7 @@ func (client *RoleAssignmentsClient) deleteCreateRequest(ctx context.Context, va
 func (client *RoleAssignmentsClient) deleteHandleResponse(resp *http.Response) (RoleAssignmentsDeleteResponse, error) {
 	result := RoleAssignmentsDeleteResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
-		return RoleAssignmentsDeleteResponse{}, err
+		return RoleAssignmentsDeleteResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -192,7 +192,7 @@ func (client *RoleAssignmentsClient) getCreateRequest(ctx context.Context, vault
 func (client *RoleAssignmentsClient) getHandleResponse(resp *http.Response) (RoleAssignmentsGetResponse, error) {
 	result := RoleAssignmentsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignment); err != nil {
-		return RoleAssignmentsGetResponse{}, err
+		return RoleAssignmentsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -248,7 +248,7 @@ func (client *RoleAssignmentsClient) listForScopeCreateRequest(ctx context.Conte
 func (client *RoleAssignmentsClient) listForScopeHandleResponse(resp *http.Response) (RoleAssignmentsListForScopeResponse, error) {
 	result := RoleAssignmentsListForScopeResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleAssignmentListResult); err != nil {
-		return RoleAssignmentsListForScopeResponse{}, err
+		return RoleAssignmentsListForScopeResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
@@ -72,7 +72,7 @@ func (client *RoleDefinitionsClient) createOrUpdateCreateRequest(ctx context.Con
 func (client *RoleDefinitionsClient) createOrUpdateHandleResponse(resp *http.Response) (RoleDefinitionsCreateOrUpdateResponse, error) {
 	result := RoleDefinitionsCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
-		return RoleDefinitionsCreateOrUpdateResponse{}, err
+		return RoleDefinitionsCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -132,7 +132,7 @@ func (client *RoleDefinitionsClient) deleteCreateRequest(ctx context.Context, va
 func (client *RoleDefinitionsClient) deleteHandleResponse(resp *http.Response) (RoleDefinitionsDeleteResponse, error) {
 	result := RoleDefinitionsDeleteResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
-		return RoleDefinitionsDeleteResponse{}, err
+		return RoleDefinitionsDeleteResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -192,7 +192,7 @@ func (client *RoleDefinitionsClient) getCreateRequest(ctx context.Context, vault
 func (client *RoleDefinitionsClient) getHandleResponse(resp *http.Response) (RoleDefinitionsGetResponse, error) {
 	result := RoleDefinitionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinition); err != nil {
-		return RoleDefinitionsGetResponse{}, err
+		return RoleDefinitionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -248,7 +248,7 @@ func (client *RoleDefinitionsClient) listCreateRequest(ctx context.Context, vaul
 func (client *RoleDefinitionsClient) listHandleResponse(resp *http.Response) (RoleDefinitionsListResponse, error) {
 	result := RoleDefinitionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RoleDefinitionListResult); err != nil {
-		return RoleDefinitionsListResponse{}, err
+		return RoleDefinitionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/maps/azalias/zz_generated_alias_client.go
+++ b/test/maps/azalias/zz_generated_alias_client.go
@@ -80,7 +80,7 @@ func (client *aliasClient) createHandleResponse(resp *http.Response) (AliasCreat
 		result.AccessControlExposeHeaders = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AliasesCreateResponse); err != nil {
-		return AliasCreateResponse{}, err
+		return AliasCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -149,7 +149,7 @@ func (client *aliasClient) listCreateRequest(ctx context.Context, options *Alias
 func (client *aliasClient) listHandleResponse(resp *http.Response) (AliasListResponseEnvelope, error) {
 	result := AliasListResponseEnvelope{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AliasListResponse); err != nil {
-		return AliasListResponseEnvelope{}, err
+		return AliasListResponseEnvelope{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -401,7 +401,7 @@ func (client *ApplicationGatewaysClient) getCreateRequest(ctx context.Context, r
 func (client *ApplicationGatewaysClient) getHandleResponse(resp *http.Response) (ApplicationGatewaysGetResponse, error) {
 	result := ApplicationGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGateway); err != nil {
-		return ApplicationGatewaysGetResponse{}, err
+		return ApplicationGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -462,7 +462,7 @@ func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyCreateRequest(ctx
 func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyHandleResponse(resp *http.Response) (ApplicationGatewaysGetSSLPredefinedPolicyResponse, error) {
 	result := ApplicationGatewaysGetSSLPredefinedPolicyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewaySSLPredefinedPolicy); err != nil {
-		return ApplicationGatewaysGetSSLPredefinedPolicyResponse{}, err
+		return ApplicationGatewaysGetSSLPredefinedPolicyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -520,7 +520,7 @@ func (client *ApplicationGatewaysClient) listCreateRequest(ctx context.Context, 
 func (client *ApplicationGatewaysClient) listHandleResponse(resp *http.Response) (ApplicationGatewaysListResponse, error) {
 	result := ApplicationGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayListResult); err != nil {
-		return ApplicationGatewaysListResponse{}, err
+		return ApplicationGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -574,7 +574,7 @@ func (client *ApplicationGatewaysClient) listAllCreateRequest(ctx context.Contex
 func (client *ApplicationGatewaysClient) listAllHandleResponse(resp *http.Response) (ApplicationGatewaysListAllResponse, error) {
 	result := ApplicationGatewaysListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayListResult); err != nil {
-		return ApplicationGatewaysListAllResponse{}, err
+		return ApplicationGatewaysListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -631,7 +631,7 @@ func (client *ApplicationGatewaysClient) listAvailableRequestHeadersCreateReques
 func (client *ApplicationGatewaysClient) listAvailableRequestHeadersHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableRequestHeadersResponse, error) {
 	result := ApplicationGatewaysListAvailableRequestHeadersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ApplicationGatewaysListAvailableRequestHeadersResponse{}, err
+		return ApplicationGatewaysListAvailableRequestHeadersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -688,7 +688,7 @@ func (client *ApplicationGatewaysClient) listAvailableResponseHeadersCreateReque
 func (client *ApplicationGatewaysClient) listAvailableResponseHeadersHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableResponseHeadersResponse, error) {
 	result := ApplicationGatewaysListAvailableResponseHeadersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ApplicationGatewaysListAvailableResponseHeadersResponse{}, err
+		return ApplicationGatewaysListAvailableResponseHeadersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -745,7 +745,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLOptionsCreateRequest(ct
 func (client *ApplicationGatewaysClient) listAvailableSSLOptionsHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableSSLOptionsResponse, error) {
 	result := ApplicationGatewaysListAvailableSSLOptionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableSSLOptions); err != nil {
-		return ApplicationGatewaysListAvailableSSLOptionsResponse{}, err
+		return ApplicationGatewaysListAvailableSSLOptionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -799,7 +799,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLPredefinedPoliciesCreat
 func (client *ApplicationGatewaysClient) listAvailableSSLPredefinedPoliciesHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableSSLPredefinedPoliciesResponse, error) {
 	result := ApplicationGatewaysListAvailableSSLPredefinedPoliciesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableSSLPredefinedPolicies); err != nil {
-		return ApplicationGatewaysListAvailableSSLPredefinedPoliciesResponse{}, err
+		return ApplicationGatewaysListAvailableSSLPredefinedPoliciesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -856,7 +856,7 @@ func (client *ApplicationGatewaysClient) listAvailableServerVariablesCreateReque
 func (client *ApplicationGatewaysClient) listAvailableServerVariablesHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableServerVariablesResponse, error) {
 	result := ApplicationGatewaysListAvailableServerVariablesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StringArray); err != nil {
-		return ApplicationGatewaysListAvailableServerVariablesResponse{}, err
+		return ApplicationGatewaysListAvailableServerVariablesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -913,7 +913,7 @@ func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsCreateRequest(c
 func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsHandleResponse(resp *http.Response) (ApplicationGatewaysListAvailableWafRuleSetsResponse, error) {
 	result := ApplicationGatewaysListAvailableWafRuleSetsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGatewayAvailableWafRuleSetsResult); err != nil {
-		return ApplicationGatewaysListAvailableWafRuleSetsResponse{}, err
+		return ApplicationGatewaysListAvailableWafRuleSetsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1130,7 +1130,7 @@ func (client *ApplicationGatewaysClient) updateTagsCreateRequest(ctx context.Con
 func (client *ApplicationGatewaysClient) updateTagsHandleResponse(resp *http.Response) (ApplicationGatewaysUpdateTagsResponse, error) {
 	result := ApplicationGatewaysUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationGateway); err != nil {
-		return ApplicationGatewaysUpdateTagsResponse{}, err
+		return ApplicationGatewaysUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -241,7 +241,7 @@ func (client *ApplicationSecurityGroupsClient) getCreateRequest(ctx context.Cont
 func (client *ApplicationSecurityGroupsClient) getHandleResponse(resp *http.Response) (ApplicationSecurityGroupsGetResponse, error) {
 	result := ApplicationSecurityGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroup); err != nil {
-		return ApplicationSecurityGroupsGetResponse{}, err
+		return ApplicationSecurityGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -299,7 +299,7 @@ func (client *ApplicationSecurityGroupsClient) listCreateRequest(ctx context.Con
 func (client *ApplicationSecurityGroupsClient) listHandleResponse(resp *http.Response) (ApplicationSecurityGroupsListResponse, error) {
 	result := ApplicationSecurityGroupsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroupListResult); err != nil {
-		return ApplicationSecurityGroupsListResponse{}, err
+		return ApplicationSecurityGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *ApplicationSecurityGroupsClient) listAllCreateRequest(ctx context.
 func (client *ApplicationSecurityGroupsClient) listAllHandleResponse(resp *http.Response) (ApplicationSecurityGroupsListAllResponse, error) {
 	result := ApplicationSecurityGroupsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroupListResult); err != nil {
-		return ApplicationSecurityGroupsListAllResponse{}, err
+		return ApplicationSecurityGroupsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *ApplicationSecurityGroupsClient) updateTagsCreateRequest(ctx conte
 func (client *ApplicationSecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (ApplicationSecurityGroupsUpdateTagsResponse, error) {
 	result := ApplicationSecurityGroupsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ApplicationSecurityGroup); err != nil {
-		return ApplicationSecurityGroupsUpdateTagsResponse{}, err
+		return ApplicationSecurityGroupsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
@@ -82,7 +82,7 @@ func (client *AvailableDelegationsClient) listCreateRequest(ctx context.Context,
 func (client *AvailableDelegationsClient) listHandleResponse(resp *http.Response) (AvailableDelegationsListResponse, error) {
 	result := AvailableDelegationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableDelegationsResult); err != nil {
-		return AvailableDelegationsListResponse{}, err
+		return AvailableDelegationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
@@ -82,7 +82,7 @@ func (client *AvailableEndpointServicesClient) listCreateRequest(ctx context.Con
 func (client *AvailableEndpointServicesClient) listHandleResponse(resp *http.Response) (AvailableEndpointServicesListResponse, error) {
 	result := AvailableEndpointServicesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EndpointServicesListResult); err != nil {
-		return AvailableEndpointServicesListResponse{}, err
+		return AvailableEndpointServicesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
@@ -82,7 +82,7 @@ func (client *AvailablePrivateEndpointTypesClient) listCreateRequest(ctx context
 func (client *AvailablePrivateEndpointTypesClient) listHandleResponse(resp *http.Response) (AvailablePrivateEndpointTypesListResponse, error) {
 	result := AvailablePrivateEndpointTypesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailablePrivateEndpointTypesResult); err != nil {
-		return AvailablePrivateEndpointTypesListResponse{}, err
+		return AvailablePrivateEndpointTypesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *AvailablePrivateEndpointTypesClient) listByResourceGroupCreateRequ
 func (client *AvailablePrivateEndpointTypesClient) listByResourceGroupHandleResponse(resp *http.Response) (AvailablePrivateEndpointTypesListByResourceGroupResponse, error) {
 	result := AvailablePrivateEndpointTypesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailablePrivateEndpointTypesResult); err != nil {
-		return AvailablePrivateEndpointTypesListByResourceGroupResponse{}, err
+		return AvailablePrivateEndpointTypesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
@@ -86,7 +86,7 @@ func (client *AvailableResourceGroupDelegationsClient) listCreateRequest(ctx con
 func (client *AvailableResourceGroupDelegationsClient) listHandleResponse(resp *http.Response) (AvailableResourceGroupDelegationsListResponse, error) {
 	result := AvailableResourceGroupDelegationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableDelegationsResult); err != nil {
-		return AvailableResourceGroupDelegationsListResponse{}, err
+		return AvailableResourceGroupDelegationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
@@ -82,7 +82,7 @@ func (client *AvailableServiceAliasesClient) listCreateRequest(ctx context.Conte
 func (client *AvailableServiceAliasesClient) listHandleResponse(resp *http.Response) (AvailableServiceAliasesListResponse, error) {
 	result := AvailableServiceAliasesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableServiceAliasesResult); err != nil {
-		return AvailableServiceAliasesListResponse{}, err
+		return AvailableServiceAliasesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -144,7 +144,7 @@ func (client *AvailableServiceAliasesClient) listByResourceGroupCreateRequest(ct
 func (client *AvailableServiceAliasesClient) listByResourceGroupHandleResponse(resp *http.Response) (AvailableServiceAliasesListByResourceGroupResponse, error) {
 	result := AvailableServiceAliasesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AvailableServiceAliasesResult); err != nil {
-		return AvailableServiceAliasesListByResourceGroupResponse{}, err
+		return AvailableServiceAliasesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
@@ -78,7 +78,7 @@ func (client *AzureFirewallFqdnTagsClient) listAllCreateRequest(ctx context.Cont
 func (client *AzureFirewallFqdnTagsClient) listAllHandleResponse(resp *http.Response) (AzureFirewallFqdnTagsListAllResponse, error) {
 	result := AzureFirewallFqdnTagsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallFqdnTagListResult); err != nil {
-		return AzureFirewallFqdnTagsListAllResponse{}, err
+		return AzureFirewallFqdnTagsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -241,7 +241,7 @@ func (client *AzureFirewallsClient) getCreateRequest(ctx context.Context, resour
 func (client *AzureFirewallsClient) getHandleResponse(resp *http.Response) (AzureFirewallsGetResponse, error) {
 	result := AzureFirewallsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewall); err != nil {
-		return AzureFirewallsGetResponse{}, err
+		return AzureFirewallsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -299,7 +299,7 @@ func (client *AzureFirewallsClient) listCreateRequest(ctx context.Context, resou
 func (client *AzureFirewallsClient) listHandleResponse(resp *http.Response) (AzureFirewallsListResponse, error) {
 	result := AzureFirewallsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallListResult); err != nil {
-		return AzureFirewallsListResponse{}, err
+		return AzureFirewallsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *AzureFirewallsClient) listAllCreateRequest(ctx context.Context, op
 func (client *AzureFirewallsClient) listAllHandleResponse(resp *http.Response) (AzureFirewallsListAllResponse, error) {
 	result := AzureFirewallsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AzureFirewallListResult); err != nil {
-		return AzureFirewallsListAllResponse{}, err
+		return AzureFirewallsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -241,7 +241,7 @@ func (client *BastionHostsClient) getCreateRequest(ctx context.Context, resource
 func (client *BastionHostsClient) getHandleResponse(resp *http.Response) (BastionHostsGetResponse, error) {
 	result := BastionHostsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHost); err != nil {
-		return BastionHostsGetResponse{}, err
+		return BastionHostsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *BastionHostsClient) listCreateRequest(ctx context.Context, options
 func (client *BastionHostsClient) listHandleResponse(resp *http.Response) (BastionHostsListResponse, error) {
 	result := BastionHostsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHostListResult); err != nil {
-		return BastionHostsListResponse{}, err
+		return BastionHostsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *BastionHostsClient) listByResourceGroupCreateRequest(ctx context.C
 func (client *BastionHostsClient) listByResourceGroupHandleResponse(resp *http.Response) (BastionHostsListByResourceGroupResponse, error) {
 	result := BastionHostsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionHostListResult); err != nil {
-		return BastionHostsListByResourceGroupResponse{}, err
+		return BastionHostsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
@@ -78,7 +78,7 @@ func (client *BgpServiceCommunitiesClient) listCreateRequest(ctx context.Context
 func (client *BgpServiceCommunitiesClient) listHandleResponse(resp *http.Response) (BgpServiceCommunitiesListResponse, error) {
 	result := BgpServiceCommunitiesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BgpServiceCommunityListResult); err != nil {
-		return BgpServiceCommunitiesListResponse{}, err
+		return BgpServiceCommunitiesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -253,7 +253,7 @@ func (client *ConnectionMonitorsClient) getCreateRequest(ctx context.Context, re
 func (client *ConnectionMonitorsClient) getHandleResponse(resp *http.Response) (ConnectionMonitorsGetResponse, error) {
 	result := ConnectionMonitorsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorResult); err != nil {
-		return ConnectionMonitorsGetResponse{}, err
+		return ConnectionMonitorsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -318,7 +318,7 @@ func (client *ConnectionMonitorsClient) listCreateRequest(ctx context.Context, r
 func (client *ConnectionMonitorsClient) listHandleResponse(resp *http.Response) (ConnectionMonitorsListResponse, error) {
 	result := ConnectionMonitorsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorListResult); err != nil {
-		return ConnectionMonitorsListResponse{}, err
+		return ConnectionMonitorsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -627,7 +627,7 @@ func (client *ConnectionMonitorsClient) updateTagsCreateRequest(ctx context.Cont
 func (client *ConnectionMonitorsClient) updateTagsHandleResponse(resp *http.Response) (ConnectionMonitorsUpdateTagsResponse, error) {
 	result := ConnectionMonitorsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionMonitorResult); err != nil {
-		return ConnectionMonitorsUpdateTagsResponse{}, err
+		return ConnectionMonitorsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddoscustompolicies_client.go
@@ -241,7 +241,7 @@ func (client *DdosCustomPoliciesClient) getCreateRequest(ctx context.Context, re
 func (client *DdosCustomPoliciesClient) getHandleResponse(resp *http.Response) (DdosCustomPoliciesGetResponse, error) {
 	result := DdosCustomPoliciesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosCustomPolicy); err != nil {
-		return DdosCustomPoliciesGetResponse{}, err
+		return DdosCustomPoliciesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -306,7 +306,7 @@ func (client *DdosCustomPoliciesClient) updateTagsCreateRequest(ctx context.Cont
 func (client *DdosCustomPoliciesClient) updateTagsHandleResponse(resp *http.Response) (DdosCustomPoliciesUpdateTagsResponse, error) {
 	result := DdosCustomPoliciesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosCustomPolicy); err != nil {
-		return DdosCustomPoliciesUpdateTagsResponse{}, err
+		return DdosCustomPoliciesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -241,7 +241,7 @@ func (client *DdosProtectionPlansClient) getCreateRequest(ctx context.Context, r
 func (client *DdosProtectionPlansClient) getHandleResponse(resp *http.Response) (DdosProtectionPlansGetResponse, error) {
 	result := DdosProtectionPlansGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlan); err != nil {
-		return DdosProtectionPlansGetResponse{}, err
+		return DdosProtectionPlansGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *DdosProtectionPlansClient) listCreateRequest(ctx context.Context, 
 func (client *DdosProtectionPlansClient) listHandleResponse(resp *http.Response) (DdosProtectionPlansListResponse, error) {
 	result := DdosProtectionPlansListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlanListResult); err != nil {
-		return DdosProtectionPlansListResponse{}, err
+		return DdosProtectionPlansListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *DdosProtectionPlansClient) listByResourceGroupCreateRequest(ctx co
 func (client *DdosProtectionPlansClient) listByResourceGroupHandleResponse(resp *http.Response) (DdosProtectionPlansListByResourceGroupResponse, error) {
 	result := DdosProtectionPlansListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlanListResult); err != nil {
-		return DdosProtectionPlansListByResourceGroupResponse{}, err
+		return DdosProtectionPlansListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *DdosProtectionPlansClient) updateTagsCreateRequest(ctx context.Con
 func (client *DdosProtectionPlansClient) updateTagsHandleResponse(resp *http.Response) (DdosProtectionPlansUpdateTagsResponse, error) {
 	result := DdosProtectionPlansUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DdosProtectionPlan); err != nil {
-		return DdosProtectionPlansUpdateTagsResponse{}, err
+		return DdosProtectionPlansUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
@@ -93,7 +93,7 @@ func (client *DefaultSecurityRulesClient) getCreateRequest(ctx context.Context, 
 func (client *DefaultSecurityRulesClient) getHandleResponse(resp *http.Response) (DefaultSecurityRulesGetResponse, error) {
 	result := DefaultSecurityRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRule); err != nil {
-		return DefaultSecurityRulesGetResponse{}, err
+		return DefaultSecurityRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *DefaultSecurityRulesClient) listCreateRequest(ctx context.Context,
 func (client *DefaultSecurityRulesClient) listHandleResponse(resp *http.Response) (DefaultSecurityRulesListResponse, error) {
 	result := DefaultSecurityRulesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRuleListResult); err != nil {
-		return DefaultSecurityRulesListResponse{}, err
+		return DefaultSecurityRulesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -253,7 +253,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) getCreateRequest(ctx cont
 func (client *ExpressRouteCircuitAuthorizationsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitAuthorizationsGetResponse, error) {
 	result := ExpressRouteCircuitAuthorizationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitAuthorization); err != nil {
-		return ExpressRouteCircuitAuthorizationsGetResponse{}, err
+		return ExpressRouteCircuitAuthorizationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) listCreateRequest(ctx con
 func (client *ExpressRouteCircuitAuthorizationsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitAuthorizationsListResponse, error) {
 	result := ExpressRouteCircuitAuthorizationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AuthorizationListResult); err != nil {
-		return ExpressRouteCircuitAuthorizationsListResponse{}, err
+		return ExpressRouteCircuitAuthorizationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -265,7 +265,7 @@ func (client *ExpressRouteCircuitConnectionsClient) getCreateRequest(ctx context
 func (client *ExpressRouteCircuitConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitConnectionsGetResponse, error) {
 	result := ExpressRouteCircuitConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitConnection); err != nil {
-		return ExpressRouteCircuitConnectionsGetResponse{}, err
+		return ExpressRouteCircuitConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -331,7 +331,7 @@ func (client *ExpressRouteCircuitConnectionsClient) listCreateRequest(ctx contex
 func (client *ExpressRouteCircuitConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitConnectionsListResponse, error) {
 	result := ExpressRouteCircuitConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitConnectionListResult); err != nil {
-		return ExpressRouteCircuitConnectionsListResponse{}, err
+		return ExpressRouteCircuitConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -253,7 +253,7 @@ func (client *ExpressRouteCircuitPeeringsClient) getCreateRequest(ctx context.Co
 func (client *ExpressRouteCircuitPeeringsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitPeeringsGetResponse, error) {
 	result := ExpressRouteCircuitPeeringsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitPeering); err != nil {
-		return ExpressRouteCircuitPeeringsGetResponse{}, err
+		return ExpressRouteCircuitPeeringsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *ExpressRouteCircuitPeeringsClient) listCreateRequest(ctx context.C
 func (client *ExpressRouteCircuitPeeringsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitPeeringsListResponse, error) {
 	result := ExpressRouteCircuitPeeringsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitPeeringListResult); err != nil {
-		return ExpressRouteCircuitPeeringsListResponse{}, err
+		return ExpressRouteCircuitPeeringsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -241,7 +241,7 @@ func (client *ExpressRouteCircuitsClient) getCreateRequest(ctx context.Context, 
 func (client *ExpressRouteCircuitsClient) getHandleResponse(resp *http.Response) (ExpressRouteCircuitsGetResponse, error) {
 	result := ExpressRouteCircuitsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuit); err != nil {
-		return ExpressRouteCircuitsGetResponse{}, err
+		return ExpressRouteCircuitsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -310,7 +310,7 @@ func (client *ExpressRouteCircuitsClient) getPeeringStatsCreateRequest(ctx conte
 func (client *ExpressRouteCircuitsClient) getPeeringStatsHandleResponse(resp *http.Response) (ExpressRouteCircuitsGetPeeringStatsResponse, error) {
 	result := ExpressRouteCircuitsGetPeeringStatsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitStats); err != nil {
-		return ExpressRouteCircuitsGetPeeringStatsResponse{}, err
+		return ExpressRouteCircuitsGetPeeringStatsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -375,7 +375,7 @@ func (client *ExpressRouteCircuitsClient) getStatsCreateRequest(ctx context.Cont
 func (client *ExpressRouteCircuitsClient) getStatsHandleResponse(resp *http.Response) (ExpressRouteCircuitsGetStatsResponse, error) {
 	result := ExpressRouteCircuitsGetStatsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitStats); err != nil {
-		return ExpressRouteCircuitsGetStatsResponse{}, err
+		return ExpressRouteCircuitsGetStatsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -433,7 +433,7 @@ func (client *ExpressRouteCircuitsClient) listCreateRequest(ctx context.Context,
 func (client *ExpressRouteCircuitsClient) listHandleResponse(resp *http.Response) (ExpressRouteCircuitsListResponse, error) {
 	result := ExpressRouteCircuitsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitListResult); err != nil {
-		return ExpressRouteCircuitsListResponse{}, err
+		return ExpressRouteCircuitsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -487,7 +487,7 @@ func (client *ExpressRouteCircuitsClient) listAllCreateRequest(ctx context.Conte
 func (client *ExpressRouteCircuitsClient) listAllHandleResponse(resp *http.Response) (ExpressRouteCircuitsListAllResponse, error) {
 	result := ExpressRouteCircuitsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuitListResult); err != nil {
-		return ExpressRouteCircuitsListAllResponse{}, err
+		return ExpressRouteCircuitsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -804,7 +804,7 @@ func (client *ExpressRouteCircuitsClient) updateTagsCreateRequest(ctx context.Co
 func (client *ExpressRouteCircuitsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRouteCircuitsUpdateTagsResponse, error) {
 	result := ExpressRouteCircuitsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCircuit); err != nil {
-		return ExpressRouteCircuitsUpdateTagsResponse{}, err
+		return ExpressRouteCircuitsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteconnections_client.go
@@ -253,7 +253,7 @@ func (client *ExpressRouteConnectionsClient) getCreateRequest(ctx context.Contex
 func (client *ExpressRouteConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteConnectionsGetResponse, error) {
 	result := ExpressRouteConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteConnection); err != nil {
-		return ExpressRouteConnectionsGetResponse{}, err
+		return ExpressRouteConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -318,7 +318,7 @@ func (client *ExpressRouteConnectionsClient) listCreateRequest(ctx context.Conte
 func (client *ExpressRouteConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteConnectionsListResponse, error) {
 	result := ExpressRouteConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteConnectionList); err != nil {
-		return ExpressRouteConnectionsListResponse{}, err
+		return ExpressRouteConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -253,7 +253,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) getCreateRequest(ctx co
 func (client *ExpressRouteCrossConnectionPeeringsClient) getHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionPeeringsGetResponse, error) {
 	result := ExpressRouteCrossConnectionPeeringsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionPeering); err != nil {
-		return ExpressRouteCrossConnectionPeeringsGetResponse{}, err
+		return ExpressRouteCrossConnectionPeeringsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) listCreateRequest(ctx c
 func (client *ExpressRouteCrossConnectionPeeringsClient) listHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionPeeringsListResponse, error) {
 	result := ExpressRouteCrossConnectionPeeringsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionPeeringList); err != nil {
-		return ExpressRouteCrossConnectionPeeringsListResponse{}, err
+		return ExpressRouteCrossConnectionPeeringsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -165,7 +165,7 @@ func (client *ExpressRouteCrossConnectionsClient) getCreateRequest(ctx context.C
 func (client *ExpressRouteCrossConnectionsClient) getHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsGetResponse, error) {
 	result := ExpressRouteCrossConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnection); err != nil {
-		return ExpressRouteCrossConnectionsGetResponse{}, err
+		return ExpressRouteCrossConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -219,7 +219,7 @@ func (client *ExpressRouteCrossConnectionsClient) listCreateRequest(ctx context.
 func (client *ExpressRouteCrossConnectionsClient) listHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsListResponse, error) {
 	result := ExpressRouteCrossConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionListResult); err != nil {
-		return ExpressRouteCrossConnectionsListResponse{}, err
+		return ExpressRouteCrossConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -361,7 +361,7 @@ func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupCreateReque
 func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsListByResourceGroupResponse, error) {
 	result := ExpressRouteCrossConnectionsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnectionListResult); err != nil {
-		return ExpressRouteCrossConnectionsListByResourceGroupResponse{}, err
+		return ExpressRouteCrossConnectionsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -594,7 +594,7 @@ func (client *ExpressRouteCrossConnectionsClient) updateTagsCreateRequest(ctx co
 func (client *ExpressRouteCrossConnectionsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRouteCrossConnectionsUpdateTagsResponse, error) {
 	result := ExpressRouteCrossConnectionsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteCrossConnection); err != nil {
-		return ExpressRouteCrossConnectionsUpdateTagsResponse{}, err
+		return ExpressRouteCrossConnectionsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutegateways_client.go
@@ -243,7 +243,7 @@ func (client *ExpressRouteGatewaysClient) getCreateRequest(ctx context.Context, 
 func (client *ExpressRouteGatewaysClient) getHandleResponse(resp *http.Response) (ExpressRouteGatewaysGetResponse, error) {
 	result := ExpressRouteGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGateway); err != nil {
-		return ExpressRouteGatewaysGetResponse{}, err
+		return ExpressRouteGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -304,7 +304,7 @@ func (client *ExpressRouteGatewaysClient) listByResourceGroupCreateRequest(ctx c
 func (client *ExpressRouteGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRouteGatewaysListByResourceGroupResponse, error) {
 	result := ExpressRouteGatewaysListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGatewayList); err != nil {
-		return ExpressRouteGatewaysListByResourceGroupResponse{}, err
+		return ExpressRouteGatewaysListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -361,7 +361,7 @@ func (client *ExpressRouteGatewaysClient) listBySubscriptionCreateRequest(ctx co
 func (client *ExpressRouteGatewaysClient) listBySubscriptionHandleResponse(resp *http.Response) (ExpressRouteGatewaysListBySubscriptionResponse, error) {
 	result := ExpressRouteGatewaysListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteGatewayList); err != nil {
-		return ExpressRouteGatewaysListBySubscriptionResponse{}, err
+		return ExpressRouteGatewaysListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
@@ -93,7 +93,7 @@ func (client *ExpressRouteLinksClient) getCreateRequest(ctx context.Context, res
 func (client *ExpressRouteLinksClient) getHandleResponse(resp *http.Response) (ExpressRouteLinksGetResponse, error) {
 	result := ExpressRouteLinksGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteLink); err != nil {
-		return ExpressRouteLinksGetResponse{}, err
+		return ExpressRouteLinksGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *ExpressRouteLinksClient) listCreateRequest(ctx context.Context, re
 func (client *ExpressRouteLinksClient) listHandleResponse(resp *http.Response) (ExpressRouteLinksListResponse, error) {
 	result := ExpressRouteLinksListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteLinkListResult); err != nil {
-		return ExpressRouteLinksListResponse{}, err
+		return ExpressRouteLinksListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -241,7 +241,7 @@ func (client *ExpressRoutePortsClient) getCreateRequest(ctx context.Context, res
 func (client *ExpressRoutePortsClient) getHandleResponse(resp *http.Response) (ExpressRoutePortsGetResponse, error) {
 	result := ExpressRoutePortsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePort); err != nil {
-		return ExpressRoutePortsGetResponse{}, err
+		return ExpressRoutePortsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *ExpressRoutePortsClient) listCreateRequest(ctx context.Context, op
 func (client *ExpressRoutePortsClient) listHandleResponse(resp *http.Response) (ExpressRoutePortsListResponse, error) {
 	result := ExpressRoutePortsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortListResult); err != nil {
-		return ExpressRoutePortsListResponse{}, err
+		return ExpressRoutePortsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *ExpressRoutePortsClient) listByResourceGroupCreateRequest(ctx cont
 func (client *ExpressRoutePortsClient) listByResourceGroupHandleResponse(resp *http.Response) (ExpressRoutePortsListByResourceGroupResponse, error) {
 	result := ExpressRoutePortsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortListResult); err != nil {
-		return ExpressRoutePortsListByResourceGroupResponse{}, err
+		return ExpressRoutePortsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *ExpressRoutePortsClient) updateTagsCreateRequest(ctx context.Conte
 func (client *ExpressRoutePortsClient) updateTagsHandleResponse(resp *http.Response) (ExpressRoutePortsUpdateTagsResponse, error) {
 	result := ExpressRoutePortsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePort); err != nil {
-		return ExpressRoutePortsUpdateTagsResponse{}, err
+		return ExpressRoutePortsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
@@ -85,7 +85,7 @@ func (client *ExpressRoutePortsLocationsClient) getCreateRequest(ctx context.Con
 func (client *ExpressRoutePortsLocationsClient) getHandleResponse(resp *http.Response) (ExpressRoutePortsLocationsGetResponse, error) {
 	result := ExpressRoutePortsLocationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortsLocation); err != nil {
-		return ExpressRoutePortsLocationsGetResponse{}, err
+		return ExpressRoutePortsLocationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -140,7 +140,7 @@ func (client *ExpressRoutePortsLocationsClient) listCreateRequest(ctx context.Co
 func (client *ExpressRoutePortsLocationsClient) listHandleResponse(resp *http.Response) (ExpressRoutePortsLocationsListResponse, error) {
 	result := ExpressRoutePortsLocationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRoutePortsLocationListResult); err != nil {
-		return ExpressRoutePortsLocationsListResponse{}, err
+		return ExpressRoutePortsLocationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
@@ -78,7 +78,7 @@ func (client *ExpressRouteServiceProvidersClient) listCreateRequest(ctx context.
 func (client *ExpressRouteServiceProvidersClient) listHandleResponse(resp *http.Response) (ExpressRouteServiceProvidersListResponse, error) {
 	result := ExpressRouteServiceProvidersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ExpressRouteServiceProviderListResult); err != nil {
-		return ExpressRouteServiceProvidersListResponse{}, err
+		return ExpressRouteServiceProvidersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -244,7 +244,7 @@ func (client *FirewallPoliciesClient) getCreateRequest(ctx context.Context, reso
 func (client *FirewallPoliciesClient) getHandleResponse(resp *http.Response) (FirewallPoliciesGetResponse, error) {
 	result := FirewallPoliciesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicy); err != nil {
-		return FirewallPoliciesGetResponse{}, err
+		return FirewallPoliciesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *FirewallPoliciesClient) listCreateRequest(ctx context.Context, res
 func (client *FirewallPoliciesClient) listHandleResponse(resp *http.Response) (FirewallPoliciesListResponse, error) {
 	result := FirewallPoliciesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyListResult); err != nil {
-		return FirewallPoliciesListResponse{}, err
+		return FirewallPoliciesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *FirewallPoliciesClient) listAllCreateRequest(ctx context.Context, 
 func (client *FirewallPoliciesClient) listAllHandleResponse(resp *http.Response) (FirewallPoliciesListAllResponse, error) {
 	result := FirewallPoliciesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyListResult); err != nil {
-		return FirewallPoliciesListAllResponse{}, err
+		return FirewallPoliciesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -253,7 +253,7 @@ func (client *FirewallPolicyRuleGroupsClient) getCreateRequest(ctx context.Conte
 func (client *FirewallPolicyRuleGroupsClient) getHandleResponse(resp *http.Response) (FirewallPolicyRuleGroupsGetResponse, error) {
 	result := FirewallPolicyRuleGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyRuleGroup); err != nil {
-		return FirewallPolicyRuleGroupsGetResponse{}, err
+		return FirewallPolicyRuleGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *FirewallPolicyRuleGroupsClient) listCreateRequest(ctx context.Cont
 func (client *FirewallPolicyRuleGroupsClient) listHandleResponse(resp *http.Response) (FirewallPolicyRuleGroupsListResponse, error) {
 	result := FirewallPolicyRuleGroupsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FirewallPolicyRuleGroupListResult); err != nil {
-		return FirewallPolicyRuleGroupsListResponse{}, err
+		return FirewallPolicyRuleGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -253,7 +253,7 @@ func (client *FlowLogsClient) getCreateRequest(ctx context.Context, resourceGrou
 func (client *FlowLogsClient) getHandleResponse(resp *http.Response) (FlowLogsGetResponse, error) {
 	result := FlowLogsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FlowLog); err != nil {
-		return FlowLogsGetResponse{}, err
+		return FlowLogsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *FlowLogsClient) listCreateRequest(ctx context.Context, resourceGro
 func (client *FlowLogsClient) listHandleResponse(resp *http.Response) (FlowLogsListResponse, error) {
 	result := FlowLogsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FlowLogListResult); err != nil {
-		return FlowLogsListResponse{}, err
+		return FlowLogsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
@@ -93,7 +93,7 @@ func (client *HubVirtualNetworkConnectionsClient) getCreateRequest(ctx context.C
 func (client *HubVirtualNetworkConnectionsClient) getHandleResponse(resp *http.Response) (HubVirtualNetworkConnectionsGetResponse, error) {
 	result := HubVirtualNetworkConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.HubVirtualNetworkConnection); err != nil {
-		return HubVirtualNetworkConnectionsGetResponse{}, err
+		return HubVirtualNetworkConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *HubVirtualNetworkConnectionsClient) listCreateRequest(ctx context.
 func (client *HubVirtualNetworkConnectionsClient) listHandleResponse(resp *http.Response) (HubVirtualNetworkConnectionsListResponse, error) {
 	result := HubVirtualNetworkConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListHubVirtualNetworkConnectionsResult); err != nil {
-		return HubVirtualNetworkConnectionsListResponse{}, err
+		return HubVirtualNetworkConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -256,7 +256,7 @@ func (client *InboundNatRulesClient) getCreateRequest(ctx context.Context, resou
 func (client *InboundNatRulesClient) getHandleResponse(resp *http.Response) (InboundNatRulesGetResponse, error) {
 	result := InboundNatRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InboundNatRule); err != nil {
-		return InboundNatRulesGetResponse{}, err
+		return InboundNatRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -318,7 +318,7 @@ func (client *InboundNatRulesClient) listCreateRequest(ctx context.Context, reso
 func (client *InboundNatRulesClient) listHandleResponse(resp *http.Response) (InboundNatRulesListResponse, error) {
 	result := InboundNatRulesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.InboundNatRuleListResult); err != nil {
-		return InboundNatRulesListResponse{}, err
+		return InboundNatRulesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -244,7 +244,7 @@ func (client *IPAllocationsClient) getCreateRequest(ctx context.Context, resourc
 func (client *IPAllocationsClient) getHandleResponse(resp *http.Response) (IPAllocationsGetResponse, error) {
 	result := IPAllocationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocation); err != nil {
-		return IPAllocationsGetResponse{}, err
+		return IPAllocationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *IPAllocationsClient) listCreateRequest(ctx context.Context, option
 func (client *IPAllocationsClient) listHandleResponse(resp *http.Response) (IPAllocationsListResponse, error) {
 	result := IPAllocationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocationListResult); err != nil {
-		return IPAllocationsListResponse{}, err
+		return IPAllocationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *IPAllocationsClient) listByResourceGroupCreateRequest(ctx context.
 func (client *IPAllocationsClient) listByResourceGroupHandleResponse(resp *http.Response) (IPAllocationsListByResourceGroupResponse, error) {
 	result := IPAllocationsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocationListResult); err != nil {
-		return IPAllocationsListByResourceGroupResponse{}, err
+		return IPAllocationsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *IPAllocationsClient) updateTagsCreateRequest(ctx context.Context, 
 func (client *IPAllocationsClient) updateTagsHandleResponse(resp *http.Response) (IPAllocationsUpdateTagsResponse, error) {
 	result := IPAllocationsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAllocation); err != nil {
-		return IPAllocationsUpdateTagsResponse{}, err
+		return IPAllocationsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -244,7 +244,7 @@ func (client *IPGroupsClient) getCreateRequest(ctx context.Context, resourceGrou
 func (client *IPGroupsClient) getHandleResponse(resp *http.Response) (IPGroupsGetResponse, error) {
 	result := IPGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroup); err != nil {
-		return IPGroupsGetResponse{}, err
+		return IPGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *IPGroupsClient) listCreateRequest(ctx context.Context, options *IP
 func (client *IPGroupsClient) listHandleResponse(resp *http.Response) (IPGroupsListResponse, error) {
 	result := IPGroupsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroupListResult); err != nil {
-		return IPGroupsListResponse{}, err
+		return IPGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *IPGroupsClient) listByResourceGroupCreateRequest(ctx context.Conte
 func (client *IPGroupsClient) listByResourceGroupHandleResponse(resp *http.Response) (IPGroupsListByResourceGroupResponse, error) {
 	result := IPGroupsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroupListResult); err != nil {
-		return IPGroupsListByResourceGroupResponse{}, err
+		return IPGroupsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *IPGroupsClient) updateGroupsCreateRequest(ctx context.Context, res
 func (client *IPGroupsClient) updateGroupsHandleResponse(resp *http.Response) (IPGroupsUpdateGroupsResponse, error) {
 	result := IPGroupsUpdateGroupsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPGroup); err != nil {
-		return IPGroupsUpdateGroupsResponse{}, err
+		return IPGroupsUpdateGroupsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
@@ -93,7 +93,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) getCreateRequest(ctx contex
 func (client *LoadBalancerBackendAddressPoolsClient) getHandleResponse(resp *http.Response) (LoadBalancerBackendAddressPoolsGetResponse, error) {
 	result := LoadBalancerBackendAddressPoolsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BackendAddressPool); err != nil {
-		return LoadBalancerBackendAddressPoolsGetResponse{}, err
+		return LoadBalancerBackendAddressPoolsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) listCreateRequest(ctx conte
 func (client *LoadBalancerBackendAddressPoolsClient) listHandleResponse(resp *http.Response) (LoadBalancerBackendAddressPoolsListResponse, error) {
 	result := LoadBalancerBackendAddressPoolsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerBackendAddressPoolListResult); err != nil {
-		return LoadBalancerBackendAddressPoolsListResponse{}, err
+		return LoadBalancerBackendAddressPoolsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
@@ -93,7 +93,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) getCreateRequest(ctx c
 func (client *LoadBalancerFrontendIPConfigurationsClient) getHandleResponse(resp *http.Response) (LoadBalancerFrontendIPConfigurationsGetResponse, error) {
 	result := LoadBalancerFrontendIPConfigurationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.FrontendIPConfiguration); err != nil {
-		return LoadBalancerFrontendIPConfigurationsGetResponse{}, err
+		return LoadBalancerFrontendIPConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) listCreateRequest(ctx 
 func (client *LoadBalancerFrontendIPConfigurationsClient) listHandleResponse(resp *http.Response) (LoadBalancerFrontendIPConfigurationsListResponse, error) {
 	result := LoadBalancerFrontendIPConfigurationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerFrontendIPConfigurationListResult); err != nil {
-		return LoadBalancerFrontendIPConfigurationsListResponse{}, err
+		return LoadBalancerFrontendIPConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
@@ -93,7 +93,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) getCreateRequest(ctx context
 func (client *LoadBalancerLoadBalancingRulesClient) getHandleResponse(resp *http.Response) (LoadBalancerLoadBalancingRulesGetResponse, error) {
 	result := LoadBalancerLoadBalancingRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancingRule); err != nil {
-		return LoadBalancerLoadBalancingRulesGetResponse{}, err
+		return LoadBalancerLoadBalancingRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) listCreateRequest(ctx contex
 func (client *LoadBalancerLoadBalancingRulesClient) listHandleResponse(resp *http.Response) (LoadBalancerLoadBalancingRulesListResponse, error) {
 	result := LoadBalancerLoadBalancingRulesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerLoadBalancingRuleListResult); err != nil {
-		return LoadBalancerLoadBalancingRulesListResponse{}, err
+		return LoadBalancerLoadBalancingRulesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
@@ -86,7 +86,7 @@ func (client *LoadBalancerNetworkInterfacesClient) listCreateRequest(ctx context
 func (client *LoadBalancerNetworkInterfacesClient) listHandleResponse(resp *http.Response) (LoadBalancerNetworkInterfacesListResponse, error) {
 	result := LoadBalancerNetworkInterfacesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
-		return LoadBalancerNetworkInterfacesListResponse{}, err
+		return LoadBalancerNetworkInterfacesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
@@ -93,7 +93,7 @@ func (client *LoadBalancerOutboundRulesClient) getCreateRequest(ctx context.Cont
 func (client *LoadBalancerOutboundRulesClient) getHandleResponse(resp *http.Response) (LoadBalancerOutboundRulesGetResponse, error) {
 	result := LoadBalancerOutboundRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OutboundRule); err != nil {
-		return LoadBalancerOutboundRulesGetResponse{}, err
+		return LoadBalancerOutboundRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *LoadBalancerOutboundRulesClient) listCreateRequest(ctx context.Con
 func (client *LoadBalancerOutboundRulesClient) listHandleResponse(resp *http.Response) (LoadBalancerOutboundRulesListResponse, error) {
 	result := LoadBalancerOutboundRulesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerOutboundRuleListResult); err != nil {
-		return LoadBalancerOutboundRulesListResponse{}, err
+		return LoadBalancerOutboundRulesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
@@ -93,7 +93,7 @@ func (client *LoadBalancerProbesClient) getCreateRequest(ctx context.Context, re
 func (client *LoadBalancerProbesClient) getHandleResponse(resp *http.Response) (LoadBalancerProbesGetResponse, error) {
 	result := LoadBalancerProbesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Probe); err != nil {
-		return LoadBalancerProbesGetResponse{}, err
+		return LoadBalancerProbesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *LoadBalancerProbesClient) listCreateRequest(ctx context.Context, r
 func (client *LoadBalancerProbesClient) listHandleResponse(resp *http.Response) (LoadBalancerProbesListResponse, error) {
 	result := LoadBalancerProbesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerProbeListResult); err != nil {
-		return LoadBalancerProbesListResponse{}, err
+		return LoadBalancerProbesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -244,7 +244,7 @@ func (client *LoadBalancersClient) getCreateRequest(ctx context.Context, resourc
 func (client *LoadBalancersClient) getHandleResponse(resp *http.Response) (LoadBalancersGetResponse, error) {
 	result := LoadBalancersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancer); err != nil {
-		return LoadBalancersGetResponse{}, err
+		return LoadBalancersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *LoadBalancersClient) listCreateRequest(ctx context.Context, resour
 func (client *LoadBalancersClient) listHandleResponse(resp *http.Response) (LoadBalancersListResponse, error) {
 	result := LoadBalancersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerListResult); err != nil {
-		return LoadBalancersListResponse{}, err
+		return LoadBalancersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *LoadBalancersClient) listAllCreateRequest(ctx context.Context, opt
 func (client *LoadBalancersClient) listAllHandleResponse(resp *http.Response) (LoadBalancersListAllResponse, error) {
 	result := LoadBalancersListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancerListResult); err != nil {
-		return LoadBalancersListAllResponse{}, err
+		return LoadBalancersListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *LoadBalancersClient) updateTagsCreateRequest(ctx context.Context, 
 func (client *LoadBalancersClient) updateTagsHandleResponse(resp *http.Response) (LoadBalancersUpdateTagsResponse, error) {
 	result := LoadBalancersUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LoadBalancer); err != nil {
-		return LoadBalancersUpdateTagsResponse{}, err
+		return LoadBalancersUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -241,7 +241,7 @@ func (client *LocalNetworkGatewaysClient) getCreateRequest(ctx context.Context, 
 func (client *LocalNetworkGatewaysClient) getHandleResponse(resp *http.Response) (LocalNetworkGatewaysGetResponse, error) {
 	result := LocalNetworkGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGateway); err != nil {
-		return LocalNetworkGatewaysGetResponse{}, err
+		return LocalNetworkGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -299,7 +299,7 @@ func (client *LocalNetworkGatewaysClient) listCreateRequest(ctx context.Context,
 func (client *LocalNetworkGatewaysClient) listHandleResponse(resp *http.Response) (LocalNetworkGatewaysListResponse, error) {
 	result := LocalNetworkGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGatewayListResult); err != nil {
-		return LocalNetworkGatewaysListResponse{}, err
+		return LocalNetworkGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -364,7 +364,7 @@ func (client *LocalNetworkGatewaysClient) updateTagsCreateRequest(ctx context.Co
 func (client *LocalNetworkGatewaysClient) updateTagsHandleResponse(resp *http.Response) (LocalNetworkGatewaysUpdateTagsResponse, error) {
 	result := LocalNetworkGatewaysUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LocalNetworkGateway); err != nil {
-		return LocalNetworkGatewaysUpdateTagsResponse{}, err
+		return LocalNetworkGatewaysUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -244,7 +244,7 @@ func (client *NatGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 func (client *NatGatewaysClient) getHandleResponse(resp *http.Response) (NatGatewaysGetResponse, error) {
 	result := NatGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGateway); err != nil {
-		return NatGatewaysGetResponse{}, err
+		return NatGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *NatGatewaysClient) listCreateRequest(ctx context.Context, resource
 func (client *NatGatewaysClient) listHandleResponse(resp *http.Response) (NatGatewaysListResponse, error) {
 	result := NatGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGatewayListResult); err != nil {
-		return NatGatewaysListResponse{}, err
+		return NatGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *NatGatewaysClient) listAllCreateRequest(ctx context.Context, optio
 func (client *NatGatewaysClient) listAllHandleResponse(resp *http.Response) (NatGatewaysListAllResponse, error) {
 	result := NatGatewaysListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGatewayListResult); err != nil {
-		return NatGatewaysListAllResponse{}, err
+		return NatGatewaysListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *NatGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 func (client *NatGatewaysClient) updateTagsHandleResponse(resp *http.Response) (NatGatewaysUpdateTagsResponse, error) {
 	result := NatGatewaysUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NatGateway); err != nil {
-		return NatGatewaysUpdateTagsResponse{}, err
+		return NatGatewaysUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceipconfigurations_client.go
@@ -93,7 +93,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) getCreateRequest(ctx conte
 func (client *NetworkInterfaceIPConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsGetResponse, error) {
 	result := NetworkInterfaceIPConfigurationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfiguration); err != nil {
-		return NetworkInterfaceIPConfigurationsGetResponse{}, err
+		return NetworkInterfaceIPConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *NetworkInterfaceIPConfigurationsClient) listCreateRequest(ctx cont
 func (client *NetworkInterfaceIPConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceIPConfigurationsListResponse, error) {
 	result := NetworkInterfaceIPConfigurationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfigurationListResult); err != nil {
-		return NetworkInterfaceIPConfigurationsListResponse{}, err
+		return NetworkInterfaceIPConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaceloadbalancers_client.go
@@ -86,7 +86,7 @@ func (client *NetworkInterfaceLoadBalancersClient) listCreateRequest(ctx context
 func (client *NetworkInterfaceLoadBalancersClient) listHandleResponse(resp *http.Response) (NetworkInterfaceLoadBalancersListResponse, error) {
 	result := NetworkInterfaceLoadBalancersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceLoadBalancerListResult); err != nil {
-		return NetworkInterfaceLoadBalancersListResponse{}, err
+		return NetworkInterfaceLoadBalancersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfaces_client.go
@@ -244,7 +244,7 @@ func (client *NetworkInterfacesClient) getCreateRequest(ctx context.Context, res
 func (client *NetworkInterfacesClient) getHandleResponse(resp *http.Response) (NetworkInterfacesGetResponse, error) {
 	result := NetworkInterfacesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
-		return NetworkInterfacesGetResponse{}, err
+		return NetworkInterfacesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -400,7 +400,7 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationC
 func (client *NetworkInterfacesClient) getVirtualMachineScaleSetIPConfigurationHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse, error) {
 	result := NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfiguration); err != nil {
-		return NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{}, err
+		return NetworkInterfacesGetVirtualMachineScaleSetIPConfigurationResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -476,7 +476,7 @@ func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterface
 func (client *NetworkInterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleResponse(resp *http.Response) (NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse, error) {
 	result := NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
-		return NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{}, err
+		return NetworkInterfacesGetVirtualMachineScaleSetNetworkInterfaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -534,7 +534,7 @@ func (client *NetworkInterfacesClient) listCreateRequest(ctx context.Context, re
 func (client *NetworkInterfacesClient) listHandleResponse(resp *http.Response) (NetworkInterfacesListResponse, error) {
 	result := NetworkInterfacesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
-		return NetworkInterfacesListResponse{}, err
+		return NetworkInterfacesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -588,7 +588,7 @@ func (client *NetworkInterfacesClient) listAllCreateRequest(ctx context.Context,
 func (client *NetworkInterfacesClient) listAllHandleResponse(resp *http.Response) (NetworkInterfacesListAllResponse, error) {
 	result := NetworkInterfacesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
-		return NetworkInterfacesListAllResponse{}, err
+		return NetworkInterfacesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -737,7 +737,7 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfiguration
 func (client *NetworkInterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceIPConfigurationListResult); err != nil {
-		return NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse{}, err
+		return NetworkInterfacesListVirtualMachineScaleSetIPConfigurationsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -799,7 +799,7 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfac
 func (client *NetworkInterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
-		return NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse{}, err
+		return NetworkInterfacesListVirtualMachineScaleSetNetworkInterfacesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -865,7 +865,7 @@ func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterf
 func (client *NetworkInterfacesClient) listVirtualMachineScaleSetVMNetworkInterfacesHandleResponse(resp *http.Response) (NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse, error) {
 	result := NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceListResult); err != nil {
-		return NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, err
+		return NetworkInterfacesListVirtualMachineScaleSetVMNetworkInterfacesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -930,7 +930,7 @@ func (client *NetworkInterfacesClient) updateTagsCreateRequest(ctx context.Conte
 func (client *NetworkInterfacesClient) updateTagsHandleResponse(resp *http.Response) (NetworkInterfacesUpdateTagsResponse, error) {
 	result := NetworkInterfacesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterface); err != nil {
-		return NetworkInterfacesUpdateTagsResponse{}, err
+		return NetworkInterfacesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkinterfacetapconfigurations_client.go
@@ -253,7 +253,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) getCreateRequest(ctx cont
 func (client *NetworkInterfaceTapConfigurationsClient) getHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsGetResponse, error) {
 	result := NetworkInterfaceTapConfigurationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceTapConfiguration); err != nil {
-		return NetworkInterfaceTapConfigurationsGetResponse{}, err
+		return NetworkInterfaceTapConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *NetworkInterfaceTapConfigurationsClient) listCreateRequest(ctx con
 func (client *NetworkInterfaceTapConfigurationsClient) listHandleResponse(resp *http.Response) (NetworkInterfaceTapConfigurationsListResponse, error) {
 	result := NetworkInterfaceTapConfigurationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkInterfaceTapConfigurationListResult); err != nil {
-		return NetworkInterfaceTapConfigurationsListResponse{}, err
+		return NetworkInterfaceTapConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkmanagementclient_client.go
@@ -86,7 +86,7 @@ func (client *NetworkManagementClient) checkDNSNameAvailabilityCreateRequest(ctx
 func (client *NetworkManagementClient) checkDNSNameAvailabilityHandleResponse(resp *http.Response) (NetworkManagementClientCheckDNSNameAvailabilityResponse, error) {
 	result := NetworkManagementClientCheckDNSNameAvailabilityResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DNSNameAvailabilityResult); err != nil {
-		return NetworkManagementClientCheckDNSNameAvailabilityResponse{}, err
+		return NetworkManagementClientCheckDNSNameAvailabilityResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -224,7 +224,7 @@ func (client *NetworkManagementClient) disconnectActiveSessionsCreateRequest(ctx
 func (client *NetworkManagementClient) disconnectActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientDisconnectActiveSessionsResponse, error) {
 	result := NetworkManagementClientDisconnectActiveSessionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionSessionDeleteResult); err != nil {
-		return NetworkManagementClientDisconnectActiveSessionsResponse{}, err
+		return NetworkManagementClientDisconnectActiveSessionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -388,7 +388,7 @@ func (client *NetworkManagementClient) getActiveSessionsCreateRequest(ctx contex
 func (client *NetworkManagementClient) getActiveSessionsHandleResponse(resp *http.Response) (NetworkManagementClientGetActiveSessionsResponse, error) {
 	result := NetworkManagementClientGetActiveSessionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionActiveSessionListResult); err != nil {
-		return NetworkManagementClientGetActiveSessionsResponse{}, err
+		return NetworkManagementClientGetActiveSessionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -450,7 +450,7 @@ func (client *NetworkManagementClient) getBastionShareableLinkCreateRequest(ctx 
 func (client *NetworkManagementClient) getBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientGetBastionShareableLinkResponse, error) {
 	result := NetworkManagementClientGetBastionShareableLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
-		return NetworkManagementClientGetBastionShareableLinkResponse{}, err
+		return NetworkManagementClientGetBastionShareableLinkResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -536,7 +536,7 @@ func (client *NetworkManagementClient) putBastionShareableLinkCreateRequest(ctx 
 func (client *NetworkManagementClient) putBastionShareableLinkHandleResponse(resp *http.Response) (NetworkManagementClientPutBastionShareableLinkResponse, error) {
 	result := NetworkManagementClientPutBastionShareableLinkResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BastionShareableLinkListResult); err != nil {
-		return NetworkManagementClientPutBastionShareableLinkResponse{}, err
+		return NetworkManagementClientPutBastionShareableLinkResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -601,7 +601,7 @@ func (client *NetworkManagementClient) supportedSecurityProvidersCreateRequest(c
 func (client *NetworkManagementClient) supportedSecurityProvidersHandleResponse(resp *http.Response) (NetworkManagementClientSupportedSecurityProvidersResponse, error) {
 	result := NetworkManagementClientSupportedSecurityProvidersResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWanSecurityProviders); err != nil {
-		return NetworkManagementClientSupportedSecurityProvidersResponse{}, err
+		return NetworkManagementClientSupportedSecurityProvidersResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkprofiles_client.go
@@ -89,7 +89,7 @@ func (client *NetworkProfilesClient) createOrUpdateCreateRequest(ctx context.Con
 func (client *NetworkProfilesClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkProfilesCreateOrUpdateResponse, error) {
 	result := NetworkProfilesCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
-		return NetworkProfilesCreateOrUpdateResponse{}, err
+		return NetworkProfilesCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -233,7 +233,7 @@ func (client *NetworkProfilesClient) getCreateRequest(ctx context.Context, resou
 func (client *NetworkProfilesClient) getHandleResponse(resp *http.Response) (NetworkProfilesGetResponse, error) {
 	result := NetworkProfilesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
-		return NetworkProfilesGetResponse{}, err
+		return NetworkProfilesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -291,7 +291,7 @@ func (client *NetworkProfilesClient) listCreateRequest(ctx context.Context, reso
 func (client *NetworkProfilesClient) listHandleResponse(resp *http.Response) (NetworkProfilesListResponse, error) {
 	result := NetworkProfilesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfileListResult); err != nil {
-		return NetworkProfilesListResponse{}, err
+		return NetworkProfilesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -345,7 +345,7 @@ func (client *NetworkProfilesClient) listAllCreateRequest(ctx context.Context, o
 func (client *NetworkProfilesClient) listAllHandleResponse(resp *http.Response) (NetworkProfilesListAllResponse, error) {
 	result := NetworkProfilesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfileListResult); err != nil {
-		return NetworkProfilesListAllResponse{}, err
+		return NetworkProfilesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -410,7 +410,7 @@ func (client *NetworkProfilesClient) updateTagsCreateRequest(ctx context.Context
 func (client *NetworkProfilesClient) updateTagsHandleResponse(resp *http.Response) (NetworkProfilesUpdateTagsResponse, error) {
 	result := NetworkProfilesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkProfile); err != nil {
-		return NetworkProfilesUpdateTagsResponse{}, err
+		return NetworkProfilesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networksecuritygroups_client.go
@@ -244,7 +244,7 @@ func (client *NetworkSecurityGroupsClient) getCreateRequest(ctx context.Context,
 func (client *NetworkSecurityGroupsClient) getHandleResponse(resp *http.Response) (NetworkSecurityGroupsGetResponse, error) {
 	result := NetworkSecurityGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroup); err != nil {
-		return NetworkSecurityGroupsGetResponse{}, err
+		return NetworkSecurityGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *NetworkSecurityGroupsClient) listCreateRequest(ctx context.Context
 func (client *NetworkSecurityGroupsClient) listHandleResponse(resp *http.Response) (NetworkSecurityGroupsListResponse, error) {
 	result := NetworkSecurityGroupsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroupListResult); err != nil {
-		return NetworkSecurityGroupsListResponse{}, err
+		return NetworkSecurityGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *NetworkSecurityGroupsClient) listAllCreateRequest(ctx context.Cont
 func (client *NetworkSecurityGroupsClient) listAllHandleResponse(resp *http.Response) (NetworkSecurityGroupsListAllResponse, error) {
 	result := NetworkSecurityGroupsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroupListResult); err != nil {
-		return NetworkSecurityGroupsListAllResponse{}, err
+		return NetworkSecurityGroupsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *NetworkSecurityGroupsClient) updateTagsCreateRequest(ctx context.C
 func (client *NetworkSecurityGroupsClient) updateTagsHandleResponse(resp *http.Response) (NetworkSecurityGroupsUpdateTagsResponse, error) {
 	result := NetworkSecurityGroupsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkSecurityGroup); err != nil {
-		return NetworkSecurityGroupsUpdateTagsResponse{}, err
+		return NetworkSecurityGroupsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkvirtualappliances_client.go
@@ -244,7 +244,7 @@ func (client *NetworkVirtualAppliancesClient) getCreateRequest(ctx context.Conte
 func (client *NetworkVirtualAppliancesClient) getHandleResponse(resp *http.Response) (NetworkVirtualAppliancesGetResponse, error) {
 	result := NetworkVirtualAppliancesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualAppliance); err != nil {
-		return NetworkVirtualAppliancesGetResponse{}, err
+		return NetworkVirtualAppliancesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *NetworkVirtualAppliancesClient) listCreateRequest(ctx context.Cont
 func (client *NetworkVirtualAppliancesClient) listHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListResponse, error) {
 	result := NetworkVirtualAppliancesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualApplianceListResult); err != nil {
-		return NetworkVirtualAppliancesListResponse{}, err
+		return NetworkVirtualAppliancesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *NetworkVirtualAppliancesClient) listByResourceGroupCreateRequest(c
 func (client *NetworkVirtualAppliancesClient) listByResourceGroupHandleResponse(resp *http.Response) (NetworkVirtualAppliancesListByResourceGroupResponse, error) {
 	result := NetworkVirtualAppliancesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualApplianceListResult); err != nil {
-		return NetworkVirtualAppliancesListByResourceGroupResponse{}, err
+		return NetworkVirtualAppliancesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *NetworkVirtualAppliancesClient) updateTagsCreateRequest(ctx contex
 func (client *NetworkVirtualAppliancesClient) updateTagsHandleResponse(resp *http.Response) (NetworkVirtualAppliancesUpdateTagsResponse, error) {
 	result := NetworkVirtualAppliancesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkVirtualAppliance); err != nil {
-		return NetworkVirtualAppliancesUpdateTagsResponse{}, err
+		return NetworkVirtualAppliancesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_networkwatchers_client.go
@@ -167,7 +167,7 @@ func (client *NetworkWatchersClient) createOrUpdateCreateRequest(ctx context.Con
 func (client *NetworkWatchersClient) createOrUpdateHandleResponse(resp *http.Response) (NetworkWatchersCreateOrUpdateResponse, error) {
 	result := NetworkWatchersCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
-		return NetworkWatchersCreateOrUpdateResponse{}, err
+		return NetworkWatchersCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -308,7 +308,7 @@ func (client *NetworkWatchersClient) getCreateRequest(ctx context.Context, resou
 func (client *NetworkWatchersClient) getHandleResponse(resp *http.Response) (NetworkWatchersGetResponse, error) {
 	result := NetworkWatchersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
-		return NetworkWatchersGetResponse{}, err
+		return NetworkWatchersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -687,7 +687,7 @@ func (client *NetworkWatchersClient) getTopologyCreateRequest(ctx context.Contex
 func (client *NetworkWatchersClient) getTopologyHandleResponse(resp *http.Response) (NetworkWatchersGetTopologyResponse, error) {
 	result := NetworkWatchersGetTopologyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Topology); err != nil {
-		return NetworkWatchersGetTopologyResponse{}, err
+		return NetworkWatchersGetTopologyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -976,7 +976,7 @@ func (client *NetworkWatchersClient) listCreateRequest(ctx context.Context, reso
 func (client *NetworkWatchersClient) listHandleResponse(resp *http.Response) (NetworkWatchersListResponse, error) {
 	result := NetworkWatchersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcherListResult); err != nil {
-		return NetworkWatchersListResponse{}, err
+		return NetworkWatchersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1033,7 +1033,7 @@ func (client *NetworkWatchersClient) listAllCreateRequest(ctx context.Context, o
 func (client *NetworkWatchersClient) listAllHandleResponse(resp *http.Response) (NetworkWatchersListAllResponse, error) {
 	result := NetworkWatchersListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcherListResult); err != nil {
-		return NetworkWatchersListAllResponse{}, err
+		return NetworkWatchersListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1252,7 +1252,7 @@ func (client *NetworkWatchersClient) updateTagsCreateRequest(ctx context.Context
 func (client *NetworkWatchersClient) updateTagsHandleResponse(resp *http.Response) (NetworkWatchersUpdateTagsResponse, error) {
 	result := NetworkWatchersUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NetworkWatcher); err != nil {
-		return NetworkWatchersUpdateTagsResponse{}, err
+		return NetworkWatchersUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
@@ -70,7 +70,7 @@ func (client *OperationsClient) listCreateRequest(ctx context.Context, options *
 func (client *OperationsClient) listHandleResponse(resp *http.Response) (OperationsListResponse, error) {
 	result := OperationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.OperationListResult); err != nil {
-		return OperationsListResponse{}, err
+		return OperationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -393,7 +393,7 @@ func (client *P2SVPNGatewaysClient) getCreateRequest(ctx context.Context, resour
 func (client *P2SVPNGatewaysClient) getHandleResponse(resp *http.Response) (P2SVPNGatewaysGetResponse, error) {
 	result := P2SVPNGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.P2SVPNGateway); err != nil {
-		return P2SVPNGatewaysGetResponse{}, err
+		return P2SVPNGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -601,7 +601,7 @@ func (client *P2SVPNGatewaysClient) listCreateRequest(ctx context.Context, optio
 func (client *P2SVPNGatewaysClient) listHandleResponse(resp *http.Response) (P2SVPNGatewaysListResponse, error) {
 	result := P2SVPNGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListP2SVPNGatewaysResult); err != nil {
-		return P2SVPNGatewaysListResponse{}, err
+		return P2SVPNGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -659,7 +659,7 @@ func (client *P2SVPNGatewaysClient) listByResourceGroupCreateRequest(ctx context
 func (client *P2SVPNGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (P2SVPNGatewaysListByResourceGroupResponse, error) {
 	result := P2SVPNGatewaysListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListP2SVPNGatewaysResult); err != nil {
-		return P2SVPNGatewaysListByResourceGroupResponse{}, err
+		return P2SVPNGatewaysListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -724,7 +724,7 @@ func (client *P2SVPNGatewaysClient) updateTagsCreateRequest(ctx context.Context,
 func (client *P2SVPNGatewaysClient) updateTagsHandleResponse(resp *http.Response) (P2SVPNGatewaysUpdateTagsResponse, error) {
 	result := P2SVPNGatewaysUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.P2SVPNGateway); err != nil {
-		return P2SVPNGatewaysUpdateTagsResponse{}, err
+		return P2SVPNGatewaysUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -253,7 +253,7 @@ func (client *PacketCapturesClient) getCreateRequest(ctx context.Context, resour
 func (client *PacketCapturesClient) getHandleResponse(resp *http.Response) (PacketCapturesGetResponse, error) {
 	result := PacketCapturesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PacketCaptureResult); err != nil {
-		return PacketCapturesGetResponse{}, err
+		return PacketCapturesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -398,7 +398,7 @@ func (client *PacketCapturesClient) listCreateRequest(ctx context.Context, resou
 func (client *PacketCapturesClient) listHandleResponse(resp *http.Response) (PacketCapturesListResponse, error) {
 	result := PacketCapturesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PacketCaptureListResult); err != nil {
-		return PacketCapturesListResponse{}, err
+		return PacketCapturesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
@@ -97,7 +97,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) getCreateRequest(ctx con
 func (client *PeerExpressRouteCircuitConnectionsClient) getHandleResponse(resp *http.Response) (PeerExpressRouteCircuitConnectionsGetResponse, error) {
 	result := PeerExpressRouteCircuitConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PeerExpressRouteCircuitConnection); err != nil {
-		return PeerExpressRouteCircuitConnectionsGetResponse{}, err
+		return PeerExpressRouteCircuitConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -163,7 +163,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) listCreateRequest(ctx co
 func (client *PeerExpressRouteCircuitConnectionsClient) listHandleResponse(resp *http.Response) (PeerExpressRouteCircuitConnectionsListResponse, error) {
 	result := PeerExpressRouteCircuitConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PeerExpressRouteCircuitConnectionListResult); err != nil {
-		return PeerExpressRouteCircuitConnectionsListResponse{}, err
+		return PeerExpressRouteCircuitConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -253,7 +253,7 @@ func (client *PrivateDNSZoneGroupsClient) getCreateRequest(ctx context.Context, 
 func (client *PrivateDNSZoneGroupsClient) getHandleResponse(resp *http.Response) (PrivateDNSZoneGroupsGetResponse, error) {
 	result := PrivateDNSZoneGroupsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateDNSZoneGroup); err != nil {
-		return PrivateDNSZoneGroupsGetResponse{}, err
+		return PrivateDNSZoneGroupsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *PrivateDNSZoneGroupsClient) listCreateRequest(ctx context.Context,
 func (client *PrivateDNSZoneGroupsClient) listHandleResponse(resp *http.Response) (PrivateDNSZoneGroupsListResponse, error) {
 	result := PrivateDNSZoneGroupsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateDNSZoneGroupListResult); err != nil {
-		return PrivateDNSZoneGroupsListResponse{}, err
+		return PrivateDNSZoneGroupsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -244,7 +244,7 @@ func (client *PrivateEndpointsClient) getCreateRequest(ctx context.Context, reso
 func (client *PrivateEndpointsClient) getHandleResponse(resp *http.Response) (PrivateEndpointsGetResponse, error) {
 	result := PrivateEndpointsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpoint); err != nil {
-		return PrivateEndpointsGetResponse{}, err
+		return PrivateEndpointsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *PrivateEndpointsClient) listCreateRequest(ctx context.Context, res
 func (client *PrivateEndpointsClient) listHandleResponse(resp *http.Response) (PrivateEndpointsListResponse, error) {
 	result := PrivateEndpointsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointListResult); err != nil {
-		return PrivateEndpointsListResponse{}, err
+		return PrivateEndpointsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *PrivateEndpointsClient) listBySubscriptionCreateRequest(ctx contex
 func (client *PrivateEndpointsClient) listBySubscriptionHandleResponse(resp *http.Response) (PrivateEndpointsListBySubscriptionResponse, error) {
 	result := PrivateEndpointsListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointListResult); err != nil {
-		return PrivateEndpointsListBySubscriptionResponse{}, err
+		return PrivateEndpointsListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -473,7 +473,7 @@ func (client *PrivateLinkServicesClient) getCreateRequest(ctx context.Context, r
 func (client *PrivateLinkServicesClient) getHandleResponse(resp *http.Response) (PrivateLinkServicesGetResponse, error) {
 	result := PrivateLinkServicesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkService); err != nil {
-		return PrivateLinkServicesGetResponse{}, err
+		return PrivateLinkServicesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -545,7 +545,7 @@ func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionCreateReque
 func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionHandleResponse(resp *http.Response) (PrivateLinkServicesGetPrivateEndpointConnectionResponse, error) {
 	result := PrivateLinkServicesGetPrivateEndpointConnectionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnection); err != nil {
-		return PrivateLinkServicesGetPrivateEndpointConnectionResponse{}, err
+		return PrivateLinkServicesGetPrivateEndpointConnectionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -603,7 +603,7 @@ func (client *PrivateLinkServicesClient) listCreateRequest(ctx context.Context, 
 func (client *PrivateLinkServicesClient) listHandleResponse(resp *http.Response) (PrivateLinkServicesListResponse, error) {
 	result := PrivateLinkServicesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkServiceListResult); err != nil {
-		return PrivateLinkServicesListResponse{}, err
+		return PrivateLinkServicesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -662,7 +662,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesCrea
 func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesHandleResponse(resp *http.Response) (PrivateLinkServicesListAutoApprovedPrivateLinkServicesResponse, error) {
 	result := PrivateLinkServicesListAutoApprovedPrivateLinkServicesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AutoApprovedPrivateLinkServicesResult); err != nil {
-		return PrivateLinkServicesListAutoApprovedPrivateLinkServicesResponse{}, err
+		return PrivateLinkServicesListAutoApprovedPrivateLinkServicesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -725,7 +725,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByRe
 func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByResourceGroupHandleResponse(resp *http.Response) (PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupResponse, error) {
 	result := PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AutoApprovedPrivateLinkServicesResult); err != nil {
-		return PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
+		return PrivateLinkServicesListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -779,7 +779,7 @@ func (client *PrivateLinkServicesClient) listBySubscriptionCreateRequest(ctx con
 func (client *PrivateLinkServicesClient) listBySubscriptionHandleResponse(resp *http.Response) (PrivateLinkServicesListBySubscriptionResponse, error) {
 	result := PrivateLinkServicesListBySubscriptionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateLinkServiceListResult); err != nil {
-		return PrivateLinkServicesListBySubscriptionResponse{}, err
+		return PrivateLinkServicesListBySubscriptionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -841,7 +841,7 @@ func (client *PrivateLinkServicesClient) listPrivateEndpointConnectionsCreateReq
 func (client *PrivateLinkServicesClient) listPrivateEndpointConnectionsHandleResponse(resp *http.Response) (PrivateLinkServicesListPrivateEndpointConnectionsResponse, error) {
 	result := PrivateLinkServicesListPrivateEndpointConnectionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnectionListResult); err != nil {
-		return PrivateLinkServicesListPrivateEndpointConnectionsResponse{}, err
+		return PrivateLinkServicesListPrivateEndpointConnectionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -910,7 +910,7 @@ func (client *PrivateLinkServicesClient) updatePrivateEndpointConnectionCreateRe
 func (client *PrivateLinkServicesClient) updatePrivateEndpointConnectionHandleResponse(resp *http.Response) (PrivateLinkServicesUpdatePrivateEndpointConnectionResponse, error) {
 	result := PrivateLinkServicesUpdatePrivateEndpointConnectionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PrivateEndpointConnection); err != nil {
-		return PrivateLinkServicesUpdatePrivateEndpointConnectionResponse{}, err
+		return PrivateLinkServicesUpdatePrivateEndpointConnectionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -244,7 +244,7 @@ func (client *PublicIPAddressesClient) getCreateRequest(ctx context.Context, res
 func (client *PublicIPAddressesClient) getHandleResponse(resp *http.Response) (PublicIPAddressesGetResponse, error) {
 	result := PublicIPAddressesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
-		return PublicIPAddressesGetResponse{}, err
+		return PublicIPAddressesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -328,7 +328,7 @@ func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressC
 func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressHandleResponse(resp *http.Response) (PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressResponse, error) {
 	result := PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
-		return PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressResponse{}, err
+		return PublicIPAddressesGetVirtualMachineScaleSetPublicIPAddressResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -386,7 +386,7 @@ func (client *PublicIPAddressesClient) listCreateRequest(ctx context.Context, re
 func (client *PublicIPAddressesClient) listHandleResponse(resp *http.Response) (PublicIPAddressesListResponse, error) {
 	result := PublicIPAddressesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
-		return PublicIPAddressesListResponse{}, err
+		return PublicIPAddressesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -440,7 +440,7 @@ func (client *PublicIPAddressesClient) listAllCreateRequest(ctx context.Context,
 func (client *PublicIPAddressesClient) listAllHandleResponse(resp *http.Response) (PublicIPAddressesListAllResponse, error) {
 	result := PublicIPAddressesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
-		return PublicIPAddressesListAllResponse{}, err
+		return PublicIPAddressesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -502,7 +502,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddress
 func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddressesHandleResponse(resp *http.Response) (PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesResponse, error) {
 	result := PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
-		return PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
+		return PublicIPAddressesListVirtualMachineScaleSetPublicIPAddressesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -577,7 +577,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIPAddre
 func (client *PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIPAddressesHandleResponse(resp *http.Response) (PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddressesResponse, error) {
 	result := PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddressesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddressListResult); err != nil {
-		return PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
+		return PublicIPAddressesListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -642,7 +642,7 @@ func (client *PublicIPAddressesClient) updateTagsCreateRequest(ctx context.Conte
 func (client *PublicIPAddressesClient) updateTagsHandleResponse(resp *http.Response) (PublicIPAddressesUpdateTagsResponse, error) {
 	result := PublicIPAddressesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPAddress); err != nil {
-		return PublicIPAddressesUpdateTagsResponse{}, err
+		return PublicIPAddressesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -244,7 +244,7 @@ func (client *PublicIPPrefixesClient) getCreateRequest(ctx context.Context, reso
 func (client *PublicIPPrefixesClient) getHandleResponse(resp *http.Response) (PublicIPPrefixesGetResponse, error) {
 	result := PublicIPPrefixesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefix); err != nil {
-		return PublicIPPrefixesGetResponse{}, err
+		return PublicIPPrefixesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *PublicIPPrefixesClient) listCreateRequest(ctx context.Context, res
 func (client *PublicIPPrefixesClient) listHandleResponse(resp *http.Response) (PublicIPPrefixesListResponse, error) {
 	result := PublicIPPrefixesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefixListResult); err != nil {
-		return PublicIPPrefixesListResponse{}, err
+		return PublicIPPrefixesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *PublicIPPrefixesClient) listAllCreateRequest(ctx context.Context, 
 func (client *PublicIPPrefixesClient) listAllHandleResponse(resp *http.Response) (PublicIPPrefixesListAllResponse, error) {
 	result := PublicIPPrefixesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefixListResult); err != nil {
-		return PublicIPPrefixesListAllResponse{}, err
+		return PublicIPPrefixesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *PublicIPPrefixesClient) updateTagsCreateRequest(ctx context.Contex
 func (client *PublicIPPrefixesClient) updateTagsHandleResponse(resp *http.Response) (PublicIPPrefixesUpdateTagsResponse, error) {
 	result := PublicIPPrefixesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PublicIPPrefix); err != nil {
-		return PublicIPPrefixesUpdateTagsResponse{}, err
+		return PublicIPPrefixesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_resourcenavigationlinks_client.go
@@ -93,7 +93,7 @@ func (client *ResourceNavigationLinksClient) listCreateRequest(ctx context.Conte
 func (client *ResourceNavigationLinksClient) listHandleResponse(resp *http.Response) (ResourceNavigationLinksListResponse, error) {
 	result := ResourceNavigationLinksListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ResourceNavigationLinksListResult); err != nil {
-		return ResourceNavigationLinksListResponse{}, err
+		return ResourceNavigationLinksListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -253,7 +253,7 @@ func (client *RouteFilterRulesClient) getCreateRequest(ctx context.Context, reso
 func (client *RouteFilterRulesClient) getHandleResponse(resp *http.Response) (RouteFilterRulesGetResponse, error) {
 	result := RouteFilterRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterRule); err != nil {
-		return RouteFilterRulesGetResponse{}, err
+		return RouteFilterRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *RouteFilterRulesClient) listByRouteFilterCreateRequest(ctx context
 func (client *RouteFilterRulesClient) listByRouteFilterHandleResponse(resp *http.Response) (RouteFilterRulesListByRouteFilterResponse, error) {
 	result := RouteFilterRulesListByRouteFilterResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterRuleListResult); err != nil {
-		return RouteFilterRulesListByRouteFilterResponse{}, err
+		return RouteFilterRulesListByRouteFilterResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -244,7 +244,7 @@ func (client *RouteFiltersClient) getCreateRequest(ctx context.Context, resource
 func (client *RouteFiltersClient) getHandleResponse(resp *http.Response) (RouteFiltersGetResponse, error) {
 	result := RouteFiltersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilter); err != nil {
-		return RouteFiltersGetResponse{}, err
+		return RouteFiltersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *RouteFiltersClient) listCreateRequest(ctx context.Context, options
 func (client *RouteFiltersClient) listHandleResponse(resp *http.Response) (RouteFiltersListResponse, error) {
 	result := RouteFiltersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterListResult); err != nil {
-		return RouteFiltersListResponse{}, err
+		return RouteFiltersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *RouteFiltersClient) listByResourceGroupCreateRequest(ctx context.C
 func (client *RouteFiltersClient) listByResourceGroupHandleResponse(resp *http.Response) (RouteFiltersListByResourceGroupResponse, error) {
 	result := RouteFiltersListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilterListResult); err != nil {
-		return RouteFiltersListByResourceGroupResponse{}, err
+		return RouteFiltersListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *RouteFiltersClient) updateTagsCreateRequest(ctx context.Context, r
 func (client *RouteFiltersClient) updateTagsHandleResponse(resp *http.Response) (RouteFiltersUpdateTagsResponse, error) {
 	result := RouteFiltersUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteFilter); err != nil {
-		return RouteFiltersUpdateTagsResponse{}, err
+		return RouteFiltersUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -253,7 +253,7 @@ func (client *RoutesClient) getCreateRequest(ctx context.Context, resourceGroupN
 func (client *RoutesClient) getHandleResponse(resp *http.Response) (RoutesGetResponse, error) {
 	result := RoutesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Route); err != nil {
-		return RoutesGetResponse{}, err
+		return RoutesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *RoutesClient) listCreateRequest(ctx context.Context, resourceGroup
 func (client *RoutesClient) listHandleResponse(resp *http.Response) (RoutesListResponse, error) {
 	result := RoutesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteListResult); err != nil {
-		return RoutesListResponse{}, err
+		return RoutesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -244,7 +244,7 @@ func (client *RouteTablesClient) getCreateRequest(ctx context.Context, resourceG
 func (client *RouteTablesClient) getHandleResponse(resp *http.Response) (RouteTablesGetResponse, error) {
 	result := RouteTablesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTable); err != nil {
-		return RouteTablesGetResponse{}, err
+		return RouteTablesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -302,7 +302,7 @@ func (client *RouteTablesClient) listCreateRequest(ctx context.Context, resource
 func (client *RouteTablesClient) listHandleResponse(resp *http.Response) (RouteTablesListResponse, error) {
 	result := RouteTablesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTableListResult); err != nil {
-		return RouteTablesListResponse{}, err
+		return RouteTablesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *RouteTablesClient) listAllCreateRequest(ctx context.Context, optio
 func (client *RouteTablesClient) listAllHandleResponse(resp *http.Response) (RouteTablesListAllResponse, error) {
 	result := RouteTablesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTableListResult); err != nil {
-		return RouteTablesListAllResponse{}, err
+		return RouteTablesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *RouteTablesClient) updateTagsCreateRequest(ctx context.Context, re
 func (client *RouteTablesClient) updateTagsHandleResponse(resp *http.Response) (RouteTablesUpdateTagsResponse, error) {
 	result := RouteTablesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.RouteTable); err != nil {
-		return RouteTablesUpdateTagsResponse{}, err
+		return RouteTablesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -241,7 +241,7 @@ func (client *SecurityPartnerProvidersClient) getCreateRequest(ctx context.Conte
 func (client *SecurityPartnerProvidersClient) getHandleResponse(resp *http.Response) (SecurityPartnerProvidersGetResponse, error) {
 	result := SecurityPartnerProvidersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProvider); err != nil {
-		return SecurityPartnerProvidersGetResponse{}, err
+		return SecurityPartnerProvidersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *SecurityPartnerProvidersClient) listCreateRequest(ctx context.Cont
 func (client *SecurityPartnerProvidersClient) listHandleResponse(resp *http.Response) (SecurityPartnerProvidersListResponse, error) {
 	result := SecurityPartnerProvidersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProviderListResult); err != nil {
-		return SecurityPartnerProvidersListResponse{}, err
+		return SecurityPartnerProvidersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *SecurityPartnerProvidersClient) listByResourceGroupCreateRequest(c
 func (client *SecurityPartnerProvidersClient) listByResourceGroupHandleResponse(resp *http.Response) (SecurityPartnerProvidersListByResourceGroupResponse, error) {
 	result := SecurityPartnerProvidersListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProviderListResult); err != nil {
-		return SecurityPartnerProvidersListByResourceGroupResponse{}, err
+		return SecurityPartnerProvidersListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *SecurityPartnerProvidersClient) updateTagsCreateRequest(ctx contex
 func (client *SecurityPartnerProvidersClient) updateTagsHandleResponse(resp *http.Response) (SecurityPartnerProvidersUpdateTagsResponse, error) {
 	result := SecurityPartnerProvidersUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityPartnerProvider); err != nil {
-		return SecurityPartnerProvidersUpdateTagsResponse{}, err
+		return SecurityPartnerProvidersUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -253,7 +253,7 @@ func (client *SecurityRulesClient) getCreateRequest(ctx context.Context, resourc
 func (client *SecurityRulesClient) getHandleResponse(resp *http.Response) (SecurityRulesGetResponse, error) {
 	result := SecurityRulesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRule); err != nil {
-		return SecurityRulesGetResponse{}, err
+		return SecurityRulesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *SecurityRulesClient) listCreateRequest(ctx context.Context, resour
 func (client *SecurityRulesClient) listHandleResponse(resp *http.Response) (SecurityRulesListResponse, error) {
 	result := SecurityRulesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SecurityRuleListResult); err != nil {
-		return SecurityRulesListResponse{}, err
+		return SecurityRulesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceassociationlinks_client.go
@@ -93,7 +93,7 @@ func (client *ServiceAssociationLinksClient) listCreateRequest(ctx context.Conte
 func (client *ServiceAssociationLinksClient) listHandleResponse(resp *http.Response) (ServiceAssociationLinksListResponse, error) {
 	result := ServiceAssociationLinksListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceAssociationLinksListResult); err != nil {
-		return ServiceAssociationLinksListResponse{}, err
+		return ServiceAssociationLinksListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -244,7 +244,7 @@ func (client *ServiceEndpointPoliciesClient) getCreateRequest(ctx context.Contex
 func (client *ServiceEndpointPoliciesClient) getHandleResponse(resp *http.Response) (ServiceEndpointPoliciesGetResponse, error) {
 	result := ServiceEndpointPoliciesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicy); err != nil {
-		return ServiceEndpointPoliciesGetResponse{}, err
+		return ServiceEndpointPoliciesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *ServiceEndpointPoliciesClient) listCreateRequest(ctx context.Conte
 func (client *ServiceEndpointPoliciesClient) listHandleResponse(resp *http.Response) (ServiceEndpointPoliciesListResponse, error) {
 	result := ServiceEndpointPoliciesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyListResult); err != nil {
-		return ServiceEndpointPoliciesListResponse{}, err
+		return ServiceEndpointPoliciesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *ServiceEndpointPoliciesClient) listByResourceGroupCreateRequest(ct
 func (client *ServiceEndpointPoliciesClient) listByResourceGroupHandleResponse(resp *http.Response) (ServiceEndpointPoliciesListByResourceGroupResponse, error) {
 	result := ServiceEndpointPoliciesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyListResult); err != nil {
-		return ServiceEndpointPoliciesListByResourceGroupResponse{}, err
+		return ServiceEndpointPoliciesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -421,7 +421,7 @@ func (client *ServiceEndpointPoliciesClient) updateTagsCreateRequest(ctx context
 func (client *ServiceEndpointPoliciesClient) updateTagsHandleResponse(resp *http.Response) (ServiceEndpointPoliciesUpdateTagsResponse, error) {
 	result := ServiceEndpointPoliciesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicy); err != nil {
-		return ServiceEndpointPoliciesUpdateTagsResponse{}, err
+		return ServiceEndpointPoliciesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -253,7 +253,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) getCreateRequest(ctx conte
 func (client *ServiceEndpointPolicyDefinitionsClient) getHandleResponse(resp *http.Response) (ServiceEndpointPolicyDefinitionsGetResponse, error) {
 	result := ServiceEndpointPolicyDefinitionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyDefinition); err != nil {
-		return ServiceEndpointPolicyDefinitionsGetResponse{}, err
+		return ServiceEndpointPolicyDefinitionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) listByResourceGroupCreateR
 func (client *ServiceEndpointPolicyDefinitionsClient) listByResourceGroupHandleResponse(resp *http.Response) (ServiceEndpointPolicyDefinitionsListByResourceGroupResponse, error) {
 	result := ServiceEndpointPolicyDefinitionsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceEndpointPolicyDefinitionListResult); err != nil {
-		return ServiceEndpointPolicyDefinitionsListByResourceGroupResponse{}, err
+		return ServiceEndpointPolicyDefinitionsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_servicetags_client.go
@@ -85,7 +85,7 @@ func (client *ServiceTagsClient) listCreateRequest(ctx context.Context, location
 func (client *ServiceTagsClient) listHandleResponse(resp *http.Response) (ServiceTagsListResponse, error) {
 	result := ServiceTagsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ServiceTagsListResult); err != nil {
-		return ServiceTagsListResponse{}, err
+		return ServiceTagsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -256,7 +256,7 @@ func (client *SubnetsClient) getCreateRequest(ctx context.Context, resourceGroup
 func (client *SubnetsClient) getHandleResponse(resp *http.Response) (SubnetsGetResponse, error) {
 	result := SubnetsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Subnet); err != nil {
-		return SubnetsGetResponse{}, err
+		return SubnetsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -318,7 +318,7 @@ func (client *SubnetsClient) listCreateRequest(ctx context.Context, resourceGrou
 func (client *SubnetsClient) listHandleResponse(resp *http.Response) (SubnetsListResponse, error) {
 	result := SubnetsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SubnetListResult); err != nil {
-		return SubnetsListResponse{}, err
+		return SubnetsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
@@ -82,7 +82,7 @@ func (client *UsagesClient) listCreateRequest(ctx context.Context, location stri
 func (client *UsagesClient) listHandleResponse(resp *http.Response) (UsagesListResponse, error) {
 	result := UsagesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.UsagesListResult); err != nil {
-		return UsagesListResponse{}, err
+		return UsagesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -253,7 +253,7 @@ func (client *VirtualHubRouteTableV2SClient) getCreateRequest(ctx context.Contex
 func (client *VirtualHubRouteTableV2SClient) getHandleResponse(resp *http.Response) (VirtualHubRouteTableV2SGetResponse, error) {
 	result := VirtualHubRouteTableV2SGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHubRouteTableV2); err != nil {
-		return VirtualHubRouteTableV2SGetResponse{}, err
+		return VirtualHubRouteTableV2SGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *VirtualHubRouteTableV2SClient) listCreateRequest(ctx context.Conte
 func (client *VirtualHubRouteTableV2SClient) listHandleResponse(resp *http.Response) (VirtualHubRouteTableV2SListResponse, error) {
 	result := VirtualHubRouteTableV2SListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubRouteTableV2SResult); err != nil {
-		return VirtualHubRouteTableV2SListResponse{}, err
+		return VirtualHubRouteTableV2SListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -241,7 +241,7 @@ func (client *VirtualHubsClient) getCreateRequest(ctx context.Context, resourceG
 func (client *VirtualHubsClient) getHandleResponse(resp *http.Response) (VirtualHubsGetResponse, error) {
 	result := VirtualHubsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHub); err != nil {
-		return VirtualHubsGetResponse{}, err
+		return VirtualHubsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VirtualHubsClient) listCreateRequest(ctx context.Context, options 
 func (client *VirtualHubsClient) listHandleResponse(resp *http.Response) (VirtualHubsListResponse, error) {
 	result := VirtualHubsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubsResult); err != nil {
-		return VirtualHubsListResponse{}, err
+		return VirtualHubsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VirtualHubsClient) listByResourceGroupCreateRequest(ctx context.Co
 func (client *VirtualHubsClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualHubsListByResourceGroupResponse, error) {
 	result := VirtualHubsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualHubsResult); err != nil {
-		return VirtualHubsListByResourceGroupResponse{}, err
+		return VirtualHubsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *VirtualHubsClient) updateTagsCreateRequest(ctx context.Context, re
 func (client *VirtualHubsClient) updateTagsHandleResponse(resp *http.Response) (VirtualHubsUpdateTagsResponse, error) {
 	result := VirtualHubsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualHub); err != nil {
-		return VirtualHubsUpdateTagsResponse{}, err
+		return VirtualHubsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -241,7 +241,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getCreateRequest(ctx conte
 func (client *VirtualNetworkGatewayConnectionsClient) getHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsGetResponse, error) {
 	result := VirtualNetworkGatewayConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayConnection); err != nil {
-		return VirtualNetworkGatewayConnectionsGetResponse{}, err
+		return VirtualNetworkGatewayConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -307,7 +307,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyCreateRequest(
 func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsGetSharedKeyResponse, error) {
 	result := VirtualNetworkGatewayConnectionsGetSharedKeyResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ConnectionSharedKey); err != nil {
-		return VirtualNetworkGatewayConnectionsGetSharedKeyResponse{}, err
+		return VirtualNetworkGatewayConnectionsGetSharedKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -365,7 +365,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) listCreateRequest(ctx cont
 func (client *VirtualNetworkGatewayConnectionsClient) listHandleResponse(resp *http.Response) (VirtualNetworkGatewayConnectionsListResponse, error) {
 	result := VirtualNetworkGatewayConnectionsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayConnectionListResult); err != nil {
-		return VirtualNetworkGatewayConnectionsListResponse{}, err
+		return VirtualNetworkGatewayConnectionsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -471,7 +471,7 @@ func (client *VirtualNetworkGatewaysClient) getCreateRequest(ctx context.Context
 func (client *VirtualNetworkGatewaysClient) getHandleResponse(resp *http.Response) (VirtualNetworkGatewaysGetResponse, error) {
 	result := VirtualNetworkGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGateway); err != nil {
-		return VirtualNetworkGatewaysGetResponse{}, err
+		return VirtualNetworkGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -997,7 +997,7 @@ func (client *VirtualNetworkGatewaysClient) listCreateRequest(ctx context.Contex
 func (client *VirtualNetworkGatewaysClient) listHandleResponse(resp *http.Response) (VirtualNetworkGatewaysListResponse, error) {
 	result := VirtualNetworkGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayListResult); err != nil {
-		return VirtualNetworkGatewaysListResponse{}, err
+		return VirtualNetworkGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1059,7 +1059,7 @@ func (client *VirtualNetworkGatewaysClient) listConnectionsCreateRequest(ctx con
 func (client *VirtualNetworkGatewaysClient) listConnectionsHandleResponse(resp *http.Response) (VirtualNetworkGatewaysListConnectionsResponse, error) {
 	result := VirtualNetworkGatewaysListConnectionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkGatewayListConnectionsResult); err != nil {
-		return VirtualNetworkGatewaysListConnectionsResponse{}, err
+		return VirtualNetworkGatewaysListConnectionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1512,7 +1512,7 @@ func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesCreateRequest(ctx
 func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesHandleResponse(resp *http.Response) (VirtualNetworkGatewaysSupportedVPNDevicesResponse, error) {
 	result := VirtualNetworkGatewaysSupportedVPNDevicesResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return VirtualNetworkGatewaysSupportedVPNDevicesResponse{}, err
+		return VirtualNetworkGatewaysSupportedVPNDevicesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -1653,7 +1653,7 @@ func (client *VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptCreateRe
 func (client *VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptHandleResponse(resp *http.Response) (VirtualNetworkGatewaysVPNDeviceConfigurationScriptResponse, error) {
 	result := VirtualNetworkGatewaysVPNDeviceConfigurationScriptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return VirtualNetworkGatewaysVPNDeviceConfigurationScriptResponse{}, err
+		return VirtualNetworkGatewaysVPNDeviceConfigurationScriptResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -253,7 +253,7 @@ func (client *VirtualNetworkPeeringsClient) getCreateRequest(ctx context.Context
 func (client *VirtualNetworkPeeringsClient) getHandleResponse(resp *http.Response) (VirtualNetworkPeeringsGetResponse, error) {
 	result := VirtualNetworkPeeringsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkPeering); err != nil {
-		return VirtualNetworkPeeringsGetResponse{}, err
+		return VirtualNetworkPeeringsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *VirtualNetworkPeeringsClient) listCreateRequest(ctx context.Contex
 func (client *VirtualNetworkPeeringsClient) listHandleResponse(resp *http.Response) (VirtualNetworkPeeringsListResponse, error) {
 	result := VirtualNetworkPeeringsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkPeeringListResult); err != nil {
-		return VirtualNetworkPeeringsListResponse{}, err
+		return VirtualNetworkPeeringsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -90,7 +90,7 @@ func (client *VirtualNetworksClient) checkIPAddressAvailabilityCreateRequest(ctx
 func (client *VirtualNetworksClient) checkIPAddressAvailabilityHandleResponse(resp *http.Response) (VirtualNetworksCheckIPAddressAvailabilityResponse, error) {
 	result := VirtualNetworksCheckIPAddressAvailabilityResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IPAddressAvailabilityResult); err != nil {
-		return VirtualNetworksCheckIPAddressAvailabilityResponse{}, err
+		return VirtualNetworksCheckIPAddressAvailabilityResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -310,7 +310,7 @@ func (client *VirtualNetworksClient) getCreateRequest(ctx context.Context, resou
 func (client *VirtualNetworksClient) getHandleResponse(resp *http.Response) (VirtualNetworksGetResponse, error) {
 	result := VirtualNetworksGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetwork); err != nil {
-		return VirtualNetworksGetResponse{}, err
+		return VirtualNetworksGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -368,7 +368,7 @@ func (client *VirtualNetworksClient) listCreateRequest(ctx context.Context, reso
 func (client *VirtualNetworksClient) listHandleResponse(resp *http.Response) (VirtualNetworksListResponse, error) {
 	result := VirtualNetworksListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListResult); err != nil {
-		return VirtualNetworksListResponse{}, err
+		return VirtualNetworksListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -422,7 +422,7 @@ func (client *VirtualNetworksClient) listAllCreateRequest(ctx context.Context, o
 func (client *VirtualNetworksClient) listAllHandleResponse(resp *http.Response) (VirtualNetworksListAllResponse, error) {
 	result := VirtualNetworksListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListResult); err != nil {
-		return VirtualNetworksListAllResponse{}, err
+		return VirtualNetworksListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -484,7 +484,7 @@ func (client *VirtualNetworksClient) listUsageCreateRequest(ctx context.Context,
 func (client *VirtualNetworksClient) listUsageHandleResponse(resp *http.Response) (VirtualNetworksListUsageResponse, error) {
 	result := VirtualNetworksListUsageResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkListUsageResult); err != nil {
-		return VirtualNetworksListUsageResponse{}, err
+		return VirtualNetworksListUsageResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -549,7 +549,7 @@ func (client *VirtualNetworksClient) updateTagsCreateRequest(ctx context.Context
 func (client *VirtualNetworksClient) updateTagsHandleResponse(resp *http.Response) (VirtualNetworksUpdateTagsResponse, error) {
 	result := VirtualNetworksUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetwork); err != nil {
-		return VirtualNetworksUpdateTagsResponse{}, err
+		return VirtualNetworksUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -241,7 +241,7 @@ func (client *VirtualNetworkTapsClient) getCreateRequest(ctx context.Context, re
 func (client *VirtualNetworkTapsClient) getHandleResponse(resp *http.Response) (VirtualNetworkTapsGetResponse, error) {
 	result := VirtualNetworkTapsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTap); err != nil {
-		return VirtualNetworkTapsGetResponse{}, err
+		return VirtualNetworkTapsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VirtualNetworkTapsClient) listAllCreateRequest(ctx context.Context
 func (client *VirtualNetworkTapsClient) listAllHandleResponse(resp *http.Response) (VirtualNetworkTapsListAllResponse, error) {
 	result := VirtualNetworkTapsListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTapListResult); err != nil {
-		return VirtualNetworkTapsListAllResponse{}, err
+		return VirtualNetworkTapsListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VirtualNetworkTapsClient) listByResourceGroupCreateRequest(ctx con
 func (client *VirtualNetworkTapsClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualNetworkTapsListByResourceGroupResponse, error) {
 	result := VirtualNetworkTapsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTapListResult); err != nil {
-		return VirtualNetworkTapsListByResourceGroupResponse{}, err
+		return VirtualNetworkTapsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *VirtualNetworkTapsClient) updateTagsCreateRequest(ctx context.Cont
 func (client *VirtualNetworkTapsClient) updateTagsHandleResponse(resp *http.Response) (VirtualNetworkTapsUpdateTagsResponse, error) {
 	result := VirtualNetworkTapsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualNetworkTap); err != nil {
-		return VirtualNetworkTapsUpdateTagsResponse{}, err
+		return VirtualNetworkTapsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -253,7 +253,7 @@ func (client *VirtualRouterPeeringsClient) getCreateRequest(ctx context.Context,
 func (client *VirtualRouterPeeringsClient) getHandleResponse(resp *http.Response) (VirtualRouterPeeringsGetResponse, error) {
 	result := VirtualRouterPeeringsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterPeering); err != nil {
-		return VirtualRouterPeeringsGetResponse{}, err
+		return VirtualRouterPeeringsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *VirtualRouterPeeringsClient) listCreateRequest(ctx context.Context
 func (client *VirtualRouterPeeringsClient) listHandleResponse(resp *http.Response) (VirtualRouterPeeringsListResponse, error) {
 	result := VirtualRouterPeeringsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterPeeringListResult); err != nil {
-		return VirtualRouterPeeringsListResponse{}, err
+		return VirtualRouterPeeringsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -244,7 +244,7 @@ func (client *VirtualRoutersClient) getCreateRequest(ctx context.Context, resour
 func (client *VirtualRoutersClient) getHandleResponse(resp *http.Response) (VirtualRoutersGetResponse, error) {
 	result := VirtualRoutersGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouter); err != nil {
-		return VirtualRoutersGetResponse{}, err
+		return VirtualRoutersGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -298,7 +298,7 @@ func (client *VirtualRoutersClient) listCreateRequest(ctx context.Context, optio
 func (client *VirtualRoutersClient) listHandleResponse(resp *http.Response) (VirtualRoutersListResponse, error) {
 	result := VirtualRoutersListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterListResult); err != nil {
-		return VirtualRoutersListResponse{}, err
+		return VirtualRoutersListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -356,7 +356,7 @@ func (client *VirtualRoutersClient) listByResourceGroupCreateRequest(ctx context
 func (client *VirtualRoutersClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualRoutersListByResourceGroupResponse, error) {
 	result := VirtualRoutersListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualRouterListResult); err != nil {
-		return VirtualRoutersListByResourceGroupResponse{}, err
+		return VirtualRoutersListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -241,7 +241,7 @@ func (client *VirtualWansClient) getCreateRequest(ctx context.Context, resourceG
 func (client *VirtualWansClient) getHandleResponse(resp *http.Response) (VirtualWansGetResponse, error) {
 	result := VirtualWansGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWAN); err != nil {
-		return VirtualWansGetResponse{}, err
+		return VirtualWansGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VirtualWansClient) listCreateRequest(ctx context.Context, options 
 func (client *VirtualWansClient) listHandleResponse(resp *http.Response) (VirtualWansListResponse, error) {
 	result := VirtualWansListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualWANsResult); err != nil {
-		return VirtualWansListResponse{}, err
+		return VirtualWansListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VirtualWansClient) listByResourceGroupCreateRequest(ctx context.Co
 func (client *VirtualWansClient) listByResourceGroupHandleResponse(resp *http.Response) (VirtualWansListByResourceGroupResponse, error) {
 	result := VirtualWansListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVirtualWANsResult); err != nil {
-		return VirtualWansListByResourceGroupResponse{}, err
+		return VirtualWansListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *VirtualWansClient) updateTagsCreateRequest(ctx context.Context, re
 func (client *VirtualWansClient) updateTagsHandleResponse(resp *http.Response) (VirtualWansUpdateTagsResponse, error) {
 	result := VirtualWansUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VirtualWAN); err != nil {
-		return VirtualWansUpdateTagsResponse{}, err
+		return VirtualWansUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -253,7 +253,7 @@ func (client *VPNConnectionsClient) getCreateRequest(ctx context.Context, resour
 func (client *VPNConnectionsClient) getHandleResponse(resp *http.Response) (VPNConnectionsGetResponse, error) {
 	result := VPNConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNConnection); err != nil {
-		return VPNConnectionsGetResponse{}, err
+		return VPNConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -315,7 +315,7 @@ func (client *VPNConnectionsClient) listByVPNGatewayCreateRequest(ctx context.Co
 func (client *VPNConnectionsClient) listByVPNGatewayHandleResponse(resp *http.Response) (VPNConnectionsListByVPNGatewayResponse, error) {
 	result := VPNConnectionsListByVPNGatewayResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNConnectionsResult); err != nil {
-		return VPNConnectionsListByVPNGatewayResponse{}, err
+		return VPNConnectionsListByVPNGatewayResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -241,7 +241,7 @@ func (client *VPNGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 func (client *VPNGatewaysClient) getHandleResponse(resp *http.Response) (VPNGatewaysGetResponse, error) {
 	result := VPNGatewaysGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNGateway); err != nil {
-		return VPNGatewaysGetResponse{}, err
+		return VPNGatewaysGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VPNGatewaysClient) listCreateRequest(ctx context.Context, options 
 func (client *VPNGatewaysClient) listHandleResponse(resp *http.Response) (VPNGatewaysListResponse, error) {
 	result := VPNGatewaysListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNGatewaysResult); err != nil {
-		return VPNGatewaysListResponse{}, err
+		return VPNGatewaysListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VPNGatewaysClient) listByResourceGroupCreateRequest(ctx context.Co
 func (client *VPNGatewaysClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNGatewaysListByResourceGroupResponse, error) {
 	result := VPNGatewaysListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNGatewaysResult); err != nil {
-		return VPNGatewaysListByResourceGroupResponse{}, err
+		return VPNGatewaysListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -494,7 +494,7 @@ func (client *VPNGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 func (client *VPNGatewaysClient) updateTagsHandleResponse(resp *http.Response) (VPNGatewaysUpdateTagsResponse, error) {
 	result := VPNGatewaysUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNGateway); err != nil {
-		return VPNGatewaysUpdateTagsResponse{}, err
+		return VPNGatewaysUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
@@ -90,7 +90,7 @@ func (client *VPNLinkConnectionsClient) listByVPNConnectionCreateRequest(ctx con
 func (client *VPNLinkConnectionsClient) listByVPNConnectionHandleResponse(resp *http.Response) (VPNLinkConnectionsListByVPNConnectionResponse, error) {
 	result := VPNLinkConnectionsListByVPNConnectionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSiteLinkConnectionsResult); err != nil {
-		return VPNLinkConnectionsListByVPNConnectionResponse{}, err
+		return VPNLinkConnectionsListByVPNConnectionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -241,7 +241,7 @@ func (client *VPNServerConfigurationsClient) getCreateRequest(ctx context.Contex
 func (client *VPNServerConfigurationsClient) getHandleResponse(resp *http.Response) (VPNServerConfigurationsGetResponse, error) {
 	result := VPNServerConfigurationsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNServerConfiguration); err != nil {
-		return VPNServerConfigurationsGetResponse{}, err
+		return VPNServerConfigurationsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VPNServerConfigurationsClient) listCreateRequest(ctx context.Conte
 func (client *VPNServerConfigurationsClient) listHandleResponse(resp *http.Response) (VPNServerConfigurationsListResponse, error) {
 	result := VPNServerConfigurationsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNServerConfigurationsResult); err != nil {
-		return VPNServerConfigurationsListResponse{}, err
+		return VPNServerConfigurationsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VPNServerConfigurationsClient) listByResourceGroupCreateRequest(ct
 func (client *VPNServerConfigurationsClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNServerConfigurationsListByResourceGroupResponse, error) {
 	result := VPNServerConfigurationsListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNServerConfigurationsResult); err != nil {
-		return VPNServerConfigurationsListByResourceGroupResponse{}, err
+		return VPNServerConfigurationsListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *VPNServerConfigurationsClient) updateTagsCreateRequest(ctx context
 func (client *VPNServerConfigurationsClient) updateTagsHandleResponse(resp *http.Response) (VPNServerConfigurationsUpdateTagsResponse, error) {
 	result := VPNServerConfigurationsUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNServerConfiguration); err != nil {
-		return VPNServerConfigurationsUpdateTagsResponse{}, err
+		return VPNServerConfigurationsUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinkconnections_client.go
@@ -97,7 +97,7 @@ func (client *VPNSiteLinkConnectionsClient) getCreateRequest(ctx context.Context
 func (client *VPNSiteLinkConnectionsClient) getHandleResponse(resp *http.Response) (VPNSiteLinkConnectionsGetResponse, error) {
 	result := VPNSiteLinkConnectionsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSiteLinkConnection); err != nil {
-		return VPNSiteLinkConnectionsGetResponse{}, err
+		return VPNSiteLinkConnectionsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
@@ -93,7 +93,7 @@ func (client *VPNSiteLinksClient) getCreateRequest(ctx context.Context, resource
 func (client *VPNSiteLinksClient) getHandleResponse(resp *http.Response) (VPNSiteLinksGetResponse, error) {
 	result := VPNSiteLinksGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSiteLink); err != nil {
-		return VPNSiteLinksGetResponse{}, err
+		return VPNSiteLinksGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *VPNSiteLinksClient) listByVPNSiteCreateRequest(ctx context.Context
 func (client *VPNSiteLinksClient) listByVPNSiteHandleResponse(resp *http.Response) (VPNSiteLinksListByVPNSiteResponse, error) {
 	result := VPNSiteLinksListByVPNSiteResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSiteLinksResult); err != nil {
-		return VPNSiteLinksListByVPNSiteResponse{}, err
+		return VPNSiteLinksListByVPNSiteResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -241,7 +241,7 @@ func (client *VPNSitesClient) getCreateRequest(ctx context.Context, resourceGrou
 func (client *VPNSitesClient) getHandleResponse(resp *http.Response) (VPNSitesGetResponse, error) {
 	result := VPNSitesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSite); err != nil {
-		return VPNSitesGetResponse{}, err
+		return VPNSitesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -295,7 +295,7 @@ func (client *VPNSitesClient) listCreateRequest(ctx context.Context, options *VP
 func (client *VPNSitesClient) listHandleResponse(resp *http.Response) (VPNSitesListResponse, error) {
 	result := VPNSitesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSitesResult); err != nil {
-		return VPNSitesListResponse{}, err
+		return VPNSitesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -353,7 +353,7 @@ func (client *VPNSitesClient) listByResourceGroupCreateRequest(ctx context.Conte
 func (client *VPNSitesClient) listByResourceGroupHandleResponse(resp *http.Response) (VPNSitesListByResourceGroupResponse, error) {
 	result := VPNSitesListByResourceGroupResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListVPNSitesResult); err != nil {
-		return VPNSitesListByResourceGroupResponse{}, err
+		return VPNSitesListByResourceGroupResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -418,7 +418,7 @@ func (client *VPNSitesClient) updateTagsCreateRequest(ctx context.Context, resou
 func (client *VPNSitesClient) updateTagsHandleResponse(resp *http.Response) (VPNSitesUpdateTagsResponse, error) {
 	result := VPNSitesUpdateTagsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.VPNSite); err != nil {
-		return VPNSitesUpdateTagsResponse{}, err
+		return VPNSitesUpdateTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -89,7 +89,7 @@ func (client *WebApplicationFirewallPoliciesClient) createOrUpdateCreateRequest(
 func (client *WebApplicationFirewallPoliciesClient) createOrUpdateHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesCreateOrUpdateResponse, error) {
 	result := WebApplicationFirewallPoliciesCreateOrUpdateResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicy); err != nil {
-		return WebApplicationFirewallPoliciesCreateOrUpdateResponse{}, err
+		return WebApplicationFirewallPoliciesCreateOrUpdateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -230,7 +230,7 @@ func (client *WebApplicationFirewallPoliciesClient) getCreateRequest(ctx context
 func (client *WebApplicationFirewallPoliciesClient) getHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesGetResponse, error) {
 	result := WebApplicationFirewallPoliciesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicy); err != nil {
-		return WebApplicationFirewallPoliciesGetResponse{}, err
+		return WebApplicationFirewallPoliciesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -288,7 +288,7 @@ func (client *WebApplicationFirewallPoliciesClient) listCreateRequest(ctx contex
 func (client *WebApplicationFirewallPoliciesClient) listHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesListResponse, error) {
 	result := WebApplicationFirewallPoliciesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicyListResult); err != nil {
-		return WebApplicationFirewallPoliciesListResponse{}, err
+		return WebApplicationFirewallPoliciesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -342,7 +342,7 @@ func (client *WebApplicationFirewallPoliciesClient) listAllCreateRequest(ctx con
 func (client *WebApplicationFirewallPoliciesClient) listAllHandleResponse(resp *http.Response) (WebApplicationFirewallPoliciesListAllResponse, error) {
 	result := WebApplicationFirewallPoliciesListAllResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.WebApplicationFirewallPolicyListResult); err != nil {
-		return WebApplicationFirewallPoliciesListAllResponse{}, err
+		return WebApplicationFirewallPoliciesListAllResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_blob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blob_client.go
@@ -1772,7 +1772,7 @@ func (client *blobClient) getTagsHandleResponse(resp *http.Response) (BlobGetTag
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.BlobTags); err != nil {
-		return BlobGetTagsResponse{}, err
+		return BlobGetTagsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
@@ -304,7 +304,7 @@ func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.BlockList); err != nil {
-		return BlockBlobGetBlockListResponse{}, err
+		return BlockBlobGetBlockListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_container_client.go
@@ -572,7 +572,7 @@ func (client *containerClient) getAccessPolicyHandleResponse(resp *http.Response
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return ContainerGetAccessPolicyResponse{}, err
+		return ContainerGetAccessPolicyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -870,7 +870,7 @@ func (client *containerClient) listBlobFlatSegmentHandleResponse(resp *http.Resp
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListBlobsFlatSegmentResponse); err != nil {
-		return ContainerListBlobFlatSegmentResponse{}, err
+		return ContainerListBlobFlatSegmentResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -959,7 +959,7 @@ func (client *containerClient) listBlobHierarchySegmentHandleResponse(resp *http
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListBlobsHierarchySegmentResponse); err != nil {
-		return ContainerListBlobHierarchySegmentResponse{}, err
+		return ContainerListBlobHierarchySegmentResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
@@ -556,7 +556,7 @@ func (client *pageBlobClient) getPageRangesHandleResponse(resp *http.Response) (
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.PageList); err != nil {
-		return PageBlobGetPageRangesResponse{}, err
+		return PageBlobGetPageRangesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -679,7 +679,7 @@ func (client *pageBlobClient) getPageRangesDiffHandleResponse(resp *http.Respons
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.PageList); err != nil {
-		return PageBlobGetPageRangesDiffResponse{}, err
+		return PageBlobGetPageRangesDiffResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/storage/2020-06-12/azblob/zz_generated_service_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_service_client.go
@@ -93,7 +93,7 @@ func (client *serviceClient) filterBlobsHandleResponse(resp *http.Response) (Ser
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.FilterBlobSegment); err != nil {
-		return ServiceFilterBlobsResponse{}, err
+		return ServiceFilterBlobsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -243,7 +243,7 @@ func (client *serviceClient) getPropertiesHandleResponse(resp *http.Response) (S
 		result.Version = &val
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.StorageServiceProperties); err != nil {
-		return ServiceGetPropertiesResponse{}, err
+		return ServiceGetPropertiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -320,7 +320,7 @@ func (client *serviceClient) getStatisticsHandleResponse(resp *http.Response) (S
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.StorageServiceStats); err != nil {
-		return ServiceGetStatisticsResponse{}, err
+		return ServiceGetStatisticsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -396,7 +396,7 @@ func (client *serviceClient) getUserDelegationKeyHandleResponse(resp *http.Respo
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.UserDelegationKey); err != nil {
-		return ServiceGetUserDelegationKeyResponse{}, err
+		return ServiceGetUserDelegationKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -473,7 +473,7 @@ func (client *serviceClient) listContainersSegmentHandleResponse(resp *http.Resp
 		result.Version = &val
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.ListContainersSegmentResponse); err != nil {
-		return ServiceListContainersSegmentResponse{}, err
+		return ServiceListContainersSegmentResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_bigdatapools_client.go
@@ -62,7 +62,7 @@ func (client *bigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataP
 func (client *bigDataPoolsClient) getHandleResponse(resp *http.Response) (BigDataPoolsGetResponse, error) {
 	result := BigDataPoolsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfo); err != nil {
-		return BigDataPoolsGetResponse{}, err
+		return BigDataPoolsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -115,7 +115,7 @@ func (client *bigDataPoolsClient) listCreateRequest(ctx context.Context, options
 func (client *bigDataPoolsClient) listHandleResponse(resp *http.Response) (BigDataPoolsListResponse, error) {
 	result := BigDataPoolsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfoListResult); err != nil {
-		return BigDataPoolsListResponse{}, err
+		return BigDataPoolsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -204,7 +204,7 @@ func (client *dataFlowClient) getDataFlowCreateRequest(ctx context.Context, data
 func (client *dataFlowClient) getDataFlowHandleResponse(resp *http.Response) (DataFlowGetDataFlowResponse, error) {
 	result := DataFlowGetDataFlowResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowResource); err != nil {
-		return DataFlowGetDataFlowResponse{}, err
+		return DataFlowGetDataFlowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -254,7 +254,7 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.C
 func (client *dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.Response) (DataFlowGetDataFlowsByWorkspaceResponse, error) {
 	result := DataFlowGetDataFlowsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowListResponse); err != nil {
-		return DataFlowGetDataFlowsByWorkspaceResponse{}, err
+		return DataFlowGetDataFlowsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -55,7 +55,7 @@ func (client *dataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.C
 func (client *dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.Response) (DataFlowDebugSessionAddDataFlowResponse, error) {
 	result := DataFlowDebugSessionAddDataFlowResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AddDataFlowToDebugSessionResponse); err != nil {
-		return DataFlowDebugSessionAddDataFlowResponse{}, err
+		return DataFlowDebugSessionAddDataFlowResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -277,7 +277,7 @@ func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceC
 func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp *http.Response) (DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
 	result := DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.QueryDataFlowDebugSessionsResponse); err != nil {
-		return DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
+		return DataFlowDebugSessionQueryDataFlowDebugSessionsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -204,7 +204,7 @@ func (client *datasetClient) getDatasetCreateRequest(ctx context.Context, datase
 func (client *datasetClient) getDatasetHandleResponse(resp *http.Response) (DatasetGetDatasetResponse, error) {
 	result := DatasetGetDatasetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetResource); err != nil {
-		return DatasetGetDatasetResponse{}, err
+		return DatasetGetDatasetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -254,7 +254,7 @@ func (client *datasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Con
 func (client *datasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Response) (DatasetGetDatasetsByWorkspaceResponse, error) {
 	result := DatasetGetDatasetsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetListResponse); err != nil {
-		return DatasetGetDatasetsByWorkspaceResponse{}, err
+		return DatasetGetDatasetsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_integrationruntimes_client.go
@@ -62,7 +62,7 @@ func (client *integrationRuntimesClient) getCreateRequest(ctx context.Context, i
 func (client *integrationRuntimesClient) getHandleResponse(resp *http.Response) (IntegrationRuntimesGetResponse, error) {
 	result := IntegrationRuntimesGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeResource); err != nil {
-		return IntegrationRuntimesGetResponse{}, err
+		return IntegrationRuntimesGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -115,7 +115,7 @@ func (client *integrationRuntimesClient) listCreateRequest(ctx context.Context, 
 func (client *integrationRuntimesClient) listHandleResponse(resp *http.Response) (IntegrationRuntimesListResponse, error) {
 	result := IntegrationRuntimesListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeListResponse); err != nil {
-		return IntegrationRuntimesListResponse{}, err
+		return IntegrationRuntimesListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -320,7 +320,7 @@ func (client *libraryClient) getCreateRequest(ctx context.Context, libraryName s
 func (client *libraryClient) getHandleResponse(resp *http.Response) (LibraryGetResponse, error) {
 	result := LibraryGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryResource); err != nil {
-		return LibraryGetResponse{}, err
+		return LibraryGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -380,13 +380,13 @@ func (client *libraryClient) getOperationResultHandleResponse(resp *http.Respons
 	case http.StatusOK:
 		var val LibraryResource
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return LibraryGetOperationResultResponse{}, err
+			return LibraryGetOperationResultResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	case http.StatusAccepted:
 		var val OperationResult
 		if err := runtime.UnmarshalAsJSON(resp, &val); err != nil {
-			return LibraryGetOperationResultResponse{}, err
+			return LibraryGetOperationResultResponse{}, runtime.NewResponseError(err, resp)
 		}
 		result.Value = val
 	default:
@@ -440,7 +440,7 @@ func (client *libraryClient) listCreateRequest(ctx context.Context, options *Lib
 func (client *libraryClient) listHandleResponse(resp *http.Response) (LibraryListResponseEnvelope, error) {
 	result := LibraryListResponseEnvelope{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryListResponse); err != nil {
-		return LibraryListResponseEnvelope{}, err
+		return LibraryListResponseEnvelope{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -204,7 +204,7 @@ func (client *linkedServiceClient) getLinkedServiceCreateRequest(ctx context.Con
 func (client *linkedServiceClient) getLinkedServiceHandleResponse(resp *http.Response) (LinkedServiceGetLinkedServiceResponse, error) {
 	result := LinkedServiceGetLinkedServiceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceResource); err != nil {
-		return LinkedServiceGetLinkedServiceResponse{}, err
+		return LinkedServiceGetLinkedServiceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -254,7 +254,7 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx
 func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(resp *http.Response) (LinkedServiceGetLinkedServicesByWorkspaceResponse, error) {
 	result := LinkedServiceGetLinkedServicesByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceListResponse); err != nil {
-		return LinkedServiceGetLinkedServicesByWorkspaceResponse{}, err
+		return LinkedServiceGetLinkedServicesByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -204,7 +204,7 @@ func (client *notebookClient) getNotebookCreateRequest(ctx context.Context, note
 func (client *notebookClient) getNotebookHandleResponse(resp *http.Response) (NotebookGetNotebookResponse, error) {
 	result := NotebookGetNotebookResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookResource); err != nil {
-		return NotebookGetNotebookResponse{}, err
+		return NotebookGetNotebookResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -254,7 +254,7 @@ func (client *notebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx con
 func (client *notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *http.Response) (NotebookGetNotebookSummaryByWorkSpaceResponse, error) {
 	result := NotebookGetNotebookSummaryByWorkSpaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
-		return NotebookGetNotebookSummaryByWorkSpaceResponse{}, err
+		return NotebookGetNotebookSummaryByWorkSpaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -304,7 +304,7 @@ func (client *notebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.C
 func (client *notebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.Response) (NotebookGetNotebooksByWorkspaceResponse, error) {
 	result := NotebookGetNotebooksByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
-		return NotebookGetNotebooksByWorkspaceResponse{}, err
+		return NotebookGetNotebooksByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -146,7 +146,7 @@ func (client *pipelineClient) createPipelineRunCreateRequest(ctx context.Context
 func (client *pipelineClient) createPipelineRunHandleResponse(resp *http.Response) (PipelineCreatePipelineRunResponse, error) {
 	result := PipelineCreatePipelineRunResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CreateRunResponse); err != nil {
-		return PipelineCreatePipelineRunResponse{}, err
+		return PipelineCreatePipelineRunResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -274,7 +274,7 @@ func (client *pipelineClient) getPipelineCreateRequest(ctx context.Context, pipe
 func (client *pipelineClient) getPipelineHandleResponse(resp *http.Response) (PipelineGetPipelineResponse, error) {
 	result := PipelineGetPipelineResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineResource); err != nil {
-		return PipelineGetPipelineResponse{}, err
+		return PipelineGetPipelineResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -324,7 +324,7 @@ func (client *pipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.C
 func (client *pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.Response) (PipelineGetPipelinesByWorkspaceResponse, error) {
 	result := PipelineGetPipelinesByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineListResponse); err != nil {
-		return PipelineGetPipelinesByWorkspaceResponse{}, err
+		return PipelineGetPipelinesByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipelinerun_client.go
@@ -114,7 +114,7 @@ func (client *pipelineRunClient) getPipelineRunCreateRequest(ctx context.Context
 func (client *pipelineRunClient) getPipelineRunHandleResponse(resp *http.Response) (PipelineRunGetPipelineRunResponse, error) {
 	result := PipelineRunGetPipelineRunResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRun); err != nil {
-		return PipelineRunGetPipelineRunResponse{}, err
+		return PipelineRunGetPipelineRunResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -175,7 +175,7 @@ func (client *pipelineRunClient) queryActivityRunsCreateRequest(ctx context.Cont
 func (client *pipelineRunClient) queryActivityRunsHandleResponse(resp *http.Response) (PipelineRunQueryActivityRunsResponse, error) {
 	result := PipelineRunQueryActivityRunsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ActivityRunsQueryResponse); err != nil {
-		return PipelineRunQueryActivityRunsResponse{}, err
+		return PipelineRunQueryActivityRunsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -228,7 +228,7 @@ func (client *pipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx c
 func (client *pipelineRunClient) queryPipelineRunsByWorkspaceHandleResponse(resp *http.Response) (PipelineRunQueryPipelineRunsByWorkspaceResponse, error) {
 	result := PipelineRunQueryPipelineRunsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRunsQueryResponse); err != nil {
-		return PipelineRunQueryPipelineRunsByWorkspaceResponse{}, err
+		return PipelineRunQueryPipelineRunsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -336,7 +336,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx c
 func (client *sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp *http.Response) (SparkJobDefinitionGetSparkJobDefinitionResponse, error) {
 	result := SparkJobDefinitionGetSparkJobDefinitionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionResource); err != nil {
-		return SparkJobDefinitionGetSparkJobDefinitionResponse{}, err
+		return SparkJobDefinitionGetSparkJobDefinitionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -386,7 +386,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateR
 func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleResponse(resp *http.Response) (SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceResponse, error) {
 	result := SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionsListResponse); err != nil {
-		return SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceResponse{}, err
+		return SparkJobDefinitionGetSparkJobDefinitionsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlpools_client.go
@@ -62,7 +62,7 @@ func (client *sqlPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName 
 func (client *sqlPoolsClient) getHandleResponse(resp *http.Response) (SQLPoolsGetResponse, error) {
 	result := SQLPoolsGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPool); err != nil {
-		return SQLPoolsGetResponse{}, err
+		return SQLPoolsGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -115,7 +115,7 @@ func (client *sqlPoolsClient) listCreateRequest(ctx context.Context, options *SQ
 func (client *sqlPoolsClient) listHandleResponse(resp *http.Response) (SQLPoolsListResponse, error) {
 	result := SQLPoolsListResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPoolInfoListResult); err != nil {
-		return SQLPoolsListResponse{}, err
+		return SQLPoolsListResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -204,7 +204,7 @@ func (client *sqlScriptClient) getSQLScriptCreateRequest(ctx context.Context, sq
 func (client *sqlScriptClient) getSQLScriptHandleResponse(resp *http.Response) (SQLScriptGetSQLScriptResponse, error) {
 	result := SQLScriptGetSQLScriptResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptResource); err != nil {
-		return SQLScriptGetSQLScriptResponse{}, err
+		return SQLScriptGetSQLScriptResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -254,7 +254,7 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceCreateRequest(ctx context
 func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http.Response) (SQLScriptGetSQLScriptsByWorkspaceResponse, error) {
 	result := SQLScriptGetSQLScriptsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptsListResponse); err != nil {
-		return SQLScriptGetSQLScriptsByWorkspaceResponse{}, err
+		return SQLScriptGetSQLScriptsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -201,7 +201,7 @@ func (client *triggerClient) getEventSubscriptionStatusCreateRequest(ctx context
 func (client *triggerClient) getEventSubscriptionStatusHandleResponse(resp *http.Response) (TriggerGetEventSubscriptionStatusResponse, error) {
 	result := TriggerGetEventSubscriptionStatusResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerSubscriptionOperationStatus); err != nil {
-		return TriggerGetEventSubscriptionStatusResponse{}, err
+		return TriggerGetEventSubscriptionStatusResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -261,7 +261,7 @@ func (client *triggerClient) getTriggerCreateRequest(ctx context.Context, trigge
 func (client *triggerClient) getTriggerHandleResponse(resp *http.Response) (TriggerGetTriggerResponse, error) {
 	result := TriggerGetTriggerResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerResource); err != nil {
-		return TriggerGetTriggerResponse{}, err
+		return TriggerGetTriggerResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -311,7 +311,7 @@ func (client *triggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Con
 func (client *triggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Response) (TriggerGetTriggersByWorkspaceResponse, error) {
 	result := TriggerGetTriggersByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerListResponse); err != nil {
-		return TriggerGetTriggersByWorkspaceResponse{}, err
+		return TriggerGetTriggersByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_triggerrun_client.go
@@ -110,7 +110,7 @@ func (client *triggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx con
 func (client *triggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *http.Response) (TriggerRunQueryTriggerRunsByWorkspaceResponse, error) {
 	result := TriggerRunQueryTriggerRunsByWorkspaceResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerRunsQueryResponse); err != nil {
-		return TriggerRunQueryTriggerRunsByWorkspaceResponse{}, err
+		return TriggerRunQueryTriggerRunsByWorkspaceResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspace_client.go
@@ -55,7 +55,7 @@ func (client *workspaceClient) getCreateRequest(ctx context.Context, options *Wo
 func (client *workspaceClient) getHandleResponse(resp *http.Response) (WorkspaceGetResponse, error) {
 	result := WorkspaceGetResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Workspace); err != nil {
-		return WorkspaceGetResponse{}, err
+		return WorkspaceGetResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_workspacegitrepomanagement_client.go
@@ -58,7 +58,7 @@ func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenCreateReques
 func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenHandleResponse(resp *http.Response) (WorkspaceGitRepoManagementGetGitHubAccessTokenResponse, error) {
 	result := WorkspaceGitRepoManagementGetGitHubAccessTokenResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GitHubAccessTokenResponse); err != nil {
-		return WorkspaceGitRepoManagementGetGitHubAccessTokenResponse{}, err
+		return WorkspaceGitRepoManagementGetGitHubAccessTokenResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparkbatch_client.go
@@ -100,7 +100,7 @@ func (client *sparkBatchClient) createSparkBatchJobCreateRequest(ctx context.Con
 func (client *sparkBatchClient) createSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchCreateSparkBatchJobResponse, error) {
 	result := SparkBatchCreateSparkBatchJobResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJob); err != nil {
-		return SparkBatchCreateSparkBatchJobResponse{}, err
+		return SparkBatchCreateSparkBatchJobResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -155,7 +155,7 @@ func (client *sparkBatchClient) getSparkBatchJobCreateRequest(ctx context.Contex
 func (client *sparkBatchClient) getSparkBatchJobHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobResponse, error) {
 	result := SparkBatchGetSparkBatchJobResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJob); err != nil {
-		return SparkBatchGetSparkBatchJobResponse{}, err
+		return SparkBatchGetSparkBatchJobResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -215,7 +215,7 @@ func (client *sparkBatchClient) getSparkBatchJobsCreateRequest(ctx context.Conte
 func (client *sparkBatchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (SparkBatchGetSparkBatchJobsResponse, error) {
 	result := SparkBatchGetSparkBatchJobsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkBatchJobCollection); err != nil {
-		return SparkBatchGetSparkBatchJobsResponse{}, err
+		return SparkBatchGetSparkBatchJobsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azspark/zz_generated_sparksession_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_sparksession_client.go
@@ -97,7 +97,7 @@ func (client *sparkSessionClient) cancelSparkStatementCreateRequest(ctx context.
 func (client *sparkSessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (SparkSessionCancelSparkStatementResponse, error) {
 	result := SparkSessionCancelSparkStatementResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatementCancellationResult); err != nil {
-		return SparkSessionCancelSparkStatementResponse{}, err
+		return SparkSessionCancelSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -151,7 +151,7 @@ func (client *sparkSessionClient) createSparkSessionCreateRequest(ctx context.Co
 func (client *sparkSessionClient) createSparkSessionHandleResponse(resp *http.Response) (SparkSessionCreateSparkSessionResponse, error) {
 	result := SparkSessionCreateSparkSessionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSession); err != nil {
-		return SparkSessionCreateSparkSessionResponse{}, err
+		return SparkSessionCreateSparkSessionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -201,7 +201,7 @@ func (client *sparkSessionClient) createSparkStatementCreateRequest(ctx context.
 func (client *sparkSessionClient) createSparkStatementHandleResponse(resp *http.Response) (SparkSessionCreateSparkStatementResponse, error) {
 	result := SparkSessionCreateSparkStatementResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatement); err != nil {
-		return SparkSessionCreateSparkStatementResponse{}, err
+		return SparkSessionCreateSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -256,7 +256,7 @@ func (client *sparkSessionClient) getSparkSessionCreateRequest(ctx context.Conte
 func (client *sparkSessionClient) getSparkSessionHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionResponse, error) {
 	result := SparkSessionGetSparkSessionResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSession); err != nil {
-		return SparkSessionGetSparkSessionResponse{}, err
+		return SparkSessionGetSparkSessionResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -316,7 +316,7 @@ func (client *sparkSessionClient) getSparkSessionsCreateRequest(ctx context.Cont
 func (client *sparkSessionClient) getSparkSessionsHandleResponse(resp *http.Response) (SparkSessionGetSparkSessionsResponse, error) {
 	result := SparkSessionGetSparkSessionsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkSessionCollection); err != nil {
-		return SparkSessionGetSparkSessionsResponse{}, err
+		return SparkSessionGetSparkSessionsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -367,7 +367,7 @@ func (client *sparkSessionClient) getSparkStatementCreateRequest(ctx context.Con
 func (client *sparkSessionClient) getSparkStatementHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementResponse, error) {
 	result := SparkSessionGetSparkStatementResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatement); err != nil {
-		return SparkSessionGetSparkStatementResponse{}, err
+		return SparkSessionGetSparkStatementResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -417,7 +417,7 @@ func (client *sparkSessionClient) getSparkStatementsCreateRequest(ctx context.Co
 func (client *sparkSessionClient) getSparkStatementsHandleResponse(resp *http.Response) (SparkSessionGetSparkStatementsResponse, error) {
 	result := SparkSessionGetSparkStatementsResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkStatementCollection); err != nil {
-		return SparkSessionGetSparkStatementsResponse{}, err
+		return SparkSessionGetSparkStatementsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_service_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_service_client.go
@@ -81,7 +81,7 @@ func (client *ServiceClient) getPropertiesHandleResponse(resp *http.Response) (S
 		result.Version = &val
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.TableServiceProperties); err != nil {
-		return ServiceGetPropertiesResponse{}, err
+		return ServiceGetPropertiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -158,7 +158,7 @@ func (client *ServiceClient) getStatisticsHandleResponse(resp *http.Response) (S
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result.TableServiceStats); err != nil {
-		return ServiceGetStatisticsResponse{}, err
+		return ServiceGetStatisticsResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }

--- a/test/tables/2019-02-02/aztables/zz_generated_table_client.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_table_client.go
@@ -98,7 +98,7 @@ func (client *TableClient) createHandleResponse(resp *http.Response) (TableCreat
 		result.PreferenceApplied = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TableResponse); err != nil {
-		return TableCreateResponse{}, err
+		return TableCreateResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -338,7 +338,7 @@ func (client *TableClient) getAccessPolicyHandleResponse(resp *http.Response) (T
 		result.Date = &date
 	}
 	if err := runtime.UnmarshalAsXML(resp, &result); err != nil {
-		return TableGetAccessPolicyResponse{}, err
+		return TableGetAccessPolicyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -436,7 +436,7 @@ func (client *TableClient) insertEntityHandleResponse(resp *http.Response) (Tabl
 		result.ContentType = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return TableInsertEntityResponse{}, err
+		return TableInsertEntityResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -624,7 +624,7 @@ func (client *TableClient) queryHandleResponse(resp *http.Response) (TableQueryR
 		result.XMSContinuationNextTableName = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TableQueryResponse); err != nil {
-		return TableQueryResponseEnvelope{}, err
+		return TableQueryResponseEnvelope{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -727,7 +727,7 @@ func (client *TableClient) queryEntitiesHandleResponse(resp *http.Response) (Tab
 		result.XMSContinuationNextRowKey = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TableEntityQueryResponse); err != nil {
-		return TableQueryEntitiesResponse{}, err
+		return TableQueryEntitiesResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
@@ -833,7 +833,7 @@ func (client *TableClient) queryEntityWithPartitionAndRowKeyHandleResponse(resp 
 		result.XMSContinuationNextRowKey = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return TableQueryEntityWithPartitionAndRowKeyResponse{}, err
+		return TableQueryEntityWithPartitionAndRowKeyResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }


### PR DESCRIPTION
If unmarshalling the successful response fails, wrap the error with
runtime.NewResponseError so the underlying HTTP response is available.