### PR TITLE
Fix codegen for optional client constant parameters

### DIFF
--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -358,7 +358,7 @@ function processOperationRequests(session: Session<CodeModel>) {
         if (param.extensions?.['x-ms-header-collection-prefix']) {
           param.schema.language.go!.headerCollectionPrefix = param.extensions['x-ms-header-collection-prefix'];
         }
-        if (param.implementation === ImplementationLocation.Client && param.schema.type !== SchemaType.Constant && param.language.default.name !== '$host') {
+        if (param.implementation === ImplementationLocation.Client && (param.schema.type !== SchemaType.Constant || !param.required) && param.language.default.name !== '$host') {
           if (param.protocol.http!.in === 'uri') {
             // this is a parameterized host param.
             // use the param name to avoid reference equality checks.

--- a/test/maps/azalias/zz_generated_alias_client.go
+++ b/test/maps/azalias/zz_generated_alias_client.go
@@ -19,12 +19,13 @@ import (
 )
 
 type aliasClient struct {
-	endpoint string
-	pl       runtime.Pipeline
+	endpoint   string
+	apiVersion *string
+	pl         runtime.Pipeline
 }
 
 // newAliasClient creates a new instance of aliasClient with the specified values.
-func newAliasClient(geography *Geography, pl runtime.Pipeline) *aliasClient {
+func newAliasClient(geography *Geography, apiVersion *string, pl runtime.Pipeline) *aliasClient {
 	hostURL := "https://{geography}.atlas.microsoft.com"
 	if geography == nil {
 		defaultValue := GeographyUs
@@ -32,8 +33,9 @@ func newAliasClient(geography *Geography, pl runtime.Pipeline) *aliasClient {
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
 	client := &aliasClient{
-		endpoint: hostURL,
-		pl:       pl,
+		endpoint:   hostURL,
+		apiVersion: apiVersion,
+		pl:         pl,
 	}
 	return client
 }
@@ -76,7 +78,9 @@ func (client *aliasClient) createCreateRequest(ctx context.Context, options *Ali
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "2.0")
+	if client.apiVersion != nil {
+		reqQP.Set("api-version", "2.0")
+	}
 	if options != nil && options.CreatorDataItemID != nil {
 		reqQP.Set("creatorDataItemId", *options.CreatorDataItemID)
 	}
@@ -151,7 +155,9 @@ func (client *aliasClient) listCreateRequest(ctx context.Context, options *Alias
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", "2.0")
+	if client.apiVersion != nil {
+		reqQP.Set("api-version", "2.0")
+	}
 	if options != nil && options.GroupBy != nil {
 		for _, qv := range options.GroupBy {
 			reqQP.Add("groupBy", string(qv))

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -54,7 +54,6 @@
       "description": "Version number of Azure Maps API.",
       "type": "string",
       "in": "query",
-      "required": true,
       "default": "2.0",
       "x-ms-parameter-location": "client"
     },


### PR DESCRIPTION
Apply the same pattern we use for optional constant method parameters.