### PR TITLE
Don't hard-code the content type for text bodies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   '@azure-tools/codegen': 2.7.0
   '@azure-tools/linq': 3.1.261
   '@azure-tools/tasks': 3.0.252
-  '@microsoft.azure/autorest.testserver': 3.1.5_e58605af5d62eced51e25286a407a18b
+  '@microsoft.azure/autorest.testserver': 3.1.8_e58605af5d62eced51e25286a407a18b
   '@rush-temp/go': 'file:projects/go.tgz'
   '@types/html-to-text': 5.1.2
   '@types/jest': 26.0.24
@@ -853,18 +853,6 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==
-  /@jest/types/27.2.4:
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.3
-      '@types/istanbul-reports': 3.0.0
-      '@types/node': 12.7.2
-      '@types/yargs': 16.0.4
-      chalk: 4.1.0
-    dev: false
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==
   /@jest/types/27.2.5:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -877,7 +865,7 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==
-  /@microsoft.azure/autorest.testserver/3.1.5_e58605af5d62eced51e25286a407a18b:
+  /@microsoft.azure/autorest.testserver/3.1.8_e58605af5d62eced51e25286a407a18b:
     dependencies:
       axios: 0.21.4
       azure-storage: 2.10.5
@@ -907,7 +895,7 @@ packages:
       '@types/jest': '*'
       typescript: '*'
     resolution:
-      integrity: sha512-WWGq9jExT0FOoLMZYv0zJqpPbXZLNH7jMEiRp+dQu6gB1rcs8Man7x2JNS0EFYjR8ybQ6qFb2EqOmyP1VhMmKQ==
+      integrity: sha512-aiYrEB67OdlWAAPQyEgA+e++92DDUt4wtC12FalE5jkQ1lzsGnepM8rphG6CXWBuQTgG0HnNfdPdk9muEg8kMA==
   /@sinonjs/commons/1.8.3:
     dependencies:
       type-detect: 4.0.8
@@ -3990,19 +3978,6 @@ packages:
       node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
     resolution:
       integrity: sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==
-  /jest-util/27.2.4:
-    dependencies:
-      '@jest/types': 27.2.4
-      '@types/node': 12.7.2
-      chalk: 4.1.0
-      graceful-fs: 4.2.4
-      is-ci: 3.0.0
-      picomatch: 2.2.3
-    dev: false
-    engines:
-      node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0
-    resolution:
-      integrity: sha512-mW++4u+fSvAt3YBWm5IpbmRAceUqa2B++JlUZTiuEt2AmNYn0Yw5oay4cP17TGsMINRNPSGiJ2zNnX60g+VbFg==
   /jest-util/27.3.1:
     dependencies:
       '@jest/types': 27.2.5
@@ -5747,7 +5722,7 @@ packages:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 27.3.1
-      jest-util: 27.2.4
+      jest-util: 27.3.1
       json5: 2.2.0
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -6283,7 +6258,7 @@ packages:
       '@azure-tools/codemodel': 4.13.349
       '@azure-tools/linq': 3.1.261
       '@azure-tools/tasks': 3.0.252
-      '@microsoft.azure/autorest.testserver': 3.1.5_e58605af5d62eced51e25286a407a18b
+      '@microsoft.azure/autorest.testserver': 3.1.8_e58605af5d62eced51e25286a407a18b
       '@types/html-to-text': 5.1.2
       '@types/jest': 26.0.24
       '@types/js-yaml': 3.12.1
@@ -6305,7 +6280,7 @@ packages:
     dev: false
     name: '@rush-temp/go'
     resolution:
-      integrity: sha512-lN0R9MOfstPaTeYd+TmFCwZOIHhNiid03OzVrmcqoNWBV3BCE1wGBZXmt77w6w8E8cHcIGL0eagK6hysCAP+pg==
+      integrity: sha512-0XQTNOf/gUR8YvOpTnuouuDF1I121gfXXXKhmrBr2TMuM8tUiy1PCFsVpNs12QsF0EA7ZQDrOPf8L9wQIv4Fgw==
       tarball: 'file:projects/go.tgz'
     version: 0.0.0
 registry: ''
@@ -6317,7 +6292,7 @@ specifiers:
   '@azure-tools/codegen': ~2.7.0
   '@azure-tools/linq': ~3.1.0
   '@azure-tools/tasks': ~3.0.0
-  '@microsoft.azure/autorest.testserver': 3.1.5
+  '@microsoft.azure/autorest.testserver': 3.1.8
   '@rush-temp/go': 'file:./projects/go.tgz'
   '@types/html-to-text': ^5.1.2
   '@types/jest': ~26.0.24

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -869,13 +869,14 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     imports.add('strings');
     imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+    const contentType = `"${op.requests![0].protocol.http!.mediaTypes[0]}"`;
     if (bodyParam!.required) {
       text += `\tbody := streaming.NopCloser(strings.NewReader(${bodyParam!.language.go!.name}))\n`;
-      text += `\treturn req, req.SetBody(body, "text/plain; encoding=UTF-8")\n`;
+      text += `\treturn req, req.SetBody(body, ${contentType})\n`;
     } else {
       text += emitParamGroupCheck(<GroupProperty>bodyParam!.language.go!.paramGroup, bodyParam!);
       text += `\tbody := streaming.NopCloser(strings.NewReader(${getParamName(bodyParam!)}))\n`;
-      text += `\treturn req, req.SetBody(body, "text/plain; encoding=UTF-8")\n`;
+      text += `\treturn req, req.SetBody(body, ${contentType})\n`;
       text += '\t}\n';
       text += '\treturn req, nil\n';
     }

--- a/src/package.json
+++ b/src/package.json
@@ -48,7 +48,7 @@
     "typescript": "~4.4.3",
     "@typescript-eslint/eslint-plugin": "~2.6.0",
     "@typescript-eslint/parser": "~2.6.0",
-    "@microsoft.azure/autorest.testserver": "3.1.5",
+    "@microsoft.azure/autorest.testserver": "3.1.8",
     "@autorest/autorest": "~3.0.6173",
     "eslint": "~6.6.0",
     "@azure-tools/codegen": "~2.7.0",

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -300,8 +300,21 @@ function processOperationRequests(session: Session<CodeModel>) {
           const newOp = clone(op);
           newOp.requests = (<Array<Request>>op.requests).filter(r => r === req);
           let name = op.language.go!.name;
-          if (req.protocol.http!.knownMediaType === 'json') {
-            name = name + 'With' + req.parameters![0].schema.language.go!.name;
+          // for the non-binary media types we create a new method with the
+          // media type name as a suffix, e.g. FooAPIWithJSON()
+          if (req.protocol.http!.knownMediaType !== KnownMediaType.Binary) {
+            let suffix: string;
+            switch (req.protocol.http!.knownMediaType) {
+              case KnownMediaType.Json:
+                suffix = 'JSON';
+                break;
+              case KnownMediaType.Xml:
+                suffix = 'XML';
+                break;
+              default:
+                suffix = (<string>req.protocol.http!.knownMediaType).capitalize();
+            }
+            name = name + 'With' + suffix;
           }
           newOp.language.go!.name = name;
           newOp.language.go!.protocolNaming = new protocolMethods(newOp.language.go!.name);

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -31,12 +31,12 @@ func TestAnalyzeBody(t *testing.T) {
 	}
 }
 
-func TestAnalyzeBodyWithSourcePath(t *testing.T) {
+func TestAnalyzeBodyWithJSON(t *testing.T) {
 	client := newMediaTypesClient()
 	body := SourcePath{
 		Source: to.StringPtr("test"),
 	}
-	result, err := client.AnalyzeBodyWithSourcePath(context.Background(), &MediaTypesClientAnalyzeBodyWithSourcePathOptions{Input: &body})
+	result, err := client.AnalyzeBodyWithJSON(context.Background(), &MediaTypesClientAnalyzeBodyWithJSONOptions{Input: &body})
 	if err != nil {
 		t.Fatalf("AnalyzeBodyWithSourcePath: %v", err)
 	}
@@ -56,4 +56,20 @@ func TestContentTypeWithEncoding(t *testing.T) {
 	if s := result.RawResponse.StatusCode; s != http.StatusOK {
 		t.Fatalf("unexpected status code %d", s)
 	}
+}
+
+func TestBinaryBodyWithThreeContentTypes(t *testing.T) {
+	t.Skip("no route")
+}
+
+func TestBinaryBodyWithThreeContentTypesWithText(t *testing.T) {
+	t.Skip("no route")
+}
+
+func TestBinaryBodyWithTwoContentTypes(t *testing.T) {
+	t.Skip("no route")
+}
+
+func TestPutTextAndJSONBodyWithJSON(t *testing.T) {
+	t.Skip("no route")
 }

--- a/test/autorest/mediatypesgroup/zz_generated_constants.go
+++ b/test/autorest/mediatypesgroup/zz_generated_constants.go
@@ -43,3 +43,26 @@ func PossibleContentTypeValues() []ContentType {
 func (c ContentType) ToPtr() *ContentType {
 	return &c
 }
+
+// ContentType1 - Content type for upload
+type ContentType1 string
+
+const (
+	// ContentType1ApplicationJSON - Content Type 'application/json'
+	ContentType1ApplicationJSON ContentType1 = "application/json"
+	// ContentType1ApplicationOctetStream - Content Type 'application/octet-stream'
+	ContentType1ApplicationOctetStream ContentType1 = "application/octet-stream"
+)
+
+// PossibleContentType1Values returns the possible values for the ContentType1 const type.
+func PossibleContentType1Values() []ContentType1 {
+	return []ContentType1{
+		ContentType1ApplicationJSON,
+		ContentType1ApplicationOctetStream,
+	}
+}
+
+// ToPtr returns a *ContentType1 pointing to the current value.
+func (c ContentType1) ToPtr() *ContentType1 {
+	return &c
+}

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypesclient_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -140,28 +141,28 @@ func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderHandleError(resp *http.
 	return runtime.NewResponseError(errors.New(string(body)), resp)
 }
 
-// AnalyzeBodyNoAcceptHeaderWithSourcePath - Analyze body, that could be different media types. Adds to AnalyzeBody by not
-// having an accept type.
+// AnalyzeBodyNoAcceptHeaderWithJSON - Analyze body, that could be different media types. Adds to AnalyzeBody by not having
+// an accept type.
 // If the operation fails it returns a generic error.
-// options - MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithSourcePath
+// options - MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithJSON
 // method.
-func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeaderWithSourcePath(ctx context.Context, options *MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathOptions) (MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse, error) {
-	req, err := client.analyzeBodyNoAcceptHeaderWithSourcePathCreateRequest(ctx, options)
+func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeaderWithJSON(ctx context.Context, options *MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONOptions) (MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse, error) {
+	req, err := client.analyzeBodyNoAcceptHeaderWithJSONCreateRequest(ctx, options)
 	if err != nil {
-		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse{}, err
+		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse{}, err
+		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusAccepted) {
-		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse{}, client.analyzeBodyNoAcceptHeaderWithSourcePathHandleError(resp)
+		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, client.analyzeBodyNoAcceptHeaderWithJSONHandleError(resp)
 	}
-	return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse{RawResponse: resp}, nil
+	return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{RawResponse: resp}, nil
 }
 
-// analyzeBodyNoAcceptHeaderWithSourcePathCreateRequest creates the AnalyzeBodyNoAcceptHeaderWithSourcePath request.
-func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithSourcePathCreateRequest(ctx context.Context, options *MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathOptions) (*policy.Request, error) {
+// analyzeBodyNoAcceptHeaderWithJSONCreateRequest creates the AnalyzeBodyNoAcceptHeaderWithJSON request.
+func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithJSONCreateRequest(ctx context.Context, options *MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONOptions) (*policy.Request, error) {
 	urlPath := "/mediatypes/analyzeNoAccept"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -173,8 +174,8 @@ func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithSourcePathCreateReq
 	return req, nil
 }
 
-// analyzeBodyNoAcceptHeaderWithSourcePathHandleError handles the AnalyzeBodyNoAcceptHeaderWithSourcePath error response.
-func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithSourcePathHandleError(resp *http.Response) error {
+// analyzeBodyNoAcceptHeaderWithJSONHandleError handles the AnalyzeBodyNoAcceptHeaderWithJSON error response.
+func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithJSONHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -185,27 +186,27 @@ func (client *MediaTypesClient) analyzeBodyNoAcceptHeaderWithSourcePathHandleErr
 	return runtime.NewResponseError(errors.New(string(body)), resp)
 }
 
-// AnalyzeBodyWithSourcePath - Analyze body, that could be different media types.
+// AnalyzeBodyWithJSON - Analyze body, that could be different media types.
 // If the operation fails it returns a generic error.
-// options - MediaTypesClientAnalyzeBodyWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithSourcePath
+// options - MediaTypesClientAnalyzeBodyWithJSONOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithJSON
 // method.
-func (client *MediaTypesClient) AnalyzeBodyWithSourcePath(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (MediaTypesClientAnalyzeBodyWithSourcePathResponse, error) {
-	req, err := client.analyzeBodyWithSourcePathCreateRequest(ctx, options)
+func (client *MediaTypesClient) AnalyzeBodyWithJSON(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithJSONOptions) (MediaTypesClientAnalyzeBodyWithJSONResponse, error) {
+	req, err := client.analyzeBodyWithJSONCreateRequest(ctx, options)
 	if err != nil {
-		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, err
+		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, err
 	}
 	resp, err := client.pl.Do(req)
 	if err != nil {
-		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, err
+		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, client.analyzeBodyWithSourcePathHandleError(resp)
+		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, client.analyzeBodyWithJSONHandleError(resp)
 	}
-	return client.analyzeBodyWithSourcePathHandleResponse(resp)
+	return client.analyzeBodyWithJSONHandleResponse(resp)
 }
 
-// analyzeBodyWithSourcePathCreateRequest creates the AnalyzeBodyWithSourcePath request.
-func (client *MediaTypesClient) analyzeBodyWithSourcePathCreateRequest(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithSourcePathOptions) (*policy.Request, error) {
+// analyzeBodyWithJSONCreateRequest creates the AnalyzeBodyWithJSON request.
+func (client *MediaTypesClient) analyzeBodyWithJSONCreateRequest(ctx context.Context, options *MediaTypesClientAnalyzeBodyWithJSONOptions) (*policy.Request, error) {
 	urlPath := "/mediatypes/analyze"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -218,17 +219,17 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathCreateRequest(ctx conte
 	return req, nil
 }
 
-// analyzeBodyWithSourcePathHandleResponse handles the AnalyzeBodyWithSourcePath response.
-func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyWithSourcePathResponse, error) {
-	result := MediaTypesClientAnalyzeBodyWithSourcePathResponse{RawResponse: resp}
+// analyzeBodyWithJSONHandleResponse handles the AnalyzeBodyWithJSON response.
+func (client *MediaTypesClient) analyzeBodyWithJSONHandleResponse(resp *http.Response) (MediaTypesClientAnalyzeBodyWithJSONResponse, error) {
+	result := MediaTypesClientAnalyzeBodyWithJSONResponse{RawResponse: resp}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Value); err != nil {
-		return MediaTypesClientAnalyzeBodyWithSourcePathResponse{}, runtime.NewResponseError(err, resp)
+		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, runtime.NewResponseError(err, resp)
 	}
 	return result, nil
 }
 
-// analyzeBodyWithSourcePathHandleError handles the AnalyzeBodyWithSourcePath error response.
-func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleError(resp *http.Response) error {
+// analyzeBodyWithJSONHandleError handles the AnalyzeBodyWithJSON error response.
+func (client *MediaTypesClient) analyzeBodyWithJSONHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)
@@ -239,7 +240,164 @@ func (client *MediaTypesClient) analyzeBodyWithSourcePathHandleError(resp *http.
 	return runtime.NewResponseError(errors.New(string(body)), resp)
 }
 
-// ContentTypeWithEncoding - Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter
+// BinaryBodyWithThreeContentTypes - Binary body with three content types. Pass in string 'hello, world' with content type
+// 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+// 'application/octet-stream'.
+// If the operation fails it returns a generic error.
+// contentType - Upload file type
+// message - The payload body.
+// options - MediaTypesClientBinaryBodyWithThreeContentTypesOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithThreeContentTypes
+// method.
+func (client *MediaTypesClient) BinaryBodyWithThreeContentTypes(ctx context.Context, contentType ContentType1, message io.ReadSeekCloser, options *MediaTypesClientBinaryBodyWithThreeContentTypesOptions) (MediaTypesClientBinaryBodyWithThreeContentTypesResponse, error) {
+	req, err := client.binaryBodyWithThreeContentTypesCreateRequest(ctx, contentType, message, options)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, client.binaryBodyWithThreeContentTypesHandleError(resp)
+	}
+	return client.binaryBodyWithThreeContentTypesHandleResponse(resp)
+}
+
+// binaryBodyWithThreeContentTypesCreateRequest creates the BinaryBodyWithThreeContentTypes request.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesCreateRequest(ctx context.Context, contentType ContentType1, message io.ReadSeekCloser, options *MediaTypesClientBinaryBodyWithThreeContentTypesOptions) (*policy.Request, error) {
+	urlPath := "/mediatypes/binaryBodyThreeContentTypes"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Content-Type", string(contentType))
+	req.Raw().Header.Set("Accept", "text/plain")
+	return req, req.SetBody(message, string(contentType))
+}
+
+// binaryBodyWithThreeContentTypesHandleResponse handles the BinaryBodyWithThreeContentTypes response.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesResponse, error) {
+	result := MediaTypesClientBinaryBodyWithThreeContentTypesResponse{RawResponse: resp}
+	return result, nil
+}
+
+// binaryBodyWithThreeContentTypesHandleError handles the BinaryBodyWithThreeContentTypes error response.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
+// BinaryBodyWithThreeContentTypesWithText - Binary body with three content types. Pass in string 'hello, world' with content
+// type 'text/plain', {'hello': world'} with content type 'application/json' and a byte string for
+// 'application/octet-stream'.
+// If the operation fails it returns a generic error.
+// message - The payload body.
+// options - MediaTypesClientBinaryBodyWithThreeContentTypesWithTextOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithThreeContentTypesWithText
+// method.
+func (client *MediaTypesClient) BinaryBodyWithThreeContentTypesWithText(ctx context.Context, message string, options *MediaTypesClientBinaryBodyWithThreeContentTypesWithTextOptions) (MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse, error) {
+	req, err := client.binaryBodyWithThreeContentTypesWithTextCreateRequest(ctx, message, options)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{}, client.binaryBodyWithThreeContentTypesWithTextHandleError(resp)
+	}
+	return client.binaryBodyWithThreeContentTypesWithTextHandleResponse(resp)
+}
+
+// binaryBodyWithThreeContentTypesWithTextCreateRequest creates the BinaryBodyWithThreeContentTypesWithText request.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextCreateRequest(ctx context.Context, message string, options *MediaTypesClientBinaryBodyWithThreeContentTypesWithTextOptions) (*policy.Request, error) {
+	urlPath := "/mediatypes/binaryBodyThreeContentTypes"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "text/plain")
+	body := streaming.NopCloser(strings.NewReader(message))
+	return req, req.SetBody(body, "text/plain")
+}
+
+// binaryBodyWithThreeContentTypesWithTextHandleResponse handles the BinaryBodyWithThreeContentTypesWithText response.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse, error) {
+	result := MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse{RawResponse: resp}
+	return result, nil
+}
+
+// binaryBodyWithThreeContentTypesWithTextHandleError handles the BinaryBodyWithThreeContentTypesWithText error response.
+func (client *MediaTypesClient) binaryBodyWithThreeContentTypesWithTextHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
+// BinaryBodyWithTwoContentTypes - Binary body with two content types. Pass in of {'hello': 'world'} for the application/json
+// content type, and a byte stream of 'hello, world!' for application/octet-stream.
+// If the operation fails it returns a generic error.
+// contentType - Upload file type
+// message - The payload body.
+// options - MediaTypesClientBinaryBodyWithTwoContentTypesOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithTwoContentTypes
+// method.
+func (client *MediaTypesClient) BinaryBodyWithTwoContentTypes(ctx context.Context, contentType ContentType1, message io.ReadSeekCloser, options *MediaTypesClientBinaryBodyWithTwoContentTypesOptions) (MediaTypesClientBinaryBodyWithTwoContentTypesResponse, error) {
+	req, err := client.binaryBodyWithTwoContentTypesCreateRequest(ctx, contentType, message, options)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, client.binaryBodyWithTwoContentTypesHandleError(resp)
+	}
+	return client.binaryBodyWithTwoContentTypesHandleResponse(resp)
+}
+
+// binaryBodyWithTwoContentTypesCreateRequest creates the BinaryBodyWithTwoContentTypes request.
+func (client *MediaTypesClient) binaryBodyWithTwoContentTypesCreateRequest(ctx context.Context, contentType ContentType1, message io.ReadSeekCloser, options *MediaTypesClientBinaryBodyWithTwoContentTypesOptions) (*policy.Request, error) {
+	urlPath := "/mediatypes/binaryBodyTwoContentTypes"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Content-Type", string(contentType))
+	req.Raw().Header.Set("Accept", "text/plain")
+	return req, req.SetBody(message, string(contentType))
+}
+
+// binaryBodyWithTwoContentTypesHandleResponse handles the BinaryBodyWithTwoContentTypes response.
+func (client *MediaTypesClient) binaryBodyWithTwoContentTypesHandleResponse(resp *http.Response) (MediaTypesClientBinaryBodyWithTwoContentTypesResponse, error) {
+	result := MediaTypesClientBinaryBodyWithTwoContentTypesResponse{RawResponse: resp}
+	return result, nil
+}
+
+// binaryBodyWithTwoContentTypesHandleError handles the BinaryBodyWithTwoContentTypes error response.
+func (client *MediaTypesClient) binaryBodyWithTwoContentTypesHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
+// ContentTypeWithEncoding - Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter
 // If the operation fails it returns a generic error.
 // options - MediaTypesClientContentTypeWithEncodingOptions contains the optional parameters for the MediaTypesClient.ContentTypeWithEncoding
 // method.
@@ -268,7 +426,7 @@ func (client *MediaTypesClient) contentTypeWithEncodingCreateRequest(ctx context
 	req.Raw().Header.Set("Accept", "application/json")
 	if options != nil && options.Input != nil {
 		body := streaming.NopCloser(strings.NewReader(*options.Input))
-		return req, req.SetBody(body, "text/plain; encoding=UTF-8")
+		return req, req.SetBody(body, "text/plain; charset=UTF-8")
 	}
 	return req, nil
 }
@@ -284,6 +442,105 @@ func (client *MediaTypesClient) contentTypeWithEncodingHandleResponse(resp *http
 
 // contentTypeWithEncodingHandleError handles the ContentTypeWithEncoding error response.
 func (client *MediaTypesClient) contentTypeWithEncodingHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
+// PutTextAndJSONBodyWithJSON - Body that's either text/plain or application/json
+// If the operation fails it returns a generic error.
+// message - The payload body.
+// options - MediaTypesClientPutTextAndJSONBodyWithJSONOptions contains the optional parameters for the MediaTypesClient.PutTextAndJSONBodyWithJSON
+// method.
+func (client *MediaTypesClient) PutTextAndJSONBodyWithJSON(ctx context.Context, message string, options *MediaTypesClientPutTextAndJSONBodyWithJSONOptions) (MediaTypesClientPutTextAndJSONBodyWithJSONResponse, error) {
+	req, err := client.putTextAndJSONBodyWithJSONCreateRequest(ctx, message, options)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return MediaTypesClientPutTextAndJSONBodyWithJSONResponse{}, client.putTextAndJSONBodyWithJSONHandleError(resp)
+	}
+	return client.putTextAndJSONBodyWithJSONHandleResponse(resp)
+}
+
+// putTextAndJSONBodyWithJSONCreateRequest creates the PutTextAndJSONBodyWithJSON request.
+func (client *MediaTypesClient) putTextAndJSONBodyWithJSONCreateRequest(ctx context.Context, message string, options *MediaTypesClientPutTextAndJSONBodyWithJSONOptions) (*policy.Request, error) {
+	urlPath := "/mediatypes/textAndJson"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "text/plain")
+	return req, runtime.MarshalAsJSON(req, message)
+}
+
+// putTextAndJSONBodyWithJSONHandleResponse handles the PutTextAndJSONBodyWithJSON response.
+func (client *MediaTypesClient) putTextAndJSONBodyWithJSONHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithJSONResponse, error) {
+	result := MediaTypesClientPutTextAndJSONBodyWithJSONResponse{RawResponse: resp}
+	return result, nil
+}
+
+// putTextAndJSONBodyWithJSONHandleError handles the PutTextAndJSONBodyWithJSON error response.
+func (client *MediaTypesClient) putTextAndJSONBodyWithJSONHandleError(resp *http.Response) error {
+	body, err := runtime.Payload(resp)
+	if err != nil {
+		return runtime.NewResponseError(err, resp)
+	}
+	if len(body) == 0 {
+		return runtime.NewResponseError(errors.New(resp.Status), resp)
+	}
+	return runtime.NewResponseError(errors.New(string(body)), resp)
+}
+
+// PutTextAndJSONBodyWithText - Body that's either text/plain or application/json
+// If the operation fails it returns a generic error.
+// message - The payload body.
+// options - MediaTypesClientPutTextAndJSONBodyWithTextOptions contains the optional parameters for the MediaTypesClient.PutTextAndJSONBodyWithText
+// method.
+func (client *MediaTypesClient) PutTextAndJSONBodyWithText(ctx context.Context, message string, options *MediaTypesClientPutTextAndJSONBodyWithTextOptions) (MediaTypesClientPutTextAndJSONBodyWithTextResponse, error) {
+	req, err := client.putTextAndJSONBodyWithTextCreateRequest(ctx, message, options)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, err
+	}
+	resp, err := client.pl.Do(req)
+	if err != nil {
+		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, err
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, client.putTextAndJSONBodyWithTextHandleError(resp)
+	}
+	return client.putTextAndJSONBodyWithTextHandleResponse(resp)
+}
+
+// putTextAndJSONBodyWithTextCreateRequest creates the PutTextAndJSONBodyWithText request.
+func (client *MediaTypesClient) putTextAndJSONBodyWithTextCreateRequest(ctx context.Context, message string, options *MediaTypesClientPutTextAndJSONBodyWithTextOptions) (*policy.Request, error) {
+	urlPath := "/mediatypes/textAndJson"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Accept", "text/plain")
+	body := streaming.NopCloser(strings.NewReader(message))
+	return req, req.SetBody(body, "text/plain")
+}
+
+// putTextAndJSONBodyWithTextHandleResponse handles the PutTextAndJSONBodyWithText response.
+func (client *MediaTypesClient) putTextAndJSONBodyWithTextHandleResponse(resp *http.Response) (MediaTypesClientPutTextAndJSONBodyWithTextResponse, error) {
+	result := MediaTypesClientPutTextAndJSONBodyWithTextResponse{RawResponse: resp}
+	return result, nil
+}
+
+// putTextAndJSONBodyWithTextHandleError handles the PutTextAndJSONBodyWithText error response.
+func (client *MediaTypesClient) putTextAndJSONBodyWithTextHandleError(resp *http.Response) error {
 	body, err := runtime.Payload(resp)
 	if err != nil {
 		return runtime.NewResponseError(err, resp)

--- a/test/autorest/mediatypesgroup/zz_generated_models.go
+++ b/test/autorest/mediatypesgroup/zz_generated_models.go
@@ -17,9 +17,9 @@ type MediaTypesClientAnalyzeBodyNoAcceptHeaderOptions struct {
 	Input io.ReadSeekCloser
 }
 
-// MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithSourcePath
+// MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithJSON
 // method.
-type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathOptions struct {
+type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONOptions struct {
 	// Input parameter.
 	Input *SourcePath
 }
@@ -30,11 +30,29 @@ type MediaTypesClientAnalyzeBodyOptions struct {
 	Input io.ReadSeekCloser
 }
 
-// MediaTypesClientAnalyzeBodyWithSourcePathOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithSourcePath
+// MediaTypesClientAnalyzeBodyWithJSONOptions contains the optional parameters for the MediaTypesClient.AnalyzeBodyWithJSON
 // method.
-type MediaTypesClientAnalyzeBodyWithSourcePathOptions struct {
+type MediaTypesClientAnalyzeBodyWithJSONOptions struct {
 	// Input parameter.
 	Input *SourcePath
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithThreeContentTypes
+// method.
+type MediaTypesClientBinaryBodyWithThreeContentTypesOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesWithTextOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithThreeContentTypesWithText
+// method.
+type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MediaTypesClientBinaryBodyWithTwoContentTypesOptions contains the optional parameters for the MediaTypesClient.BinaryBodyWithTwoContentTypes
+// method.
+type MediaTypesClientBinaryBodyWithTwoContentTypesOptions struct {
+	// placeholder for future optional parameters
 }
 
 // MediaTypesClientContentTypeWithEncodingOptions contains the optional parameters for the MediaTypesClient.ContentTypeWithEncoding
@@ -42,6 +60,18 @@ type MediaTypesClientAnalyzeBodyWithSourcePathOptions struct {
 type MediaTypesClientContentTypeWithEncodingOptions struct {
 	// Input parameter.
 	Input *string
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithJSONOptions contains the optional parameters for the MediaTypesClient.PutTextAndJSONBodyWithJSON
+// method.
+type MediaTypesClientPutTextAndJSONBodyWithJSONOptions struct {
+	// placeholder for future optional parameters
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithTextOptions contains the optional parameters for the MediaTypesClient.PutTextAndJSONBodyWithText
+// method.
+type MediaTypesClientPutTextAndJSONBodyWithTextOptions struct {
+	// placeholder for future optional parameters
 }
 
 // SourcePath - Uri or local path to source data.

--- a/test/autorest/mediatypesgroup/zz_generated_response_types.go
+++ b/test/autorest/mediatypesgroup/zz_generated_response_types.go
@@ -16,8 +16,8 @@ type MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse struct {
 	RawResponse *http.Response
 }
 
-// MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse contains the response from method MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithSourcePath.
-type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithSourcePathResponse struct {
+// MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse contains the response from method MediaTypesClient.AnalyzeBodyNoAcceptHeaderWithJSON.
+type MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse struct {
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
@@ -34,15 +34,51 @@ type MediaTypesClientAnalyzeBodyResult struct {
 	Value *string
 }
 
-// MediaTypesClientAnalyzeBodyWithSourcePathResponse contains the response from method MediaTypesClient.AnalyzeBodyWithSourcePath.
-type MediaTypesClientAnalyzeBodyWithSourcePathResponse struct {
-	MediaTypesClientAnalyzeBodyWithSourcePathResult
+// MediaTypesClientAnalyzeBodyWithJSONResponse contains the response from method MediaTypesClient.AnalyzeBodyWithJSON.
+type MediaTypesClientAnalyzeBodyWithJSONResponse struct {
+	MediaTypesClientAnalyzeBodyWithJSONResult
 	// RawResponse contains the underlying HTTP response.
 	RawResponse *http.Response
 }
 
-// MediaTypesClientAnalyzeBodyWithSourcePathResult contains the result from method MediaTypesClient.AnalyzeBodyWithSourcePath.
-type MediaTypesClientAnalyzeBodyWithSourcePathResult struct {
+// MediaTypesClientAnalyzeBodyWithJSONResult contains the result from method MediaTypesClient.AnalyzeBodyWithJSON.
+type MediaTypesClientAnalyzeBodyWithJSONResult struct {
+	Value *string
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypes.
+type MediaTypesClientBinaryBodyWithThreeContentTypesResponse struct {
+	MediaTypesClientBinaryBodyWithThreeContentTypesResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesResult contains the result from method MediaTypesClient.BinaryBodyWithThreeContentTypes.
+type MediaTypesClientBinaryBodyWithThreeContentTypesResult struct {
+	Value *string
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse contains the response from method MediaTypesClient.BinaryBodyWithThreeContentTypesWithText.
+type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResponse struct {
+	MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult contains the result from method MediaTypesClient.BinaryBodyWithThreeContentTypesWithText.
+type MediaTypesClientBinaryBodyWithThreeContentTypesWithTextResult struct {
+	Value *string
+}
+
+// MediaTypesClientBinaryBodyWithTwoContentTypesResponse contains the response from method MediaTypesClient.BinaryBodyWithTwoContentTypes.
+type MediaTypesClientBinaryBodyWithTwoContentTypesResponse struct {
+	MediaTypesClientBinaryBodyWithTwoContentTypesResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// MediaTypesClientBinaryBodyWithTwoContentTypesResult contains the result from method MediaTypesClient.BinaryBodyWithTwoContentTypes.
+type MediaTypesClientBinaryBodyWithTwoContentTypesResult struct {
 	Value *string
 }
 
@@ -55,5 +91,29 @@ type MediaTypesClientContentTypeWithEncodingResponse struct {
 
 // MediaTypesClientContentTypeWithEncodingResult contains the result from method MediaTypesClient.ContentTypeWithEncoding.
 type MediaTypesClientContentTypeWithEncodingResult struct {
+	Value *string
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithJSONResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithJSON.
+type MediaTypesClientPutTextAndJSONBodyWithJSONResponse struct {
+	MediaTypesClientPutTextAndJSONBodyWithJSONResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithJSONResult contains the result from method MediaTypesClient.PutTextAndJSONBodyWithJSON.
+type MediaTypesClientPutTextAndJSONBodyWithJSONResult struct {
+	Value *string
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithTextResponse contains the response from method MediaTypesClient.PutTextAndJSONBodyWithText.
+type MediaTypesClientPutTextAndJSONBodyWithTextResponse struct {
+	MediaTypesClientPutTextAndJSONBodyWithTextResult
+	// RawResponse contains the underlying HTTP response.
+	RawResponse *http.Response
+}
+
+// MediaTypesClientPutTextAndJSONBodyWithTextResult contains the result from method MediaTypesClient.PutTextAndJSONBodyWithText.
+type MediaTypesClientPutTextAndJSONBodyWithTextResult struct {
 	Value *string
 }


### PR DESCRIPTION
Use the content type as specified in the swagger.  This requied updating
the test server to fix a bug in the content type for mediatypesgroup.
The upgrade exposed a naming bug for operations with multiple requests
which has also been fixed.